### PR TITLE
rake lex improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,7 @@ jobs:
         ruby-version: 3.2
         bundler-cache: true
     - name: Lex ruby/ruby
-      run: bundle exec rake lex
-      env:
-        TARGET: ruby
+      run: bundle exec rake lex:ruby
 
   lex-rails:
     runs-on: ubuntu-latest
@@ -45,9 +43,7 @@ jobs:
         ruby-version: 3.2
         bundler-cache: true
     - name: Lex rails/rails
-      run: bundle exec rake lex
-      env:
-        TARGET: rails
+      run: bundle exec rake lex:rails
 
   lex-discourse:
     runs-on: ubuntu-latest
@@ -59,9 +55,7 @@ jobs:
         ruby-version: 3.2
         bundler-cache: true
     - name: Lex discourse/discourse
-      run: bundle exec rake lex
-      env:
-        TARGET: discourse
+      run: bundle exec rake lex:discourse
 
   memcheck:
     runs-on: ubuntu-latest

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,8 @@ require "rake/testtask"
 require "rake/clean"
 require "ruby_memcheck"
 
+Rake.add_rakelib("tasks")
+
 RubyMemcheck.config(binary_name: "yarp")
 
 task compile: :make
@@ -72,114 +74,5 @@ TEMPLATES.each do |filepath|
   file filepath => ["bin/templates/#{filepath}.erb", "config.yml"] do |t|
     require_relative "bin/template"
     template(t.name, locals)
-  end
-end
-
-desc "Lex ruby/spec files and compare with lex_compat"
-task lex: :compile do
-  $:.unshift(File.expand_path("lib", __dir__))
-  require "yarp"
-  require "ripper"
-  require "timeout"
-  require "yaml"
-
-  passing = 0
-  failing = 0
-  todo = 0
-
-  if ENV["FILEPATHS"]
-    filepaths = Dir[ENV["FILEPATHS"]]
-    todos = []
-  else
-    target = YAML.safe_load_file("targets.yml").fetch(ENV["TARGET"])
-    dirpath = File.join("tmp", "targets", ENV["TARGET"])
-
-    unless File.directory?(dirpath)
-      FileUtils.mkdir_p(dirpath)
-      Dir.chdir(dirpath) do
-        sh "git init"
-        sh "git remote add origin #{target.fetch("repo")}"
-        sh "git fetch --depth=1 origin #{target.fetch("sha")}"
-        sh "git reset --hard FETCH_HEAD"
-      end
-    end
-
-    filepaths = Dir[File.join(dirpath, "**", "*.rb")]
-
-    if excludes = target["excludes"]
-      filepaths -= excludes.map { |exclude| File.join(dirpath, exclude) }
-    end
-
-    todos = target.fetch("todos", []).map { |todo| File.join(dirpath, todo) }
-    todo = todos.length if !ENV["TODOS"]
-  end
-
-  filepaths.each.with_index(1) do |filepath, index|
-    print("#{filepath} ") if ENV["CI"]
-
-    source = File.read(filepath)
-    passed =
-      begin
-        Timeout.timeout(5) do
-          lexed = YARP.lex_compat(source)
-          lexed.errors.empty? && YARP.lex_ripper(source) == lexed.value
-        rescue
-          false
-        end
-      rescue Timeout::Error
-        false
-      end
-
-    if passed
-      print(ENV["CI"] ? "." : "\033[32m.\033[0m")
-      passing += 1
-    else
-      todos.delete(filepath) if todos.include?(filepath)
-      next if !ENV["TODOS"]
-
-      warn(filepath) if ENV["VERBOSE"]
-      print(ENV["CI"] ? "E" : "\033[31mE\033[0m")
-      failing += 1
-    end
-
-    puts if ENV["CI"]
-  end
-
-  puts("\n\n")
-  puts("Some files listed as todo are passing:\n  #{todos.join("\n  ")}") if todos.any?
-  puts(<<~RESULTS)
-    PASSING=#{passing}
-    FAILING=#{failing + todo}
-    PERCENT=#{(passing.to_f / (passing + failing + todo) * 100).round(2)}%
-  RESULTS
-
-  exit(1) if failing > 0
-end
-
-desc "Lint config.yml"
-task :lint do
-  require "yaml"
-  config = YAML.safe_load_file("config.yml")
-
-  tokens = config.fetch("tokens")[4..].map { |token| token.fetch("name") }
-  if tokens.sort != tokens
-    warn("Tokens are not sorted alphabetically")
-
-    tokens.sort.zip(tokens).each do |(sorted, unsorted)|
-      warn("Expected #{sorted} got #{unsorted}") if sorted != unsorted
-    end
-
-    exit(1)
-  end
-
-  nodes = config.fetch("nodes").map { |node| node.fetch("name") }
-  if nodes.sort != nodes
-    warn("Nodes are not sorted alphabetically")
-
-    nodes.sort.zip(nodes).each do |(sorted, unsorted)|
-      warn("Expected #{sorted} got #{unsorted}") if sorted != unsorted
-    end
-
-    exit(1)
   end
 end

--- a/targets.yml
+++ b/targets.yml
@@ -14,6 +14,7 @@ ruby:
     - spec/ruby/command_line/fixtures/bad_syntax.rb
   todos:
     - basictest/test.rb
+    - benchmark/app_lc_fizzbuzz.rb
     - benchmark/app_pentomino.rb
     - bootstraptest/runner.rb
     - ext/etc/mkconstants.rb
@@ -152,4 +153,6 @@ discourse:
     - plugins/chat/spec/plugin_spec.rb
     - script/import_scripts/yahoogroup.rb
     - spec/lib/discourse_spec.rb
