### PR TITLE
WIP: tokenize string literals

### DIFF
--- a/src/lexer/string_literal.c
+++ b/src/lexer/string_literal.c
@@ -1,0 +1,66 @@
+#include "lexer/string_literal.h"
+#include "util/stack.h"
+
+// constructors
+yp_string_literal_t
+yp_string_literal_new_string(interpolation_t interpolation, char starts_with, char ends_with) {
+  return (yp_string_literal_t) {
+    .type = LITERAL_STRING,
+    .as.string = {
+        .interpolation = interpolation,
+        .starts_with = starts_with,
+        .ends_with = ends_with,
+        .ends_with_nesting = 0,
+    },
+  };
+}
+yp_string_literal_t
+yp_string_literal_new_symbol(interpolation_t interpolation) {
+  return (yp_string_literal_t) {
+        .type = LITERAL_SYMBOL,
+        .as.symbol = {
+            .interpolation = interpolation,
+        },
+    };
+}
+yp_string_literal_t
+yp_string_literal_new_regexp(interpolation_t interpolation, char starts_with, char ends_with) {
+  return (yp_string_literal_t) {
+        .type = LITERAL_REGEXP,
+        .as.regexp = {
+            .interpolation = interpolation,
+            .starts_with = starts_with,
+            .ends_with = ends_with,
+            .ends_with_nesting = 0,
+        },
+    };
+}
+yp_string_literal_t
+yp_string_literal_new_array(interpolation_t interpolation, char starts_with, char ends_with) {
+  return (yp_string_literal_t) {
+        .type = LITERAL_ARRAY,
+        .as.array = {
+            .interpolation = interpolation,
+            .starts_with = starts_with,
+            .ends_with = ends_with,
+            .ends_with_nesting = 0,
+        },
+    };
+}
+yp_string_literal_t
+yp_string_literal_new_heredoc(interpolation_t interpolation, const char *heredoc_id_ended_at, bool squiggly) {
+  return (yp_string_literal_t) {
+        .type = LITERAL_HEREDOC,
+        .as.heredoc = {
+            .interpolation = interpolation,
+            .heredoc_id_ended_at = heredoc_id_ended_at,
+            .heredoc_ended_at = 0,
+            .squiggly = squiggly,
+        },
+    };
+}
+
+// stack
+STACK_IMPL(yp_string_literal_stack_t, yp_string_literal_t, yp_string_literal_stack_create,
+           yp_string_literal_stack_destroy, yp_string_literal_stack_push, yp_string_literal_stack_pop,
+           yp_string_literal_stack_last, yp_string_literal_stack_size);

--- a/src/lexer/string_literal.h
+++ b/src/lexer/string_literal.h
@@ -1,0 +1,49 @@
+#ifndef YARP_LEXER_STRING_LITERAL_H
+#define YARP_LEXER_STRING_LITERAL_H
+
+#include "lexer/string_literals/array.h"
+#include "lexer/string_literals/heredoc.h"
+#include "lexer/string_literals/interpolation.h"
+#include "lexer/string_literals/regexp.h"
+#include "lexer/string_literals/string.h"
+#include "lexer/string_literals/symbol.h"
+#include "util/stack.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct {
+  enum {
+    LITERAL_STRING,
+    LITERAL_SYMBOL,
+    LITERAL_REGEXP,
+    LITERAL_ARRAY,
+    LITERAL_HEREDOC,
+  } type;
+
+  union {
+    yp_string_literal_string_t string;
+    yp_string_literal_symbol_t symbol;
+    yp_string_literal_regexp_t regexp;
+    yp_string_literal_array_t array;
+    yp_string_literal_heredoc_t heredoc;
+  } as;
+} yp_string_literal_t;
+
+// constructors
+yp_string_literal_t
+yp_string_literal_new_string(interpolation_t interpolation, char starts_with, char ends_with);
+yp_string_literal_t
+yp_string_literal_new_symbol(interpolation_t interpolation);
+yp_string_literal_t
+yp_string_literal_new_regexp(interpolation_t interpolation, char starts_with, char ends_with);
+yp_string_literal_t
+yp_string_literal_new_array(interpolation_t interpolation, char starts_with, char ends_with);
+yp_string_literal_t
+yp_string_literal_new_heredoc(interpolation_t interpolation, const char *heredoc_id_ended_at, bool squiggly);
+
+// stack
+STACK_DECL(yp_string_literal_stack_t, yp_string_literal_t, yp_string_literal_stack_create,
+           yp_string_literal_stack_destroy, yp_string_literal_stack_push, yp_string_literal_stack_pop,
+           yp_string_literal_stack_last, yp_string_literal_stack_size);
+
+#endif // YARP_LEXER_STRING_LITERAL_H

