### PR TITLE
Include UTF-16 encoding

### DIFF
--- a/src/encoding.h
+++ b/src/encoding.h
@@ -5,9 +5,24 @@
 #include <stddef.h>
 #include <stdint.h>
 
-size_t yp_encoding_ascii_alpha_char(const char *c);
-size_t yp_encoding_ascii_alnum_char(const char *c);
-size_t yp_encoding_utf8_alpha_char(const char *c);
-size_t yp_encoding_utf8_alnum_char(const char *c);
+size_t
+yp_encoding_ascii_alpha_char(const char *c);
+size_t
+yp_encoding_ascii_alnum_char(const char *c);
+
+size_t
+yp_encoding_utf8_alpha_char(const char *c);
+size_t
+yp_encoding_utf8_alnum_char(const char *c);
+
+size_t
+yp_encoding_utf16be_alpha_char(const char *c);
+size_t
+yp_encoding_utf16be_alnum_char(const char *c);
+
+size_t
+yp_encoding_utf16le_alpha_char(const char *c);
+size_t
+yp_encoding_utf16le_alnum_char(const char *c);
 
 #endif

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1100,6 +1100,12 @@ parser_lex_magic_comments(yp_parser_t *parser) {
     } else if (strncmp(pointer, "utf-8", 5) == 0) {
       parser->encoding.alnum_char = yp_encoding_utf8_alnum_char;
       parser->encoding.alpha_char = yp_encoding_utf8_alpha_char;
+    } else if (strncmp(pointer, "utf-16-be", 9) == 0) {
+      parser->encoding.alnum_char = yp_encoding_utf16be_alnum_char;
+      parser->encoding.alpha_char = yp_encoding_utf16be_alpha_char;
+    } else if (strncmp(pointer, "utf-16-le", 9) == 0) {
+      parser->encoding.alnum_char = yp_encoding_utf16le_alnum_char;
+      parser->encoding.alpha_char = yp_encoding_utf16le_alpha_char;
     } else {
       // TODO: handling invalid encoding.
       fprintf(stderr, "Could not parse encoding: %.*s\n", (int) (parser->current.end - pointer), pointer);


### PR DESCRIPTION
Might end up deleting this code later. It's super unclear to me if ruby respects UTF-16 encoding in files or not. In theory I think it doesn't, since UTF-16 isn't compatible with ASCII (ish). But in practice it looks like I can `Ripper.lex` files with this encoding?