+    - spec/lib/tiny_japanese_segmenter_spec.rb
     - spec/models/reviewable_spec.rb
+    - spec/requests/tags_controller_spec.rb

--- a/tasks/lex.rake
+++ b/tasks/lex.rake
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+module YARP
+  class LexTask
+    attr_reader :todos, :passing, :failing
+
+    def initialize(todos)
+      @todos = todos
+      @passing = 0
+      @failing = 0
+    end
+
+    def compare(filepath)
+      if lex(filepath)
+        todos.delete(filepath) if todos.include?(filepath)
+        @passing += 1
+        true
+      else
+        @failing += 1 if ENV["TODOS"] || !todos.include?(filepath)
+        false
+      end
+    end
+
+    def failed?
+      failing > 0
+    end
+
+    def summary
+      <<~RESULTS
+        PASSING=#{passing}
+        FAILING=#{failing + todos.length}
+        PERCENT=#{(passing.to_f / (passing + failing + todos.length) * 100).round(2)}%
+      RESULTS
+    end
+
+    private
+
+    # For the given filepath, read it and lex it with both lex_compat and
+    # lex_ripper. Compare the output of both and ensure they match.
+    def lex(filepath)
+      source = File.read(filepath)
+      lexed = YARP.lex_compat(source)
+      lexed.errors.empty? && YARP.lex_ripper(source) == lexed.value
+    rescue
+      false
+    end
+  end
+end
+
+# For each of the targets in targets.yml, we're going to define a task that will
+# clone the repo into tmp/targets/TARGET at the specified SHA.
+require "yaml"
+YAML.safe_load_file("targets.yml").each do |name, target|
+  repo = target.fetch("repo")
+  dirpath = File.join("tmp", "targets", name)
+
+  desc "Clone #{repo} into #{dirpath}"
+  file dirpath do
+    mkdir_p dirpath
+    chdir dirpath do
+      sh "git init"
+      sh "git remote add origin #{repo}"
+      sh "git fetch --depth=1 origin #{target.fetch("sha")}"
+      sh "git reset --hard FETCH_HEAD"
+    end
+  end
+
+  desc "Lex #{repo} and compare with lex_compat"
+  task "lex:#{name}" => [dirpath, :compile] do
+    $:.unshift(File.expand_path("../lib", __dir__))
+    require "ripper"
+    require "yarp"
+
+    plain_text = ENV.fetch("CI", false)
+    warn_failing = ENV.fetch("VERBOSE", false)
+
+    lex_task = YARP::LexTask.new(target.fetch("todos", []).map { |todo| File.join(dirpath, todo) })
+    filepaths = Dir[File.join(dirpath, "**", "*.rb")]
+
+    if excludes = target["excludes"]
+      filepaths -= excludes.map { |exclude| File.join(dirpath, exclude) }
+    end
+
+    filepaths.each do |filepath|
+      print("#{filepath} ") if plain_text
+
+      if lex_task.compare(filepath)
+        print(plain_text ? "." : "\033[32m.\033[0m")
+      else
+        warn(filepath) if warn_failing
+        print(plain_text ? "E" : "\033[31mE\033[0m")
+      end
+
+      puts if plain_text
+    end
+
+    puts("\n\n")
+
+    if lex_task.todos.length != target.fetch("todos", []).length
+      puts("Some files listed as todo are passing. This is the new list:")
+      puts("    - #{lex_task.todos.join("\n    - ")}")
+    end
+
+    puts(lex_task.summary)
+    exit(1) if lex_task.failed?
+  end
+end
+
+desc "Lex files and compare with lex_compat"
+task lex: :compile do
+  $:.unshift(File.expand_path("../lib", __dir__))
+  require "ripper"
+  require "yarp"
+
+  plain_text = ENV.fetch("CI", false)
+  warn_failing = ENV.fetch("VERBOSE", false)
+
+  lex_task = YARP::LexTask.new([])
+  filepaths = Dir[ENV.fetch("FILEPATHS")]
+
+  filepaths.each do |filepath|
+    print("#{filepath} ") if plain_text
+
+    if lex_task.compare(filepath)
+      print(plain_text ? "." : "\033[32m.\033[0m")
+    else
+      warn(filepath) if warn_failing
+      print(plain_text ? "E" : "\033[31mE\033[0m")
+    end
+
+    puts if plain_text
+  end
+
+  puts("\n\n#{lex_task.summary}")
+  exit(1) if lex_task.failed?
+end

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+desc "Lint config.yml"
+task :lint do
+  require "yaml"
+  config = YAML.safe_load_file(File.expand_path("../config.yml", __dir__))
+
+  tokens = config.fetch("tokens")[4..].map { |token| token.fetch("name") }
+  if tokens.sort != tokens
+    warn("Tokens are not sorted alphabetically")
+
+    tokens.sort.zip(tokens).each do |(sorted, unsorted)|
+      warn("Expected #{sorted} got #{unsorted}") if sorted != unsorted
+    end
+
+    exit(1)
+  end
+
+  nodes = config.fetch("nodes").map { |node| node.fetch("name") }
+  if nodes.sort != nodes
+    warn("Nodes are not sorted alphabetically")
+
+    nodes.sort.zip(nodes).each do |(sorted, unsorted)|
+      warn("Expected #{sorted} got #{unsorted}") if sorted != unsorted
+    end
+
+    exit(1)
+  end
+end


### PR DESCRIPTION
Each of the targets now gets its own task, and we're using rake like it's supposed to be used when checking for the presence of the target directory.

Each target now shows up under `rake -T` which is a nice improvement.

TODOS now functions in the opposite way when printing out its summary where it prints out the new list as opposed to the files that were removed. This should make it easier to copy paste back into the `targets.yml` file.