### PR TITLE
Fix parsing magic comments for encoding

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1538,7 +1538,7 @@ parser_lex_magic_comments(yp_parser_t *parser) {
     // First, we're going to loop through each of the encodings that we handle
     // explicitly. If we found one that we understand, we'll use that value.
 #define ENCODING(value, prebuilt) \
-    if (width == sizeof(value) - 1 && strncmp(start, value, sizeof(value) - 1) == 0) { \
+    if (width == sizeof(value) - 1 && strncasecmp(start, value, sizeof(value) - 1) == 0) { \
       parser->encoding = prebuilt; \
       return; \
     }

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -2663,6 +2663,9 @@ class ParseTest < Test::Unit::TestCase
 
   test "encoding magic comment" do
     assert YARP.parse("#encoding: utf-8").errors.empty?
+    assert YARP.parse("#encoding: UTF-8").errors.empty?
+    assert YARP.parse("# -*- encoding: UTF-8 -*-").errors.empty?
+    assert YARP.parse("# -*- encoding: utf-8 -*-").errors.empty?
     refute YARP.parse("#encoding: utf8").errors.empty?
   end
 


### PR DESCRIPTION
I've noticed that the magic comments for encodings (aka `#encoding: foo`) are not working properly:

```
irb(main):001:0> YARP.parse('#encoding: utf-8')
=> 
#<YARP::ParseResult:0x0000000100e77128                
 @comments=[#<YARP::Comment:0x0000000100e773f8 @location=(0..16), @type=:inline>],
 @errors=[#<YARP::ParseError:0x0000000100e77358 @location=(11..11), @message="Could not understand the encoding specified in the magic comment.">],
 @node=Program(Scope([]), Statements([]))>            
```

I think it is due to lack of bounds checking when we iterate on the given string. This PR fixes it.

#### After

```
irb(main):001:0> YARP.parse('#encoding: utf-8')
=> #<YARP::ParseResult:0x0000000105a64748 @comments=[#<YARP::Comment:0x0000000105a64950 @location=(0..16), @type=:inline>], @errors=[], @node=Program(Scope([]), Statements([]))>
irb(main):002:0> YARP.parse('#encoding: utf8')
=> 
#<YARP::ParseResult:0x0000000105a8d8f0                                  
 @comments=[#<YARP::Comment:0x0000000105a8dad0 @location=(0..15), @type=:inline>],
 @errors=[#<YARP::ParseError:0x0000000105a8da80 @location=(11..11), @message="Could not understand the encoding specified in the magic comment.">],
 @node=Program(Scope([]), Statements([]))>
```