--- a/src/lexer/string_literal_extend.c
+++ b/src/lexer/string_literal_extend.c
@@ -1,0 +1,24 @@
+#include "lexer/string_literal_extend.h"
+#include "lexer/string_literals/array_extend.h"
+#include "lexer/string_literals/heredoc_extend.h"
+#include "lexer/string_literals/regexp_extend.h"
+#include "lexer/string_literals/string_extend.h"
+#include "lexer/string_literals/symbol_extend.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend(yp_string_literal_t *string_literal, yp_parser_t *parser) {
+  switch (string_literal->type) {
+    case LITERAL_STRING:
+      return yp_string_literal_string_extend(&(string_literal->as.string), parser);
+    case LITERAL_SYMBOL:
+      return yp_string_literal_symbol_extend(&(string_literal->as.symbol), parser);
+    case LITERAL_REGEXP:
+      return yp_string_literal_regexp_extend(&(string_literal->as.regexp), parser);
+    case LITERAL_ARRAY:
+      return yp_string_literal_array_extend(&(string_literal->as.array), parser);
+    case LITERAL_HEREDOC:
+      return yp_string_literal_heredoc_extend(&(string_literal->as.heredoc), parser);
+  }
+
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literal_extend.h
+++ b/src/lexer/string_literal_extend.h
@@ -1,0 +1,10 @@
+#ifndef YARP_LEXER_STRING_LITERAL_EXTEND_H
+#define YARP_LEXER_STRING_LITERAL_EXTEND_H
+
+#include "lexer/string_literal.h"
+#include "lexer/string_literals/action.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend(yp_string_literal_t *string_literal, yp_parser_t *parser);
+
+#endif // YARP_LEXER_STRING_LITERAL_EXTEND_H

--- a/src/lexer/string_literals/action.h
+++ b/src/lexer/string_literals/action.h
@@ -1,0 +1,13 @@
+#ifndef YARP_STRING_LITERALS_ACTTION_H
+#define YARP_STRING_LITERALS_ACTTION_H
+
+#include "ast.h"
+#include "parser.h"
+
+typedef enum {
+  EXTEND_ACTION_NONE,
+  EXTEND_ACTION_EMIT_TOKEN,
+  EXTEND_ACTION_READ_INTERPOLATED_CONTENT,
+} yp_string_literal_extend_action_t;
+
+#endif // YARP_STRING_LITERALS_ACTTION_H

--- a/src/lexer/string_literals/array.h
+++ b/src/lexer/string_literals/array.h
@@ -1,0 +1,14 @@
+#ifndef YARP_STRING_LITERALS_ARRAY_H
+#define YARP_STRING_LITERALS_ARRAY_H
+
+#include "lexer/string_literals/interpolation.h"
+#include <stddef.h>
+
+typedef struct {
+  interpolation_t interpolation;
+  char starts_with;
+  char ends_with;
+  size_t ends_with_nesting;
+} yp_string_literal_array_t;
+
+#endif // YARP_STRING_LITERALS_ARRAY_H

--- a/src/lexer/string_literals/array_extend.c
+++ b/src/lexer/string_literals/array_extend.c
@@ -1,0 +1,7 @@
+#include "lexer/string_literals/array_extend.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_array_extend(yp_string_literal_array_t *literal, yp_parser_t *parser) {
+  // TODO: implement me
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/array_extend.h
+++ b/src/lexer/string_literals/array_extend.h
@@ -1,0 +1,11 @@
+#ifndef YARP_STRING_LITERALS_ARRAY_EXTEND_H
+#define YARP_STRING_LITERALS_ARRAY_EXTEND_H
+
+#include "lexer/string_literals/action.h"
+#include "lexer/string_literals/array.h"
+#include "parser.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_array_extend(yp_string_literal_array_t *literal, yp_parser_t *parser);
+
+#endif // YARP_STRING_LITERALS_ARRAY_EXTEND_H

