### PR TITLE
introduce yp_input_t

### DIFF
--- a/bin/template
+++ b/bin/template
@@ -56,8 +56,8 @@ class TokenParam < Struct.new(:name)
   def rbs_class = "Token"
   def child_nodes = nil
 
-  def start_location(params) = "#{name}->start - parser->start"
-  def end_location(params) = "#{name}->end - parser->start"
+  def start_location(params) = "#{name}->start - parser->input.start"
+  def end_location(params) = "#{name}->end - parser->input.start"
   def location(params) = "{ .start = #{start_location(params)}, .end = #{end_location(params)} }"
 end
 

--- a/bin/templates/ext/yarp/node.c.erb
+++ b/bin/templates/ext/yarp/node.c.erb
@@ -34,8 +34,8 @@ yp_token_new(yp_parser_t *parser, yp_token_t *token) {
     token_type(token),
     rb_str_new(token->start, token->end - token->start),
     location_new(&(yp_location_t) {
-      .start = token->start - parser->start,
-      .end = token->end - parser->start,
+      .start = token->start - parser->input.start,
+      .end = token->end - parser->input.start,
     }),
   };
 

--- a/bin/templates/src/serialize.c.erb
+++ b/bin/templates/src/serialize.c.erb
@@ -8,8 +8,8 @@
 static void
 serialize_token(yp_parser_t *parser, yp_token_t *token, yp_buffer_t *buffer) {
   yp_buffer_append_u8(buffer, token->type);
-  yp_buffer_append_u64(buffer, token->start - parser->start);
-  yp_buffer_append_u64(buffer, token->end - parser->start);
+  yp_buffer_append_u64(buffer, token->start - parser->input.start);
+  yp_buffer_append_u64(buffer, token->end - parser->input.start);
 }
 
 void

--- a/src/input.h
+++ b/src/input.h
@@ -1,0 +1,10 @@
+#ifndef YARP_INPUT_H
+#define YARP_INPUT_H
+
+typedef struct {
+  const char *start; // the pointer to the start of the source
+  const char *end;   // the pointer to the end of the source
+  const char *pos;   // the pointer to the current position
+} yp_input_t;
+
+#endif // YARP_INPUT_H

--- a/src/parser.h
+++ b/src/parser.h
@@ -2,6 +2,7 @@
 #define YARP_PARSER_H
 
 #include "ast.h"
+#include "input.h"
 #include <stdbool.h>
 
 // When lexing Ruby source, the lexer has a small amount of state to tell which
@@ -86,14 +87,13 @@ struct yp_parser {
     size_t index;                           // the current index into the lexer state stack
   } lex_modes;
 
-  const char *start;   // the pointer to the start of the source
-  const char *end;     // the pointer to the end of the source
+  yp_input_t input;
   yp_token_t previous; // the previous token we were considering
   yp_token_t current;  // the current token we're considering
   int lineno;          // the current line number we're looking at
 
   yp_error_handler_t *error_handler; // the error handler
-  yp_node_t *current_scope;    // the current local scope
+  yp_node_t *current_scope;          // the current local scope
 };
 
 #endif // YARP_PARSER_H


### PR DESCRIPTION
I've started working on string literals and I think we need a concept of input:

1. I do need to pass something mutable to string_extend function that holds current src pointer. It will be `yp_input_t *`.
2. At some point we will support magic encoding comment that forces input to be re-encoded, it looks like a good place to me store an external callback and do re-encoding that (potentially) re-creates the source and takes ownership over it. This struct probably will be extended to something like a tagged enum (borrowed src vs owned re-encoded src).
3. This struct looks like a good place to me to store an extra buffer with unescaped sequences.

This PR currently has issues with formatting, I'll rebase it once PR with operator -> operator_ renaming is merged.