### PR TITLE
Fix `and` & `or` with calls and arguments

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4242,16 +4242,29 @@ parse_assoc(yp_parser_t *parser, yp_node_t *hash, yp_token_type_t terminator) {
   return true;
 }
 
+static inline
+bool is_not_argument_delimiter(yp_parser_t *parser, yp_token_type_t terminator) {
+  return !match_any_type_p(
+    parser, 8,
+    terminator,
+    YP_TOKEN_KEYWORD_AND,
+    YP_TOKEN_KEYWORD_DO,
+    YP_TOKEN_KEYWORD_OR,
+    YP_TOKEN_KEYWORD_THEN,
+    YP_TOKEN_NEWLINE,
+    YP_TOKEN_SEMICOLON,
+    YP_TOKEN_EOF
+  ) &&
+  !context_terminator(parser->current_context->context, &parser->current);
+}
+
 // Parse a list of arguments.
 static void
 parse_arguments(yp_parser_t *parser, yp_node_t *arguments, yp_token_type_t terminator) {
   bool parsed_double_splat_argument = false;
   bool parsed_block_argument = false;
 
-  while (
-    !match_any_type_p(parser, 6, terminator, YP_TOKEN_KEYWORD_DO, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF) &&
-    !context_terminator(parser->current_context->context, &parser->current)
-  ) {
+  while (is_not_argument_delimiter(parser, terminator)) {
     if (yp_arguments_node_size(arguments) > 0) {
       expect(parser, YP_TOKEN_COMMA, "Expected a ',' to delimit arguments.");
     }

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -293,8 +293,7 @@ class ErrorsTest < Test::Unit::TestCase
           [StarNode(
              STAR("*"),
              CallNode(nil, nil, IDENTIFIER("bar"), nil, nil, nil, nil, "bar")
-           ),
-           MissingNode()]
+           )]
         ),
         MISSING(""),
         nil,
@@ -305,8 +304,6 @@ class ErrorsTest < Test::Unit::TestCase
     )
 
     assert_errors expected, "foo(*bar and baz)", [
-      "Expected a ',' to delimit arguments.",
-      "Expected to be able to parse an argument.",
       "Expected a ')' to close the argument list."
     ]
   end

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -76,6 +76,58 @@ class ParseTest < Test::Unit::TestCase
     assert_parses AndNode(expression("1"), expression("2"), KEYWORD_AND("and")), "1 and 2"
   end
 
+  test "and & or keyword with calls" do
+    expected = OrNode(
+      AndNode(
+        CallNode(
+          nil,
+          nil,
+          IDENTIFIER("ruby_version_is"),
+          nil,
+          ArgumentsNode(
+            [StringNode(
+               STRING_BEGIN("'"),
+               STRING_CONTENT("3"),
+               STRING_END("'"),
+               "3"
+             )]
+          ),
+          nil,
+          nil,
+          "ruby_version_is"
+        ),
+        CallNode(
+          nil,
+          nil,
+          IDENTIFIER("platform_is"),
+          nil,
+          ArgumentsNode(
+            [SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("windows"), nil)]
+          ),
+          nil,
+          nil,
+          "platform_is"
+        ),
+        KEYWORD_AND("and")
+      ),
+      KEYWORD_OR("or"),
+      CallNode(
+        nil,
+        nil,
+        IDENTIFIER("foo"),
+        nil,
+        ArgumentsNode(
+          [SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil),
+           SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("b"), nil)]
+        ),
+        nil,
+        nil,
+        "foo"
+      )
+    )
+    assert_parses expected, "ruby_version_is '3' and platform_is :windows or foo :a, :b"
+  end
+
   test "and operator" do
     assert_parses AndNode(expression("1"), expression("2"), AMPERSAND_AMPERSAND("&&")), "1 && 2"
   end
@@ -5877,7 +5929,7 @@ class ParseTest < Test::Unit::TestCase
       ],
       EQUAL("="),
       IntegerNode()
-    )    
+    )
 
     assert_parses expected, "$foo, $bar = 1"
   end


### PR DESCRIPTION
Fixes parsing codes like:

```ruby
ruby_version_is '3' and platform_is :windows or foo :a, :b
```
