### PR TITLE
Implement begin node

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -334,6 +334,22 @@ nodes:
 
           [1, 2, 3]
           ^^^^^^^^^
+  - name: BeginNode
+    child_nodes:
+      - name: begin_keyword
+        type: token
+      - name: statements
+        type: node
+      - name: end_keyword
+        type: token
+    location: begin_keyword->end_keyword
+    comment: |
+      Represents a begin statement.
+
+          begin
+            foo
+          end
+          ^^^^^
   - name: BlockParameterNode
     child_nodes:
       - name: operator

--- a/src/parser.h
+++ b/src/parser.h
@@ -94,6 +94,7 @@ typedef enum {
   YP_CONTEXT_WHILE,    // a while statement
   YP_CONTEXT_UNTIL,    // an until statement
   YP_CONTEXT_EMBEXPR,  // an interpolated expression
+  YP_CONTEXT_BEGIN,    // a begin statement
 } yp_context_t;
 
 // This is a node in a linked list of contexts.

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -210,7 +210,7 @@ class ParseTest < Test::Unit::TestCase
       nil,
       PARENTHESIS_RIGHT(")"),
       "call"
-    )    
+    )
 
     assert_parses expected, "a.()"
   end
@@ -224,7 +224,7 @@ class ParseTest < Test::Unit::TestCase
       ArgumentsNode([expression("1"), expression("2"), expression("3")]),
       PARENTHESIS_RIGHT(")"),
       "call"
-    )    
+    )
 
     assert_parses expected, "a.(1, 2, 3)"
   end
@@ -1157,6 +1157,19 @@ class ParseTest < Test::Unit::TestCase
     )
 
     assert_parses expected, "a if b if c"
+  end
+
+   test "begin statements" do
+    expected = BeginNode(
+      KEYWORD_BEGIN("begin"),
+      Statements([expression("a")]),
+      KEYWORD_END("end"),
+    )
+
+    assert_parses expected, "begin\na\nend"
+    assert_parses expected, "begin; a; end"
+    assert_parses expected, "begin a\n end"
+    assert_parses expected, "begin a; end"
   end
 
   private


### PR DESCRIPTION
Implement parsing begin nodes.

To my surprise, it appears that Ruby accepts any statement you put side by side with `begin`. This already works with this implementation, possibly because it's captured by `statements`, but I wondered if we need an optional thing right after the `begin` keyword. E.g.:
```ruby
# I believe `puts 'a'` is being automatically considered as part of `statements`
# Should we differentiate it in any way or is this enough?
begin puts 'a'
end
```

I will follow this PR up with `ensure` and then `rescue`.