### PR TITLE
Fix parsing arrays with newlines and without trailing comma

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5208,6 +5208,9 @@ parse_expression_prefix(yp_parser_t *parser, binding_power_t binding_power) {
       yp_node_t *array = yp_array_node_create(parser, &opening, &opening);
 
       while (!match_any_type_p(parser, 2, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_EOF)) {
+        // Handle the case where we don't have a comma and we have a newline followed by a right bracket.
+        if (accept(parser, YP_TOKEN_NEWLINE) && match_type_p(parser, YP_TOKEN_BRACKET_RIGHT)) break;
+
         if (yp_array_node_size(array) != 0) {
           expect(parser, YP_TOKEN_COMMA, "Expected a separator for the elements in an array.");
         }

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -123,6 +123,20 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "[:a, :b,\n:c,1,\n\n\n\n:d,\n]"
   end
 
+  test "array literal with newlines without trailing comma" do
+    expected = ArrayNode(
+      [SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil),
+        SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("b"), nil),
+        SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("c"), nil),
+        IntegerNode(),
+        SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("d"), nil)],
+      BRACKET_LEFT("["),
+      BRACKET_RIGHT("]")
+    )
+
+    assert_parses expected, "[:a, :b,\n:c,1,\n\n\n\n:d\n\n\n]"
+  end
+
   test "array literal with labels" do
     expected = ArrayNode(
       [HashNode(


### PR DESCRIPTION
Fixes parsing arrays with newlines but without trailing comma:

```ruby
[:a,
 :b
]
```

Takes `rake lex` from `88.87%` to `90.22%`.