### PR TITLE
Implement return + Update next and break

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -369,13 +369,9 @@ nodes:
     child_nodes:
       - name: keyword
         type: token
-      - name: lparen
-        type: token?
       - name: arguments
         type: node?
-      - name: rparen
-        type: token?
-    location: keyword->rparen|arguments|lparen|keyword
+    location: keyword->arguments|keyword
     comment: |
       Represents the use of the `break` keyword.
 
@@ -802,13 +798,9 @@ nodes:
     child_nodes:
       - name: keyword
         type: token
-      - name: lparen
-        type: token?
       - name: arguments
         type: node?
-      - name: rparen
-        type: token?
-    location: keyword->rparen|arguments|lparen|keyword
+    location: keyword->arguments|keyword
     comment: |
       Represents the use of the `next` keyword.
 
@@ -1066,6 +1058,18 @@ nodes:
 
           retry
           ^^^^^
+  - name: ReturnNode
+    child_nodes:
+      - name: keyword
+        type: token
+      - name: arguments
+        type: node?
+    location: keyword->arguments|keyword
+    comment: |
+      Represents the use of the `return` keyword.
+
+          return 1
+          ^^^^^^^^
   - name: SClassNode
     child_nodes:
       - name: scope

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -127,6 +127,42 @@ class ErrorsTest < Test::Unit::TestCase
     assert_errors expression('(1 + 2'), '(1 + 2', ["Expected a closing parenthesis."]
   end
 
+  test "(1, 2, 3)" do
+    assert_errors expression("(1, 2, 3)"), "(1, 2, 3)", ["Expected a closing parenthesis."]
+  end
+
+  test "return(1, 2, 3)" do
+    puts "\n\n\n"
+
+    assert_errors expression("return(1, 2, 3)"), "return(1, 2, 3)", ["Expected a closing parenthesis.",
+    "Expected an ',' to delimit arguments.",
+    "Expected to be able to parse an argument."]
+  end
+
+  test "return 1,;" do
+    assert_errors expression("return 1,;"), "return 1,;", ["Expected to be able to parse an argument."]
+  end
+
+  test "next(1, 2, 3)" do
+    assert_errors expression("next(1, 2, 3)"), "next(1, 2, 3)", ["Expected a closing parenthesis.",
+    "Expected an ',' to delimit arguments.",
+    "Expected to be able to parse an argument."]
+  end
+
+  test "next 1,;" do
+    assert_errors expression("next 1,;"), "next 1,;", ["Expected to be able to parse an argument."]
+  end
+
+  test "break(1, 2, 3)" do
+    assert_errors expression("break(1, 2, 3)"), "break(1, 2, 3)", ["Expected a closing parenthesis.",
+    "Expected an ',' to delimit arguments.",
+    "Expected to be able to parse an argument."]
+  end
+
+  test "break 1,;" do
+    assert_errors expression("break 1,;"), "break 1,;", ["Expected to be able to parse an argument."]
+  end
+
   private
 
   def assert_errors(expected, source, errors)

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -202,19 +202,109 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "break" do
-    assert_parses BreakNode(KEYWORD_BREAK("break"), nil, nil, nil), "break"
+    expected = BreakNode(
+      KEYWORD_BREAK("break"),
+      nil,
+    )
+
+    assert_parses expected, "break"
+  end
+
+  test "break 1" do
+    expected = BreakNode(
+      KEYWORD_BREAK("break"),
+      ArgumentsNode([
+        expression("1"),
+      ]),
+    )
+    assert_parses expected, "break 1"
+  end
+
+  test "break 1, 2, 3" do
+    expected = BreakNode(
+      KEYWORD_BREAK("break"),
+      ArgumentsNode([
+        expression("1"),
+        expression("2"),
+        expression("3"),
+      ]),
+    )
+    assert_parses expected, "break 1, 2, 3"
+  end
+
+  test "break 1, 2,\n3" do
+    expected = BreakNode(
+      KEYWORD_BREAK("break"),
+      ArgumentsNode([
+        expression("1"),
+        expression("2"),
+        expression("3"),
+      ]),
+    )
+    assert_parses expected, "break 1, 2,\n3"
   end
 
   test "break()" do
-    assert_parses BreakNode(KEYWORD_BREAK("break"), PARENTHESIS_LEFT("("), nil, PARENTHESIS_RIGHT(")")), "break()"
+    expected = BreakNode(
+      KEYWORD_BREAK("break"),
+      ArgumentsNode([
+        expression("()"),
+      ]),
+    )
+    assert_parses expected, "break()"
   end
 
   test "break(1)" do
