### PR TITLE
Fix parsing constants as method name

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5194,6 +5194,7 @@ parse_method_definition_name(yp_parser_t *parser) {
   switch (parser->current.type) {
     case YP_CASE_OPERATOR:
     case YP_CASE_KEYWORD:
+    case YP_TOKEN_CONSTANT:
     case YP_TOKEN_IDENTIFIER:
       parser_lex(parser);
       return parser->previous;

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1485,6 +1485,24 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "def m(a, **nil)\nend"
   end
 
+  test "def with constant name" do
+    expected = DefNode(
+      CONSTANT("Array_function"),
+      SelfNode(),
+      ParametersNode([], [], nil, [], nil, nil),
+      Statements([]),
+      Scope([]),
+      Location(),
+      Location(),
+      nil,
+      nil,
+      nil,
+      Location()
+    )
+
+    assert_parses expected, "def self.Array_function; end"
+  end
+
   test "method call with label keyword args" do
     expected = CallNode(
       nil,


### PR DESCRIPTION
Fixes parsing:

```ruby
def self.Array_function(arg)
end
```
