### PR TITLE
Constants

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -301,6 +301,14 @@ nodes:
     child_nodes:
       - token value
     location: value
+  - name: ClassNode
+    child_nodes:
+      - node scope
+      - token class_keyword
+      - node constant_path
+      - node statements
+      - token end_keyword
+    location: class_keyword->end_keyword
   - name: ClassVariableRead
     child_nodes:
       - token name

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1175,6 +1175,21 @@ parse_expression(yp_parser_t *parser, binding_power_t binding_power) {
       node = yp_node_pre_execution_node_create(parser, &keyword, &opening, statements, &closing);
       break;
     }
+    case YP_TOKEN_KEYWORD_CLASS: {
+      yp_token_t class_keyword = parser->previous;
+      yp_node_t *name = parse_expression(parser, BINDING_POWER_NONE);
+
+      yp_node_t *scope = yp_node_scope_create(parser);
+      yp_node_t *parent_scope = parser->current_scope;
+      parser->current_scope = scope;
+
+      yp_node_t *statements = parse_statements(parser, YP_TOKEN_KEYWORD_END);
+      consume(parser, YP_TOKEN_KEYWORD_END, "Expected `end` to close `class` statement.");
+
+      node = yp_node_class_node_create(parser, scope, &class_keyword, name, statements, &parser->previous);
+      parser->current_scope = parent_scope;
+      break;
+    }
     case YP_TOKEN_KEYWORD_END_UPCASE: {
       yp_token_t keyword = parser->previous;
       consume(parser, YP_TOKEN_BRACE_LEFT, "Expected '{' after 'END'.");

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -101,6 +101,24 @@ class ParseTest < Test::Unit::TestCase
     assert_parses CharacterLiteral(CHARACTER_LITERAL("?a")), "?a"
   end
 
+  test "class" do
+    expected = ClassNode(
+      Scope([IDENTIFIER("a")]),
+      KEYWORD_CLASS("class"),
+      ConstantRead(CONSTANT("A")),
+      Statements([
+        LocalVariableWrite(
+          IDENTIFIER("a"),
+          EQUAL("="),
+          IntegerLiteral(INTEGER("1"))
+        )
+      ]),
+      KEYWORD_END("end")
+    )
+
+    assert_parses expected, "class A a = 1 end"
+  end
+
   test "class variable read" do
     assert_parses ClassVariableRead(CLASS_VARIABLE("@@abc")), "@@abc"
   end


### PR DESCRIPTION
`ClassNode`, `ModuleNode`, `ConstantRead`, `ConstantPathNode`.

For those following along, I'm very aware that the pratt parser is allowing things that shouldn't be allowed at the moment. We're going to have to split it up eventually. But for now it's really convenient so I'm leaving it to get more nodes in place.