### PR TITLE
Fix parsing keyword args

### DIFF
--- a/include/yarp/parser.h
+++ b/include/yarp/parser.h
@@ -362,6 +362,9 @@ struct yp_parser {
   // expression and impacts that calculation of newlines.
   bool pattern_matching_newlines;
 
+  // This flag indicates that we are currently parsing a keyword argument.
+  bool in_keyword_arg;
+
   // This is the path of the file being parsed
   // We use the filepath when constructing SourceFileNodes
   yp_string_t filepath_string;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4702,7 +4702,7 @@ parser_lex(yp_parser_t *parser) {
             case YP_IGNORED_NEWLINE_NONE:
               break;
             case YP_IGNORED_NEWLINE_PATTERN:
-              if (parser->pattern_matching_newlines) {
+              if (parser->pattern_matching_newlines || parser->in_keyword_arg) {
                 if (!lexed_comment) parser_lex_ignored_newline(parser);
                 lex_state_set(parser, YP_LEX_STATE_BEG);
                 parser->command_start = true;
@@ -7449,6 +7449,7 @@ parse_parameters(
         break;
       }
       case YP_TOKEN_LABEL: {
+        if (!uses_parentheses) parser->in_keyword_arg = true;
         update_parameter_state(parser, &parser->current, &order);
         parser_lex(parser);
 
@@ -7495,6 +7496,7 @@ parse_parameters(
           }
         }
 
+        parser->in_keyword_arg = false;
         break;
       }
       case YP_TOKEN_USTAR:
@@ -11495,6 +11497,7 @@ yp_parser_init(yp_parser_t *parser, const char *source, size_t size, const char 
     .encoding_comment_start = source,
     .lex_callback = NULL,
     .pattern_matching_newlines = false,
+    .in_keyword_arg = false,
     .filepath_string = filepath_string,
   };
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -16,7 +16,6 @@ class ParseTest < Test::Unit::TestCase
     seattlerb/heredoc_nested.rb
     seattlerb/heredoc_trailing_slash_continued_call.rb
     seattlerb/pct_w_heredoc_interp_nested.rb
-    seattlerb/required_kwarg_no_value.rb
   ]
 
   # Because the filepath in SourceFileNodes is different from one maching to the

--- a/test/snapshots/seattlerb/required_kwarg_no_value.rb
+++ b/test/snapshots/seattlerb/required_kwarg_no_value.rb
@@ -1,0 +1,27 @@
+ProgramNode(0...16)(
+  ScopeNode(0...0)([]),
+  StatementsNode(0...16)(
+    [DefNode(0...16)(
+       IDENTIFIER(4...5)("x"),
+       nil,
+       ParametersNode(6...12)(
+         [],
+         [],
+         [],
+         nil,
+         [KeywordParameterNode(6...8)(LABEL(6...8)("a:"), nil),
+          KeywordParameterNode(10...12)(LABEL(10...12)("b:"), nil)],
+         nil,
+         nil
+       ),
+       nil,
+       ScopeNode(0...3)([LABEL(6...7)("a"), LABEL(10...11)("b")]),
+       (0...3),
+       nil,
+       nil,
+       nil,
+       nil,
+       (13...16)
+     )]
+  )
+)

--- a/test/snapshots/whitequark/args.rb
+++ b/test/snapshots/whitequark/args.rb
@@ -705,7 +705,7 @@ ProgramNode(0...690)(
          nil,
          nil
        ),
-       nil,
+       StatementsNode(0...0)([]),
        ScopeNode(559...562)([LABEL(565...568)("foo")]),
        (559...562),
        nil,

--- a/test/snapshots/whitequark/ruby_bug_9669.rb
+++ b/test/snapshots/whitequark/ruby_bug_9669.rb
@@ -4,19 +4,18 @@ ProgramNode(0...31)(
     [DefNode(0...19)(
        IDENTIFIER(4...5)("a"),
        nil,
-       ParametersNode(6...15)(
+       ParametersNode(6...8)(
          [],
          [],
          [],
          nil,
-         [KeywordParameterNode(6...15)(
-            LABEL(6...8)("b:"),
-            ReturnNode(9...15)(KEYWORD_RETURN(9...15)("return"), nil)
-          )],
+         [KeywordParameterNode(6...8)(LABEL(6...8)("b:"), nil)],
          nil,
          nil
        ),
-       nil,
+       StatementsNode(9...15)(
+         [ReturnNode(9...15)(KEYWORD_RETURN(9...15)("return"), nil)]
+       ),
        ScopeNode(0...3)([LABEL(6...7)("b")]),
        (0...3),
        nil,


### PR DESCRIPTION
Fixes https://github.com/Shopify/yarp/issues/751 parsing code like:

```ruby
def foo a:, b:
  bar
  baz
  qux
end
```
