### PR TITLE
Fix calls with hash arguments with do-blocks

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4215,7 +4215,7 @@ parse_arguments(yp_parser_t *parser, yp_node_t *arguments, yp_token_type_t termi
         yp_token_t closing = not_provided(parser);
         argument = yp_node_hash_node_create(parser, &opening, &closing);
 
-        while (!match_any_type_p(parser, 5, terminator, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF, YP_TOKEN_BRACE_RIGHT)) {
+        while (!match_any_type_p(parser, 6, terminator, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_KEYWORD_DO)) {
           if (!parse_assoc(parser, argument)) {
             break;
           }

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -5204,6 +5204,49 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "foo bar, (baz do end)"
   end
 
+  test "method call with hash and a do block" do
+    expected = CallNode(
+      nil,
+      nil,
+      IDENTIFIER("foo"),
+      nil,
+      ArgumentsNode([
+        SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil),
+        HashNode(
+          nil,
+          [AssocNode(
+              SymbolNode(nil, LABEL("b"), LABEL_END(":")),
+              TrueNode(),
+              nil
+            )],
+          nil
+        )
+      ]),
+      nil,
+      BlockNode(
+        KEYWORD_DO("do"),
+        ParametersNode([
+          RequiredParameterNode(IDENTIFIER("a")),
+          RequiredParameterNode(IDENTIFIER("b"))
+          ], [], nil, [], nil, nil),
+        Statements([
+          CallNode(
+            nil,
+            nil, IDENTIFIER("puts"),
+            nil,
+            ArgumentsNode([LocalVariableRead(IDENTIFIER("a"))]),
+            nil,
+            nil,
+            "puts"
+          )]),
+        KEYWORD_END("end")
+      ),
+      "foo"
+    )
+
+    assert_parses expected, "foo :a, b: true do |a, b| puts a end"
+  end
+
   private
 
   def assert_serializes(expected, source)


### PR DESCRIPTION
This PR fixes calls where there is a hash argument and a do-block, e.g.

```ruby
foo :a, b: true do
end
```
