### PR TITLE
Improve parameter order

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1271,6 +1271,8 @@ nodes:
         type: node[]
       - name: optionals
         type: node[]
+      - name: posts
+        type: node[]
       - name: rest
         type: node?
         kind: RestParameterNode

--- a/test/fixtures/methods.rb
+++ b/test/fixtures/methods.rb
@@ -1,6 +1,10 @@
 def foo((bar, baz))
 end
 
+def foo((bar, baz), optional = 1, (bin, bag))
+end
+
+
 def a; ensure; end
 
 def (b).a

--- a/test/snapshots/blocks.rb
+++ b/test/snapshots/blocks.rb
@@ -120,6 +120,7 @@ ProgramNode(0...402)(
              [RequiredParameterNode(54...55)(),
               RequiredParameterNode(57...61)()],
              [],
+             [],
              nil,
              [],
              nil,
@@ -298,6 +299,7 @@ ProgramNode(0...402)(
                   "[]"
                 )
               )],
+             [],
              nil,
              [],
              nil,
@@ -459,6 +461,7 @@ ProgramNode(0...402)(
                 EQUAL(265...266)("="),
                 IntegerNode(267...268)()
               )],
+             [],
              nil,
              [KeywordParameterNode(270...272)(LABEL(270...272)("z:"), nil)],
              nil,