--- a/src/lexer/string_literals/handlers/emit_captured.c
+++ b/src/lexer/string_literals/handlers/emit_captured.c
@@ -1,0 +1,12 @@
+#include "lexer/string_literals/handlers/emit_captured.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_emit_captured(yp_parser_t *parser) {
+  if (parser->current.start != parser->current.end) {
+    parser->current.type = YP_TOKEN_STRING_CONTENT;
+    return EXTEND_ACTION_EMIT_TOKEN;
+  }
+
+  // Nothing has been captured
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/handlers/emit_captured.h
+++ b/src/lexer/string_literals/handlers/emit_captured.h
@@ -1,0 +1,11 @@
+#ifndef YARP_STRING_LITERALS_HANDLERS_EMIT_CAPTURED_H
+#define YARP_STRING_LITERALS_HANDLERS_EMIT_CAPTURED_H
+
+#include "lexer/string_literals/action.h"
+#include "lexer/string_literals/interpolation.h"
+#include "parser.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_emit_captured(yp_parser_t *parser);
+
+#endif // YARP_STRING_LITERALS_HANDLERS_EMIT_CAPTURED_H

--- a/src/lexer/string_literals/handlers/eof.c
+++ b/src/lexer/string_literals/handlers/eof.c
@@ -1,0 +1,18 @@
+#include "lexer/string_literals/handlers/eof.h"
+#include "lexer/string_literals/handlers/emit_captured.h"
+#include "lexer/string_literals/handlers/try.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_eof(yp_parser_t *parser) {
+  if (parser->current.end >= parser->end) {
+    // EOF reached, emit what has been captured so far (if any)
+    try_handler(yp_string_literal_emit_captured(parser));
+
+    // Nothing has been captured, emit EOF
+    parser->current.type = YP_TOKEN_EOF;
+    // TODO: pop current literal
+    return EXTEND_ACTION_EMIT_TOKEN;
+  }
+
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/handlers/eof.h
+++ b/src/lexer/string_literals/handlers/eof.h
@@ -1,0 +1,11 @@
+#ifndef YARP_STRING_LITERALS_HANDLERS_EOF_H
+#define YARP_STRING_LITERALS_HANDLERS_EOF_H
+
+#include "lexer/string_literals/action.h"
+#include "parser.h"
+#include <stddef.h>
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_eof(yp_parser_t *parser);
+
+#endif // YARP_STRING_LITERALS_HANDLERS_EOF_H

--- a/src/lexer/string_literals/handlers/escape.c
+++ b/src/lexer/string_literals/handlers/escape.c
@@ -1,0 +1,7 @@
+#include "lexer/string_literals/handlers/escape.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_escape(yp_parser_t *parser) {
+  // FIXME: these must be an actual logic of escape sequence handling
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/handlers/escape.h
+++ b/src/lexer/string_literals/handlers/escape.h
@@ -1,0 +1,11 @@
+#ifndef YARP_STRING_LITERALS_HANDLERS_ESCAPE_H
+#define YARP_STRING_LITERALS_HANDLERS_ESCAPE_H
+
+#include "lexer/string_literals/action.h"
+#include "parser.h"
+#include <stddef.h>
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_escape(yp_parser_t *parser);
+
+#endif // YARP_STRING_LITERALS_HANDLERS_ESCAPE_H

--- a/src/lexer/string_literals/handlers/escaped_start_or_end.c
+++ b/src/lexer/string_literals/handlers/escaped_start_or_end.c
@@ -1,0 +1,23 @@
+#include "escaped_start_or_end.h"
+#include "emit_captured.h"
+#include "try.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_escaped_start_or_end(yp_parser_t *parser, char starts_with, char ends_with) {
+  if (parser->current.end < parser->end && *parser->current.end == '\\') {
+    if (parser->current.end + 1 < parser->end) {
+      char escaped_char = *(parser->current.end + 1);
+      if (escaped_char == starts_with || escaped_char == ends_with) {
+        try_handler(yp_string_literal_emit_captured(parser));
+
+        parser->current.end += 2;
+        parser->current.type = YP_TOKEN_STRING_CONTENT;
+        // TODO: store escaped char directly somewhere
+
+        return EXTEND_ACTION_EMIT_TOKEN;
+      }
+    }
+  }
+
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/handlers/escaped_start_or_end.h
+++ b/src/lexer/string_literals/handlers/escaped_start_or_end.h
@@ -1,0 +1,11 @@
+#ifndef YARP_STRING_LITERALS_HANDLERS_ESCAPED_START_OR_END_H
+#define YARP_STRING_LITERALS_HANDLERS_ESCAPED_START_OR_END_H
+
+#include "lexer/string_literals/action.h"
+#include "parser.h"
+#include <stddef.h>
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_escaped_start_or_end(yp_parser_t *parser, char starts_with, char ends_with);
+
+#endif // YARP_STRING_LITERALS_HANDLERS_ESCAPED_START_OR_END_H

