### PR TITLE
Fix argument calls in block statements

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2562,6 +2562,9 @@ lex_token_type(yp_parser_t *parser) {
           if (lex_state_operator_p(parser)) {
             lex_state_set(parser, YP_LEX_STATE_ARG);
           } else {
+            if (lex_state_p(parser, YP_LEX_STATE_ARG)) {
+              parser->command_start = true;
+            }
             lex_state_set(parser, YP_LEX_STATE_BEG | YP_LEX_STATE_LABEL);
           }
 
@@ -4355,7 +4358,11 @@ parse_arguments_list(yp_parser_t *parser, yp_arguments_t *arguments, bool accept
         // operator. In this case we assume the subsequent token is part of an
         // argument to this method call.
         arguments->arguments = yp_arguments_node_create(parser);
-        parse_arguments(parser, arguments->arguments, YP_TOKEN_EOF);
+        if (parser->current_context->context == YP_CONTEXT_BLOCK_BRACES) {
+          parse_arguments(parser, arguments->arguments, YP_TOKEN_EOF|YP_TOKEN_BRACE_RIGHT);
+        } else {
+          parse_arguments(parser, arguments->arguments, YP_TOKEN_EOF);
+        }
       }
 
       break;

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -4066,6 +4066,44 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "x.reduce(0) { |x, memo| memo += x }"
   end
 
+  test "method call with block with one argument and statement" do
+    expected = CallNode(
+      nil,
+      nil,
+      IDENTIFIER("foo"),
+      nil,
+      nil,
+      nil,
+      BlockNode(
+        BRACE_LEFT("{"),
+        ParametersNode(
+          [RequiredParameterNode(IDENTIFIER("x"))],
+          [],
+          nil,
+          [],
+          nil,
+          nil
+        ),
+        Statements(
+          [CallNode(
+             nil,
+             nil,
+             IDENTIFIER("puts"),
+             nil,
+             ArgumentsNode([LocalVariableRead(IDENTIFIER("x"))]),
+             nil,
+             nil,
+             "puts"
+           )]
+        ),
+        BRACE_RIGHT("}")
+      ),
+      "foo"
+    )
+
+    assert_parses expected, "foo { |x| puts x}"
+  end
+
   test "def + without parentheses" do
     expected = DefNode(
       KEYWORD_DEF("def"),


### PR DESCRIPTION
This PR adds support for `do end` blocks and fixes parsing the arguments of calls which are inside blocks, for example:

```ruby
foo { |x| puts x }
```

**Before**:

```
irb(main):001:0> YARP.parse "foo { |x| puts x }"
=> 
#<YARP::ParseResult:0x0000000105bd5eb0                
 @comments=[],                                        
 @errors=                                             
  [#<YARP::ParseError:0x0000000105b519f8 @location=(16..16), @message="Expected a ',' to delimit arguments.">,
   #<YARP::ParseError:0x0000000105b51980 @location=(16..16), @message="Expected to be able to parse an argument.">],
 @node=                                               
  Program(                                            
    Scope([IDENTIFIER("x")]),                         
    Statements(                                       
      [CallNode(                                      
         nil,                                         
         nil,                                         
         IDENTIFIER("foo"),                           
         nil,                                         
         nil,
         nil,
         BlockNode(
           BRACE_LEFT("{"),
           ParametersNode([RequiredParameterNode(IDENTIFIER("x"))], [], nil, [], nil, nil),
           Statements([CallNode(nil, nil, IDENTIFIER("puts"), nil, ArgumentsNode([LocalVariableRead(IDENTIFIER("x")), MissingNode()]), nil, nil, "puts")]),
           BRACE_RIGHT("}")
         ),
         "foo"
       )]
    )
  ),
 @warnings=[]>
```

**After**

```
irb(main):001:0> YARP.parse "foo { |x| puts x }"
=> 
#<YARP::ParseResult:0x00000001032b2bc8
 @comments=[],
 @errors=[],
 @node=
  Program(
    Scope([IDENTIFIER("x")]),
    Statements(
      [CallNode(
         nil,
         nil,
         IDENTIFIER("foo"),
         nil,
         nil,
         nil,
         BlockNode(
           BRACE_LEFT("{"),
           ParametersNode([RequiredParameterNode(IDENTIFIER("x"))], [], nil, [], nil, nil),
           Statements([CallNode(nil, nil, IDENTIFIER("puts"), nil, ArgumentsNode([LocalVariableRead(IDENTIFIER("x"))]), nil, nil, "puts")]),
           BRACE_RIGHT("}")
         ),
         "foo"
       )]
    )
  ),
 @warnings=[]>
```