### PR TITLE
Implement dynamic symbols with %s

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -768,6 +768,10 @@ lex_token_type(yp_parser_t *parser) {
               parser->current.end++;
               lex_mode_push(parser, (yp_lex_mode_t) { .mode = YP_LEX_STRING, .term = terminator(*parser->current.end++), .interp = true });
               return YP_TOKEN_STRING_BEGIN;
+            case 's':
+              parser->current.end++;
+              lex_mode_push(parser, (yp_lex_mode_t) { .mode = YP_LEX_STRING, .term = terminator(*parser->current.end++), .interp = false });
+              return YP_TOKEN_SYMBOL_BEGIN;
             case 'w':
               parser->current.end++;
               lex_mode_push(parser, (yp_lex_mode_t) { .mode = YP_LEX_LIST, .term = terminator(*parser->current.end++), .interp = false });
@@ -1059,6 +1063,7 @@ lex_token_type(yp_parser_t *parser) {
           lex_mode_pop(parser);
 
           yp_token_type_t type = lex_identifier(parser);
+
           return match(parser, '=') ? YP_TOKEN_IDENTIFIER : type;
         }
       }

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -119,6 +119,10 @@ class ErrorsTest < Test::Unit::TestCase
     assert_errors expression('"hello'), '"hello', ["Expected a closing delimiter for an interpolated string."]
   end
 
+  test "unterminated %s symbol" do
+    assert_errors expression("%s[abc"), "%s[abc", ["Expected a closing delimiter for a dynamic symbol."]
+  end
+
   private
 
   def assert_errors(expected, source, errors)

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1053,6 +1053,20 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "undef :\"abc\#{1}\""
   end
 
+  test "%s symbol" do
+    expected = SymbolNode(SYMBOL_BEGIN("%s["), STRING_CONTENT("abc"), STRING_END("]"))
+    assert_parses expected, "%s[abc]"
+  end
+
+  test "alias with %s symbol" do
+    expected = AliasNode(
+      KEYWORD_ALIAS("alias"),
+      SymbolNode(SYMBOL_BEGIN("%s["), STRING_CONTENT("abc"), STRING_END("]")),
+      SymbolNode(SYMBOL_BEGIN("%s["), STRING_CONTENT("def"), STRING_END("]"))
+    )
+    assert_parses expected, "alias %s[abc] %s[def]"
+  end
+
   test "ternary" do
     expected = Ternary(
       CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, "a"),


### PR DESCRIPTION
I ended up not modifying the `parse_symbol` because to match ripper lexing tokens, I used the `LEX_STRING` mode without interpolation when encoutering a "%s", which matches the already implemented behavior of a dynamic symbol. 

I'm not sure about what the error should be when missing the terminator, I used the same error as dynamic symbols. MRI seems to error an unterminated string in that case

```ruby
# ruby 3.1.2
ruby -e '%s[af'
-e:1: unterminated string meets end of file
```

Closes #154