--- a/src/lexer/string_literals/handlers/interpolation.c
+++ b/src/lexer/string_literals/handlers/interpolation.c
@@ -1,0 +1,46 @@
+#include "interpolation.h"
+#include "emit_captured.h"
+#include "try.h"
+
+// Handles regular "#{42}" interpolation
+static yp_string_literal_extend_action_t
+yp_string_literal_extend_regular_interpolation(yp_parser_t *parser, interpolation_t *interpolation) {
+  if (parser->current.end + 1 < parser->end && *parser->current.end == '#' && *(parser->current.end + 1) == '{') {
+    try_handler(yp_string_literal_emit_captured(parser));
+
+    parser->current.type = YP_TOKEN_EMBEXPR_BEGIN;
+    // Consue "#{"
+    parser->current.end += 2;
+    // Start interpolation
+    interpolation->active = true;
+
+    return EXTEND_ACTION_EMIT_TOKEN;
+  }
+
+  return EXTEND_ACTION_NONE;
+}
+
+// Handles "#@foo" / "#@@foo" interpolation
+static yp_string_literal_extend_action_t
+yp_string_literal_extend_raw_ivar_or_cvar_interpolation(yp_parser_t *parser, interpolation_t *interpolation) {
+  // TODO: requires a shared read_identifier method
+  return EXTEND_ACTION_NONE;
+}
+
+// Handles "#$foo" interpolation
+static yp_string_literal_extend_action_t
+yp_string_literal_extend_raw_gvar_interpolation(yp_parser_t *parser, interpolation_t *interpolation) {
+  // TODO: requires a shared read_identifier method
+  return EXTEND_ACTION_NONE;
+}
+
+// Handles generic interpolation
+// Internally is just a combination of 3 small parser.
+yp_string_literal_extend_action_t
+yp_string_literal_extend_interpolation(yp_parser_t *parser, interpolation_t *interpolation) {
+  try_handler(yp_string_literal_extend_regular_interpolation(parser, interpolation));
+  try_handler(yp_string_literal_extend_raw_ivar_or_cvar_interpolation(parser, interpolation));
+  try_handler(yp_string_literal_extend_raw_gvar_interpolation(parser, interpolation));
+
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/handlers/interpolation.h
+++ b/src/lexer/string_literals/handlers/interpolation.h
@@ -1,0 +1,12 @@
+#ifndef YARP_STRING_LITERALS_HANDLERS_INTERPOLATION_H
+#define YARP_STRING_LITERALS_HANDLERS_INTERPOLATION_H
+
+#include "lexer/string_literals/action.h"
+#include "lexer/string_literals/interpolation.h"
+#include "parser.h"
+#include <stddef.h>
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_interpolation(yp_parser_t *parser, interpolation_t *interpolation);
+
+#endif // YARP_STRING_LITERALS_HANDLERS_INTERPOLATION_H

--- a/src/lexer/string_literals/handlers/interpolation_end.c
+++ b/src/lexer/string_literals/handlers/interpolation_end.c
@@ -1,0 +1,20 @@
+#include "interpolation_end.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_interpolation_end(yp_parser_t *parser, interpolation_t *interpolation) {
+  if (interpolation->active) {
+    if (parser->current.end < parser->end && *parser->current.end == '}' &&
+        interpolation->curly_level == parser->curly_level) {
+      // Close interpolation
+      parser->current.type = YP_TOKEN_BRACE_RIGHT;
+      parser->current.end++;
+      interpolation->active = false;
+      return EXTEND_ACTION_EMIT_TOKEN;
+    } else {
+      // Yield control to lexer to read interpolated tokens
+      return EXTEND_ACTION_READ_INTERPOLATED_CONTENT;
+    }
+  }
+
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/handlers/interpolation_end.h
+++ b/src/lexer/string_literals/handlers/interpolation_end.h
@@ -1,0 +1,12 @@
+#ifndef YARP_STRING_LITERALS_HANDLERS_INTERPOLATION_END_H
+#define YARP_STRING_LITERALS_HANDLERS_INTERPOLATION_END_H
+
+#include "lexer/string_literals/action.h"
+#include "lexer/string_literals/interpolation.h"
+#include "parser.h"
+#include <stddef.h>
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_interpolation_end(yp_parser_t *parser, interpolation_t *interpolation);
+
+#endif // YARP_STRING_LITERALS_HANDLERS_INTERPOLATION_END_H

--- a/src/lexer/string_literals/handlers/line_continuation.c
+++ b/src/lexer/string_literals/handlers/line_continuation.c
@@ -1,0 +1,16 @@
+#include "lexer/string_literals/handlers/line_continuation.h"
+#include "lexer/string_literals/handlers/emit_captured.h"
+#include "lexer/string_literals/handlers/try.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_line_continuation(yp_parser_t *parser) {
+  if (*parser->current.end == '\\' && parser->current.end + 1 < parser->end && *parser->current.end == '\n') {
+    try_handler(yp_string_literal_emit_captured(parser));
+
+    parser->current.type = YP_TOKEN_STRING_CONTENT;
+    parser->current.end += 2;
+    return EXTEND_ACTION_EMIT_TOKEN;
+  }
+
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/handlers/line_continuation.h
+++ b/src/lexer/string_literals/handlers/line_continuation.h
@@ -1,0 +1,11 @@
+#ifndef YARP_STRING_LITERALS_HANDLERS_LINE_CONTINUATION_H
+#define YARP_STRING_LITERALS_HANDLERS_LINE_CONTINUATION_H
+
+#include "lexer/string_literals/action.h"
+#include "parser.h"
+#include <stddef.h>
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_line_continuation(yp_parser_t *parser);
+
+#endif // YARP_STRING_LITERALS_HANDLERS_LINE_CONTINUATION_H

--- a/src/lexer/string_literals/handlers/string_end.c
+++ b/src/lexer/string_literals/handlers/string_end.c
@@ -1,0 +1,33 @@
+#include "string_end.h"
+#include "emit_captured.h"
+#include "try.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_string_end(yp_parser_t *parser, char starts_with, char ends_with, size_t *ends_with_nesting) {
+  if (parser->current.end < parser->end) {
+    char c = *parser->current.end;
+    if (c == ends_with) {
+      if (*ends_with_nesting == 0) {
+        // match, actual string end
+        try_handler(yp_string_literal_emit_captured(parser));
+
+        parser->current.type = YP_TOKEN_STRING_END;
+        parser->current.end++;
+
+        return EXTEND_ACTION_EMIT_TOKEN;
+      } else {
+        // just a part of the string content like
+        // %Q{ {} }
+        //      ^
+        *ends_with_nesting -= 1;
+      }
+    } else if (c == starts_with) {
+      // also track occurrence of `starts_with` byte to handle cases like
+      // %Q{ {} }
+      //     ^^
+      *ends_with_nesting += 1;
+    }
+  }
+
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/handlers/string_end.h
+++ b/src/lexer/string_literals/handlers/string_end.h
@@ -1,0 +1,11 @@
+#ifndef YARP_STRING_LITERALS_HANDLERS_STRING_END_H
+#define YARP_STRING_LITERALS_HANDLERS_STRING_END_H
+
+#include "lexer/string_literals/action.h"
+#include "parser.h"
+#include <stddef.h>
+
+yp_string_literal_extend_action_t
+yp_string_literal_extend_string_end(yp_parser_t *parser, char starts_with, char ends_with, size_t *ends_with_nesting);
+
+#endif // YARP_STRING_LITERALS_HANDLERS_STRING_END_H

--- a/src/lexer/string_literals/handlers/try.h
+++ b/src/lexer/string_literals/handlers/try.h
@@ -1,0 +1,12 @@
+#ifndef YARP_STRING_LITERALS_HANDLERS_TRY_H
+#define YARP_STRING_LITERALS_HANDLERS_TRY_H
+
+#define try_handler(call)                                                                                              \
+  {                                                                                                                    \
+    yp_string_literal_extend_action_t action = call;                                                                   \
+    if (action != EXTEND_ACTION_NONE) {                                                                                \
+      return action;                                                                                                   \
+    }                                                                                                                  \
+  }
+
+#endif // YARP_STRING_LITERALS_HANDLERS_TRY_H

--- a/src/lexer/string_literals/heredoc.h
+++ b/src/lexer/string_literals/heredoc.h
@@ -1,0 +1,14 @@
+#ifndef YARP_STRING_LITERALS_HEREDOC_H
+#define YARP_STRING_LITERALS_HEREDOC_H
+
+#include "lexer/string_literals/interpolation.h"
+#include <stddef.h>
+
+typedef struct {
+  interpolation_t interpolation;
+  const char *heredoc_id_ended_at;
+  const char *heredoc_ended_at;
+  bool squiggly;
+} yp_string_literal_heredoc_t;
+
+#endif // YARP_STRING_LITERALS_HEREDOC_H

--- a/src/lexer/string_literals/heredoc_extend.c
+++ b/src/lexer/string_literals/heredoc_extend.c
@@ -1,0 +1,7 @@
+#include "heredoc_extend.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_heredoc_extend(yp_string_literal_heredoc_t *literal, yp_parser_t *parser) {
+  // TODO: implement me
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/heredoc_extend.h
+++ b/src/lexer/string_literals/heredoc_extend.h
@@ -1,0 +1,11 @@
+#ifndef YARP_STRING_LITERALS_HEREDOC_EXTEND_H
+#define YARP_STRING_LITERALS_HEREDOC_EXTEND_H
+
+#include "lexer/string_literals/action.h"
+#include "lexer/string_literals/heredoc.h"
+#include "parser.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_heredoc_extend(yp_string_literal_heredoc_t *literal, yp_parser_t *parser);
+
+#endif // YARP_STRING_LITERALS_HEREDOC_EXTEND_H

--- a/src/lexer/string_literals/interpolation.c
+++ b/src/lexer/string_literals/interpolation.c
@@ -1,0 +1,11 @@
+#include "interpolation.h"
+
+interpolation_t
+yp_interpolation_unsupported() {
+  return (interpolation_t) { .curly_level = 0, .active = false, .supported = false };
+}
+
+interpolation_t
+yp_interpolation_supported(size_t curly_level) {
+  return (interpolation_t) { .curly_level = curly_level, .active = false, .supported = true };
+}

--- a/src/lexer/string_literals/interpolation.h
+++ b/src/lexer/string_literals/interpolation.h
@@ -1,0 +1,18 @@
+#ifndef YARP_STRING_LITERALS_INTERPOLATION_H
+#define YARP_STRING_LITERALS_INTERPOLATION_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct {
+  size_t curly_level; // stores current level of curly braces to distinguish "%Q{{}}"
+  bool active;
+  bool supported;
+} interpolation_t;
+
+interpolation_t
+yp_interpolation_unsupported();
+interpolation_t
+yp_interpolation_supported(size_t curly_level);
+
+#endif // YARP_STRING_LITERALS_INTERPOLATION_H

