### PR TITLE
Fix break in blocks without any arguments

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5325,7 +5325,7 @@ parse_expression_prefix(yp_parser_t *parser) {
       if (!accept_any(parser, 3, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF)) {
         arguments = yp_arguments_node_create(parser);
 
-        while (!match_type_p(parser, YP_TOKEN_EOF)) {
+        while (!match_type_p(parser, YP_TOKEN_EOF) && !context_terminator(parser->current_context->context, &parser->current)) {
           yp_node_t *expression = parse_expression(parser, BINDING_POWER_NONE, "Expected to be able to parse an argument.");
           yp_arguments_node_append(arguments, expression);
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -5440,7 +5440,7 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "Kernel.Integer(10)"
   end
 
-  test "block with braces and break" do
+  test "block with braces and break with arguments" do
     expected = CallNode(
       CallNode(
         nil,
@@ -5466,6 +5466,41 @@ class ParseTest < Test::Unit::TestCase
       "=="
     )
     assert_parses expected, "foo { break 42 } == 42"
+  end
+
+  test "block with braces and break without arguments" do
+    expected = CallNode(
+      CallNode(
+        nil,
+        nil,
+        IDENTIFIER("foo"),
+        nil,
+        nil,
+        nil,
+        BlockNode(
+          BRACE_LEFT("{"),
+          ParametersNode(
+            [RequiredParameterNode(IDENTIFIER("a"))],
+            [],
+            nil,
+            [],
+            nil,
+            nil
+          ),
+          Statements([BreakNode(ArgumentsNode([]), Location())]),
+          BRACE_RIGHT("}")
+        ),
+        "foo"
+      ),
+      nil,
+      EQUAL_EQUAL("=="),
+      nil,
+      ArgumentsNode([IntegerNode()]),
+      nil,
+      nil,
+      "=="
+    )
+    assert_parses expected, "foo { |a| break } == 42"
   end
 
   private


### PR DESCRIPTION
Fixes parsing code like:

```ruby
[:a].bsearch { |v| break }
```

Similar to #331 but this time without any arguments to the `break` node.

