### PR TITLE
Make sure `rake generate_compilation_database` shows the abort message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ src/ast.h: bin/templates/src/ast.h.erb
 	rake $@
 
 clean:
-	rm -f build/librubyparser.$(SOEXT) ext/yarp/node.c lib/yarp/{node,prettyprint,serialize}.rb src/{ast.h,node.{c,h},serialize.c,token_type.c}
+	rm -f build/librubyparser.$(SOEXT) ext/yarp/node.c lib/yarp/{node,serialize}.rb src/{ast.h,node.{c,h},prettyprint.c,serialize.c,token_type.c}
 
 .PHONY: clean

--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,7 @@ task make: :templates do
   sh "make"
 end
 
-task generate_compilation_database: :templates do
+task generate_compilation_database: [:clobber, :templates] do
   sh "which bear" do |ok, _|
     abort("Installing bear is required to generate the compilation database") unless ok
   end
@@ -53,6 +53,13 @@ end
 
 # So `rake clobber` will delete generated files
 CLOBBER.concat(TEMPLATES)
+if RbConfig::CONFIG["host_os"] =~ /darwin/
+  so_ext = "dylib"
+else
+  so_ext = "so"
+end
+CLOBBER << "build/librubyparser.#{so_ext}"
+CLOBBER << "lib/yarp.so"
 
 TEMPLATES.each do |filepath|
   desc "Template #{filepath}"


### PR DESCRIPTION
`sh` fails when the command returns a non-zero exit code, so the `abort` logic was never executed.

To make sure users see the message we should be passing a block to `sh`.