--- a/src/lexer/string_literals/regexp.c
+++ b/src/lexer/string_literals/regexp.c
@@ -1,0 +1,7 @@
+#include "regexp_extend.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_regexp_extend(yp_string_literal_regexp_t *literal, yp_parser_t *parser) {
+  // TODO: implement me
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/regexp.h
+++ b/src/lexer/string_literals/regexp.h
@@ -1,0 +1,14 @@
+#ifndef YARP_STRING_LITERALS_REGEXP_H
+#define YARP_STRING_LITERALS_REGEXP_H
+
+#include "lexer/string_literals/interpolation.h"
+#include <stddef.h>
+
+typedef struct {
+  interpolation_t interpolation;
+  char starts_with;
+  char ends_with;
+  size_t ends_with_nesting;
+} yp_string_literal_regexp_t;
+
+#endif // YARP_STRING_LITERALS_REGEXP_H

--- a/src/lexer/string_literals/regexp_extend.h
+++ b/src/lexer/string_literals/regexp_extend.h
@@ -1,0 +1,11 @@
+#ifndef YARP_STRING_LITERALS_REGEXP_EXTEND_H
+#define YARP_STRING_LITERALS_REGEXP_EXTEND_H
+
+#include "lexer/string_literals/action.h"
+#include "lexer/string_literals/regexp.h"
+#include "parser.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_regexp_extend(yp_string_literal_regexp_t *literal, yp_parser_t *parser);
+
+#endif // YARP_STRING_LITERALS_REGEXP_EXTEND_H