@@ -484,6 +487,7 @@ ProgramNode(0...402)(
          BlockParametersNode(286...287)(
            ParametersNode(286...287)(
              [RequiredParameterNode(286...287)()],
+             [],
              [],
              nil,
              [],
@@ -517,6 +521,7 @@ ProgramNode(0...402)(
            ParametersNode(310...311)(
              [RequiredParameterNode(310...311)()],
              [],
+             [],
              nil,
              [],
              nil,
@@ -542,6 +547,7 @@ ProgramNode(0...402)(
          BlockParametersNode(326...327)(
            ParametersNode(326...327)(
              [RequiredParameterNode(326...327)()],
+             [],
              [],
              nil,
              [],
@@ -609,6 +615,7 @@ ProgramNode(0...402)(
                 ParametersNode(365...377)(
                   [],
                   [],
+                  [],
                   nil,
                   [KeywordParameterNode(365...369)(
                      LABEL(365...367)("a:"),
@@ -646,6 +653,7 @@ ProgramNode(0...402)(
          BlockParametersNode(393...397)(
            ParametersNode(393...397)(
              [RequiredParameterNode(393...396)()],
+             [],
              [],
              RestParameterNode(396...397)(COMMA(396...397)(","), nil),
              [],

--- a/test/snapshots/break.rb
+++ b/test/snapshots/break.rb
@@ -126,6 +126,7 @@ ProgramNode(0...168)(
              ParametersNode(152...153)(
                [RequiredParameterNode(152...153)()],
                [],
+               [],
                nil,
                [],
                nil,

--- a/test/snapshots/keyword_method_names.rb
+++ b/test/snapshots/keyword_method_names.rb
@@ -74,6 +74,7 @@ ProgramNode(0...185)(
        ParametersNode(76...84)(
          [RequiredParameterNode(76...77)()],
          [],
+         [],
          nil,
          [],
          NoKeywordsParameterNode(79...84)((79...81), (81...84)),

--- a/test/snapshots/lambda.rb
+++ b/test/snapshots/lambda.rb
@@ -9,6 +9,7 @@ ProgramNode(0...30)(
          ParametersNode(6...9)(
            [RequiredParameterNode(6...9)()],
            [],
+           [],
            nil,
            [],
            nil,
@@ -25,6 +26,7 @@ ProgramNode(0...30)(
        PARENTHESIS_LEFT(18...19)("("),
        BlockParametersNode(19...29)(
          ParametersNode(19...29)(
+           [],
            [],
            [],
            nil,

--- a/test/snapshots/method_calls.rb
+++ b/test/snapshots/method_calls.rb
@@ -839,6 +839,7 @@ ProgramNode(0...960)(
              [RequiredParameterNode(405...406)(),
               RequiredParameterNode(408...409)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/methods.rb
+++ b/test/snapshots/methods.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...943)(
-  ScopeNode(0...0)([IDENTIFIER(238...239)("a"), IDENTIFIER(732...733)("c")]),
-  StatementsNode(0...943)(
+ProgramNode(0...995)(
+  ScopeNode(0...0)([IDENTIFIER(290...291)("a"), IDENTIFIER(784...785)("c")]),
+  StatementsNode(0...995)(
     [DefNode(0...23)(
        IDENTIFIER(4...7)("foo"),
        nil,
@@ -11,6 +11,7 @@ ProgramNode(0...943)(
             PARENTHESIS_LEFT(8...9)("("),
             PARENTHESIS_RIGHT(17...18)(")")
           )],
+         [],
          [],
          nil,
          [],
@@ -28,134 +29,176 @@ ProgramNode(0...943)(
        nil,
        (20...23)
      ),
-     DefNode(25...43)(
-       IDENTIFIER(29...30)("a"),
+     DefNode(25...74)(
+       IDENTIFIER(29...32)("foo"),
        nil,
-       nil,
-       BeginNode(0...43)(
+       ParametersNode(33...69)(
+         [RequiredDestructuredParameterNode(33...43)(
+            [RequiredParameterNode(34...37)(),
+             RequiredParameterNode(39...42)()],
+            PARENTHESIS_LEFT(33...34)("("),
+            PARENTHESIS_RIGHT(42...43)(")")
+          )],
+         [OptionalParameterNode(45...57)(
+            IDENTIFIER(45...53)("optional"),
+            EQUAL(54...55)("="),
+            IntegerNode(56...57)()
+          )],
+         [RequiredDestructuredParameterNode(59...69)(
+            [RequiredParameterNode(60...63)(),
+             RequiredParameterNode(65...68)()],
+            PARENTHESIS_LEFT(59...60)("("),
+            PARENTHESIS_RIGHT(68...69)(")")
+          )],
          nil,
+         [],
          nil,
-         nil,
-         nil,
-         EnsureNode(32...43)(
-           KEYWORD_ENSURE(32...38)("ensure"),
-           nil,
-           KEYWORD_END(40...43)("end")
-         ),
-         KEYWORD_END(40...43)("end")
+         nil
        ),
-       ScopeNode(25...28)([]),
+       nil,
+       ScopeNode(25...28)(
+         [IDENTIFIER(34...37)("bar"),
+          IDENTIFIER(39...42)("baz"),
+          IDENTIFIER(45...53)("optional"),
+          IDENTIFIER(60...63)("bin"),
+          IDENTIFIER(65...68)("bag")]
+       ),
        (25...28),
        nil,
+       (32...33),
+       (69...70),
        nil,
-       nil,
-       nil,
-       (40...43)
+       (71...74)
      ),
-     DefNode(45...58)(
-       IDENTIFIER(53...54)("a"),
-       ParenthesesNode(49...52)(
-         CallNode(50...51)(
+     DefNode(77...95)(
+       IDENTIFIER(81...82)("a"),
+       nil,
+       nil,
+       BeginNode(0...95)(
+         nil,
+         nil,
+         nil,
+         nil,
+         EnsureNode(84...95)(
+           KEYWORD_ENSURE(84...90)("ensure"),
+           nil,
+           KEYWORD_END(92...95)("end")
+         ),
+         KEYWORD_END(92...95)("end")
+       ),
+       ScopeNode(77...80)([]),
+       (77...80),
+       nil,
+       nil,
+       nil,
+       nil,
+       (92...95)
+     ),
+     DefNode(97...110)(
+       IDENTIFIER(105...106)("a"),
+       ParenthesesNode(101...104)(
+         CallNode(102...103)(
            nil,
            nil,
-           IDENTIFIER(50...51)("b"),
+           IDENTIFIER(102...103)("b"),
            nil,
            nil,
            nil,
            nil,
            "b"
          ),
-         (49...50),
-         (51...52)
+         (101...102),
+         (103...104)
        ),
        nil,
        nil,
-       ScopeNode(45...48)([]),
-       (45...48),
-       (52...53),
+       ScopeNode(97...100)([]),
+       (97...100),
+       (104...105),
        nil,
        nil,
        nil,
-       (55...58)
+       (107...110)
      ),
-     DefNode(60...74)(
-       IDENTIFIER(69...70)("b"),
-       ParenthesesNode(64...67)(
-         CallNode(65...66)(
+     DefNode(112...126)(
+       IDENTIFIER(121...122)("b"),
+       ParenthesesNode(116...119)(
+         CallNode(117...118)(
            nil,
            nil,
-           IDENTIFIER(65...66)("a"),
+           IDENTIFIER(117...118)("a"),
            nil,
            nil,
            nil,
            nil,
            "a"
          ),
-         (64...65),
-         (66...67)
+         (116...117),
+         (118...119)
        ),
        nil,
        nil,
-       ScopeNode(60...63)([]),
-       (60...63),
-       (67...69),
+       ScopeNode(112...115)([]),
+       (112...115),
+       (119...121),
        nil,
        nil,
        nil,
-       (71...74)
+       (123...126)
      ),
-     DefNode(76...91)(
-       IDENTIFIER(86...87)("a"),
-       FalseNode(80...85)(),
+     DefNode(128...143)(
+       IDENTIFIER(138...139)("a"),
+       FalseNode(132...137)(),
        nil,
        nil,
-       ScopeNode(76...79)([]),
-       (76...79),
-       (85...86),
+       ScopeNode(128...131)([]),
+       (128...131),
+       (137...138),
        nil,
        nil,
        nil,
-       (88...91)
+       (140...143)
      ),
-     DefNode(93...107)(
-       IDENTIFIER(97...98)("a"),
+     DefNode(145...159)(
+       IDENTIFIER(149...150)("a"),
        nil,
-       ParametersNode(99...102)(
+       ParametersNode(151...154)(
+         [],
          [],
          [],
          nil,
          [],
-         ForwardingParameterNode(99...102)(),
+         ForwardingParameterNode(151...154)(),
          nil
        ),
        nil,
-       ScopeNode(93...96)([UDOT_DOT_DOT(99...102)("...")]),
-       (93...96),
+       ScopeNode(145...148)([UDOT_DOT_DOT(151...154)("...")]),
+       (145...148),
        nil,
-       (98...99),
-       (102...103),
+       (150...151),
+       (154...155),
        nil,
-       (104...107)
+       (156...159)
      ),
-     DefNode(109...123)(
-       IDENTIFIER(118...119)("a"),
-       GlobalVariableReadNode(113...117)(GLOBAL_VARIABLE(113...117)("$var")),
+     DefNode(161...175)(
+       IDENTIFIER(170...171)("a"),
+       GlobalVariableReadNode(165...169)(GLOBAL_VARIABLE(165...169)("$var")),
        nil,
        nil,
-       ScopeNode(109...112)([]),
-       (109...112),
-       (117...118),
+       ScopeNode(161...164)([]),
+       (161...164),
+       (169...170),
        nil,
        nil,
        nil,
-       (120...123)
+       (172...175)
      ),
-     DefNode(125...136)(
-       IDENTIFIER(131...132)("b"),
-       CallNode(129...130)(
+     DefNode(177...188)(
+       IDENTIFIER(183...184)("b"),
+       CallNode(181...182)(
          nil,
          nil,
-         IDENTIFIER(129...130)("a"),
+         IDENTIFIER(181...182)("a"),
          nil,
          nil,
          nil,
@@ -164,181 +207,127 @@ ProgramNode(0...943)(
        ),
        nil,
        nil,
-       ScopeNode(125...128)([]),
-       (125...128),
-       (130...131),
+       ScopeNode(177...180)([]),
+       (177...180),
+       (182...183),
        nil,
        nil,
        nil,
-       (133...136)
+       (185...188)
      ),
-     DefNode(138...152)(
-       IDENTIFIER(147...148)("a"),
-       InstanceVariableReadNode(142...146)(),
+     DefNode(190...204)(
+       IDENTIFIER(199...200)("a"),
+       InstanceVariableReadNode(194...198)(),
        nil,
        nil,
-       ScopeNode(138...141)([]),
-       (138...141),
-       (146...147),
+       ScopeNode(190...193)([]),
+       (190...193),
+       (198...199),
        nil,
        nil,
        nil,
-       (149...152)
+       (201...204)
      ),
-     DefNode(154...167)(
-       IDENTIFIER(158...159)("a"),
+     DefNode(206...219)(
+       IDENTIFIER(210...211)("a"),
        nil,
-       ParametersNode(160...162)(
+       ParametersNode(212...214)(
+         [],
          [],
          [],
          nil,
-         [KeywordParameterNode(160...162)(LABEL(160...162)("b:"), nil)],
+         [KeywordParameterNode(212...214)(LABEL(212...214)("b:"), nil)],
          nil,
          nil
        ),
        nil,
-       ScopeNode(154...157)([LABEL(160...161)("b")]),
-       (154...157),
+       ScopeNode(206...209)([LABEL(212...213)("b")]),
+       (206...209),
        nil,
        nil,
        nil,
        nil,
-       (164...167)
+       (216...219)
      ),
-     StringNode(169...175)(
-       STRING_BEGIN(169...171)("%,"),
-       STRING_CONTENT(171...174)("abc"),
-       STRING_END(174...175)(","),
+     StringNode(221...227)(
+       STRING_BEGIN(221...223)("%,"),
+       STRING_CONTENT(223...226)("abc"),
+       STRING_END(226...227)(","),
        "abc"
      ),
-     DefNode(177...190)(
-       IDENTIFIER(181...182)("a"),
+     DefNode(229...242)(
+       IDENTIFIER(233...234)("a"),
        nil,
-       ParametersNode(183...185)(
+       ParametersNode(235...237)(
+         [],
          [],
          [],
          nil,
-         [KeywordParameterNode(183...185)(LABEL(183...185)("b:"), nil)],
+         [KeywordParameterNode(235...237)(LABEL(235...237)("b:"), nil)],
          nil,
          nil
        ),
        nil,
-       ScopeNode(177...180)([LABEL(183...184)("b")]),
-       (177...180),
+       ScopeNode(229...232)([LABEL(235...236)("b")]),
+       (229...232),
        nil,
-       (182...183),
-       (185...186),
+       (234...235),
+       (237...238),
        nil,
-       (187...190)
+       (239...242)
      ),
-     DefNode(192...206)(
-       IDENTIFIER(196...197)("a"),
+     DefNode(244...258)(
+       IDENTIFIER(248...249)("a"),
        nil,
-       ParametersNode(198...201)(
+       ParametersNode(250...253)(
+         [],
          [],
          [],
          nil,
          [],
-         KeywordRestParameterNode(198...201)(
-           USTAR_STAR(198...200)("**"),
-           IDENTIFIER(200...201)("b")
+         KeywordRestParameterNode(250...253)(
+           USTAR_STAR(250...252)("**"),
+           IDENTIFIER(252...253)("b")
          ),
          nil
        ),
        nil,
-       ScopeNode(192...195)([IDENTIFIER(200...201)("b")]),
-       (192...195),
+       ScopeNode(244...247)([IDENTIFIER(252...253)("b")]),
+       (244...247),
        nil,
-       (197...198),
-       (201...202),
+       (249...250),
+       (253...254),
        nil,
-       (203...206)
+       (255...258)
      ),
-     DefNode(208...221)(
-       IDENTIFIER(212...213)("a"),
+     DefNode(260...273)(
+       IDENTIFIER(264...265)("a"),
        nil,
-       ParametersNode(214...216)(
+       ParametersNode(266...268)(
+         [],
          [],
          [],
          nil,
          [],
-         KeywordRestParameterNode(214...216)(USTAR_STAR(214...216)("**"), nil),
+         KeywordRestParameterNode(266...268)(USTAR_STAR(266...268)("**"), nil),
          nil
        ),
        nil,
-       ScopeNode(208...211)([USTAR_STAR(214...216)("**")]),
-       (208...211),
+       ScopeNode(260...263)([USTAR_STAR(266...268)("**")]),
+       (260...263),
        nil,
-       (213...214),
-       (216...217),
-       nil,
-       (218...221)
-     ),
-     DefNode(223...236)(
-       IDENTIFIER(231...232)("a"),
-       ParenthesesNode(227...230)(
-         IntegerNode(228...229)(),
-         (227...228),
-         (229...230)
-       ),
-       nil,
-       nil,
-       ScopeNode(223...226)([]),
-       (223...226),
-       (230...231),
-       nil,
-       nil,
-       nil,
-       (233...236)
-     ),
-     LocalVariableWriteNode(238...243)(
-       (238...239),
-       IntegerNode(242...243)(),
-       (240...241),
-       0
-     ),
-     DefNode(245...254)(
-       IDENTIFIER(249...250)("a"),
-       nil,
-       nil,
-       nil,
-       ScopeNode(245...248)([]),
-       (245...248),
-       nil,
-       nil,
-       nil,
-       nil,
-       (251...254)
-     ),
-     DefNode(256...273)(
-       IDENTIFIER(260...261)("a"),
-       nil,
-       ParametersNode(262...269)(
-         [RequiredParameterNode(262...263)(),
-          RequiredParameterNode(265...266)(),
-          RequiredParameterNode(268...269)()],
-         [],
-         nil,
-         [],
-         nil,
-         nil
-       ),
-       nil,
-       ScopeNode(256...259)(
-         [IDENTIFIER(262...263)("b"),
-          IDENTIFIER(265...266)("c"),
-          IDENTIFIER(268...269)("d")]
-       ),
-       (256...259),
-       nil,
-       nil,
-       nil,
+       (265...266),
+       (268...269),
        nil,
        (270...273)
      ),
      DefNode(275...288)(
        IDENTIFIER(283...284)("a"),
-       NilNode(279...282)(),
+       ParenthesesNode(279...282)(
+         IntegerNode(280...281)(),
+         (279...280),
+         (281...282)
+       ),
        nil,
        nil,
        ScopeNode(275...278)([]),
@@ -349,159 +338,161 @@ ProgramNode(0...943)(
        nil,
        (285...288)
      ),
-     DefNode(290...308)(
-       IDENTIFIER(294...295)("a"),
+     LocalVariableWriteNode(290...295)(
+       (290...291),
+       IntegerNode(294...295)(),
+       (292...293),
+       0
+     ),
+     DefNode(297...306)(
+       IDENTIFIER(301...302)("a"),
        nil,
-       ParametersNode(296...304)(
+       nil,
+       nil,
+       ScopeNode(297...300)([]),
+       (297...300),
+       nil,
+       nil,
+       nil,
+       nil,
+       (303...306)
+     ),
+     DefNode(308...325)(
+       IDENTIFIER(312...313)("a"),
+       nil,
+       ParametersNode(314...321)(
+         [RequiredParameterNode(314...315)(),
+          RequiredParameterNode(317...318)(),
+          RequiredParameterNode(320...321)()],
          [],
          [],
          nil,
-         [KeywordParameterNode(296...298)(LABEL(296...298)("b:"), nil),
-          KeywordParameterNode(300...304)(
-            LABEL(300...302)("c:"),
-            IntegerNode(303...304)()
-          )],
+         [],
          nil,
          nil
        ),
        nil,
-       ScopeNode(290...293)([LABEL(296...297)("b"), LABEL(300...301)("c")]),
-       (290...293),
-       nil,
-       nil,
-       nil,
-       nil,
-       (305...308)
-     ),
-     DefNode(310...329)(
-       IDENTIFIER(314...315)("a"),
-       nil,
-       ParametersNode(316...324)(
-         [],
-         [],
-         nil,
-         [KeywordParameterNode(316...318)(LABEL(316...318)("b:"), nil),
-          KeywordParameterNode(320...324)(
-            LABEL(320...322)("c:"),
-            IntegerNode(323...324)()
-          )],
-         nil,
-         nil
+       ScopeNode(308...311)(
+         [IDENTIFIER(314...315)("b"),
+          IDENTIFIER(317...318)("c"),
+          IDENTIFIER(320...321)("d")]
        ),
+       (308...311),
        nil,
-       ScopeNode(310...313)([LABEL(316...317)("b"), LABEL(320...321)("c")]),
-       (310...313),
        nil,
-       (315...316),
-       (324...325),
        nil,
-       (326...329)
+       nil,
+       (322...325)
      ),
-     DefNode(331...352)(
+     DefNode(327...340)(
        IDENTIFIER(335...336)("a"),
+       NilNode(331...334)(),
        nil,
-       ParametersNode(337...347)(
+       nil,
+       ScopeNode(327...330)([]),
+       (327...330),
+       (334...335),
+       nil,
+       nil,
+       nil,
+       (337...340)
+     ),
+     DefNode(342...360)(
+       IDENTIFIER(346...347)("a"),
+       nil,
+       ParametersNode(348...356)(
+         [],
          [],
          [],
          nil,
-         [KeywordParameterNode(337...343)(
-            LABEL(337...339)("b:"),
-            IntegerNode(342...343)()
-          ),
-          KeywordParameterNode(345...347)(LABEL(345...347)("c:"), nil)],
+         [KeywordParameterNode(348...350)(LABEL(348...350)("b:"), nil),
+          KeywordParameterNode(352...356)(
+            LABEL(352...354)("c:"),
+            IntegerNode(355...356)()
+          )],
          nil,
          nil
        ),
        nil,
-       ScopeNode(331...334)([LABEL(337...338)("b"), LABEL(345...346)("c")]),
-       (331...334),
+       ScopeNode(342...345)([LABEL(348...349)("b"), LABEL(352...353)("c")]),
+       (342...345),
        nil,
-       (336...337),
-       (347...348),
        nil,
-       (349...352)
+       nil,
+       nil,
+       (357...360)
      ),
-     StringNode(354...360)(
-       STRING_BEGIN(354...356)("%."),
-       STRING_CONTENT(356...359)("abc"),
-       STRING_END(359...360)("."),
-       "abc"
-     ),
-     DefNode(362...384)(
+     DefNode(362...381)(
        IDENTIFIER(366...367)("a"),
        nil,
-       ParametersNode(368...380)(
+       ParametersNode(368...376)(
          [],
-         [OptionalParameterNode(368...373)(
-            IDENTIFIER(368...369)("b"),
-            EQUAL(370...371)("="),
-            IntegerNode(372...373)()
-          ),
-          OptionalParameterNode(375...380)(
-            IDENTIFIER(375...376)("c"),
-            EQUAL(377...378)("="),
-            IntegerNode(379...380)()
-          )],
+         [],
+         [],
          nil,
-         [],
+         [KeywordParameterNode(368...370)(LABEL(368...370)("b:"), nil),
+          KeywordParameterNode(372...376)(
+            LABEL(372...374)("c:"),
+            IntegerNode(375...376)()
+          )],
          nil,
          nil
        ),
        nil,
-       ScopeNode(362...365)(
-         [IDENTIFIER(368...369)("b"), IDENTIFIER(375...376)("c")]
-       ),
+       ScopeNode(362...365)([LABEL(368...369)("b"), LABEL(372...373)("c")]),
        (362...365),
        nil,
+       (367...368),
+       (376...377),
        nil,
-       nil,
-       nil,
-       (381...384)
+       (378...381)
      ),
-     DefNode(386...397)(
-       IDENTIFIER(390...391)("a"),
+     DefNode(383...404)(
+       IDENTIFIER(387...388)("a"),
        nil,
+       ParametersNode(389...399)(
+         [],
+         [],
+         [],
+         nil,
+         [KeywordParameterNode(389...395)(
+            LABEL(389...391)("b:"),
+            IntegerNode(394...395)()
+          ),
+          KeywordParameterNode(397...399)(LABEL(397...399)("c:"), nil)],
+         nil,
+         nil
+       ),
        nil,
+       ScopeNode(383...386)([LABEL(389...390)("b"), LABEL(397...398)("c")]),
+       (383...386),
        nil,
-       ScopeNode(386...389)([]),
-       (386...389),
+       (388...389),
+       (399...400),
        nil,
-       (391...392),
-       (392...393),
-       nil,
-       (394...397)
+       (401...404)
      ),
-     DefNode(399...417)(
-       IDENTIFIER(403...404)("a"),
+     StringNode(406...412)(
+       STRING_BEGIN(406...408)("%."),
+       STRING_CONTENT(408...411)("abc"),
+       STRING_END(411...412)("."),
+       "abc"
+     ),
+     DefNode(414...436)(
+       IDENTIFIER(418...419)("a"),
        nil,
-       ParametersNode(405...413)(
-         [RequiredParameterNode(405...406)()],
-         [OptionalParameterNode(408...413)(
-            IDENTIFIER(408...409)("c"),
-            EQUAL(410...411)("="),
-            IntegerNode(412...413)()
+       ParametersNode(420...432)(
+         [],
+         [OptionalParameterNode(420...425)(
+            IDENTIFIER(420...421)("b"),
+            EQUAL(422...423)("="),
+            IntegerNode(424...425)()
+          ),
+          OptionalParameterNode(427...432)(
+            IDENTIFIER(427...428)("c"),
+            EQUAL(429...430)("="),
+            IntegerNode(431...432)()
           )],
-         nil,
-         [],
-         nil,
-         nil
-       ),
-       nil,
-       ScopeNode(399...402)(
-         [IDENTIFIER(405...406)("b"), IDENTIFIER(408...409)("c")]
-       ),
-       (399...402),
-       nil,
-       nil,
-       nil,
-       nil,
-       (414...417)
-     ),
-     DefNode(419...430)(
-       IDENTIFIER(423...424)("a"),
-       nil,
-       ParametersNode(425...426)(
-         [RequiredParameterNode(425...426)()],
          [],
          nil,
          [],
@@ -509,166 +500,231 @@ ProgramNode(0...943)(
          nil
        ),
        nil,
-       ScopeNode(419...422)([IDENTIFIER(425...426)("b")]),
-       (419...422),
+       ScopeNode(414...417)(
+         [IDENTIFIER(420...421)("b"), IDENTIFIER(427...428)("c")]
+       ),
+       (414...417),
        nil,
        nil,
        nil,
        nil,
-       (427...430)
+       (433...436)
      ),
-     DefNode(432...464)(
-       IDENTIFIER(436...437)("a"),
+     DefNode(438...449)(
+       IDENTIFIER(442...443)("a"),
        nil,
        nil,
-       BeginNode(0...464)(
+       nil,
+       ScopeNode(438...441)([]),
+       (438...441),
+       nil,
+       (443...444),
+       (444...445),
+       nil,
+       (446...449)
+     ),
+     DefNode(451...469)(
+       IDENTIFIER(455...456)("a"),
+       nil,
+       ParametersNode(457...465)(
+         [RequiredParameterNode(457...458)()],
+         [OptionalParameterNode(460...465)(
+            IDENTIFIER(460...461)("c"),
+            EQUAL(462...463)("="),
+            IntegerNode(464...465)()
+          )],
+         [],
+         nil,
+         [],
+         nil,
+         nil
+       ),
+       nil,
+       ScopeNode(451...454)(
+         [IDENTIFIER(457...458)("b"), IDENTIFIER(460...461)("c")]
+       ),
+       (451...454),
+       nil,
+       nil,
+       nil,
+       nil,
+       (466...469)
+     ),
+     DefNode(471...482)(
+       IDENTIFIER(475...476)("a"),
+       nil,
+       ParametersNode(477...478)(
+         [RequiredParameterNode(477...478)()],
+         [],
+         [],
+         nil,
+         [],
+         nil,
+         nil
+       ),
+       nil,
+       ScopeNode(471...474)([IDENTIFIER(477...478)("b")]),
+       (471...474),
+       nil,
+       nil,
+       nil,
+       nil,
+       (479...482)
+     ),
+     DefNode(484...516)(
+       IDENTIFIER(488...489)("a"),
+       nil,
+       nil,
+       BeginNode(0...516)(
          nil,
          nil,
-         RescueNode(439...445)(
-           KEYWORD_RESCUE(439...445)("rescue"),
+         RescueNode(491...497)(
+           KEYWORD_RESCUE(491...497)("rescue"),
            [],
            nil,
            nil,
            nil,
            nil
          ),
-         ElseNode(447...459)(
-           KEYWORD_ELSE(447...451)("else"),
+         ElseNode(499...511)(
+           KEYWORD_ELSE(499...503)("else"),
            nil,
-           KEYWORD_ENSURE(453...459)("ensure")
+           KEYWORD_ENSURE(505...511)("ensure")
          ),
-         EnsureNode(453...464)(
-           KEYWORD_ENSURE(453...459)("ensure"),
+         EnsureNode(505...516)(
+           KEYWORD_ENSURE(505...511)("ensure"),
            nil,
-           KEYWORD_END(461...464)("end")
+           KEYWORD_END(513...516)("end")
          ),
-         KEYWORD_END(461...464)("end")
+         KEYWORD_END(513...516)("end")
        ),
-       ScopeNode(432...435)([]),
-       (432...435),
+       ScopeNode(484...487)([]),
+       (484...487),
        nil,
        nil,
        nil,
        nil,
-       (461...464)
+       (513...516)
      ),
-     DefNode(466...478)(
-       IDENTIFIER(470...471)("a"),
+     DefNode(518...530)(
+       IDENTIFIER(522...523)("a"),
        nil,
-       ParametersNode(472...474)(
+       ParametersNode(524...526)(
          [],
          [],
-         RestParameterNode(472...474)(
-           STAR(472...473)("*"),
-           IDENTIFIER(473...474)("b")
+         [],
+         RestParameterNode(524...526)(
+           STAR(524...525)("*"),
+           IDENTIFIER(525...526)("b")
          ),
          [],
          nil,
          nil
        ),
        nil,
-       ScopeNode(466...469)([IDENTIFIER(473...474)("b")]),
-       (466...469),
+       ScopeNode(518...521)([IDENTIFIER(525...526)("b")]),
+       (518...521),
        nil,
        nil,
        nil,
        nil,
-       (475...478)
+       (527...530)
      ),
-     DefNode(480...492)(
-       IDENTIFIER(484...485)("a"),
+     DefNode(532...544)(
+       IDENTIFIER(536...537)("a"),
        nil,
-       ParametersNode(486...487)(
+       ParametersNode(538...539)(
          [],
          [],
-         RestParameterNode(486...487)(USTAR(486...487)("*"), nil),
+         [],
+         RestParameterNode(538...539)(USTAR(538...539)("*"), nil),
          [],
          nil,
          nil
        ),
        nil,
-       ScopeNode(480...483)([USTAR(486...487)("*")]),
-       (480...483),
+       ScopeNode(532...535)([USTAR(538...539)("*")]),
+       (532...535),
        nil,
-       (485...486),
-       (487...488),
+       (537...538),
+       (539...540),
        nil,
-       (489...492)
+       (541...544)
      ),
-     DefNode(494...509)(
-       IDENTIFIER(498...499)("a"),
+     DefNode(546...561)(
+       IDENTIFIER(550...551)("a"),
        nil,
        nil,
-       StatementsNode(500...505)(
-         [LocalVariableWriteNode(500...505)(
-            (500...501),
-            IntegerNode(504...505)(),
-            (502...503),
+       StatementsNode(552...557)(
+         [LocalVariableWriteNode(552...557)(
+            (552...553),
+            IntegerNode(556...557)(),
+            (554...555),
             0
           )]
        ),
-       ScopeNode(494...497)([IDENTIFIER(500...501)("b")]),
-       (494...497),
+       ScopeNode(546...549)([IDENTIFIER(552...553)("b")]),
+       (546...549),
        nil,
        nil,
        nil,
        nil,
-       (506...509)
+       (558...561)
      ),
-     DefNode(511...525)(
-       IDENTIFIER(520...521)("a"),
-       SelfNode(515...519)(),
+     DefNode(563...577)(
+       IDENTIFIER(572...573)("a"),
+       SelfNode(567...571)(),
        nil,
        nil,
-       ScopeNode(511...514)([]),
-       (511...514),
-       (519...520),
+       ScopeNode(563...566)([]),
+       (563...566),
+       (571...572),
        nil,
        nil,
        nil,
-       (522...525)
+       (574...577)
      ),
-     DefNode(527...541)(
-       IDENTIFIER(536...537)("a"),
-       TrueNode(531...535)(),
+     DefNode(579...593)(
+       IDENTIFIER(588...589)("a"),
+       TrueNode(583...587)(),
        nil,
        nil,
-       ScopeNode(527...530)([]),
-       (527...530),
-       (535...536),
+       ScopeNode(579...582)([]),
+       (579...582),
+       (587...588),
        nil,
        nil,
        nil,
-       (538...541)
+       (590...593)
      ),
-     DefNode(543...552)(
-       IDENTIFIER(547...548)("a"),
+     DefNode(595...604)(
+       IDENTIFIER(599...600)("a"),
        nil,
        nil,
        nil,
-       ScopeNode(543...546)([]),
-       (543...546),
+       ScopeNode(595...598)([]),
+       (595...598),
        nil,
        nil,
        nil,
        nil,
-       (549...552)
+       (601...604)
      ),
-     DefNode(554...588)(
-       IDENTIFIER(558...560)("hi"),
+     DefNode(606...640)(
+       IDENTIFIER(610...612)("hi"),
        nil,
        nil,
-       StatementsNode(561...584)(
-         [IfNode(561...579)(
-            KEYWORD_IF_MODIFIER(572...574)("if"),
-            TrueNode(575...579)(),
-            StatementsNode(561...571)(
-              [ReturnNode(561...571)(
-                 KEYWORD_RETURN(561...567)("return"),
-                 ArgumentsNode(568...571)(
-                   [SymbolNode(568...571)(
-                      SYMBOL_BEGIN(568...569)(":"),
-                      IDENTIFIER(569...571)("hi"),
+       StatementsNode(613...636)(
+         [IfNode(613...631)(
+            KEYWORD_IF_MODIFIER(624...626)("if"),
+            TrueNode(627...631)(),
+            StatementsNode(613...623)(
+              [ReturnNode(613...623)(
+                 KEYWORD_RETURN(613...619)("return"),
+                 ArgumentsNode(620...623)(
+                   [SymbolNode(620...623)(
+                      SYMBOL_BEGIN(620...621)(":"),
+                      IDENTIFIER(621...623)("hi"),
                       nil,
                       "hi"
                     )]
@@ -678,429 +734,436 @@ ProgramNode(0...943)(
             nil,
             nil
           ),
-          SymbolNode(580...584)(
-            SYMBOL_BEGIN(580...581)(":"),
-            IDENTIFIER(581...584)("bye"),
+          SymbolNode(632...636)(
+            SYMBOL_BEGIN(632...633)(":"),
+            IDENTIFIER(633...636)("bye"),
             nil,
             "bye"
           )]
        ),
-       ScopeNode(554...557)([]),
-       (554...557),
+       ScopeNode(606...609)([]),
+       (606...609),
        nil,
        nil,
        nil,
        nil,
-       (585...588)
+       (637...640)
      ),
-     DefNode(590...601)(
-       IDENTIFIER(594...597)("foo"),
+     DefNode(642...653)(
+       IDENTIFIER(646...649)("foo"),
        nil,
        nil,
-       StatementsNode(600...601)([IntegerNode(600...601)()]),
-       ScopeNode(590...593)([]),
-       (590...593),
+       StatementsNode(652...653)([IntegerNode(652...653)()]),
+       ScopeNode(642...645)([]),
+       (642...645),
        nil,
        nil,
        nil,
-       (598...599),
+       (650...651),
        nil
      ),
-     DefNode(602...613)(
-       IDENTIFIER(606...609)("bar"),
+     DefNode(654...665)(
+       IDENTIFIER(658...661)("bar"),
        nil,
        nil,
-       StatementsNode(612...613)([IntegerNode(612...613)()]),
-       ScopeNode(602...605)([]),
-       (602...605),
+       StatementsNode(664...665)([IntegerNode(664...665)()]),
+       ScopeNode(654...657)([]),
+       (654...657),
        nil,
        nil,
        nil,
-       (610...611),
+       (662...663),
        nil
      ),
-     DefNode(615...633)(
-       IDENTIFIER(619...622)("foo"),
+     DefNode(667...685)(
+       IDENTIFIER(671...674)("foo"),
        nil,
-       ParametersNode(623...626)(
-         [RequiredParameterNode(623...626)()],
+       ParametersNode(675...678)(
+         [RequiredParameterNode(675...678)()],
+         [],
          [],
          nil,
          [],
          nil,
          nil
        ),
-       StatementsNode(630...633)([IntegerNode(630...633)()]),
-       ScopeNode(615...618)([IDENTIFIER(623...626)("bar")]),
-       (615...618),
+       StatementsNode(682...685)([IntegerNode(682...685)()]),
+       ScopeNode(667...670)([IDENTIFIER(675...678)("bar")]),
+       (667...670),
        nil,
-       (622...623),
-       (626...627),
-       (628...629),
-       nil
-     ),
-     DefNode(635...648)(
-       IDENTIFIER(639...642)("foo"),
-       nil,
-       nil,
-       StatementsNode(645...648)([IntegerNode(645...648)()]),
-       ScopeNode(635...638)([]),
-       (635...638),
-       nil,
-       nil,
-       nil,
-       (643...644),
-       nil
-     ),
-     DefNode(650...669)(
-       IDENTIFIER(654...655)("a"),
-       nil,
-       ParametersNode(656...657)(
-         [],
-         [],
-         RestParameterNode(656...657)(USTAR(656...657)("*"), nil),
-         [],
-         nil,
-         nil
-       ),
-       StatementsNode(660...664)(
-         [CallNode(660...664)(
-            nil,
-            nil,
-            IDENTIFIER(660...661)("b"),
-            PARENTHESIS_LEFT(661...662)("("),
-            ArgumentsNode(662...663)(
-              [SplatNode(662...663)(USTAR(662...663)("*"), nil)]
-            ),
-            PARENTHESIS_RIGHT(663...664)(")"),
-            nil,
-            "b"
-          )]
-       ),
-       ScopeNode(650...653)([USTAR(656...657)("*")]),
-       (650...653),
-       nil,
-       (655...656),
-       (657...658),
-       nil,
-       (666...669)
-     ),
-     DefNode(671...694)(
-       IDENTIFIER(675...676)("a"),
-       nil,
-       ParametersNode(677...680)(
-         [],
-         [],
-         nil,
-         [],
-         ForwardingParameterNode(677...680)(),
-         nil
-       ),
-       StatementsNode(683...689)(
-         [CallNode(683...689)(
-            nil,
-            nil,
-            IDENTIFIER(683...684)("b"),
-            PARENTHESIS_LEFT(684...685)("("),
-            ArgumentsNode(685...688)([ForwardingArgumentsNode(685...688)()]),
-            PARENTHESIS_RIGHT(688...689)(")"),
-            nil,
-            "b"
-          )]
-       ),
-       ScopeNode(671...674)([UDOT_DOT_DOT(677...680)("...")]),
-       (671...674),
-       nil,
-       (676...677),
+       (674...675),
+       (678...679),
        (680...681),
-       nil,
-       (691...694)
+       nil
      ),
-     DefNode(696...725)(
-       IDENTIFIER(700...701)("a"),
+     DefNode(687...700)(
+       IDENTIFIER(691...694)("foo"),
        nil,
-       ParametersNode(702...705)(
+       nil,
+       StatementsNode(697...700)([IntegerNode(697...700)()]),
+       ScopeNode(687...690)([]),
+       (687...690),
+       nil,
+       nil,
+       nil,
+       (695...696),
+       nil
+     ),
+     DefNode(702...721)(
+       IDENTIFIER(706...707)("a"),
+       nil,
+       ParametersNode(708...709)(
          [],
+         [],
+         [],
+         RestParameterNode(708...709)(USTAR(708...709)("*"), nil),
          [],
          nil,
-         [],
-         ForwardingParameterNode(702...705)(),
          nil
        ),
-       StatementsNode(708...720)(
-         [CallNode(708...720)(
+       StatementsNode(712...716)(
+         [CallNode(712...716)(
             nil,
             nil,
-            IDENTIFIER(708...709)("b"),
-            PARENTHESIS_LEFT(709...710)("("),
-            ArgumentsNode(710...719)(
-              [IntegerNode(710...711)(),
-               IntegerNode(713...714)(),
-               ForwardingArgumentsNode(716...719)()]
+            IDENTIFIER(712...713)("b"),
+            PARENTHESIS_LEFT(713...714)("("),
+            ArgumentsNode(714...715)(
+              [SplatNode(714...715)(USTAR(714...715)("*"), nil)]
             ),
-            PARENTHESIS_RIGHT(719...720)(")"),
+            PARENTHESIS_RIGHT(715...716)(")"),
             nil,
             "b"
           )]
        ),
-       ScopeNode(696...699)([UDOT_DOT_DOT(702...705)("...")]),
-       (696...699),
+       ScopeNode(702...705)([USTAR(708...709)("*")]),
+       (702...705),
        nil,
-       (701...702),
-       (705...706),
+       (707...708),
+       (709...710),
        nil,
-       (722...725)
+       (718...721)
      ),
-     DefNode(727...744)(
-       IDENTIFIER(739...740)("a"),
-       ParenthesesNode(731...738)(
-         LocalVariableWriteNode(732...737)(
-           (732...733),
-           CallNode(736...737)(
-             nil,
-             nil,
-             IDENTIFIER(736...737)("b"),
-             nil,
-             nil,
-             nil,
-             nil,
-             "b"
-           ),
-           (734...735),
-           0
-         ),
-         (731...732),
-         (737...738)
-       ),
+     DefNode(723...746)(
+       IDENTIFIER(727...728)("a"),
        nil,
-       nil,
-       ScopeNode(727...730)([]),
-       (727...730),
-       (738...739),
-       nil,
-       nil,
-       nil,
-       (741...744)
-     ),
-     DefNode(746...758)(
-       IDENTIFIER(750...751)("a"),
-       nil,
-       ParametersNode(752...754)(
+       ParametersNode(729...732)(
+         [],
          [],
          [],
          nil,
          [],
-         nil,
-         BlockParameterNode(752...754)(IDENTIFIER(753...754)("b"), (752...753))
-       ),
-       nil,
-       ScopeNode(746...749)([IDENTIFIER(753...754)("b")]),
-       (746...749),
-       nil,
-       nil,
-       nil,
-       nil,
-       (755...758)
-     ),
-     DefNode(760...772)(
-       IDENTIFIER(764...765)("a"),
-       nil,
-       ParametersNode(766...767)(
-         [],
-         [],
-         nil,
-         [],
-         nil,
-         BlockParameterNode(766...767)(nil, (766...767))
-       ),
-       nil,
-       ScopeNode(760...763)([AMPERSAND(766...767)("&")]),
-       (760...763),
-       nil,
-       (765...766),
-       (767...768),
-       nil,
-       (769...772)
-     ),
-     DefNode(774...789)(
-       IDENTIFIER(784...785)("a"),
-       ClassVariableReadNode(778...783)(),
-       nil,
-       nil,
-       ScopeNode(774...777)([]),
-       (774...777),
-       (783...784),
-       nil,
-       nil,
-       nil,
-       (786...789)
-     ),
-     DefNode(791...808)(
-       CONSTANT(803...804)("C"),
-       ParenthesesNode(795...802)(
-         LocalVariableWriteNode(796...801)(
-           (796...797),
-           CallNode(800...801)(
-             nil,
-             nil,
-             IDENTIFIER(800...801)("b"),
-             nil,
-             nil,
-             nil,
-             nil,
-             "b"
-           ),
-           (798...799),
-           0
-         ),
-         (795...796),
-         (801...802)
-       ),
-       nil,
-       nil,
-       ScopeNode(791...794)([]),
-       (791...794),
-       (802...803),
-       nil,
-       nil,
-       nil,
-       (805...808)
-     ),
-     DefNode(810...838)(
-       CONSTANT(819...833)("Array_function"),
-       SelfNode(814...818)(),
-       nil,
-       nil,
-       ScopeNode(810...813)([]),
-       (810...813),
-       (818...819),
-       nil,
-       nil,
-       nil,
-       (835...838)
-     ),
-     ConstantPathWriteNode(840...849)(
-       ConstantReadNode(840...845)(),
-       EQUAL(846...847)("="),
-       IntegerNode(848...849)()
-     ),
-     DefNode(851...866)(
-       IDENTIFIER(861...862)("a"),
-       ConstantReadNode(855...860)(),
-       nil,
-       nil,
-       ScopeNode(851...854)([]),
-       (851...854),
-       (860...861),
-       nil,
-       nil,
-       nil,
-       (863...866)
-     ),
-     DefNode(868...899)(
-       IDENTIFIER(872...873)("a"),
-       nil,
-       ParametersNode(874...877)(
-         [],
-         [],
-         nil,
-         [],
-         ForwardingParameterNode(874...877)(),
+         ForwardingParameterNode(729...732)(),
          nil
        ),
-       StatementsNode(880...894)(
-         [InterpolatedStringNode(880...894)(
-            STRING_BEGIN(880...881)("\""),
-            [StringNode(881...884)(
+       StatementsNode(735...741)(
+         [CallNode(735...741)(
+            nil,
+            nil,
+            IDENTIFIER(735...736)("b"),
+            PARENTHESIS_LEFT(736...737)("("),
+            ArgumentsNode(737...740)([ForwardingArgumentsNode(737...740)()]),
+            PARENTHESIS_RIGHT(740...741)(")"),
+            nil,
+            "b"
+          )]
+       ),
+       ScopeNode(723...726)([UDOT_DOT_DOT(729...732)("...")]),
+       (723...726),
+       nil,
+       (728...729),
+       (732...733),
+       nil,
+       (743...746)
+     ),
+     DefNode(748...777)(
+       IDENTIFIER(752...753)("a"),
+       nil,
+       ParametersNode(754...757)(
+         [],
+         [],
+         [],
+         nil,
+         [],
+         ForwardingParameterNode(754...757)(),
+         nil
+       ),
+       StatementsNode(760...772)(
+         [CallNode(760...772)(
+            nil,
+            nil,
+            IDENTIFIER(760...761)("b"),
+            PARENTHESIS_LEFT(761...762)("("),
+            ArgumentsNode(762...771)(
+              [IntegerNode(762...763)(),
+               IntegerNode(765...766)(),
+               ForwardingArgumentsNode(768...771)()]
+            ),
+            PARENTHESIS_RIGHT(771...772)(")"),
+            nil,
+            "b"
+          )]
+       ),
+       ScopeNode(748...751)([UDOT_DOT_DOT(754...757)("...")]),
+       (748...751),
+       nil,
+       (753...754),
+       (757...758),
+       nil,
+       (774...777)
+     ),
+     DefNode(779...796)(
+       IDENTIFIER(791...792)("a"),
+       ParenthesesNode(783...790)(
+         LocalVariableWriteNode(784...789)(
+           (784...785),
+           CallNode(788...789)(
+             nil,
+             nil,
+             IDENTIFIER(788...789)("b"),
+             nil,
+             nil,
+             nil,
+             nil,
+             "b"
+           ),
+           (786...787),
+           0
+         ),
+         (783...784),
+         (789...790)
+       ),
+       nil,
+       nil,
+       ScopeNode(779...782)([]),
+       (779...782),
+       (790...791),
+       nil,
+       nil,
+       nil,
+       (793...796)
+     ),
+     DefNode(798...810)(
+       IDENTIFIER(802...803)("a"),
+       nil,
+       ParametersNode(804...806)(
+         [],
+         [],
+         [],
+         nil,
+         [],
+         nil,
+         BlockParameterNode(804...806)(IDENTIFIER(805...806)("b"), (804...805))
+       ),
+       nil,
+       ScopeNode(798...801)([IDENTIFIER(805...806)("b")]),
+       (798...801),
+       nil,
+       nil,
+       nil,
+       nil,
+       (807...810)
+     ),
+     DefNode(812...824)(
+       IDENTIFIER(816...817)("a"),
+       nil,
+       ParametersNode(818...819)(
+         [],
+         [],
+         [],
+         nil,
+         [],
+         nil,
+         BlockParameterNode(818...819)(nil, (818...819))
+       ),
+       nil,
+       ScopeNode(812...815)([AMPERSAND(818...819)("&")]),
+       (812...815),
+       nil,
+       (817...818),
+       (819...820),
+       nil,
+       (821...824)
+     ),
+     DefNode(826...841)(
+       IDENTIFIER(836...837)("a"),
+       ClassVariableReadNode(830...835)(),
+       nil,
+       nil,
+       ScopeNode(826...829)([]),
+       (826...829),
+       (835...836),
+       nil,
+       nil,
+       nil,
+       (838...841)
+     ),
+     DefNode(843...860)(
+       CONSTANT(855...856)("C"),
+       ParenthesesNode(847...854)(
+         LocalVariableWriteNode(848...853)(
+           (848...849),
+           CallNode(852...853)(
+             nil,
+             nil,
+             IDENTIFIER(852...853)("b"),
+             nil,
+             nil,
+             nil,
+             nil,
+             "b"
+           ),
+           (850...851),
+           0
+         ),
+         (847...848),
+         (853...854)
+       ),
+       nil,
+       nil,
+       ScopeNode(843...846)([]),
+       (843...846),
+       (854...855),
+       nil,
+       nil,
+       nil,
+       (857...860)
+     ),
+     DefNode(862...890)(
+       CONSTANT(871...885)("Array_function"),
+       SelfNode(866...870)(),
+       nil,
+       nil,
+       ScopeNode(862...865)([]),
+       (862...865),
+       (870...871),
+       nil,
+       nil,
+       nil,
+       (887...890)
+     ),
+     ConstantPathWriteNode(892...901)(
+       ConstantReadNode(892...897)(),
+       EQUAL(898...899)("="),
+       IntegerNode(900...901)()
+     ),
+     DefNode(903...918)(
+       IDENTIFIER(913...914)("a"),
+       ConstantReadNode(907...912)(),
+       nil,
+       nil,
+       ScopeNode(903...906)([]),
+       (903...906),
+       (912...913),
+       nil,
+       nil,
+       nil,
+       (915...918)
+     ),
+     DefNode(920...951)(
+       IDENTIFIER(924...925)("a"),
+       nil,
+       ParametersNode(926...929)(
+         [],
+         [],
+         [],
+         nil,
+         [],
+         ForwardingParameterNode(926...929)(),
+         nil
+       ),
+       StatementsNode(932...946)(
+         [InterpolatedStringNode(932...946)(
+            STRING_BEGIN(932...933)("\""),
+            [StringNode(933...936)(
                nil,
-               STRING_CONTENT(881...884)("foo"),
+               STRING_CONTENT(933...936)("foo"),
                nil,
                "foo"
              ),
-             StringInterpolatedNode(884...893)(
-               EMBEXPR_BEGIN(884...886)("\#{"),
-               StatementsNode(886...892)(
-                 [CallNode(886...892)(
+             StringInterpolatedNode(936...945)(
+               EMBEXPR_BEGIN(936...938)("\#{"),
+               StatementsNode(938...944)(
+                 [CallNode(938...944)(
                     nil,
                     nil,
-                    IDENTIFIER(886...887)("b"),
-                    PARENTHESIS_LEFT(887...888)("("),
-                    ArgumentsNode(888...891)(
-                      [ForwardingArgumentsNode(888...891)()]
+                    IDENTIFIER(938...939)("b"),
+                    PARENTHESIS_LEFT(939...940)("("),
+                    ArgumentsNode(940...943)(
+                      [ForwardingArgumentsNode(940...943)()]
                     ),
-                    PARENTHESIS_RIGHT(891...892)(")"),
+                    PARENTHESIS_RIGHT(943...944)(")"),
                     nil,
                     "b"
                   )]
                ),
-               EMBEXPR_END(892...893)("}")
+               EMBEXPR_END(944...945)("}")
              )],
-            STRING_END(893...894)("\"")
+            STRING_END(945...946)("\"")
           )]
        ),
-       ScopeNode(868...871)([UDOT_DOT_DOT(874...877)("...")]),
-       (868...871),
+       ScopeNode(920...923)([UDOT_DOT_DOT(926...929)("...")]),
+       (920...923),
        nil,
-       (873...874),
-       (877...878),
+       (925...926),
+       (929...930),
        nil,
-       (896...899)
+       (948...951)
      ),
-     DefNode(901...943)(
-       IDENTIFIER(905...908)("foo"),
+     DefNode(953...995)(
+       IDENTIFIER(957...960)("foo"),
        nil,
        nil,
-       StatementsNode(911...939)(
-         [CallNode(911...939)(
-            HashNode(911...912)(
-              BRACE_LEFT(911...912)("{"),
+       StatementsNode(963...991)(
+         [CallNode(963...991)(
+            HashNode(963...964)(
+              BRACE_LEFT(963...964)("{"),
               [],
-              BRACE_RIGHT(912...913)("}")
+              BRACE_RIGHT(964...965)("}")
             ),
-            DOT(913...914)("."),
-            IDENTIFIER(914...919)("merge"),
+            DOT(965...966)("."),
+            IDENTIFIER(966...971)("merge"),
             nil,
-            ArgumentsNode(920...939)(
-              [HashNode(920...939)(
+            ArgumentsNode(972...991)(
+              [HashNode(972...991)(
                  nil,
-                 [AssocSplatNode(920...925)(
-                    CallNode(922...925)(
+                 [AssocSplatNode(972...977)(
+                    CallNode(974...977)(
                       nil,
                       nil,
-                      IDENTIFIER(922...925)("bar"),
+                      IDENTIFIER(974...977)("bar"),
                       nil,
                       nil,
                       nil,
                       nil,
                       "bar"
                     ),
-                    (920...922)
+                    (972...974)
                   ),
-                  AssocSplatNode(927...932)(
-                    CallNode(929...932)(
+                  AssocSplatNode(979...984)(
+                    CallNode(981...984)(
                       nil,
                       nil,
-                      IDENTIFIER(929...932)("baz"),
+                      IDENTIFIER(981...984)("baz"),
                       nil,
                       nil,
                       nil,
                       nil,
                       "baz"
                     ),
-                    (927...929)
+                    (979...981)
                   ),
-                  AssocSplatNode(934...939)(
-                    CallNode(936...939)(
+                  AssocSplatNode(986...991)(
+                    CallNode(988...991)(
                       nil,
                       nil,
-                      IDENTIFIER(936...939)("qux"),
+                      IDENTIFIER(988...991)("qux"),
                       nil,
                       nil,
                       nil,
                       nil,
                       "qux"
                     ),
-                    (934...936)
+                    (986...988)
                   )],
                  nil
                )]
@@ -1110,13 +1173,13 @@ ProgramNode(0...943)(
             "merge"
           )]
        ),
-       ScopeNode(901...904)([]),
-       (901...904),
+       ScopeNode(953...956)([]),
+       (953...956),
        nil,
        nil,
        nil,
        nil,
-       (940...943)
+       (992...995)
      )]
   )
 )

--- a/test/snapshots/non_alphanumeric_methods.rb
+++ b/test/snapshots/non_alphanumeric_methods.rb
@@ -117,6 +117,7 @@ ProgramNode(0...434)(
        ParametersNode(110...113)(
          [],
          [],
+         [],
          nil,
          [],
          KeywordRestParameterNode(110...113)(
@@ -152,6 +153,7 @@ ProgramNode(0...434)(
        nil,
        ParametersNode(138...139)(
          [RequiredParameterNode(138...139)()],
+         [],
          [],
          nil,
          [],

--- a/test/snapshots/procs.rb
+++ b/test/snapshots/procs.rb
@@ -1,3 +1,6 @@
+ProgramNode(0...262)(
+  ScopeNode(0...0)([]),
+  StatementsNode(0...262)(
     [LambdaNode(0...19)(
        ScopeNode(0...2)(
          [IDENTIFIER(4...5)("a"),
@@ -10,6 +13,7 @@
        BlockParametersNode(4...14)(
          ParametersNode(4...5)(
            [RequiredParameterNode(4...5)()],
+           [],
            [],
            nil,
            [],
@@ -128,6 +132,7 @@
               EQUAL(108...109)("="),
               IntegerNode(110...111)()
             )],
+           [],
            nil,
            [KeywordParameterNode(113...115)(LABEL(113...115)("c:"), nil),
             KeywordParameterNode(117...119)(LABEL(117...119)("d:"), nil)],
@@ -162,6 +167,7 @@
               EQUAL(140...141)("="),
               IntegerNode(142...143)()
             )],
+           [],
            RestParameterNode(145...147)(
              USTAR(145...146)("*"),
              IDENTIFIER(146...147)("c")
@@ -202,6 +208,7 @@
               EQUAL(182...183)("="),
               IntegerNode(184...185)()
             )],
+           [],
            RestParameterNode(187...189)(
              USTAR(187...188)("*"),
              IDENTIFIER(188...189)("c")
@@ -230,6 +237,7 @@
          ParametersNode(224...225)(
            [RequiredParameterNode(224...225)()],
            [],
+           [],
            nil,
            [],
            nil,
@@ -246,6 +254,7 @@
             BlockParametersNode(232...233)(
               ParametersNode(232...233)(
                 [RequiredParameterNode(232...233)()],
+                [],
                 [],
                 nil,
                 [],
@@ -272,22 +281,23 @@
           )]
        )
      ),
-     LambdaNode(247...0)(
-       Scope(247...249)(
+     LambdaNode(247...262)(
+       ScopeNode(247...249)(
          [IDENTIFIER(252...253)("a"),
           IDENTIFIER(255...256)("b"),
           IDENTIFIER(260...261)("c")]
        ),
        MINUS_GREATER(247...249)("->"),
        PARENTHESIS_LEFT(250...251)("("),
-       BlockParametersNode(252...261)(
-         ParametersNode(252...261)(
-           [RequiredDestructuredParameterNode(252...257)(
-              [RequiredParameterNode(252...253)(IDENTIFIER(252...253)("a")),
-               RequiredParameterNode(255...256)(IDENTIFIER(255...256)("b"))],
+       BlockParametersNode(251...261)(
+         ParametersNode(251...261)(
+           [RequiredDestructuredParameterNode(251...257)(
+              [RequiredParameterNode(252...253)(),
+               RequiredParameterNode(255...256)()],
               PARENTHESIS_LEFT(251...252)("("),
               PARENTHESIS_RIGHT(256...257)(")")
             )],
+           [],
            [],
            RestParameterNode(259...261)(
              USTAR(259...260)("*"),
@@ -300,7 +310,7 @@
          []
        ),
        PARENTHESIS_RIGHT(261...262)(")"),
-       StatementsNode(0...0)([])
+       nil
      )]
   )
 )

--- a/test/snapshots/rescue.rb
+++ b/test/snapshots/rescue.rb
@@ -137,6 +137,7 @@ ProgramNode(0...212)(
            ParametersNode(165...166)(
              [RequiredParameterNode(165...166)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/args_kw_block.rb
+++ b/test/snapshots/seattlerb/args_kw_block.rb
@@ -7,6 +7,7 @@ ProgramNode(0...20)(
        ParametersNode(6...14)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(6...10)(
             LABEL(6...8)("a:"),

--- a/test/snapshots/seattlerb/block_arg__bare.rb
+++ b/test/snapshots/seattlerb/block_arg__bare.rb
@@ -7,6 +7,7 @@ ProgramNode(0...13)(
        ParametersNode(6...7)(
          [],
          [],
+         [],
          nil,
          [],
          nil,

--- a/test/snapshots/seattlerb/block_arg_kwsplat.rb
+++ b/test/snapshots/seattlerb/block_arg_kwsplat.rb
@@ -14,6 +14,7 @@ ProgramNode(0...11)(
            ParametersNode(5...8)(
              [],
              [],
+             [],
              nil,
              [],
              KeywordRestParameterNode(5...8)(

--- a/test/snapshots/seattlerb/block_arg_opt_arg_block.rb
+++ b/test/snapshots/seattlerb/block_arg_opt_arg_block.rb
@@ -17,13 +17,13 @@ ProgramNode(0...21)(
          ),
          BlockParametersNode(5...18)(
            ParametersNode(5...18)(
-             [RequiredParameterNode(5...6)(),
-              RequiredParameterNode(13...14)()],
+             [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...11)(
                 IDENTIFIER(8...9)("c"),
                 EQUAL(9...10)("="),
                 IntegerNode(10...11)()
               )],
+             [RequiredParameterNode(13...14)()],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_arg_opt_splat.rb
+++ b/test/snapshots/seattlerb/block_arg_opt_splat.rb
@@ -22,6 +22,7 @@ ProgramNode(0...20)(
                 EQUAL(10...11)("="),
                 IntegerNode(12...13)()
               )],
+             [],
              RestParameterNode(15...17)(
                USTAR(15...16)("*"),
                IDENTIFIER(16...17)("d")

--- a/test/snapshots/seattlerb/block_arg_opt_splat_arg_block_omfg.rb
+++ b/test/snapshots/seattlerb/block_arg_opt_splat_arg_block_omfg.rb
@@ -18,13 +18,13 @@ ProgramNode(0...25)(
          ),
          BlockParametersNode(5...22)(
            ParametersNode(5...22)(
-             [RequiredParameterNode(5...6)(),
-              RequiredParameterNode(17...18)()],
+             [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...11)(
                 IDENTIFIER(8...9)("c"),
                 EQUAL(9...10)("="),
                 IntegerNode(10...11)()
               )],
+             [RequiredParameterNode(17...18)()],
              RestParameterNode(13...15)(
                USTAR(13...14)("*"),
                IDENTIFIER(14...15)("d")

--- a/test/snapshots/seattlerb/block_arg_optional.rb
+++ b/test/snapshots/seattlerb/block_arg_optional.rb
@@ -18,6 +18,7 @@ ProgramNode(0...13)(
                 EQUAL(7...8)("="),
                 IntegerNode(9...10)()
               )],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_arg_scope.rb
+++ b/test/snapshots/seattlerb/block_arg_scope.rb
@@ -14,6 +14,7 @@ ProgramNode(0...12)(
            ParametersNode(5...6)(
              [RequiredParameterNode(5...6)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_arg_scope2.rb
+++ b/test/snapshots/seattlerb/block_arg_scope2.rb
@@ -18,6 +18,7 @@ ProgramNode(0...14)(
            ParametersNode(4...5)(
              [RequiredParameterNode(4...5)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_arg_splat_arg.rb
+++ b/test/snapshots/seattlerb/block_arg_splat_arg.rb
@@ -16,9 +16,9 @@ ProgramNode(0...16)(
          ),
          BlockParametersNode(5...13)(
            ParametersNode(5...13)(
-             [RequiredParameterNode(5...6)(),
-              RequiredParameterNode(12...13)()],
+             [RequiredParameterNode(5...6)()],
              [],
+             [RequiredParameterNode(12...13)()],
              RestParameterNode(8...10)(
                USTAR(8...9)("*"),
                IDENTIFIER(9...10)("c")

--- a/test/snapshots/seattlerb/block_args_kwargs.rb
+++ b/test/snapshots/seattlerb/block_args_kwargs.rb
@@ -14,6 +14,7 @@ ProgramNode(0...23)(
            ParametersNode(5...13)(
              [],
              [],
+             [],
              nil,
              [],
              KeywordRestParameterNode(5...13)(

--- a/test/snapshots/seattlerb/block_args_no_kwargs.rb
+++ b/test/snapshots/seattlerb/block_args_no_kwargs.rb
@@ -14,6 +14,7 @@ ProgramNode(0...13)(
            ParametersNode(5...10)(
              [],
              [],
+             [],
              nil,
              [],
              NoKeywordsParameterNode(5...10)((5...7), (7...10)),

--- a/test/snapshots/seattlerb/block_args_opt1.rb
+++ b/test/snapshots/seattlerb/block_args_opt1.rb
@@ -18,6 +18,7 @@ ProgramNode(0...24)(
                 EQUAL(10...11)("="),
                 IntegerNode(12...14)()
               )],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_args_opt2.rb
+++ b/test/snapshots/seattlerb/block_args_opt2.rb
@@ -23,6 +23,7 @@ ProgramNode(0...18)(
                 EQUAL(12...13)("="),
                 IntegerNode(13...14)()
               )],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_args_opt2_2.rb
+++ b/test/snapshots/seattlerb/block_args_opt2_2.rb
@@ -27,6 +27,7 @@ ProgramNode(0...35)(
                 EQUAL(18...19)("="),
                 IntegerNode(20...22)()
               )],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_args_opt3.rb
+++ b/test/snapshots/seattlerb/block_args_opt3.rb
@@ -28,6 +28,7 @@ ProgramNode(0...42)(
                 EQUAL(18...19)("="),
                 IntegerNode(20...22)()
               )],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_break.rb
+++ b/test/snapshots/seattlerb/block_break.rb
@@ -27,6 +27,7 @@ ProgramNode(0...26)(
                 ParametersNode(18...21)(
                   [RequiredParameterNode(18...21)()],
                   [],
+                  [],
                   nil,
                   [],
                   nil,

--- a/test/snapshots/seattlerb/block_call_defn_call_block_call.rb
+++ b/test/snapshots/seattlerb/block_call_defn_call_block_call.rb
@@ -13,6 +13,7 @@ ProgramNode(0...30)(
             ParametersNode(8...9)(
               [RequiredParameterNode(8...9)()],
               [],
+              [],
               nil,
               [],
               nil,

--- a/test/snapshots/seattlerb/block_call_dot_op2_brace_block.rb
+++ b/test/snapshots/seattlerb/block_call_dot_op2_brace_block.rb
@@ -60,6 +60,7 @@ ProgramNode(0...31)(
            ParametersNode(23...24)(
              [RequiredParameterNode(23...24)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_call_dot_op2_cmd_args_do_block.rb
+++ b/test/snapshots/seattlerb/block_call_dot_op2_cmd_args_do_block.rb
@@ -71,6 +71,7 @@ ProgramNode(0...33)(
            ParametersNode(25...26)(
              [RequiredParameterNode(25...26)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_decomp_anon_splat_arg.rb
+++ b/test/snapshots/seattlerb/block_decomp_anon_splat_arg.rb
@@ -19,6 +19,7 @@ ProgramNode(0...14)(
                 PARENTHESIS_RIGHT(10...11)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_decomp_arg_splat.rb
+++ b/test/snapshots/seattlerb/block_decomp_arg_splat.rb
@@ -19,6 +19,7 @@ ProgramNode(0...14)(
                 PARENTHESIS_RIGHT(10...11)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_decomp_arg_splat_arg.rb
+++ b/test/snapshots/seattlerb/block_decomp_arg_splat_arg.rb
@@ -27,6 +27,7 @@ ProgramNode(0...18)(
                 PARENTHESIS_RIGHT(14...15)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_decomp_splat.rb
+++ b/test/snapshots/seattlerb/block_decomp_splat.rb
@@ -21,6 +21,7 @@ ProgramNode(0...12)(
                 PARENTHESIS_RIGHT(8...9)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_kw.rb
+++ b/test/snapshots/seattlerb/block_kw.rb
@@ -14,6 +14,7 @@ ProgramNode(0...15)(
            ParametersNode(8...12)(
              [],
              [],
+             [],
              nil,
              [KeywordParameterNode(8...12)(
                 LABEL(8...10)("k:"),

--- a/test/snapshots/seattlerb/block_kw__required.rb
+++ b/test/snapshots/seattlerb/block_kw__required.rb
@@ -14,6 +14,7 @@ ProgramNode(0...16)(
            ParametersNode(9...11)(
              [],
              [],
+             [],
              nil,
              [KeywordParameterNode(9...11)(LABEL(9...11)("k:"), nil)],
              nil,

--- a/test/snapshots/seattlerb/block_kwarg_lvar.rb
+++ b/test/snapshots/seattlerb/block_kwarg_lvar.rb
@@ -14,6 +14,7 @@ ProgramNode(0...20)(
            ParametersNode(6...14)(
              [],
              [],
+             [],
              nil,
              [KeywordParameterNode(6...14)(
                 LABEL(6...9)("kw:"),

--- a/test/snapshots/seattlerb/block_kwarg_lvar_multiple.rb
+++ b/test/snapshots/seattlerb/block_kwarg_lvar_multiple.rb
@@ -14,6 +14,7 @@ ProgramNode(0...33)(
            ParametersNode(6...26)(
              [],
              [],
+             [],
              nil,
              [KeywordParameterNode(6...14)(
                 LABEL(6...9)("kw:"),

--- a/test/snapshots/seattlerb/block_next.rb
+++ b/test/snapshots/seattlerb/block_next.rb
@@ -27,6 +27,7 @@ ProgramNode(0...25)(
                 ParametersNode(17...20)(
                   [RequiredParameterNode(17...20)()],
                   [],
+                  [],
                   nil,
                   [],
                   nil,

--- a/test/snapshots/seattlerb/block_opt_arg.rb
+++ b/test/snapshots/seattlerb/block_opt_arg.rb
@@ -12,12 +12,13 @@ ProgramNode(0...14)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("b"), IDENTIFIER(10...11)("c")]),
          BlockParametersNode(5...11)(
            ParametersNode(5...11)(
-             [RequiredParameterNode(10...11)()],
+             [],
              [OptionalParameterNode(5...8)(
                 IDENTIFIER(5...6)("b"),
                 EQUAL(6...7)("="),
                 IntegerNode(7...8)()
               )],
+             [RequiredParameterNode(10...11)()],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_opt_splat.rb
+++ b/test/snapshots/seattlerb/block_opt_splat.rb
@@ -18,6 +18,7 @@ ProgramNode(0...17)(
                 EQUAL(7...8)("="),
                 IntegerNode(9...10)()
               )],
+             [],
              RestParameterNode(12...14)(
                USTAR(12...13)("*"),
                IDENTIFIER(13...14)("c")

--- a/test/snapshots/seattlerb/block_opt_splat_arg_block_omfg.rb
+++ b/test/snapshots/seattlerb/block_opt_splat_arg_block_omfg.rb
@@ -17,12 +17,13 @@ ProgramNode(0...22)(
          ),
          BlockParametersNode(5...19)(
            ParametersNode(5...19)(
-             [RequiredParameterNode(14...15)()],
+             [],
              [OptionalParameterNode(5...8)(
                 IDENTIFIER(5...6)("b"),
                 EQUAL(6...7)("="),
                 IntegerNode(7...8)()
               )],
+             [RequiredParameterNode(14...15)()],
              RestParameterNode(10...12)(
                USTAR(10...11)("*"),
                IDENTIFIER(11...12)("c")

--- a/test/snapshots/seattlerb/block_optarg.rb
+++ b/test/snapshots/seattlerb/block_optarg.rb
@@ -23,6 +23,7 @@ ProgramNode(0...14)(
                   "c"
                 )
               )],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_paren_splat.rb
+++ b/test/snapshots/seattlerb/block_paren_splat.rb
@@ -22,6 +22,7 @@ ProgramNode(0...15)(
                 PARENTHESIS_RIGHT(11...12)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_reg_optarg.rb
+++ b/test/snapshots/seattlerb/block_reg_optarg.rb
@@ -23,6 +23,7 @@ ProgramNode(0...17)(
                   "d"
                 )
               )],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/block_return.rb
+++ b/test/snapshots/seattlerb/block_return.rb
@@ -28,6 +28,7 @@ ProgramNode(0...27)(
                 ParametersNode(19...22)(
                   [RequiredParameterNode(19...22)()],
                   [],
+                  [],
                   nil,
                   [],
                   nil,

--- a/test/snapshots/seattlerb/block_splat_reg.rb
+++ b/test/snapshots/seattlerb/block_splat_reg.rb
@@ -12,8 +12,9 @@ ProgramNode(0...13)(
          ScopeNode(2...3)([IDENTIFIER(6...7)("b"), IDENTIFIER(9...10)("c")]),
          BlockParametersNode(5...10)(
            ParametersNode(5...10)(
-             [RequiredParameterNode(9...10)()],
              [],
+             [],
+             [RequiredParameterNode(9...10)()],
              RestParameterNode(5...7)(
                USTAR(5...6)("*"),
                IDENTIFIER(6...7)("b")

--- a/test/snapshots/seattlerb/bug236.rb
+++ b/test/snapshots/seattlerb/bug236.rb
@@ -14,6 +14,7 @@ ProgramNode(0...15)(
            ParametersNode(3...5)(
              [RequiredParameterNode(3...4)()],
              [],
+             [],
              RestParameterNode(4...5)(COMMA(4...5)(","), nil),
              [],
              nil,
@@ -39,6 +40,7 @@ ProgramNode(0...15)(
          BlockParametersNode(12...13)(
            ParametersNode(12...13)(
              [RequiredParameterNode(12...13)()],
+             [],
              [],
              nil,
              [],

--- a/test/snapshots/seattlerb/bug_args__19.rb
+++ b/test/snapshots/seattlerb/bug_args__19.rb
@@ -19,6 +19,7 @@ ProgramNode(0...16)(
                 PARENTHESIS_RIGHT(10...11)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/bug_args_masgn.rb
+++ b/test/snapshots/seattlerb/bug_args_masgn.rb
@@ -24,6 +24,7 @@ ProgramNode(0...17)(
               ),
               RequiredParameterNode(13...14)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/bug_args_masgn2.rb
+++ b/test/snapshots/seattlerb/bug_args_masgn2.rb
@@ -30,6 +30,7 @@ ProgramNode(0...22)(
               ),
               RequiredParameterNode(18...19)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/bug_args_masgn_outer_parens__19.rb
+++ b/test/snapshots/seattlerb/bug_args_masgn_outer_parens__19.rb
@@ -28,6 +28,7 @@ ProgramNode(0...19)(
                 PARENTHESIS_RIGHT(15...16)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/bug_masgn_right.rb
+++ b/test/snapshots/seattlerb/bug_masgn_right.rb
@@ -24,6 +24,7 @@ ProgramNode(0...17)(
                 PARENTHESIS_RIGHT(13...14)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/case_in.rb
+++ b/test/snapshots/seattlerb/case_in.rb
@@ -449,6 +449,7 @@ ProgramNode(0...747)(
                  ParametersNode(449...450)(
                    [RequiredParameterNode(449...450)()],
                    [],
+                   [],
                    nil,
                    [],
                    nil,

--- a/test/snapshots/seattlerb/defn_arg_asplat_arg.rb
+++ b/test/snapshots/seattlerb/defn_arg_asplat_arg.rb
@@ -5,8 +5,9 @@ ProgramNode(0...29)(
        IDENTIFIER(4...8)("call"),
        nil,
        ParametersNode(9...24)(
-         [RequiredParameterNode(9...15)(), RequiredParameterNode(20...24)()],
+         [RequiredParameterNode(9...15)()],
          [],
+         [RequiredParameterNode(20...24)()],
          RestParameterNode(17...18)(USTAR(17...18)("*"), nil),
          [],
          nil,

--- a/test/snapshots/seattlerb/defn_arg_forward_args.rb
+++ b/test/snapshots/seattlerb/defn_arg_forward_args.rb
@@ -7,6 +7,7 @@ ProgramNode(0...29)(
        ParametersNode(6...12)(
          [RequiredParameterNode(6...7)()],
          [],
+         [],
          nil,
          [],
          ForwardingParameterNode(9...12)(),

--- a/test/snapshots/seattlerb/defn_args_forward_args.rb
+++ b/test/snapshots/seattlerb/defn_args_forward_args.rb
@@ -9,6 +9,7 @@ ProgramNode(0...41)(
           RequiredParameterNode(9...10)(),
           RequiredParameterNode(12...13)()],
          [],
+         [],
          nil,
          [],
          ForwardingParameterNode(15...18)(),

--- a/test/snapshots/seattlerb/defn_forward_args.rb
+++ b/test/snapshots/seattlerb/defn_forward_args.rb
@@ -7,6 +7,7 @@ ProgramNode(0...23)(
        ParametersNode(6...9)(
          [],
          [],
+         [],
          nil,
          [],
          ForwardingParameterNode(6...9)(),

--- a/test/snapshots/seattlerb/defn_kwarg_env.rb
+++ b/test/snapshots/seattlerb/defn_kwarg_env.rb
@@ -7,6 +7,7 @@ ProgramNode(0...45)(
        ParametersNode(9...18)(
          [],
          [],
+         [],
          nil,
          [],
          KeywordRestParameterNode(9...18)(

--- a/test/snapshots/seattlerb/defn_kwarg_kwarg.rb
+++ b/test/snapshots/seattlerb/defn_kwarg_kwarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...24)(
        ParametersNode(6...19)(
          [RequiredParameterNode(6...7)()],
          [],
+         [],
          nil,
          [KeywordParameterNode(9...13)(
             LABEL(9...11)("b:"),

--- a/test/snapshots/seattlerb/defn_kwarg_kwsplat.rb
+++ b/test/snapshots/seattlerb/defn_kwarg_kwsplat.rb
@@ -7,6 +7,7 @@ ProgramNode(0...20)(
        ParametersNode(6...15)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(6...10)(
             LABEL(6...8)("b:"),

--- a/test/snapshots/seattlerb/defn_kwarg_kwsplat_anon.rb
+++ b/test/snapshots/seattlerb/defn_kwarg_kwsplat_anon.rb
@@ -7,6 +7,7 @@ ProgramNode(0...19)(
        ParametersNode(6...14)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(6...10)(
             LABEL(6...8)("b:"),

--- a/test/snapshots/seattlerb/defn_kwarg_lvar.rb
+++ b/test/snapshots/seattlerb/defn_kwarg_lvar.rb
@@ -7,6 +7,7 @@ ProgramNode(0...26)(
        ParametersNode(8...16)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(8...16)(
             LABEL(8...11)("kw:"),

--- a/test/snapshots/seattlerb/defn_kwarg_no_parens.rb
+++ b/test/snapshots/seattlerb/defn_kwarg_no_parens.rb
@@ -7,6 +7,7 @@ ProgramNode(0...14)(
        ParametersNode(6...10)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(6...10)(
             LABEL(6...8)("a:"),

--- a/test/snapshots/seattlerb/defn_kwarg_val.rb
+++ b/test/snapshots/seattlerb/defn_kwarg_val.rb
@@ -7,6 +7,7 @@ ProgramNode(0...17)(
        ParametersNode(6...12)(
          [RequiredParameterNode(6...7)()],
          [],
+         [],
          nil,
          [KeywordParameterNode(9...12)(
             LABEL(9...11)("b:"),

--- a/test/snapshots/seattlerb/defn_no_kwargs.rb
+++ b/test/snapshots/seattlerb/defn_no_kwargs.rb
@@ -7,6 +7,7 @@ ProgramNode(0...17)(
        ParametersNode(6...11)(
          [],
          [],
+         [],
          nil,
          [],
          NoKeywordsParameterNode(6...11)((6...8), (8...11)),

--- a/test/snapshots/seattlerb/defn_oneliner.rb
+++ b/test/snapshots/seattlerb/defn_oneliner.rb
@@ -7,6 +7,7 @@ ProgramNode(0...27)(
        ParametersNode(9...12)(
          [RequiredParameterNode(9...12)()],
          [],
+         [],
          nil,
          [],
          nil,

--- a/test/snapshots/seattlerb/defn_oneliner_eq2.rb
+++ b/test/snapshots/seattlerb/defn_oneliner_eq2.rb
@@ -14,6 +14,7 @@ ProgramNode(0...28)(
             ParametersNode(17...18)(
               [RequiredParameterNode(17...18)()],
               [],
+              [],
               nil,
               [],
               nil,

--- a/test/snapshots/seattlerb/defn_oneliner_rescue.rb
+++ b/test/snapshots/seattlerb/defn_oneliner_rescue.rb
@@ -7,6 +7,7 @@ ProgramNode(0...130)(
        ParametersNode(9...12)(
          [RequiredParameterNode(9...12)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -52,6 +53,7 @@ ProgramNode(0...130)(
        ParametersNode(56...59)(
          [RequiredParameterNode(56...59)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -86,6 +88,7 @@ ProgramNode(0...130)(
        nil,
        ParametersNode(101...104)(
          [RequiredParameterNode(101...104)()],
+         [],
          [],
          nil,
          [],

--- a/test/snapshots/seattlerb/defn_opt_last_arg.rb
+++ b/test/snapshots/seattlerb/defn_opt_last_arg.rb
@@ -11,6 +11,7 @@ ProgramNode(0...21)(
             EQUAL(10...11)("="),
             FalseNode(12...17)()
           )],
+         [],
          nil,
          [],
          nil,

--- a/test/snapshots/seattlerb/defn_opt_reg.rb
+++ b/test/snapshots/seattlerb/defn_opt_reg.rb
@@ -5,12 +5,13 @@ ProgramNode(0...19)(
        IDENTIFIER(4...5)("f"),
        nil,
        ParametersNode(6...14)(
-         [RequiredParameterNode(13...14)()],
+         [],
          [OptionalParameterNode(6...11)(
             IDENTIFIER(6...7)("a"),
             EQUAL(7...8)("="),
             NilNode(8...11)()
           )],
+         [RequiredParameterNode(13...14)()],
          nil,
          [],
          nil,

--- a/test/snapshots/seattlerb/defn_opt_splat_arg.rb
+++ b/test/snapshots/seattlerb/defn_opt_splat_arg.rb
@@ -5,12 +5,13 @@ ProgramNode(0...24)(
        IDENTIFIER(4...5)("f"),
        nil,
        ParametersNode(7...19)(
-         [RequiredParameterNode(18...19)()],
+         [],
          [OptionalParameterNode(7...12)(
             IDENTIFIER(7...8)("a"),
             EQUAL(9...10)("="),
             IntegerNode(11...12)()
           )],
+         [RequiredParameterNode(18...19)()],
          RestParameterNode(14...16)(
            USTAR(14...15)("*"),
            IDENTIFIER(15...16)("b")

--- a/test/snapshots/seattlerb/defn_powarg.rb
+++ b/test/snapshots/seattlerb/defn_powarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...17)(
        ParametersNode(6...12)(
          [],
          [],
+         [],
          nil,
          [],
          KeywordRestParameterNode(6...12)(

--- a/test/snapshots/seattlerb/defn_reg_opt_reg.rb
+++ b/test/snapshots/seattlerb/defn_reg_opt_reg.rb
@@ -5,7 +5,7 @@ ProgramNode(0...23)(
        IDENTIFIER(4...5)("f"),
        nil,
        ParametersNode(6...18)(
-         [RequiredParameterNode(6...7)(), RequiredParameterNode(17...18)()],
+         [RequiredParameterNode(6...7)()],
          [OptionalParameterNode(9...15)(
             IDENTIFIER(9...10)("b"),
             EQUAL(11...12)("="),
@@ -16,6 +16,7 @@ ProgramNode(0...23)(
               "c"
             )
           )],
+         [RequiredParameterNode(17...18)()],
          nil,
          [],
          nil,

--- a/test/snapshots/seattlerb/defn_splat_arg.rb
+++ b/test/snapshots/seattlerb/defn_splat_arg.rb
@@ -5,8 +5,9 @@ ProgramNode(0...15)(
        IDENTIFIER(4...5)("f"),
        nil,
        ParametersNode(6...10)(
-         [RequiredParameterNode(9...10)()],
          [],
+         [],
+         [RequiredParameterNode(9...10)()],
          RestParameterNode(6...7)(USTAR(6...7)("*"), nil),
          [],
          nil,

--- a/test/snapshots/seattlerb/defs_kwarg.rb
+++ b/test/snapshots/seattlerb/defs_kwarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...19)(
        ParametersNode(11...15)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(11...15)(
             LABEL(11...13)("b:"),

--- a/test/snapshots/seattlerb/defs_oneliner.rb
+++ b/test/snapshots/seattlerb/defs_oneliner.rb
@@ -7,6 +7,7 @@ ProgramNode(0...32)(
        ParametersNode(14...17)(
          [RequiredParameterNode(14...17)()],
          [],
+         [],
          nil,
          [],
          nil,

--- a/test/snapshots/seattlerb/defs_oneliner_eq2.rb
+++ b/test/snapshots/seattlerb/defs_oneliner_eq2.rb
@@ -14,6 +14,7 @@ ProgramNode(0...33)(
             ParametersNode(22...23)(
               [RequiredParameterNode(22...23)()],
               [],
+              [],
               nil,
               [],
               nil,

--- a/test/snapshots/seattlerb/defs_oneliner_rescue.rb
+++ b/test/snapshots/seattlerb/defs_oneliner_rescue.rb
@@ -7,6 +7,7 @@ ProgramNode(0...145)(
        ParametersNode(14...17)(
          [RequiredParameterNode(14...17)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -52,6 +53,7 @@ ProgramNode(0...145)(
        ParametersNode(66...69)(
          [RequiredParameterNode(66...69)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -86,6 +88,7 @@ ProgramNode(0...145)(
        SelfNode(106...110)(),
        ParametersNode(116...119)(
          [RequiredParameterNode(116...119)()],
+         [],
          [],
          nil,
          [],

--- a/test/snapshots/seattlerb/do_bug.rb
+++ b/test/snapshots/seattlerb/do_bug.rb
@@ -33,6 +33,7 @@ ProgramNode(0...33)(
            ParametersNode(12...13)(
              [RequiredParameterNode(12...13)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/f_kw.rb
+++ b/test/snapshots/seattlerb/f_kw.rb
@@ -7,6 +7,7 @@ ProgramNode(0...15)(
        ParametersNode(6...10)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(6...10)(
             LABEL(6...8)("k:"),

--- a/test/snapshots/seattlerb/f_kw__required.rb
+++ b/test/snapshots/seattlerb/f_kw__required.rb
@@ -7,6 +7,7 @@ ProgramNode(0...13)(
        ParametersNode(6...8)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(6...8)(LABEL(6...8)("k:"), nil)],
          nil,

--- a/test/snapshots/seattlerb/iter_args_1.rb
+++ b/test/snapshots/seattlerb/iter_args_1.rb
@@ -14,6 +14,7 @@ ProgramNode(0...11)(
            ParametersNode(5...8)(
              [RequiredParameterNode(5...6)(), RequiredParameterNode(7...8)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/iter_args_10_1.rb
+++ b/test/snapshots/seattlerb/iter_args_10_1.rb
@@ -22,6 +22,7 @@ ProgramNode(0...21)(
                 EQUAL(10...11)("="),
                 IntegerNode(12...14)()
               )],
+             [],
              RestParameterNode(16...18)(
                USTAR(16...17)("*"),
                IDENTIFIER(17...18)("c")

--- a/test/snapshots/seattlerb/iter_args_10_2.rb
+++ b/test/snapshots/seattlerb/iter_args_10_2.rb
@@ -23,6 +23,7 @@ ProgramNode(0...25)(
                 EQUAL(10...11)("="),
                 IntegerNode(12...14)()
               )],
+             [],
              RestParameterNode(16...18)(
                USTAR(16...17)("*"),
                IDENTIFIER(17...18)("c")

--- a/test/snapshots/seattlerb/iter_args_11_1.rb
+++ b/test/snapshots/seattlerb/iter_args_11_1.rb
@@ -17,13 +17,13 @@ ProgramNode(0...24)(
          ),
          BlockParametersNode(5...21)(
            ParametersNode(5...21)(
-             [RequiredParameterNode(5...6)(),
-              RequiredParameterNode(20...21)()],
+             [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...14)(
                 IDENTIFIER(8...9)("b"),
                 EQUAL(10...11)("="),
                 IntegerNode(12...14)()
               )],
+             [RequiredParameterNode(20...21)()],
              RestParameterNode(16...18)(
                USTAR(16...17)("*"),
                IDENTIFIER(17...18)("c")

--- a/test/snapshots/seattlerb/iter_args_11_2.rb
+++ b/test/snapshots/seattlerb/iter_args_11_2.rb
@@ -18,13 +18,13 @@ ProgramNode(0...28)(
          ),
          BlockParametersNode(5...25)(
            ParametersNode(5...25)(
-             [RequiredParameterNode(5...6)(),
-              RequiredParameterNode(20...21)()],
+             [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...14)(
                 IDENTIFIER(8...9)("b"),
                 EQUAL(10...11)("="),
                 IntegerNode(12...14)()
               )],
+             [RequiredParameterNode(20...21)()],
              RestParameterNode(16...18)(
                USTAR(16...17)("*"),
                IDENTIFIER(17...18)("c")

--- a/test/snapshots/seattlerb/iter_args_2__19.rb
+++ b/test/snapshots/seattlerb/iter_args_2__19.rb
@@ -19,6 +19,7 @@ ProgramNode(0...14)(
                 PARENTHESIS_RIGHT(10...11)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/iter_args_3.rb
+++ b/test/snapshots/seattlerb/iter_args_3.rb
@@ -26,6 +26,7 @@ ProgramNode(0...20)(
               ),
               RequiredParameterNode(16...17)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/iter_args_4.rb
+++ b/test/snapshots/seattlerb/iter_args_4.rb
@@ -16,9 +16,9 @@ ProgramNode(0...16)(
          ),
          BlockParametersNode(5...13)(
            ParametersNode(5...13)(
-             [RequiredParameterNode(5...6)(),
-              RequiredParameterNode(12...13)()],
+             [RequiredParameterNode(5...6)()],
              [],
+             [RequiredParameterNode(12...13)()],
              RestParameterNode(8...10)(
                USTAR(8...9)("*"),
                IDENTIFIER(9...10)("b")

--- a/test/snapshots/seattlerb/iter_args_5.rb
+++ b/test/snapshots/seattlerb/iter_args_5.rb
@@ -14,6 +14,7 @@ ProgramNode(0...13)(
            ParametersNode(5...10)(
              [RequiredParameterNode(5...6)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/iter_args_6.rb
+++ b/test/snapshots/seattlerb/iter_args_6.rb
@@ -16,13 +16,13 @@ ProgramNode(0...18)(
          ),
          BlockParametersNode(5...15)(
            ParametersNode(5...15)(
-             [RequiredParameterNode(5...6)(),
-              RequiredParameterNode(14...15)()],
+             [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...12)(
                 IDENTIFIER(8...9)("b"),
                 EQUAL(9...10)("="),
                 IntegerNode(10...12)()
               )],
+             [RequiredParameterNode(14...15)()],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/iter_args_7_1.rb
+++ b/test/snapshots/seattlerb/iter_args_7_1.rb
@@ -18,6 +18,7 @@ ProgramNode(0...18)(
                 EQUAL(7...8)("="),
                 IntegerNode(9...11)()
               )],
+             [],
              RestParameterNode(13...15)(
                USTAR(13...14)("*"),
                IDENTIFIER(14...15)("b")

--- a/test/snapshots/seattlerb/iter_args_7_2.rb
+++ b/test/snapshots/seattlerb/iter_args_7_2.rb
@@ -22,6 +22,7 @@ ProgramNode(0...22)(
                 EQUAL(7...8)("="),
                 IntegerNode(9...11)()
               )],
+             [],
              RestParameterNode(13...15)(
                USTAR(13...14)("*"),
                IDENTIFIER(14...15)("b")

--- a/test/snapshots/seattlerb/iter_args_8_1.rb
+++ b/test/snapshots/seattlerb/iter_args_8_1.rb
@@ -16,12 +16,13 @@ ProgramNode(0...21)(
          ),
          BlockParametersNode(5...18)(
            ParametersNode(5...18)(
-             [RequiredParameterNode(17...18)()],
+             [],
              [OptionalParameterNode(5...11)(
                 IDENTIFIER(5...6)("a"),
                 EQUAL(7...8)("="),
                 IntegerNode(9...11)()
               )],
+             [RequiredParameterNode(17...18)()],
              RestParameterNode(13...15)(
                USTAR(13...14)("*"),
                IDENTIFIER(14...15)("b")

--- a/test/snapshots/seattlerb/iter_args_8_2.rb
+++ b/test/snapshots/seattlerb/iter_args_8_2.rb
@@ -17,12 +17,13 @@ ProgramNode(0...25)(
          ),
          BlockParametersNode(5...22)(
            ParametersNode(5...22)(
-             [RequiredParameterNode(17...18)()],
+             [],
              [OptionalParameterNode(5...11)(
                 IDENTIFIER(5...6)("a"),
                 EQUAL(7...8)("="),
                 IntegerNode(9...11)()
               )],
+             [RequiredParameterNode(17...18)()],
              RestParameterNode(13...15)(
                USTAR(13...14)("*"),
                IDENTIFIER(14...15)("b")

--- a/test/snapshots/seattlerb/iter_args_9_1.rb
+++ b/test/snapshots/seattlerb/iter_args_9_1.rb
@@ -12,12 +12,13 @@ ProgramNode(0...17)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("a"), IDENTIFIER(13...14)("b")]),
          BlockParametersNode(5...14)(
            ParametersNode(5...14)(
-             [RequiredParameterNode(13...14)()],
+             [],
              [OptionalParameterNode(5...11)(
                 IDENTIFIER(5...6)("a"),
                 EQUAL(7...8)("="),
                 IntegerNode(9...11)()
               )],
+             [RequiredParameterNode(13...14)()],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/iter_args_9_2.rb
+++ b/test/snapshots/seattlerb/iter_args_9_2.rb
@@ -16,12 +16,13 @@ ProgramNode(0...21)(
          ),
          BlockParametersNode(5...18)(
            ParametersNode(5...18)(
-             [RequiredParameterNode(13...14)()],
+             [],
              [OptionalParameterNode(5...11)(
                 IDENTIFIER(5...6)("a"),
                 EQUAL(7...8)("="),
                 IntegerNode(9...11)()
               )],
+             [RequiredParameterNode(13...14)()],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/iter_kwarg.rb
+++ b/test/snapshots/seattlerb/iter_kwarg.rb
@@ -14,6 +14,7 @@ ProgramNode(0...12)(
            ParametersNode(5...9)(
              [],
              [],
+             [],
              nil,
              [KeywordParameterNode(5...9)(
                 LABEL(5...7)("b:"),

--- a/test/snapshots/seattlerb/iter_kwarg_kwsplat.rb
+++ b/test/snapshots/seattlerb/iter_kwarg_kwsplat.rb
@@ -14,6 +14,7 @@ ProgramNode(0...17)(
            ParametersNode(5...14)(
              [],
              [],
+             [],
              nil,
              [KeywordParameterNode(5...9)(
                 LABEL(5...7)("b:"),

--- a/test/snapshots/seattlerb/kill_me.rb
+++ b/test/snapshots/seattlerb/kill_me.rb
@@ -27,6 +27,7 @@ ProgramNode(0...18)(
                 PARENTHESIS_RIGHT(14...15)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/kill_me2.rb
+++ b/test/snapshots/seattlerb/kill_me2.rb
@@ -12,8 +12,9 @@ ProgramNode(0...13)(
          ScopeNode(2...3)([IDENTIFIER(6...7)("a"), IDENTIFIER(9...10)("b")]),
          BlockParametersNode(5...10)(
            ParametersNode(5...10)(
-             [RequiredParameterNode(9...10)()],
              [],
+             [],
+             [RequiredParameterNode(9...10)()],
              RestParameterNode(5...7)(
                USTAR(5...6)("*"),
                IDENTIFIER(6...7)("a")

--- a/test/snapshots/seattlerb/kill_me3.rb
+++ b/test/snapshots/seattlerb/kill_me3.rb
@@ -16,8 +16,9 @@ ProgramNode(0...17)(
          ),
          BlockParametersNode(5...14)(
            ParametersNode(5...14)(
-             [RequiredParameterNode(9...10)()],
              [],
+             [],
+             [RequiredParameterNode(9...10)()],
              RestParameterNode(5...7)(
                USTAR(5...6)("*"),
                IDENTIFIER(6...7)("a")

--- a/test/snapshots/seattlerb/kill_me_10.rb
+++ b/test/snapshots/seattlerb/kill_me_10.rb
@@ -27,6 +27,7 @@ ProgramNode(0...18)(
                 PARENTHESIS_RIGHT(14...15)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/kill_me_11.rb
+++ b/test/snapshots/seattlerb/kill_me_11.rb
@@ -19,6 +19,7 @@ ProgramNode(0...14)(
                 PARENTHESIS_RIGHT(10...11)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/kill_me_12.rb
+++ b/test/snapshots/seattlerb/kill_me_12.rb
@@ -20,6 +20,7 @@ ProgramNode(0...17)(
                 PARENTHESIS_RIGHT(13...14)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/kill_me_6.rb
+++ b/test/snapshots/seattlerb/kill_me_6.rb
@@ -29,6 +29,7 @@ ProgramNode(0...21)(
                 PARENTHESIS_RIGHT(17...18)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/kill_me_7.rb
+++ b/test/snapshots/seattlerb/kill_me_7.rb
@@ -20,6 +20,7 @@ ProgramNode(0...17)(
                 PARENTHESIS_RIGHT(13...14)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/kill_me_8.rb
+++ b/test/snapshots/seattlerb/kill_me_8.rb
@@ -25,6 +25,7 @@ ProgramNode(0...20)(
                 PARENTHESIS_RIGHT(16...17)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/kill_me_9.rb
+++ b/test/snapshots/seattlerb/kill_me_9.rb
@@ -22,6 +22,7 @@ ProgramNode(0...15)(
                 PARENTHESIS_RIGHT(11...12)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/parse_line_call_no_args.rb
+++ b/test/snapshots/seattlerb/parse_line_call_no_args.rb
@@ -14,6 +14,7 @@ ProgramNode(0...23)(
            ParametersNode(6...10)(
              [RequiredParameterNode(6...7)(), RequiredParameterNode(9...10)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/parse_line_defn_complex.rb
+++ b/test/snapshots/seattlerb/parse_line_defn_complex.rb
@@ -7,6 +7,7 @@ ProgramNode(0...40)(
        ParametersNode(6...7)(
          [RequiredParameterNode(6...7)()],
          [],
+         [],
          nil,
          [],
          nil,

--- a/test/snapshots/seattlerb/parse_line_defn_no_parens_args.rb
+++ b/test/snapshots/seattlerb/parse_line_defn_no_parens_args.rb
@@ -7,6 +7,7 @@ ProgramNode(0...11)(
        ParametersNode(6...7)(
          [RequiredParameterNode(6...7)()],
          [],
+         [],
          nil,
          [],
          nil,

--- a/test/snapshots/seattlerb/parse_line_iter_call_no_parens.rb
+++ b/test/snapshots/seattlerb/parse_line_iter_call_no_parens.rb
@@ -26,6 +26,7 @@ ProgramNode(0...25)(
              [RequiredParameterNode(8...9)(),
               RequiredParameterNode(11...12)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/parse_line_iter_call_parens.rb
+++ b/test/snapshots/seattlerb/parse_line_iter_call_parens.rb
@@ -26,6 +26,7 @@ ProgramNode(0...26)(
              [RequiredParameterNode(9...10)(),
               RequiredParameterNode(12...13)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/seattlerb/stabby_arg_no_paren.rb
+++ b/test/snapshots/seattlerb/stabby_arg_no_paren.rb
@@ -9,6 +9,7 @@ ProgramNode(0...2)(
          ParametersNode(2...3)(
            [RequiredParameterNode(2...3)()],
            [],
+           [],
            nil,
            [],
            nil,

--- a/test/snapshots/seattlerb/stabby_arg_opt_splat_arg_block_omfg.rb
+++ b/test/snapshots/seattlerb/stabby_arg_opt_splat_arg_block_omfg.rb
@@ -13,12 +13,13 @@ ProgramNode(0...21)(
        PARENTHESIS_LEFT(2...3)("("),
        BlockParametersNode(3...20)(
          ParametersNode(3...20)(
-           [RequiredParameterNode(3...4)(), RequiredParameterNode(15...16)()],
+           [RequiredParameterNode(3...4)()],
            [OptionalParameterNode(6...9)(
               IDENTIFIER(6...7)("c"),
               EQUAL(7...8)("="),
               IntegerNode(8...9)()
             )],
+           [RequiredParameterNode(15...16)()],
            RestParameterNode(11...13)(
              USTAR(11...12)("*"),
              IDENTIFIER(12...13)("d")

--- a/test/snapshots/seattlerb/stabby_block_kw.rb
+++ b/test/snapshots/seattlerb/stabby_block_kw.rb
@@ -9,6 +9,7 @@ ProgramNode(0...9)(
          ParametersNode(4...8)(
            [],
            [],
+           [],
            nil,
            [KeywordParameterNode(4...8)(
               LABEL(4...6)("k:"),

--- a/test/snapshots/seattlerb/stabby_block_kw__required.rb
+++ b/test/snapshots/seattlerb/stabby_block_kw__required.rb
@@ -9,6 +9,7 @@ ProgramNode(0...7)(
          ParametersNode(4...6)(
            [],
            [],
+           [],
            nil,
            [KeywordParameterNode(4...6)(LABEL(4...6)("k:"), nil)],
            nil,

--- a/test/snapshots/seattlerb/stabby_proc_scope.rb
+++ b/test/snapshots/seattlerb/stabby_proc_scope.rb
@@ -9,6 +9,7 @@ ProgramNode(0...8)(
          ParametersNode(3...4)(
            [RequiredParameterNode(3...4)()],
            [],
+           [],
            nil,
            [],
            nil,

--- a/test/snapshots/seattlerb/wtf.rb
+++ b/test/snapshots/seattlerb/wtf.rb
@@ -13,6 +13,7 @@ ProgramNode(0...16)(
               EQUAL(7...8)("="),
               NilNode(8...11)()
             )],
+           [],
            nil,
            [],
            nil,

--- a/test/snapshots/unparser/corpus/literal/block.rb
+++ b/test/snapshots/unparser/corpus/literal/block.rb
@@ -24,6 +24,7 @@ ProgramNode(0...737)(
            ParametersNode(15...16)(
              [RequiredParameterNode(15...16)()],
              [],
+             [],
              nil,
              [],
              nil,
@@ -49,6 +50,7 @@ ProgramNode(0...737)(
          BlockParametersNode(27...29)(
            ParametersNode(27...29)(
              [RequiredParameterNode(27...28)()],
+             [],
              [],
              RestParameterNode(28...29)(COMMA(28...29)(","), nil),
              [],
@@ -78,6 +80,7 @@ ProgramNode(0...737)(
            ParametersNode(40...42)(
              [RequiredParameterNode(40...41)()],
              [],
+             [],
              RestParameterNode(41...42)(COMMA(41...42)(","), nil),
              [],
              nil,
@@ -106,6 +109,7 @@ ProgramNode(0...737)(
            ParametersNode(56...60)(
              [RequiredParameterNode(56...57)(),
               RequiredParameterNode(59...60)()],
+             [],
              [],
              nil,
              [],
@@ -151,6 +155,7 @@ ProgramNode(0...737)(
            ParametersNode(88...93)(
              [RequiredParameterNode(88...89)()],
              [],
+             [],
              RestParameterNode(91...93)(
                USTAR(91...92)("*"),
                IDENTIFIER(92...93)("b")
@@ -181,6 +186,7 @@ ProgramNode(0...737)(
          BlockParametersNode(110...114)(
            ParametersNode(110...114)(
              [RequiredParameterNode(110...111)()],
+             [],
              [],
              RestParameterNode(113...114)(USTAR(113...114)("*"), nil),
              [],
@@ -254,6 +260,7 @@ ProgramNode(0...737)(
               ),
               RequiredParameterNode(157...158)()],
              [],
+             [],
              nil,
              [],
              nil,
@@ -302,6 +309,7 @@ ProgramNode(0...737)(
            ParametersNode(177...179)(
              [],
              [],
+             [],
              RestParameterNode(177...179)(
                USTAR(177...178)("*"),
                IDENTIFIER(178...179)("a")
@@ -341,6 +349,7 @@ ProgramNode(0...737)(
          BlockParametersNode(197...201)(
            ParametersNode(197...198)(
              [RequiredParameterNode(197...198)()],
+             [],
              [],
              nil,
              [],
@@ -407,6 +416,7 @@ ProgramNode(0...737)(
            ParametersNode(237...238)(
              [],
              [],
+             [],
              RestParameterNode(237...238)(USTAR(237...238)("*"), nil),
              [],
              nil,
@@ -456,6 +466,7 @@ ProgramNode(0...737)(
                 PARENTHESIS_LEFT(257...258)("("),
                 PARENTHESIS_RIGHT(259...260)(")")
               )],
+             [],
              [],
              nil,
              [],
@@ -510,6 +521,7 @@ ProgramNode(0...737)(
                 PARENTHESIS_LEFT(279...280)("("),
                 PARENTHESIS_RIGHT(283...284)(")")
               )],
+             [],
              [],
              nil,
              [],
@@ -566,6 +578,7 @@ ProgramNode(0...737)(
                 PARENTHESIS_RIGHT(310...311)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,
@@ -618,6 +631,7 @@ ProgramNode(0...737)(
                 PARENTHESIS_LEFT(330...331)("("),
                 PARENTHESIS_RIGHT(335...336)(")")
               )],
+             [],
              [],
              nil,
              [],

--- a/test/snapshots/unparser/corpus/literal/def.rb
+++ b/test/snapshots/unparser/corpus/literal/def.rb
@@ -178,6 +178,7 @@ ProgramNode(0...913)(
        ParametersNode(113...123)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(113...117)(LABEL(113...117)("bar:"), nil),
           KeywordParameterNode(119...123)(LABEL(119...123)("baz:"), nil)],
@@ -397,6 +398,7 @@ ProgramNode(0...913)(
        ParametersNode(279...282)(
          [RequiredParameterNode(279...282)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -417,6 +419,7 @@ ProgramNode(0...913)(
        ParametersNode(303...311)(
          [RequiredParameterNode(303...306)(),
           RequiredParameterNode(308...311)()],
+         [],
          [],
          nil,
          [],
@@ -444,6 +447,7 @@ ProgramNode(0...913)(
             EQUAL(336...337)("="),
             ParenthesesNode(338...340)(nil, (338...339), (339...340))
           )],
+         [],
          nil,
          [],
          nil,
@@ -484,6 +488,7 @@ ProgramNode(0...913)(
               (376...377)
             )
           )],
+         [],
          nil,
          [],
          nil,
@@ -508,6 +513,7 @@ ProgramNode(0...913)(
             EQUAL(396...397)("="),
             TrueNode(398...402)()
           )],
+         [],
          nil,
          [],
          nil,
@@ -532,6 +538,7 @@ ProgramNode(0...913)(
             EQUAL(432...433)("="),
             TrueNode(434...438)()
           )],
+         [],
          nil,
          [],
          nil,
@@ -552,6 +559,7 @@ ProgramNode(0...913)(
        IDENTIFIER(455...458)("foo"),
        nil,
        ParametersNode(459...465)(
+         [],
          [],
          [],
          nil,
@@ -575,6 +583,7 @@ ProgramNode(0...913)(
        IDENTIFIER(476...479)("foo"),
        nil,
        ParametersNode(480...488)(
+         [],
          [],
          [],
          nil,
@@ -609,6 +618,7 @@ ProgramNode(0...913)(
        ParametersNode(503...513)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(503...513)(
             LABEL(503...507)("bar:"),
@@ -639,6 +649,7 @@ ProgramNode(0...913)(
        IDENTIFIER(524...527)("foo"),
        nil,
        ParametersNode(528...529)(
+         [],
          [],
          [],
          RestParameterNode(528...529)(USTAR(528...529)("*"), nil),
@@ -672,6 +683,7 @@ ProgramNode(0...913)(
        ParametersNode(550...554)(
          [],
          [],
+         [],
          RestParameterNode(550...554)(
            USTAR(550...551)("*"),
            IDENTIFIER(551...554)("bar")
@@ -694,6 +706,7 @@ ProgramNode(0...913)(
        nil,
        ParametersNode(575...584)(
          [RequiredParameterNode(575...578)()],
+         [],
          [],
          RestParameterNode(580...584)(
            USTAR(580...581)("*"),
@@ -724,6 +737,7 @@ ProgramNode(0...913)(
             EQUAL(609...610)("="),
             TrueNode(611...615)()
           )],
+         [],
          RestParameterNode(617...621)(
            USTAR(617...618)("*"),
            IDENTIFIER(618...621)("bor")
@@ -764,6 +778,7 @@ ProgramNode(0...913)(
             EQUAL(646...647)("="),
             TrueNode(648...652)()
           )],
+         [],
          RestParameterNode(654...658)(
            USTAR(654...655)("*"),
            IDENTIFIER(655...658)("bor")
@@ -809,6 +824,7 @@ ProgramNode(0...913)(
             EQUAL(696...697)("="),
             TrueNode(698...702)()
           )],
+         [],
          RestParameterNode(704...708)(
            USTAR(704...705)("*"),
            IDENTIFIER(705...708)("bor")
@@ -834,6 +850,7 @@ ProgramNode(0...913)(
        IDENTIFIER(725...728)("foo"),
        nil,
        ParametersNode(729...735)(
+         [],
          [],
          [],
          nil,
@@ -869,6 +886,7 @@ ProgramNode(0...913)(
        nil,
        ParametersNode(756...767)(
          [RequiredParameterNode(756...759)()],
+         [],
          [],
          nil,
          [],
@@ -937,6 +955,7 @@ ProgramNode(0...913)(
             PARENTHESIS_RIGHT(815...816)(")")
           )],
          [],
+         [],
          nil,
          [],
          nil,
@@ -955,6 +974,7 @@ ProgramNode(0...913)(
        IDENTIFIER(827...830)("foo"),
        nil,
        ParametersNode(831...849)(
+         [],
          [],
          [],
          nil,

--- a/test/snapshots/unparser/corpus/literal/defs.rb
+++ b/test/snapshots/unparser/corpus/literal/defs.rb
@@ -112,6 +112,7 @@ ProgramNode(0...266)(
                ParametersNode(107...110)(
                  [RequiredParameterNode(107...110)()],
                  [],
+                 [],
                  nil,
                  [],
                  nil,

--- a/test/snapshots/unparser/corpus/literal/dstr.rb
+++ b/test/snapshots/unparser/corpus/literal/dstr.rb
@@ -263,6 +263,7 @@ ProgramNode(0...299)(
            ParametersNode(278...279)(
              [RequiredParameterNode(278...279)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/unparser/corpus/literal/if.rb
+++ b/test/snapshots/unparser/corpus/literal/if.rb
@@ -183,6 +183,7 @@ ProgramNode(0...242)(
              ParametersNode(208...212)(
                [RequiredParameterNode(208...212)()],
                [],
+               [],
                nil,
                [],
                nil,

--- a/test/snapshots/unparser/corpus/literal/lambda.rb
+++ b/test/snapshots/unparser/corpus/literal/lambda.rb
@@ -27,6 +27,7 @@ ProgramNode(0...76)(
              [RequiredParameterNode(21...22)(),
               RequiredParameterNode(24...25)()],
              [],
+             [],
              nil,
              [],
              nil,
@@ -56,6 +57,7 @@ ProgramNode(0...76)(
          ParametersNode(45...46)(
            [RequiredParameterNode(45...46)()],
            [],
+           [],
            nil,
            [],
            nil,
@@ -76,6 +78,7 @@ ProgramNode(0...76)(
          ParametersNode(55...59)(
            [RequiredParameterNode(55...56)(),
             RequiredParameterNode(58...59)()],
+           [],
            [],
            nil,
            [],
@@ -99,6 +102,7 @@ ProgramNode(0...76)(
          ParametersNode(68...72)(
            [RequiredParameterNode(68...69)(),
             RequiredParameterNode(71...72)()],
+           [],
            [],
            nil,
            [],

--- a/test/snapshots/unparser/corpus/literal/since/31.rb
+++ b/test/snapshots/unparser/corpus/literal/since/31.rb
@@ -7,6 +7,7 @@ ProgramNode(0...51)(
        ParametersNode(8...9)(
          [],
          [],
+         [],
          nil,
          [],
          nil,
@@ -39,6 +40,7 @@ ProgramNode(0...51)(
        nil,
        ParametersNode(33...37)(
          [RequiredParameterNode(33...34)()],
+         [],
          [],
          nil,
          [],

--- a/test/snapshots/unparser/corpus/literal/since/32.rb
+++ b/test/snapshots/unparser/corpus/literal/since/32.rb
@@ -7,6 +7,7 @@ ProgramNode(0...90)(
        ParametersNode(8...20)(
          [RequiredParameterNode(8...16)()],
          [],
+         [],
          nil,
          [],
          KeywordRestParameterNode(18...20)(USTAR_STAR(18...20)("**"), nil),
@@ -46,6 +47,7 @@ ProgramNode(0...90)(
        nil,
        ParametersNode(55...66)(
          [RequiredParameterNode(55...63)()],
+         [],
          [],
          RestParameterNode(65...66)(USTAR(65...66)("*"), nil),
          [],

--- a/test/snapshots/unparser/corpus/literal/while.rb
+++ b/test/snapshots/unparser/corpus/literal/while.rb
@@ -21,6 +21,7 @@ ProgramNode(0...616)(
                 ParametersNode(18...21)(
                   [RequiredParameterNode(18...21)()],
                   [],
+                  [],
                   nil,
                   [],
                   nil,
@@ -230,6 +231,7 @@ ProgramNode(0...616)(
                 ParametersNode(249...252)(
                   [RequiredParameterNode(249...252)()],
                   [],
+                  [],
                   nil,
                   [],
                   nil,
@@ -294,6 +296,7 @@ ProgramNode(0...616)(
               BlockParametersNode(320...323)(
                 ParametersNode(320...323)(
                   [RequiredParameterNode(320...323)()],
+                  [],
                   [],
                   nil,
                   [],

--- a/test/snapshots/unparser/corpus/semantic/block.rb
+++ b/test/snapshots/unparser/corpus/semantic/block.rb
@@ -77,6 +77,7 @@ ProgramNode(0...148)(
            ParametersNode(74...75)(
              [RequiredParameterNode(74...75)()],
              [],
+             [],
              nil,
              [],
              nil,
@@ -114,6 +115,7 @@ ProgramNode(0...148)(
          BlockParametersNode(98...99)(
            ParametersNode(98...99)(
              [RequiredParameterNode(98...99)()],
+             [],
              [],
              nil,
              [],

--- a/test/snapshots/while.rb
+++ b/test/snapshots/while.rb
@@ -93,6 +93,7 @@ ProgramNode(0...309)(
                 "tap"
               )
             )],
+           [],
            nil,
            [],
            nil,

--- a/test/snapshots/whitequark/anonymous_blockarg.rb
+++ b/test/snapshots/whitequark/anonymous_blockarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...23)(
        ParametersNode(8...9)(
          [],
          [],
+         [],
          nil,
          [],
          nil,

--- a/test/snapshots/whitequark/arg.rb
+++ b/test/snapshots/whitequark/arg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...37)(
        ParametersNode(6...9)(
          [RequiredParameterNode(6...9)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -26,6 +27,7 @@ ProgramNode(0...37)(
        nil,
        ParametersNode(23...31)(
          [RequiredParameterNode(23...26)(), RequiredParameterNode(28...31)()],
+         [],
          [],
          nil,
          [],

--- a/test/snapshots/whitequark/arg_duplicate_ignored.rb
+++ b/test/snapshots/whitequark/arg_duplicate_ignored.rb
@@ -7,6 +7,7 @@ ProgramNode(0...40)(
        ParametersNode(8...12)(
          [RequiredParameterNode(8...9)(), RequiredParameterNode(11...12)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -26,6 +27,7 @@ ProgramNode(0...40)(
        nil,
        ParametersNode(28...34)(
          [RequiredParameterNode(28...30)(), RequiredParameterNode(32...34)()],
+         [],
          [],
          nil,
          [],

--- a/test/snapshots/whitequark/args.rb
+++ b/test/snapshots/whitequark/args.rb
@@ -7,6 +7,7 @@ ProgramNode(0...690)(
        ParametersNode(6...8)(
          [],
          [],
+         [],
          nil,
          [],
          nil,
@@ -35,6 +36,7 @@ ProgramNode(0...690)(
             PARENTHESIS_RIGHT(26...27)(")")
           )],
          [],
+         [],
          nil,
          [],
          nil,
@@ -58,6 +60,7 @@ ProgramNode(0...690)(
             PARENTHESIS_LEFT(42...43)("("),
             PARENTHESIS_RIGHT(44...45)(")")
           )],
+         [],
          [],
          nil,
          [],
@@ -83,6 +86,7 @@ ProgramNode(0...690)(
             PARENTHESIS_LEFT(60...61)("("),
             PARENTHESIS_RIGHT(65...66)(")")
           )],
+         [],
          [],
          nil,
          [],
@@ -110,6 +114,7 @@ ProgramNode(0...690)(
             PARENTHESIS_LEFT(81...82)("("),
             PARENTHESIS_RIGHT(84...85)(")")
           )],
+         [],
          [],
          nil,
          [],
@@ -139,6 +144,7 @@ ProgramNode(0...690)(
             PARENTHESIS_RIGHT(106...107)(")")
           )],
          [],
+         [],
          nil,
          [],
          nil,
@@ -166,6 +172,7 @@ ProgramNode(0...690)(
             PARENTHESIS_RIGHT(127...128)(")")
           )],
          [],
+         [],
          nil,
          [],
          nil,
@@ -191,6 +198,7 @@ ProgramNode(0...690)(
             PARENTHESIS_LEFT(143...144)("("),
             PARENTHESIS_RIGHT(151...152)(")")
           )],
+         [],
          [],
          nil,
          [],
@@ -221,6 +229,7 @@ ProgramNode(0...690)(
             PARENTHESIS_LEFT(167...168)("("),
             PARENTHESIS_RIGHT(173...174)(")")
           )],
+         [],
          [],
          nil,
          [],
@@ -253,6 +262,7 @@ ProgramNode(0...690)(
             PARENTHESIS_RIGHT(198...199)(")")
           )],
          [],
+         [],
          nil,
          [],
          nil,
@@ -282,6 +292,7 @@ ProgramNode(0...690)(
             PARENTHESIS_RIGHT(220...221)(")")
           )],
          [],
+         [],
          nil,
          [],
          nil,
@@ -302,6 +313,7 @@ ProgramNode(0...690)(
        IDENTIFIER(233...234)("f"),
        nil,
        ParametersNode(236...246)(
+         [],
          [],
          [],
          nil,
@@ -327,6 +339,7 @@ ProgramNode(0...690)(
        IDENTIFIER(258...259)("f"),
        nil,
        ParametersNode(261...286)(
+         [],
          [],
          [],
          nil,
@@ -364,6 +377,7 @@ ProgramNode(0...690)(
        ParametersNode(300...309)(
          [],
          [],
+         [],
          nil,
          [],
          KeywordRestParameterNode(300...305)(
@@ -389,6 +403,7 @@ ProgramNode(0...690)(
        ParametersNode(322...327)(
          [],
          [],
+         [],
          RestParameterNode(322...323)(STAR(322...323)("*"), nil),
          [],
          KeywordRestParameterNode(325...327)(USTAR_STAR(325...327)("**"), nil),
@@ -409,6 +424,7 @@ ProgramNode(0...690)(
        IDENTIFIER(338...339)("f"),
        nil,
        ParametersNode(340...346)(
+         [],
          [],
          [],
          RestParameterNode(340...342)(
@@ -434,8 +450,9 @@ ProgramNode(0...690)(
        IDENTIFIER(357...358)("f"),
        nil,
        ParametersNode(359...368)(
-         [RequiredParameterNode(363...364)()],
          [],
+         [],
+         [RequiredParameterNode(363...364)()],
          RestParameterNode(359...361)(
            STAR(359...360)("*"),
            IDENTIFIER(360...361)("r")
@@ -476,6 +493,7 @@ ProgramNode(0...690)(
        ParametersNode(394...399)(
          [RequiredParameterNode(394...395)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -497,6 +515,7 @@ ProgramNode(0...690)(
        nil,
        ParametersNode(412...421)(
          [RequiredParameterNode(412...413)()],
+         [],
          [],
          RestParameterNode(415...417)(
            USTAR(415...416)("*"),
@@ -523,9 +542,9 @@ ProgramNode(0...690)(
        IDENTIFIER(432...433)("f"),
        nil,
        ParametersNode(434...446)(
-         [RequiredParameterNode(434...435)(),
-          RequiredParameterNode(441...442)()],
+         [RequiredParameterNode(434...435)()],
          [],
+         [RequiredParameterNode(441...442)()],
          RestParameterNode(437...439)(
            USTAR(437...438)("*"),
            IDENTIFIER(438...439)("r")
@@ -558,6 +577,7 @@ ProgramNode(0...690)(
             EQUAL(463...464)("="),
             IntegerNode(464...465)()
           )],
+         [],
          nil,
          [],
          nil,
@@ -586,6 +606,7 @@ ProgramNode(0...690)(
             EQUAL(486...487)("="),
             IntegerNode(487...488)()
           )],
+         [],
          RestParameterNode(490...492)(
            USTAR(490...491)("*"),
            IDENTIFIER(491...492)("r")
@@ -612,13 +633,13 @@ ProgramNode(0...690)(
        IDENTIFIER(507...508)("f"),
        nil,
        ParametersNode(509...526)(
-         [RequiredParameterNode(509...510)(),
-          RequiredParameterNode(521...522)()],
+         [RequiredParameterNode(509...510)()],
          [OptionalParameterNode(512...515)(
             IDENTIFIER(512...513)("o"),
             EQUAL(513...514)("="),
             IntegerNode(514...515)()
           )],
+         [RequiredParameterNode(521...522)()],
          RestParameterNode(517...519)(
            USTAR(517...518)("*"),
            IDENTIFIER(518...519)("r")
@@ -646,13 +667,13 @@ ProgramNode(0...690)(
        IDENTIFIER(537...538)("f"),
        nil,
        ParametersNode(539...552)(
-         [RequiredParameterNode(539...540)(),
-          RequiredParameterNode(547...548)()],
+         [RequiredParameterNode(539...540)()],
          [OptionalParameterNode(542...545)(
             IDENTIFIER(542...543)("o"),
             EQUAL(543...544)("="),
             IntegerNode(544...545)()
           )],
+         [RequiredParameterNode(547...548)()],
          nil,
          [],
          nil,
@@ -678,6 +699,7 @@ ProgramNode(0...690)(
        ParametersNode(565...569)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(565...569)(LABEL(565...569)("foo:"), nil)],
          nil,
@@ -696,6 +718,7 @@ ProgramNode(0...690)(
        IDENTIFIER(581...582)("f"),
        nil,
        ParametersNode(583...590)(
+         [],
          [],
          [],
          nil,
@@ -734,6 +757,7 @@ ProgramNode(0...690)(
             EQUAL(605...606)("="),
             IntegerNode(606...607)()
           )],
+         [],
          nil,
          [],
          nil,
@@ -760,6 +784,7 @@ ProgramNode(0...690)(
             EQUAL(625...626)("="),
             IntegerNode(626...627)()
           )],
+         [],
          RestParameterNode(629...631)(
            USTAR(629...630)("*"),
            IDENTIFIER(630...631)("r")
@@ -785,12 +810,13 @@ ProgramNode(0...690)(
        IDENTIFIER(646...647)("f"),
        nil,
        ParametersNode(648...662)(
-         [RequiredParameterNode(657...658)()],
+         [],
          [OptionalParameterNode(648...651)(
             IDENTIFIER(648...649)("o"),
             EQUAL(649...650)("="),
             IntegerNode(650...651)()
           )],
+         [RequiredParameterNode(657...658)()],
          RestParameterNode(653...655)(
            USTAR(653...654)("*"),
            IDENTIFIER(654...655)("r")
@@ -817,12 +843,13 @@ ProgramNode(0...690)(
        IDENTIFIER(673...674)("f"),
        nil,
        ParametersNode(675...685)(
-         [RequiredParameterNode(680...681)()],
+         [],
          [OptionalParameterNode(675...678)(
             IDENTIFIER(675...676)("o"),
             EQUAL(676...677)("="),
             IntegerNode(677...678)()
           )],
+         [RequiredParameterNode(680...681)()],
          nil,
          [],
          nil,

--- a/test/snapshots/whitequark/blockarg.rb
+++ b/test/snapshots/whitequark/blockarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...18)(
        ParametersNode(6...12)(
          [],
          [],
+         [],
          nil,
          [],
          nil,

--- a/test/snapshots/whitequark/blockargs.rb
+++ b/test/snapshots/whitequark/blockargs.rb
@@ -34,6 +34,7 @@ ProgramNode(0...550)(
            ParametersNode(21...23)(
              [],
              [],
+             [],
              nil,
              [],
              nil,
@@ -60,6 +61,7 @@ ProgramNode(0...550)(
          ),
          BlockParametersNode(32...41)(
            ParametersNode(32...41)(
+             [],
              [],
              [],
              nil,
@@ -91,6 +93,7 @@ ProgramNode(0...550)(
            ParametersNode(50...55)(
              [],
              [],
+             [],
              RestParameterNode(50...51)(USTAR(50...51)("*"), nil),
              [],
              nil,
@@ -119,8 +122,9 @@ ProgramNode(0...550)(
          ),
          BlockParametersNode(64...73)(
            ParametersNode(64...73)(
-             [RequiredParameterNode(68...69)()],
              [],
+             [],
+             [RequiredParameterNode(68...69)()],
              RestParameterNode(64...66)(
                USTAR(64...65)("*"),
                IDENTIFIER(65...66)("r")
@@ -152,6 +156,7 @@ ProgramNode(0...550)(
            ParametersNode(82...88)(
              [],
              [],
+             [],
              RestParameterNode(82...84)(
                USTAR(82...83)("*"),
                IDENTIFIER(83...84)("s")
@@ -181,6 +186,7 @@ ProgramNode(0...550)(
            ParametersNode(97...99)(
              [],
              [],
+             [],
              RestParameterNode(97...99)(
                USTAR(97...98)("*"),
                IDENTIFIER(98...99)("s")
@@ -208,6 +214,7 @@ ProgramNode(0...550)(
          ScopeNode(105...106)([USTAR(108...109)("*")]),
          BlockParametersNode(108...109)(
            ParametersNode(108...109)(
+             [],
              [],
              [],
              RestParameterNode(108...109)(USTAR(108...109)("*"), nil),
@@ -270,6 +277,7 @@ ProgramNode(0...550)(
            ParametersNode(142...147)(
              [RequiredParameterNode(142...143)()],
              [],
+             [],
              nil,
              [],
              nil,
@@ -303,6 +311,7 @@ ProgramNode(0...550)(
            ParametersNode(156...164)(
              [RequiredParameterNode(156...157)()],
              [],
+             [],
              RestParameterNode(159...160)(USTAR(159...160)("*"), nil),
              [],
              nil,
@@ -335,9 +344,9 @@ ProgramNode(0...550)(
          ),
          BlockParametersNode(173...185)(
            ParametersNode(173...185)(
-             [RequiredParameterNode(173...174)(),
-              RequiredParameterNode(180...181)()],
+             [RequiredParameterNode(173...174)()],
              [],
+             [RequiredParameterNode(180...181)()],
              RestParameterNode(176...178)(
                USTAR(176...177)("*"),
                IDENTIFIER(177...178)("r")
@@ -374,6 +383,7 @@ ProgramNode(0...550)(
            ParametersNode(194...203)(
              [RequiredParameterNode(194...195)()],
              [],
+             [],
              RestParameterNode(197...199)(
                USTAR(197...198)("*"),
                IDENTIFIER(198...199)("s")
@@ -408,6 +418,7 @@ ProgramNode(0...550)(
            ParametersNode(212...217)(
              [RequiredParameterNode(212...213)()],
              [],
+             [],
              RestParameterNode(215...217)(
                USTAR(215...216)("*"),
                IDENTIFIER(216...217)("s")
@@ -439,6 +450,7 @@ ProgramNode(0...550)(
            ParametersNode(226...230)(
              [RequiredParameterNode(226...227)()],
              [],
+             [],
              RestParameterNode(229...230)(USTAR(229...230)("*"), nil),
              [],
              nil,
@@ -468,6 +480,7 @@ ProgramNode(0...550)(
              [RequiredParameterNode(239...240)(),
               RequiredParameterNode(242...243)()],
              [],
+             [],
              RestParameterNode(243...244)(COMMA(243...244)(","), nil),
              [],
              nil,
@@ -496,6 +509,7 @@ ProgramNode(0...550)(
            ParametersNode(253...257)(
              [RequiredParameterNode(253...254)(),
               RequiredParameterNode(256...257)()],
+             [],
              [],
              nil,
              [],
@@ -531,6 +545,7 @@ ProgramNode(0...550)(
                 EQUAL(270...271)("="),
                 IntegerNode(271...272)()
               )],
+             [],
              nil,
              [],
              nil,
@@ -564,13 +579,13 @@ ProgramNode(0...550)(
          ),
          BlockParametersNode(285...302)(
            ParametersNode(285...302)(
-             [RequiredParameterNode(285...286)(),
-              RequiredParameterNode(297...298)()],
+             [RequiredParameterNode(285...286)()],
              [OptionalParameterNode(288...291)(
                 IDENTIFIER(288...289)("o"),
                 EQUAL(289...290)("="),
                 IntegerNode(290...291)()
               )],
+             [RequiredParameterNode(297...298)()],
              RestParameterNode(293...295)(
                USTAR(293...294)("*"),
                IDENTIFIER(294...295)("r")
@@ -618,6 +633,7 @@ ProgramNode(0...550)(
                 EQUAL(321...322)("="),
                 IntegerNode(322...323)()
               )],
+             [],
              RestParameterNode(325...327)(
                USTAR(325...326)("*"),
                IDENTIFIER(326...327)("r")
@@ -653,13 +669,13 @@ ProgramNode(0...550)(
          ),
          BlockParametersNode(340...353)(
            ParametersNode(340...353)(
-             [RequiredParameterNode(340...341)(),
-              RequiredParameterNode(348...349)()],
+             [RequiredParameterNode(340...341)()],
              [OptionalParameterNode(343...346)(
                 IDENTIFIER(343...344)("o"),
                 EQUAL(344...345)("="),
                 IntegerNode(345...346)()
               )],
+             [RequiredParameterNode(348...349)()],
              nil,
              [],
              nil,
@@ -689,6 +705,7 @@ ProgramNode(0...550)(
            ParametersNode(362...364)(
              [RequiredParameterNode(362...363)()],
              [],
+             [],
              RestParameterNode(363...364)(COMMA(363...364)(","), nil),
              [],
              nil,
@@ -714,6 +731,7 @@ ProgramNode(0...550)(
          BlockParametersNode(373...374)(
            ParametersNode(373...374)(
              [RequiredParameterNode(373...374)()],
+             [],
              [],
              nil,
              [],
@@ -741,6 +759,7 @@ ProgramNode(0...550)(
            ParametersNode(383...384)(
              [RequiredParameterNode(383...384)()],
              [],
+             [],
              nil,
              [],
              nil,
@@ -766,6 +785,7 @@ ProgramNode(0...550)(
          BlockParametersNode(393...394)(
            ParametersNode(393...394)(
              [RequiredParameterNode(393...394)()],
+             [],
              [],
              nil,
              [],
@@ -793,6 +813,7 @@ ProgramNode(0...550)(
          ),
          BlockParametersNode(403...413)(
            ParametersNode(403...413)(
+             [],
              [],
              [],
              nil,
@@ -830,6 +851,7 @@ ProgramNode(0...550)(
          ),
          BlockParametersNode(422...447)(
            ParametersNode(422...447)(
+             [],
              [],
              [],
              nil,
@@ -871,6 +893,7 @@ ProgramNode(0...550)(
            ParametersNode(456...460)(
              [],
              [],
+             [],
              nil,
              [KeywordParameterNode(456...460)(LABEL(456...460)("foo:"), nil)],
              nil,
@@ -903,6 +926,7 @@ ProgramNode(0...550)(
                 EQUAL(470...471)("="),
                 IntegerNode(471...472)()
               )],
+             [],
              nil,
              [],
              nil,
@@ -940,6 +964,7 @@ ProgramNode(0...550)(
                 EQUAL(486...487)("="),
                 IntegerNode(487...488)()
               )],
+             [],
              RestParameterNode(490...492)(
                USTAR(490...491)("*"),
                IDENTIFIER(491...492)("r")
@@ -975,12 +1000,13 @@ ProgramNode(0...550)(
          ),
          BlockParametersNode(505...519)(
            ParametersNode(505...519)(
-             [RequiredParameterNode(514...515)()],
+             [],
              [OptionalParameterNode(505...508)(
                 IDENTIFIER(505...506)("o"),
                 EQUAL(506...507)("="),
                 IntegerNode(507...508)()
               )],
+             [RequiredParameterNode(514...515)()],
              RestParameterNode(510...512)(
                USTAR(510...511)("*"),
                IDENTIFIER(511...512)("r")
@@ -1015,12 +1041,13 @@ ProgramNode(0...550)(
          ),
          BlockParametersNode(528...538)(
            ParametersNode(528...538)(
-             [RequiredParameterNode(533...534)()],
+             [],
              [OptionalParameterNode(528...531)(
                 IDENTIFIER(528...529)("o"),
                 EQUAL(529...530)("="),
                 IntegerNode(530...531)()
               )],
+             [RequiredParameterNode(533...534)()],
              nil,
              [],
              nil,

--- a/test/snapshots/whitequark/bug_435.rb
+++ b/test/snapshots/whitequark/bug_435.rb
@@ -14,6 +14,7 @@ ProgramNode(0...14)(
                  ParametersNode(6...9)(
                    [RequiredParameterNode(6...9)()],
                    [],
+                   [],
                    nil,
                    [],
                    nil,

--- a/test/snapshots/whitequark/bug_lambda_leakage.rb
+++ b/test/snapshots/whitequark/bug_lambda_leakage.rb
@@ -9,6 +9,7 @@ ProgramNode(0...19)(
          ParametersNode(3...8)(
            [RequiredParameterNode(3...8)()],
            [],
+           [],
            nil,
            [],
            nil,

--- a/test/snapshots/whitequark/endless_comparison_method.rb
+++ b/test/snapshots/whitequark/endless_comparison_method.rb
@@ -7,6 +7,7 @@ ProgramNode(0...179)(
        ParametersNode(7...12)(
          [RequiredParameterNode(7...12)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -37,6 +38,7 @@ ProgramNode(0...179)(
        nil,
        ParametersNode(37...42)(
          [RequiredParameterNode(37...42)()],
+         [],
          [],
          nil,
          [],
@@ -69,6 +71,7 @@ ProgramNode(0...179)(
        ParametersNode(67...72)(
          [RequiredParameterNode(67...72)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -99,6 +102,7 @@ ProgramNode(0...179)(
        nil,
        ParametersNode(97...102)(
          [RequiredParameterNode(97...102)()],
+         [],
          [],
          nil,
          [],
@@ -131,6 +135,7 @@ ProgramNode(0...179)(
        ParametersNode(128...133)(
          [RequiredParameterNode(128...133)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -161,6 +166,7 @@ ProgramNode(0...179)(
        nil,
        ParametersNode(158...163)(
          [RequiredParameterNode(158...163)()],
+         [],
          [],
          nil,
          [],

--- a/test/snapshots/whitequark/endless_method.rb
+++ b/test/snapshots/whitequark/endless_method.rb
@@ -20,6 +20,7 @@ ProgramNode(0...78)(
        ParametersNode(24...25)(
          [RequiredParameterNode(24...25)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -81,6 +82,7 @@ ProgramNode(0...78)(
        ),
        ParametersNode(68...69)(
          [RequiredParameterNode(68...69)()],
+         [],
          [],
          nil,
          [],

--- a/test/snapshots/whitequark/endless_method_command_syntax.rb
+++ b/test/snapshots/whitequark/endless_method_command_syntax.rb
@@ -69,6 +69,7 @@ ProgramNode(0...278)(
        ParametersNode(58...59)(
          [RequiredParameterNode(58...59)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -189,6 +190,7 @@ ProgramNode(0...278)(
        ParametersNode(141...142)(
          [RequiredParameterNode(141...142)()],
          [],
+         [],
          nil,
          [],
          nil,
@@ -219,6 +221,7 @@ ProgramNode(0...278)(
        nil,
        ParametersNode(166...167)(
          [RequiredParameterNode(166...167)()],
+         [],
          [],
          nil,
          [],
@@ -277,6 +280,7 @@ ProgramNode(0...278)(
        SelfNode(220...224)(),
        ParametersNode(233...234)(
          [RequiredParameterNode(233...234)()],
+         [],
          [],
          nil,
          [],

--- a/test/snapshots/whitequark/endless_method_forwarded_args_legacy.rb
+++ b/test/snapshots/whitequark/endless_method_forwarded_args_legacy.rb
@@ -7,6 +7,7 @@ ProgramNode(0...23)(
        ParametersNode(8...11)(
          [],
          [],
+         [],
          nil,
          [],
          ForwardingParameterNode(8...11)(),

--- a/test/snapshots/whitequark/forward_arg.rb
+++ b/test/snapshots/whitequark/forward_arg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...27)(
        ParametersNode(8...11)(
          [],
          [],
+         [],
          nil,
          [],
          ForwardingParameterNode(8...11)(),

--- a/test/snapshots/whitequark/forward_arg_with_open_args.rb
+++ b/test/snapshots/whitequark/forward_arg_with_open_args.rb
@@ -9,6 +9,7 @@ ProgramNode(0...292)(
             ParametersNode(9...12)(
               [],
               [],
+              [],
               nil,
               [],
               ForwardingParameterNode(9...12)(),
@@ -46,6 +47,7 @@ ProgramNode(0...292)(
             ParametersNode(39...42)(
               [],
               [],
+              [],
               nil,
               [],
               ForwardingParameterNode(39...42)(),
@@ -81,6 +83,7 @@ ProgramNode(0...292)(
        ParametersNode(68...71)(
          [],
          [],
+         [],
          nil,
          [],
          ForwardingParameterNode(68...71)(),
@@ -99,6 +102,7 @@ ProgramNode(0...292)(
        IDENTIFIER(81...84)("foo"),
        nil,
        ParametersNode(85...88)(
+         [],
          [],
          [],
          nil,
@@ -132,6 +136,7 @@ ProgramNode(0...292)(
        ParametersNode(113...119)(
          [RequiredParameterNode(113...114)()],
          [],
+         [],
          nil,
          [],
          ForwardingParameterNode(116...119)(),
@@ -164,6 +169,7 @@ ProgramNode(0...292)(
        nil,
        ParametersNode(144...150)(
          [RequiredParameterNode(144...145)()],
+         [],
          [],
          nil,
          [],
@@ -202,6 +208,7 @@ ProgramNode(0...292)(
             EQUAL(180...181)("="),
             IntegerNode(182...183)()
           )],
+         [],
          nil,
          [],
          ForwardingParameterNode(185...188)(),
@@ -230,6 +237,7 @@ ProgramNode(0...292)(
             EQUAL(204...205)("="),
             IntegerNode(206...207)()
           )],
+         [],
          nil,
          [],
          ForwardingParameterNode(209...212)(),
@@ -267,6 +275,7 @@ ProgramNode(0...292)(
             EQUAL(239...240)("="),
             IntegerNode(241...242)()
           )],
+         [],
          nil,
          [],
          ForwardingParameterNode(244...247)(),
@@ -299,6 +308,7 @@ ProgramNode(0...292)(
        nil,
        ParametersNode(272...278)(
          [RequiredParameterNode(272...273)()],
+         [],
          [],
          nil,
          [],

--- a/test/snapshots/whitequark/forward_args_legacy.rb
+++ b/test/snapshots/whitequark/forward_args_legacy.rb
@@ -7,6 +7,7 @@ ProgramNode(0...77)(
        ParametersNode(8...11)(
          [],
          [],
+         [],
          nil,
          [],
          ForwardingParameterNode(8...11)(),
@@ -38,6 +39,7 @@ ProgramNode(0...77)(
        ParametersNode(37...40)(
          [],
          [],
+         [],
          nil,
          [],
          ForwardingParameterNode(37...40)(),
@@ -56,6 +58,7 @@ ProgramNode(0...77)(
        IDENTIFIER(52...55)("foo"),
        nil,
        ParametersNode(56...59)(
+         [],
          [],
          [],
          nil,

--- a/test/snapshots/whitequark/forwarded_argument_with_kwrestarg.rb
+++ b/test/snapshots/whitequark/forwarded_argument_with_kwrestarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...45)(
        ParametersNode(8...20)(
          [RequiredParameterNode(8...16)()],
          [],
+         [],
          nil,
          [],
          KeywordRestParameterNode(18...20)(USTAR_STAR(18...20)("**"), nil),

--- a/test/snapshots/whitequark/forwarded_argument_with_restarg.rb
+++ b/test/snapshots/whitequark/forwarded_argument_with_restarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...43)(
        ParametersNode(8...19)(
          [RequiredParameterNode(8...16)()],
          [],
+         [],
          RestParameterNode(18...19)(USTAR(18...19)("*"), nil),
          [],
          nil,

--- a/test/snapshots/whitequark/forwarded_kwrestarg.rb
+++ b/test/snapshots/whitequark/forwarded_kwrestarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...25)(
        ParametersNode(8...10)(
          [],
          [],
+         [],
          nil,
          [],
          KeywordRestParameterNode(8...10)(USTAR_STAR(8...10)("**"), nil),

--- a/test/snapshots/whitequark/forwarded_kwrestarg_with_additional_kwarg.rb
+++ b/test/snapshots/whitequark/forwarded_kwrestarg_with_additional_kwarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...41)(
        ParametersNode(8...10)(
          [],
          [],
+         [],
          nil,
          [],
          KeywordRestParameterNode(8...10)(USTAR_STAR(8...10)("**"), nil),

--- a/test/snapshots/whitequark/forwarded_restarg.rb
+++ b/test/snapshots/whitequark/forwarded_restarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...23)(
        ParametersNode(8...9)(
          [],
          [],
+         [],
          RestParameterNode(8...9)(USTAR(8...9)("*"), nil),
          [],
          nil,

--- a/test/snapshots/whitequark/kwarg.rb
+++ b/test/snapshots/whitequark/kwarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...16)(
        ParametersNode(6...10)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(6...10)(LABEL(6...10)("foo:"), nil)],
          nil,

--- a/test/snapshots/whitequark/kwnilarg.rb
+++ b/test/snapshots/whitequark/kwnilarg.rb
@@ -9,6 +9,7 @@ ProgramNode(0...46)(
          ParametersNode(3...8)(
            [],
            [],
+           [],
            nil,
            [],
            NoKeywordsParameterNode(3...8)((3...5), (5...8)),
@@ -23,6 +24,7 @@ ProgramNode(0...46)(
        IDENTIFIER(18...19)("f"),
        nil,
        ParametersNode(20...25)(
+         [],
          [],
          [],
          nil,
@@ -50,6 +52,7 @@ ProgramNode(0...46)(
          ScopeNode(35...36)([]),
          BlockParametersNode(38...43)(
            ParametersNode(38...43)(
+             [],
              [],
              [],
              nil,

--- a/test/snapshots/whitequark/kwoptarg.rb
+++ b/test/snapshots/whitequark/kwoptarg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...18)(
        ParametersNode(6...12)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(6...12)(
             LABEL(6...10)("foo:"),

--- a/test/snapshots/whitequark/kwoptarg_with_kwrestarg_and_forwarded_args.rb
+++ b/test/snapshots/whitequark/kwoptarg_with_kwrestarg_and_forwarded_args.rb
@@ -7,6 +7,7 @@ ProgramNode(0...28)(
        ParametersNode(6...16)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(6...12)(LABEL(6...8)("a:"), NilNode(9...12)())],
          KeywordRestParameterNode(14...16)(USTAR_STAR(14...16)("**"), nil),

--- a/test/snapshots/whitequark/kwrestarg_named.rb
+++ b/test/snapshots/whitequark/kwrestarg_named.rb
@@ -7,6 +7,7 @@ ProgramNode(0...17)(
        ParametersNode(6...11)(
          [],
          [],
+         [],
          nil,
          [],
          KeywordRestParameterNode(6...11)(

--- a/test/snapshots/whitequark/kwrestarg_unnamed.rb
+++ b/test/snapshots/whitequark/kwrestarg_unnamed.rb
@@ -7,6 +7,7 @@ ProgramNode(0...14)(
        ParametersNode(6...8)(
          [],
          [],
+         [],
          nil,
          [],
          KeywordRestParameterNode(6...8)(USTAR_STAR(6...8)("**"), nil),

--- a/test/snapshots/whitequark/method_definition_in_while_cond.rb
+++ b/test/snapshots/whitequark/method_definition_in_while_cond.rb
@@ -28,6 +28,7 @@ ProgramNode(0...185)(
                 "tap"
               )
             )],
+           [],
            nil,
            [],
            nil,
@@ -105,6 +106,7 @@ ProgramNode(0...185)(
                 "tap"
               )
             )],
+           [],
            nil,
            [],
            nil,

--- a/test/snapshots/whitequark/optarg.rb
+++ b/test/snapshots/whitequark/optarg.rb
@@ -11,6 +11,7 @@ ProgramNode(0...44)(
             EQUAL(10...11)("="),
             IntegerNode(12...13)()
           )],
+         [],
          nil,
          [],
          nil,
@@ -40,6 +41,7 @@ ProgramNode(0...44)(
             EQUAL(36...37)("="),
             IntegerNode(37...38)()
           )],
+         [],
          nil,
          [],
          nil,

--- a/test/snapshots/whitequark/parser_bug_272.rb
+++ b/test/snapshots/whitequark/parser_bug_272.rb
@@ -14,6 +14,7 @@ ProgramNode(0...15)(
            ParametersNode(9...10)(
              [RequiredParameterNode(9...10)()],
              [],
+             [],
              nil,
              [],
              nil,

--- a/test/snapshots/whitequark/parser_bug_507.rb
+++ b/test/snapshots/whitequark/parser_bug_507.rb
@@ -11,6 +11,7 @@ ProgramNode(0...6)(
            ParametersNode(7...12)(
              [],
              [],
+             [],
              RestParameterNode(7...12)(
                STAR(7...8)("*"),
                IDENTIFIER(8...12)("args")

--- a/test/snapshots/whitequark/parser_bug_645.rb
+++ b/test/snapshots/whitequark/parser_bug_645.rb
@@ -17,6 +17,7 @@ ProgramNode(0...11)(
                 BRACE_RIGHT(9...10)("}")
               )
             )],
+           [],
            nil,
            [],
            nil,

--- a/test/snapshots/whitequark/procarg0.rb
+++ b/test/snapshots/whitequark/procarg0.rb
@@ -21,6 +21,7 @@ ProgramNode(0...32)(
                 PARENTHESIS_RIGHT(14...15)(")")
               )],
              [],
+             [],
              nil,
              [],
              nil,
@@ -46,6 +47,7 @@ ProgramNode(0...32)(
          BlockParametersNode(26...29)(
            ParametersNode(26...29)(
              [RequiredParameterNode(26...29)()],
+             [],
              [],
              nil,
              [],

--- a/test/snapshots/whitequark/restarg_named.rb
+++ b/test/snapshots/whitequark/restarg_named.rb
@@ -7,6 +7,7 @@ ProgramNode(0...16)(
        ParametersNode(6...10)(
          [],
          [],
+         [],
          RestParameterNode(6...10)(
            USTAR(6...7)("*"),
            IDENTIFIER(7...10)("foo")

--- a/test/snapshots/whitequark/restarg_unnamed.rb
+++ b/test/snapshots/whitequark/restarg_unnamed.rb
@@ -7,6 +7,7 @@ ProgramNode(0...13)(
        ParametersNode(6...7)(
          [],
          [],
+         [],
          RestParameterNode(6...7)(USTAR(6...7)("*"), nil),
          [],
          nil,

--- a/test/snapshots/whitequark/ruby_bug_10653.rb
+++ b/test/snapshots/whitequark/ruby_bug_10653.rb
@@ -108,6 +108,7 @@ ProgramNode(6...93)(
                 ParametersNode(79...80)(
                   [RequiredParameterNode(79...80)()],
                   [],
+                  [],
                   nil,
                   [],
                   nil,

--- a/test/snapshots/whitequark/ruby_bug_12073.rb
+++ b/test/snapshots/whitequark/ruby_bug_12073.rb
@@ -33,6 +33,7 @@ ProgramNode(0...49)(
        ParametersNode(23...28)(
          [RequiredParameterNode(23...28)()],
          [],
+         [],
          nil,
          [],
          nil,

--- a/test/snapshots/whitequark/ruby_bug_15789.rb
+++ b/test/snapshots/whitequark/ruby_bug_15789.rb
@@ -37,6 +37,7 @@ ProgramNode(0...23)(
                      )
                    )
                  )],
+                [],
                 nil,
                 [],
                 nil,
@@ -64,6 +65,7 @@ ProgramNode(0...23)(
             PARENTHESIS_LEFT(26...27)("("),
             BlockParametersNode(27...35)(
               ParametersNode(27...35)(
+                [],
                 [],
                 [],
                 nil,

--- a/test/snapshots/whitequark/ruby_bug_9669.rb
+++ b/test/snapshots/whitequark/ruby_bug_9669.rb
@@ -7,6 +7,7 @@ ProgramNode(0...31)(
        ParametersNode(6...15)(
          [],
          [],
+         [],
          nil,
          [KeywordParameterNode(6...15)(
             LABEL(6...8)("b:"),

--- a/test/snapshots/whitequark/send_lambda.rb
+++ b/test/snapshots/whitequark/send_lambda.rb
@@ -9,6 +9,7 @@ ProgramNode(0...23)(
          ParametersNode(3...4)(
            [],
            [],
+           [],
            RestParameterNode(3...4)(STAR(3...4)("*"), nil),
            [],
            nil,

--- a/test/snapshots/whitequark/send_lambda_args.rb
+++ b/test/snapshots/whitequark/send_lambda_args.rb
@@ -9,6 +9,7 @@ ProgramNode(0...17)(
          ParametersNode(4...5)(
            [RequiredParameterNode(4...5)()],
            [],
+           [],
            nil,
            [],
            nil,
@@ -26,6 +27,7 @@ ProgramNode(0...17)(
        BlockParametersNode(15...16)(
          ParametersNode(15...16)(
            [RequiredParameterNode(15...16)()],
+           [],
            [],
            nil,
            [],

--- a/test/snapshots/whitequark/send_lambda_args_noparen.rb
+++ b/test/snapshots/whitequark/send_lambda_args_noparen.rb
@@ -9,6 +9,7 @@ ProgramNode(0...15)(
          ParametersNode(3...7)(
            [],
            [],
+           [],
            nil,
            [KeywordParameterNode(3...7)(
               LABEL(3...5)("a:"),
@@ -28,6 +29,7 @@ ProgramNode(0...15)(
        nil,
        BlockParametersNode(16...18)(
          ParametersNode(16...18)(
+           [],
            [],
            [],
            nil,

--- a/test/snapshots/whitequark/send_lambda_args_shadow.rb
+++ b/test/snapshots/whitequark/send_lambda_args_shadow.rb
@@ -13,6 +13,7 @@ ProgramNode(0...15)(
          ParametersNode(3...4)(
            [RequiredParameterNode(3...4)()],
            [],
+           [],
            nil,
            [],
            nil,

--- a/test/snapshots/whitequark/trailing_forward_arg.rb
+++ b/test/snapshots/whitequark/trailing_forward_arg.rb
@@ -7,6 +7,7 @@ ProgramNode(0...40)(
        ParametersNode(8...17)(
          [RequiredParameterNode(8...9)(), RequiredParameterNode(11...12)()],
          [],
+         [],
          nil,
          [],
          ForwardingParameterNode(14...17)(),

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,8 +11,8 @@ module YARP
   module Assertions
     private
 
-    def assert_equal_nodes(expected, actual, message: nil, compare_location: true)
-      assert_equal expected.class, actual.class, message || PP.pp(actual, +"")
+    def assert_equal_nodes(expected, actual, compare_location: true)
+      assert_equal expected.class, actual.class
   
       case expected
       when Array


### PR DESCRIPTION
This resurrects https://github.com/Shopify/yarp/pull/227 (thanks @ccocchi ! I took the liberty of co-authoring you)

and in the second commit uses this newly tracked state to split required params which are after the optional arguments into their own list.