### PR TITLE
Create new scopes for blocks

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4503,6 +4503,7 @@ parse_block(yp_parser_t *parser) {
     expect(parser, YP_TOKEN_KEYWORD_END, "Expected block beginning with 'do' to end with 'end'.");
   }
 
+  yp_node_destroy(parser, scope);
   parser->current_scope = parent_scope;
   return yp_node_block_node_create(parser, &opening, arguments, statements, &parser->previous);
 }


### PR DESCRIPTION
This PR fixes the lexer state where two or more blocks share a common argument name, like:

```ruby
it { a.foo { |x| } }
it { b.bar { |x| } }
```

#### `rake lex` results

**Before**
```
PASSING=2591
FAILING=2063
```

**After**
```
PASSING=3047
FAILING=1607
```

This may not be enough though, I feel like the scopes should have a `parent` scope, otherwise we fail to correctly parse codes like:

```ruby
a = foo
bar do |x|
  baz == a
end
```