### PR TITLE
Add checking errors in `assert_parses`

### DIFF
--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -17,6 +17,10 @@ module YARP
     def self.null
       new(0, 0)
     end
+
+    def ==(other)
+      self.class == other.class && start_offset == other.start_offset && end_offset == other.end_offset
+    end
   end
 
   # This represents a comment that was encountered during parsing.
@@ -44,6 +48,10 @@ module YARP
 
     def deconstruct_keys(keys)
       { message: message, location: location }
+    end
+
+    def ==(other)
+      self.class == other.class && message == other.message && location == other.location
     end
   end
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -2668,8 +2668,8 @@ class ParseTest < Test::Unit::TestCase
     assert_equal expected, node
   end
 
-  def assert_parses(expected, source)
-    assert_equal expected, expression(source)
+  def assert_parses(expected, source, errors = nil)
+    assert_equal expected, expression(source, errors)
     assert_serializes expected, source
 
     YARP.lex_ripper(source).zip(YARP.lex_compat(source)).each do |(ripper, yarp)|
@@ -2677,10 +2677,13 @@ class ParseTest < Test::Unit::TestCase
     end
   end
 
-  def expression(source)
+  def expression(source, errors = nil)
     result = YARP.parse(source)
-    assert_empty result.errors, PP.pp(result.node, +"")
-
+    if errors.nil?
+      assert_empty result.errors, PP.pp(result.node, +"")
+    else
+      assert_equal errors, result.errors
+    end
     result.node => YARP::Program[statements: YARP::Statements[body: [*, node]]]
     node
   end


### PR DESCRIPTION
In order to check both the parse result and possible errors, I extended `assert_parses` in a way that it will also check for the expected errors. Not used anywhere yet.