### PR TITLE
The Ruby tests require Ruby 3.1+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@
 
 source "https://rubygems.org"
 
+ruby ">= 3.1.0"
+
 gemspec


### PR DESCRIPTION
@kddnewton The gemspec declares YARP runs with Ruby 2.6+, but I found the tests will only run on Ruby 3.1+. Moreover, the gemspec requirement doesn't prohibit the rake task from executing. Please let me know if you'd prefer to resolve the issue differently.