-    assert_parses BreakNode(KEYWORD_BREAK("break"), PARENTHESIS_LEFT("("), ArgumentsNode([expression("1")]), PARENTHESIS_RIGHT(")")), "break(1)"
+    expected = BreakNode(
+      KEYWORD_BREAK("break"),
+      ArgumentsNode([
+        expression("(1)"),
+      ]),
+    )
+
+    assert_parses expected, "break(1)"
   end
 
-  test "break(1, 2, 3)" do
-    assert_parses BreakNode(KEYWORD_BREAK("break"), PARENTHESIS_LEFT("("), ArgumentsNode([expression("1"), expression("2"), expression("3")]), PARENTHESIS_RIGHT(")")), "break(1, 2, 3)"
+  test "break (1), (2), (3)" do
+    expected = BreakNode(
+      KEYWORD_BREAK("break"),
+      ArgumentsNode([
+        expression("(1)"),
+        expression("(2)"),
+        expression("(3)"),
+      ]),
+    )
+    assert_parses expected, "break (1), (2), (3)"
+  end
+
+  test "break [1, 2, 3]" do
+    expected = BreakNode(
+      KEYWORD_BREAK("break"),
+      ArgumentsNode([
+        expression("[1, 2, 3]"),
+      ]),
+    )
+    assert_parses expected, "break [1, 2, 3]"
+  end
+
+  test "break multiple statements inside of parentheses" do
+    expected = BreakNode(
+      KEYWORD_BREAK("break"),
+      ArgumentsNode([
+        ParenthesesNode(
+          PARENTHESIS_LEFT("("),
+          Statements([expression("1"), expression("2")]),
+          PARENTHESIS_RIGHT(")")
+        )
+      ])
+    )
+
+    assert_parses expected, <<~RUBY
+      break(
+        1
+        2
+      )
+    RUBY
   end
 
   test "call with ? identifier" do
@@ -914,19 +1004,109 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "next" do
-    assert_parses NextNode(KEYWORD_NEXT("next"), nil, nil, nil), "next"
+    expected = NextNode(
+      KEYWORD_NEXT("next"),
+      nil,
+    )
+
+    assert_parses expected, "next"
+  end
+
+  test "next 1" do
+    expected = NextNode(
+      KEYWORD_NEXT("next"),
+      ArgumentsNode([
+        expression("1"),
+      ]),
+    )
+    assert_parses expected, "next 1"
+  end
+
+  test "next 1, 2, 3" do
+    expected = NextNode(
+      KEYWORD_NEXT("next"),
+      ArgumentsNode([
+        expression("1"),
+        expression("2"),
+        expression("3"),
+      ]),
+    )
+    assert_parses expected, "next 1, 2, 3"
+  end
+
+  test "next 1, 2,\n3" do
+    expected = NextNode(
+      KEYWORD_NEXT("next"),
+      ArgumentsNode([
+        expression("1"),
+        expression("2"),
+        expression("3"),
+      ]),
+    )
+    assert_parses expected, "next 1, 2,\n3"
   end
 
   test "next()" do
-    assert_parses NextNode(KEYWORD_NEXT("next"), PARENTHESIS_LEFT("("), nil, PARENTHESIS_RIGHT(")")), "next()"
+    expected = NextNode(
+      KEYWORD_NEXT("next"),
+      ArgumentsNode([
+        expression("()"),
+      ]),
+    )
+    assert_parses expected, "next()"
   end
 
   test "next(1)" do
-    assert_parses NextNode(KEYWORD_NEXT("next"), PARENTHESIS_LEFT("("), ArgumentsNode([expression("1")]), PARENTHESIS_RIGHT(")")), "next(1)"
+    expected = NextNode(
+      KEYWORD_NEXT("next"),
+      ArgumentsNode([
+        expression("(1)"),
+      ]),
+    )
+
+    assert_parses expected, "next(1)"
   end
 