--- a/src/lexer/string_literals/string.h
+++ b/src/lexer/string_literals/string.h
@@ -1,0 +1,14 @@
+#ifndef YARP_STRING_LITERALS_STRING_H
+#define YARP_STRING_LITERALS_STRING_H
+
+#include "lexer/string_literals/interpolation.h"
+#include <stddef.h>
+
+typedef struct {
+  interpolation_t interpolation;
+  char starts_with;
+  char ends_with;
+  size_t ends_with_nesting;
+} yp_string_literal_string_t;
+
+#endif // YARP_STRING_LITERALS_STRING_H

--- a/src/lexer/string_literals/string_extend.c
+++ b/src/lexer/string_literals/string_extend.c
@@ -1,0 +1,38 @@
+#include "lexer/string_literals/handlers/eof.h"
+#include "lexer/string_literals/handlers/escape.h"
+#include "lexer/string_literals/handlers/escaped_start_or_end.h"
+#include "lexer/string_literals/handlers/interpolation.h"
+#include "lexer/string_literals/handlers/interpolation_end.h"
+#include "lexer/string_literals/handlers/line_continuation.h"
+#include "lexer/string_literals/handlers/string_end.h"
+#include "lexer/string_literals/handlers/try.h"
+#include "lexer/string_literals/string_extend.h"
+#include "parser.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_string_extend(yp_string_literal_string_t *literal, yp_parser_t *parser) {
+  if (literal->interpolation.supported) {
+    try_handler(yp_string_literal_extend_interpolation_end(parser, &(literal->interpolation)));
+  }
+
+  while (1) {
+    try_handler(yp_string_literal_extend_eof(parser));
+
+    if (literal->interpolation.supported) {
+      try_handler(yp_string_literal_extend_line_continuation(parser));
+    }
+
+    if (literal->interpolation.supported) {
+      try_handler(yp_string_literal_extend_escape(parser));
+    } else {
+      try_handler(yp_string_literal_extend_escaped_start_or_end(parser, literal->starts_with, literal->ends_with));
+    }
+
+    try_handler(yp_string_literal_extend_interpolation(parser, &(literal->interpolation)));
+
+    try_handler(yp_string_literal_extend_string_end(parser, literal->starts_with, literal->ends_with,
+                                                    &(literal->ends_with_nesting)));
+
+    parser->current.end++;
+  }
+}

