### PR TITLE
Fix parsing hashes without final comma

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4185,6 +4185,8 @@ parse_assoc(yp_parser_t *parser, yp_node_t *hash) {
   }
 
   yp_node_list_append(parser, hash, &hash->as.hash_node.elements, element);
+
+  while (accept(parser, YP_TOKEN_NEWLINE));
   return true;
 }
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -3888,6 +3888,22 @@ class ParseTest < Test::Unit::TestCase
     assert_parses HashNode(BRACE_LEFT("{"), [], BRACE_RIGHT("}")), "{\n}\n"
   end
 
+  test "parses hash without final comma" do
+    expected = HashNode(
+      BRACE_LEFT("{"),
+      [
+        AssocNode(SymbolNode(nil, LABEL("a"), LABEL_END(":")), expression("b"), nil),
+        AssocNode(SymbolNode(nil, LABEL("c"), LABEL_END(":")), expression("d"), nil),
+      ],
+      BRACE_RIGHT("}")
+    )
+
+    assert_parses expected, "{
+      a: b,
+      c: d\n\n\n
+    }"
+  end
+
   test "begin with rescue and ensure statements" do
     expected = BeginNode(
       KEYWORD_BEGIN("begin"),


### PR DESCRIPTION
Fixes parsing:

```ruby
options = {
  a: :a,
  b: 1
}
```