### PR TITLE
Add generate compilation database rake task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ test-native/run-one
 /src/prettyprint.c
 /src/serialize.c
 /src/token_type.c
+
+compile_commands.json
+.cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,16 @@ If you want to contribute code, please first open or contribute to a discussion.
 
 We could always use more tests! One of the biggest challenges of this project is building up a big test suite. If you want to contribute tests, feel free to open a pull request. These will get merged in as soon as possible.
 
+## Language server support
+
+To get clangd support in the editor for development, generate the compilation database. This command will
+create an ignored `compile_commands.json` file at the project root, which is used by clangd to provide functionality.
+```shell
+bundle exec rake generate_compilation_database
+```
+
+For VS Code, install the [clangd extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) to get the features provided by the language server.
+
 ## Documentation
 
 We could always use more documentation! If you want to contribute documentation, feel free to open a pull request. These will get merged in as soon as possible. Documenting functions or methods is always useful, but we also need more guides and tutorials. If you have an idea for a guide or tutorial, feel free to open an issue and we can discuss it.

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,13 @@ task make: :templates do
   sh "make"
 end
 
+task generate_compilation_database: :templates do
+  sh "which bear"
+  abort("Installing bear is required to generate the compilation database") unless $?.success?
+
+  sh "bear -- make"
+end
+
 # So `rake clobber` will delete generated files
 CLOBBER.concat(TEMPLATES)
 

--- a/src/regexp.h
+++ b/src/regexp.h
@@ -1,16 +1,17 @@
 #ifndef YARP_REGEXP_H
 #define YARP_REGEXP_H
 
+#include "parser.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
-#include <parser.h>
 #include <util/yp_string.h>
 #include <util/yp_string_list.h>
 
 // Parse a regular expression and extract the names of all of the named capture
 // groups.
 __attribute__((__visibility__("default"))) extern bool
-yp_regexp_named_capture_group_names(const char *source, size_t size, yp_string_list_t *named_captures);
+yp_regexp_named_capture_group_names(const char *source, size_t size,
+                                    yp_string_list_t *named_captures);
 
 #endif


### PR DESCRIPTION
To get clangd support in editors, we need a way of generating the `compile_commands.json` file, which tells the language server how to parse each individual file and prevents errors like `can't find header` or related.

There are a few options on how to generate the file, but a pretty easy one is `bear`, which basically executes the compilation commands and keeps track of all options to generate the file.

This PR
- Adds a rake task to run `make` with `bear` and generate the `compile_commands.json`
- Adds the `compile_commands.json` and clangd's `.cache` folder to gitignore
- Adds a few instructions in the README on how to set it up
- Finally, with clangd configured, it started complaining that we should've not been using angle brackets for including our own project files and to use quotes instead. Doing that fixed all encountered clangd issues and it also re-formatted the `regexp.h` file