### PR TITLE
Fix method calls where there is begin in args

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -7380,7 +7380,9 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
       yp_token_t begin_keyword = parser->previous;
       accept_any(parser, 2, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
 
+      yp_accepts_block_stack_push(parser, true);
       yp_node_t *begin_statements = parse_statements(parser, YP_CONTEXT_BEGIN);
+      yp_accepts_block_stack_pop(parser);
       accept_any(parser, 2, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
 
       yp_node_t *begin_node = yp_begin_node_create(parser, &begin_keyword, begin_statements);

--- a/test/fixtures/method_calls.rb
+++ b/test/fixtures/method_calls.rb
@@ -109,3 +109,5 @@ foo class Bar baz do end end
 foo module Bar baz do end end
 
 foo [baz do end]
+
+p begin 1.times do 1 end end

--- a/test/snapshots/method_calls.rb
+++ b/test/snapshots/method_calls.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...944)(
+ProgramNode(0...960)(
   Scope(0...0)([]),
-  StatementsNode(0...944)(
+  StatementsNode(0...960)(
     [CallNode(0...14)(
        CallNode(0...3)(
          nil,
@@ -1630,6 +1630,42 @@ ProgramNode(0...944)(
        nil,
        nil,
        "foo"
+     ),
+     CallNode(959...960)(
+       nil,
+       nil,
+       IDENTIFIER(959...960)("p"),
+       nil,
+       ArgumentsNode(961...987)(
+         [BeginNode(961...987)(
+            KEYWORD_BEGIN(961...966)("begin"),
+            StatementsNode(967...983)(
+              [CallNode(967...983)(
+                 IntegerNode(967...968)(),
+                 DOT(968...969)("."),
+                 IDENTIFIER(969...974)("times"),
+                 nil,
+                 nil,
+                 nil,
+                 BlockNode(975...983)(
+                   Scope(975...977)([]),
+                   nil,
+                   StatementsNode(978...979)([IntegerNode(978...979)()]),
+                   (975...977),
+                   (980...983)
+                 ),
+                 "times"
+               )]
+            ),
+            nil,
+            nil,
+            nil,
+            KEYWORD_END(984...987)("end")
+          )]
+       ),
+       nil,
+       nil,
+       "p"
      )]
   )
 )


### PR DESCRIPTION
Fixes parsing:

```ruby
p begin 1.times do 1 end end
```