### PR TITLE
Add all-no-debug to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 all: build/librubyparser.$(SOEXT)
 
 build/librubyparser.$(SOEXT): $(shell find src -name '*.c') $(shell find src -name '*.h') Makefile build include/yarp/ast.h
-	$(CC) $(CFLAGS) -std=c99 -Wall -Werror -Wpedantic -fPIC -g -fvisibility=hidden -shared -Iinclude -o $@ $(shell find src -name '*.c')
+	$(CC) $(CFLAGS) $(DEBUG_FLAGS) -std=c99 -Wall -Werror -Wpedantic -fPIC -g -fvisibility=hidden -shared -Iinclude -o $@ $(shell find src -name '*.c')
 
 build:
 	mkdir -p build
@@ -41,3 +41,6 @@ clean:
 		src/util/yp_strspn.c
 
 .PHONY: clean
+
+all-no-debug: DEBUG_FLAGS := -DNDEBUG=1
+all-no-debug: all


### PR DESCRIPTION
Add a non-debugging build to the makefile that runs without assertions. Tested by adding an `assert(false)` and ensuring it raised with `make all` but not with `make all-no-debug`

Closes #659