--- a/src/lexer/string_literals/string_extend.h
+++ b/src/lexer/string_literals/string_extend.h
@@ -1,0 +1,10 @@
+#ifndef YARP_STRING_LITERALS_STRING_EXTEND_H
+#define YARP_STRING_LITERALS_STRING_EXTEND_H
+
+#include "lexer/string_literals/action.h"
+#include "parser.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_string_extend(yp_string_literal_string_t *literal, yp_parser_t *parser);
+
+#endif // YARP_STRING_LITERALS_STRING_EXTEND_H

--- a/src/lexer/string_literals/symbol.h
+++ b/src/lexer/string_literals/symbol.h
@@ -1,0 +1,10 @@
+#ifndef YARP_STRING_LITERALS_SYMBOL_H
+#define YARP_STRING_LITERALS_SYMBOL_H
+
+#include "lexer/string_literals/interpolation.h"
+
+typedef struct {
+  interpolation_t interpolation;
+} yp_string_literal_symbol_t;
+
+#endif // YARP_STRING_LITERALS_SYMBOL_H

--- a/src/lexer/string_literals/symbol_extend.c
+++ b/src/lexer/string_literals/symbol_extend.c
@@ -1,0 +1,7 @@
+#include "lexer/string_literals/symbol_extend.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_symbol_extend(yp_string_literal_symbol_t *literal, yp_parser_t *parser) {
+  // TODO: implement me
+  return EXTEND_ACTION_NONE;
+}

--- a/src/lexer/string_literals/symbol_extend.h
+++ b/src/lexer/string_literals/symbol_extend.h
@@ -1,0 +1,10 @@
+#ifndef YARP_STRING_LITERALS_SYMBOL_EXTEND_H
+#define YARP_STRING_LITERALS_SYMBOL_EXTEND_H
+
+#include "lexer/string_literals/action.h"
+#include "parser.h"
+
+yp_string_literal_extend_action_t
+yp_string_literal_symbol_extend(yp_string_literal_symbol_t *literal, yp_parser_t *parser);
+
+#endif // YARP_STRING_LITERALS_SYMBOL_EXTEND_H

--- a/src/parser.h
+++ b/src/parser.h
@@ -2,6 +2,8 @@
 #define YARP_PARSER_H
 
 #include "ast.h"
+#include "error.h"
+#include "lexer/string_literal.h"
 #include <stdbool.h>
 
 // When lexing Ruby source, the lexer has a small amount of state to tell which
@@ -86,6 +88,8 @@ struct yp_parser {
     size_t index;                           // the current index into the lexer state stack
   } lex_modes;
 
+  yp_string_literal_stack_t string_literals; // the stack of string literals (including word lists, regexes, heredocs)
+
   const char *start;   // the pointer to the start of the source
   const char *end;     // the pointer to the end of the source
   yp_token_t previous; // the previous token we were considering
@@ -95,6 +99,8 @@ struct yp_parser {
   yp_error_list_t error_list;        // the list of errors that have been found while parsing
   yp_error_handler_t *error_handler; // the error handler
   yp_node_t *current_scope;          // the current local scope
+
+  size_t curly_level; // the number of nested braces that we are currently in
 };
 
 #endif // YARP_PARSER_H

