### PR TITLE
Add support for constant method names

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6425,6 +6425,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, binding_power_t bin
       switch (parser->current.type) {
         case YP_CASE_OPERATOR:
         case YP_CASE_KEYWORD:
+        case YP_TOKEN_CONSTANT:
         case YP_TOKEN_IDENTIFIER: {
           parser_lex(parser);
           message = parser->previous;

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -5406,6 +5406,20 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "case this; when FooBar, BazBonk; end"
   end
 
+  test "calls with constants" do
+    expected = CallNode(
+      ConstantRead(CONSTANT("Kernel")),
+      DOT("."),
+      CONSTANT("Integer"),
+      PARENTHESIS_LEFT("("),
+      ArgumentsNode([IntegerNode()]),
+      PARENTHESIS_RIGHT(")"),
+      nil,
+      "Integer"
+    )
+    assert_parses expected, "Kernel.Integer(10)"
+  end
+
   private
 
   def assert_serializes(expected, source)


### PR DESCRIPTION
Fixes parsing

```ruby
Kernel.Integer(10)
```