### PR TITLE
Fix parsing binary `+` and `/` with surrounding spaces

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1037,6 +1037,7 @@ lex_token_type(yp_parser_t *parser) {
         case '/':
           if (match(parser, '=')) return YP_TOKEN_SLASH_EQUAL;
           if (*parser->current.end == ' ') return YP_TOKEN_SLASH;
+          if (token_type_is_numeric(parser->previous.type)) return YP_TOKEN_SLASH;
 
           // If the previous token is an identifier and it is in the local
           // table, then this is a division. Otherwise, it is a regexp.

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -235,6 +235,12 @@ class ParseTest < Test::Unit::TestCase
     assert_parses CallNode(expression("1"), nil, SLASH("/"), nil, ArgumentsNode([expression("2")]), nil, "/"), "1 / 2"
   end
 
+  test "binary / without spaces" do
+    assert_parses CallNode(
+      ImaginaryLiteral(IMAGINARY_NUMBER("1i")), nil, SLASH("/"), nil, ArgumentsNode([ImaginaryLiteral(IMAGINARY_NUMBER("2i"))]), nil, "/"
+    ), "1i/2i"
+  end
+
   test "binary *" do
     assert_parses CallNode(expression("1"), nil, STAR("*"), nil, ArgumentsNode([expression("2")]), nil, "*"), "1 * 2"
   end


### PR DESCRIPTION
The following piece of code is being parsed incorrectly as an integer literal:

```ruby
1+1
```

```
irb(main):004:0> YARP.parse('1+1').node
=> Program(Scope([]), Statements([IntegerLiteral(INTEGER("1"))]))
```

This PR fixes the parser so that the code is parser correctly:

```
irb(main):004:0> YARP.parse('1+134').node
=> Program(Scope([]), Statements([CallNode(IntegerLiteral(INTEGER("1")), nil, PLUS("+"), nil, ArgumentsNode([IntegerLiteral(INTEGER("134"))]), nil, "+")]))
```