--- a/src/util/stack.h
+++ b/src/util/stack.h
@@ -1,0 +1,54 @@
+#ifndef YARP_STACK_H
+#define YARP_STACK_H
+
+#include <stddef.h>
+#include <stdlib.h>
+
+#define STACK_DECL(stack_type, item_type, create_fn, destroy_fn, push_fn, pop_fn, last_fn, size_fn)                    \
+  typedef struct {                                                                                                     \
+    item_type *ptr;                                                                                                    \
+    size_t size;                                                                                                       \
+    size_t capacity;                                                                                                   \
+  } stack_type;                                                                                                        \
+  stack_type create_fn(size_t capacity);                                                                               \
+  void destroy_fn(stack_type *stack);                                                                                  \
+  void push_fn(stack_type *stack, item_type item);                                                                     \
+  item_type pop_fn(stack_type *stack);                                                                                 \
+  item_type *last_fn(stack_type *stack);                                                                               \
+  size_t size_fn(const stack_type *stack);
+
+#define STACK_IMPL(stack_type, item_type, create_fn, destroy_fn, push_fn, pop_fn, last_fn, size_fn)                    \
+  stack_type create_fn(size_t capacity) {                                                                              \
+    item_type *ptr = (item_type *) malloc(sizeof(item_type) * capacity);                                               \
+    return (stack_type) { .ptr = ptr, .size = 0, .capacity = capacity };                                               \
+  }                                                                                                                    \
+  void destroy_fn(stack_type *stack) {                                                                                 \
+    free(stack->ptr);                                                                                                  \
+  }                                                                                                                    \
+  void push_fn(stack_type *stack, item_type item) {                                                                    \
+    if (stack->capacity == stack->size) {                                                                              \
+      stack->capacity = stack->capacity * 2;                                                                           \
+      stack->ptr = realloc(stack->ptr, sizeof(item_type) * stack->capacity);                                           \
+    }                                                                                                                  \
+    stack->ptr[stack->size] = item;                                                                                    \
+    stack->size += 1;                                                                                                  \
+  }                                                                                                                    \
+  item_type pop_fn(stack_type *stack) {                                                                                \
+    item_type last = stack->ptr[stack->size - 1];                                                                      \
+    if (stack->size > 0) {                                                                                             \
+      stack->size -= 1;                                                                                                \
+    }                                                                                                                  \
+    return last;                                                                                                       \
+  }                                                                                                                    \
+  item_type *last_fn(stack_type *stack) {                                                                              \
+    if (stack->size > 0) {                                                                                             \
+      return stack->ptr + stack->size - 1;                                                                             \
+    } else {                                                                                                           \
+      return NULL;                                                                                                     \
+    }                                                                                                                  \
+  }                                                                                                                    \
+  size_t size_fn(const stack_type *stack) {                                                                            \
+    return stack->size;                                                                                                \
+  }
+
+#endif // YARP_STACK_H


### PR DESCRIPTION
WIP, but feel free to leave comments on design.

The idea is to have a stack of literals (I guess I'll move some logic from `yp_lex_mode_t`) that are types and have attached data specific for their type.

Every time when we read token we check if we have something on the literals stack and if so we ask this literal to extend itself.

`extend` is a type-specific function (with a type-based "router" under the hood) that knows how to handle the type (i.e. what to do with spaces in arrays, interpolation, heredoc start/end, regexp options etc). The output of this function is an action for the lexer:

+ `EXTEND_ACTION_EMIT_TOKEN` - means that literal was able to handle next token on its own, usually string content, but can also be interpolation start/end token, or even `YP_TOKEN_EMBEXPR_BEGIN` that is `"@foo"` in `"#@foo"`. The token is in `parser->current`
+ `EXTEND_ACTION_READ_INTERPOLATED_CONTENT` - special action, returned if start of the interpolation has been found (of course if interpolation is disabled for current literal it cannot be returned), must delegate logic of tokenization to the "standard" flow.
+ `EXTEND_ACTION_NONE` - used interally by sub-action to indicate that action failed find anything, and next action can take it (all string literals are just a composition of smaller actions).

If the stack of literals is empty we also run standard flow.

The idea of having it is that we can move EVERYTHING related to strings parsing to a separate abstraction. WDYT?

[Here's how I extracted it in Rust](https://github.com/iliabylich/ruby-parser/blob/master/src/lexer/mod.rs#L127)