### PR TITLE
Fix state for double colon

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2771,6 +2771,11 @@ lex_token_type(yp_parser_t *parser) {
         // :: symbol
         case ':':
           if (match(parser, ':')) {
+            if (lex_state_beg_p(parser) || lex_state_p(parser, YP_LEX_STATE_CLASS) || (lex_state_p(parser, YP_LEX_STATE_ARG_ANY) && space_seen)) {
+              lex_state_set(parser, YP_LEX_STATE_BEG);
+            } else {
+              lex_state_set(parser, YP_LEX_STATE_DOT);
+            }
             lex_state_set(parser, YP_LEX_STATE_DOT);
             return YP_TOKEN_COLON_COLON;
           }
@@ -5427,7 +5432,7 @@ parse_expression_prefix(yp_parser_t *parser) {
         if (match_any_type_p(parser, 2, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
           statements = parse_rescues_as_begin(parser, statements);
         }
-        
+
         expect(parser, YP_TOKEN_KEYWORD_END, "Expected `end` to close `class` statement.");
 
         yp_node_t *scope = parser->current_scope->node;
@@ -5456,7 +5461,7 @@ parse_expression_prefix(yp_parser_t *parser) {
       if (match_any_type_p(parser, 2, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
         statements = parse_rescues_as_begin(parser, statements);
       }
-      
+
       expect(parser, YP_TOKEN_KEYWORD_END, "Expected `end` to close `class` statement.");
 
       yp_node_t *scope = parser->current_scope->node;
@@ -5790,7 +5795,7 @@ parse_expression_prefix(yp_parser_t *parser) {
       if (match_any_type_p(parser, 2, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
         statements = parse_rescues_as_begin(parser, statements);
       }
-      
+
       yp_node_t *scope = parser->current_scope->node;
       yp_parser_scope_pop(parser);
 


### PR DESCRIPTION
Fixes the state for `::`. I took a look [how CRuby does this](https://github.com/ruby/ruby/blob/0d415a322f5dd7158efcbc6c3226266e312620c7/parse.y#L10278) so tried to implement the same.

Example:

```ruby
Klass          = ::Digest::SHA256
```

**Before**

```
Ripper lex                                                             YARP lex                                                              
---------------------------------------------------------------------- ----------------------------------------------------------------------
[[1, 0], :on_const, "Klass", CMDARG]                                   [[1, 0], :on_const, "Klass", CMDARG]                                  
[[1, 15], :on_op, "=", BEG]                                            [[1, 15], :on_op, "=", BEG]                                           
[[1, 17], :on_op, "::", BEG]                                           [[1, 17], :on_op, "::", DOT]                                          
[[1, 19], :on_const, "Digest", ARG]                                    [[1, 19], :on_const, "Digest", ARG]                                   
[[1, 25], :on_op, "::", DOT]                                           [[1, 25], :on_op, "::", DOT]                                          
[[1, 27], :on_const, "SHA256", ARG]                                    [[1, 27], :on_const, "SHA256", ARG]                                   
[[1, 33], :on_nl, "\n", BEG]                                           [[1, 33], :on_nl, "\n", BEG]                                          
```

**After**

```
Ripper lex                                                             YARP lex                                                              
---------------------------------------------------------------------- ----------------------------------------------------------------------
[[1, 0], :on_const, "Klass", CMDARG]                                   [[1, 0], :on_const, "Klass", CMDARG]                                  
[[1, 15], :on_op, "=", BEG]                                            [[1, 15], :on_op, "=", BEG]                                           
[[1, 17], :on_op, "::", BEG]                                           [[1, 17], :on_op, "::", BEG]                                          
[[1, 19], :on_const, "Digest", ARG]                                    [[1, 19], :on_const, "Digest", ARG]                                   
[[1, 25], :on_op, "::", DOT]                                           [[1, 25], :on_op, "::", DOT]                                          
[[1, 27], :on_const, "SHA256", ARG]                                    [[1, 27], :on_const, "SHA256", ARG]                                   
[[1, 33], :on_nl, "\n", BEG]                                           [[1, 33], :on_nl, "\n", BEG]                                          
```