### PR TITLE
Binding power for assignments

### DIFF
--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -3080,15 +3080,15 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "operator and assignment" do
-    assert_parses OperatorAndAssignmentNode(expression("a"), expression("b"), Location()), "a &&= b"
+    assert_parses OperatorAndAssignmentNode(LocalVariableWrite(IDENTIFIER("a"), nil, nil), expression("b"), Location()), "a &&= b"
   end
 
   test "operator or assignment" do
-    assert_parses OperatorOrAssignmentNode(expression("a"), PIPE_PIPE_EQUAL("||="), expression("b")), "a ||= b"
+    assert_parses OperatorOrAssignmentNode(LocalVariableWrite(IDENTIFIER("a"), nil, nil), PIPE_PIPE_EQUAL("||="), expression("b")), "a ||= b"
   end
 
   test "operator assignment" do
-    assert_parses OperatorAssignmentNode(expression("a"), PLUS_EQUAL("+="), expression("b")), "a += b"
+    assert_parses OperatorAssignmentNode(LocalVariableWrite(IDENTIFIER("a"), nil, nil), PLUS_EQUAL("+="), expression("b")), "a += b"
   end
 
   test "post execution" do
@@ -5305,7 +5305,7 @@ class ParseTest < Test::Unit::TestCase
         ),
         Statements(
           [OperatorAssignmentNode(
-            LocalVariableRead(IDENTIFIER("memo")),
+            LocalVariableWrite(IDENTIFIER("memo"), nil, nil),
             PLUS_EQUAL("+="),
             LocalVariableRead(IDENTIFIER("x"))
           )]


### PR DESCRIPTION
This commit does a couple of things.

1. It changes operator assignments to parse targets. This means that expressions like a += 1 will now have a LocalVariableWrite on the left-hand side as opposed to a call.
2. It changes the binding power of the assignment operators to have a much stronger left binding power and a much weaker right binding power.
3. It also fixes up argument parsing on the next, return, and break keywords to check token_begins_expression_p instead.

Closes #388.
Closes #399.