-  test "next(1, 2, 3)" do
-    assert_parses NextNode(KEYWORD_NEXT("next"), PARENTHESIS_LEFT("("), ArgumentsNode([expression("1"), expression("2"), expression("3")]), PARENTHESIS_RIGHT(")")), "next(1, 2, 3)"
+  test "next (1), (2), (3)" do
+    expected = NextNode(
+      KEYWORD_NEXT("next"),
+      ArgumentsNode([
+        expression("(1)"),
+        expression("(2)"),
+        expression("(3)"),
+      ]),
+    )
+    assert_parses expected, "next (1), (2), (3)"
+  end
+
+  test "next [1, 2, 3]" do
+    expected = NextNode(
+      KEYWORD_NEXT("next"),
+      ArgumentsNode([
+        expression("[1, 2, 3]"),
+      ]),
+    )
+    assert_parses expected, "next [1, 2, 3]"
+  end
+
+  test "next multiple statements inside of parentheses" do
+    expected = NextNode(
+      KEYWORD_NEXT("next"),
+      ArgumentsNode([
+        ParenthesesNode(
+          PARENTHESIS_LEFT("("),
+          Statements([expression("1"), expression("2")]),
+          PARENTHESIS_RIGHT(")")
+        )
+      ])
+    )
+
+    assert_parses expected, <<~RUBY
+      next(
+        1
+        2
+      )
+    RUBY
   end
 
   test "nil" do
@@ -983,6 +1163,112 @@ class ParseTest < Test::Unit::TestCase
 
   test "retry" do
     assert_parses RetryNode(KEYWORD_RETRY("retry")), "retry"
+  end
+
+  test "return" do
+    expected = ReturnNode(
+      KEYWORD_RETURN("return"),
+      nil,
+    )
+
+    assert_parses expected, "return"
+  end
+
+  test "return 1" do
+    expected = ReturnNode(
+      KEYWORD_RETURN("return"),
+      ArgumentsNode([
+        expression("1"),
+      ]),
+    )
+    assert_parses expected, "return 1"
+  end
+
+  test "return 1, 2, 3" do
+    expected = ReturnNode(
+      KEYWORD_RETURN("return"),
+      ArgumentsNode([
+        expression("1"),
+        expression("2"),
+        expression("3"),
+      ]),
+    )
+    assert_parses expected, "return 1, 2, 3"
+  end
+
+  test "return 1, 2,\n3" do
+    expected = ReturnNode(
+      KEYWORD_RETURN("return"),
+      ArgumentsNode([
+        expression("1"),
+        expression("2"),
+        expression("3"),
+      ]),
+    )
+    assert_parses expected, "return 1, 2,\n3"
+  end
+
+  test "return()" do
+    expected = ReturnNode(
+      KEYWORD_RETURN("return"),
+      ArgumentsNode([
+        expression("()"),
+      ]),
+    )
+    assert_parses expected, "return()"
+  end
+
+  test "return(1)" do
+    expected = ReturnNode(
+      KEYWORD_RETURN("return"),
+      ArgumentsNode([
+        expression("(1)"),
+      ]),
+    )
+
+    assert_parses expected, "return(1)"
+  end
+
+  test "return (1), (2), (3)" do
+    expected = ReturnNode(
+      KEYWORD_RETURN("return"),
+      ArgumentsNode([
+        expression("(1)"),
+        expression("(2)"),
+        expression("(3)"),
+      ]),
+    )
+    assert_parses expected, "return (1), (2), (3)"
+  end
+
+  test "return [1, 2, 3]" do
+    expected = ReturnNode(
+      KEYWORD_RETURN("return"),
+      ArgumentsNode([
+        expression("[1, 2, 3]"),
+      ]),
+    )
+    assert_parses expected, "return [1, 2, 3]"
+  end
+
+  test "return multiple statements inside of parentheses" do
+    expected = ReturnNode(
+      KEYWORD_RETURN("return"),
+      ArgumentsNode([
+        ParenthesesNode(
+          PARENTHESIS_LEFT("("),
+          Statements([expression("1"), expression("2")]),
+          PARENTHESIS_RIGHT(")")
+        )
+      ])
+    )
+
+    assert_parses expected, <<~RUBY
+      return(
+        1
+        2
+      )
+    RUBY
   end
 
   test "self" do


### PR DESCRIPTION
I've added two new helpers `parse_arguments_without_parenthesis` and `parse_arguments_list_without_parenthesis` to perform the logic of their counter parts, but using `NEWLINE|SEMICOLON|EOF` as the mark of the end of arg list. 

This captures all of the following cases: 
``` ruby 
return 
return 1
return 1, 2, 3
return 1,
  2, 3
return ()
return (1)
return (1), (2), (3)
return (
  1
  2 
)
```

While refusing to parse: 
```ruby
return(1, 2, 3)
return 1,;
```

The parts that I would like extra review on would be: 
- Is it sensible to include the `EOF` in the termination check for arg list?
- Are the new methods overkill?
- Should this be split into multiple PRs?