### PR TITLE
Fix end positions of integers, floats, and rationals

### DIFF
--- a/test/snapshots/numbers.rb
+++ b/test/snapshots/numbers.rb
@@ -20,8 +20,8 @@ ProgramNode(0...161)(
      IntegerNode(72...75)(),
      IntegerNode(77...80)(),
      IntegerNode(82...85)(),
-     ImaginaryNode(87...89)(IntegerNode(87...89)()),
-     RationalNode(91...93)(IntegerNode(91...93)()),
+     ImaginaryNode(87...89)(IntegerNode(87...88)()),
+     RationalNode(91...93)(IntegerNode(91...92)()),
      CallNode(95...97)(
        IntegerNode(96...97)(),
        nil,
@@ -32,11 +32,11 @@ ProgramNode(0...161)(
        nil,
        "-@"
      ),
-     ImaginaryNode(99...102)(RationalNode(99...102)(IntegerNode(99...101)())),
-     ImaginaryNode(104...109)(RationalNode(104...109)(FloatNode(104...108)())),
+     ImaginaryNode(99...102)(RationalNode(99...101)(IntegerNode(99...100)())),
+     ImaginaryNode(104...109)(RationalNode(104...108)(FloatNode(104...107)())),
      CallNode(111...115)(
        ImaginaryNode(112...115)(
-         RationalNode(112...115)(IntegerNode(112...114)())
+         RationalNode(112...114)(IntegerNode(112...113)())
        ),
        nil,
        UMINUS_NUM(111...112)("-"),
@@ -48,7 +48,7 @@ ProgramNode(0...161)(
      ),
      CallNode(117...123)(
        ImaginaryNode(118...123)(
-         RationalNode(118...123)(FloatNode(118...122)())
+         RationalNode(118...122)(FloatNode(118...121)())
        ),
        nil,
        UMINUS_NUM(117...118)("-"),
@@ -58,15 +58,15 @@ ProgramNode(0...161)(
        nil,
        "-@"
      ),
-     RationalNode(125...129)(IntegerNode(125...129)()),
-     ImaginaryNode(131...135)(IntegerNode(131...135)()),
+     RationalNode(125...129)(IntegerNode(125...128)()),
+     ImaginaryNode(131...135)(IntegerNode(131...134)()),
      ImaginaryNode(137...142)(
-       RationalNode(137...142)(IntegerNode(137...141)())
+       RationalNode(137...141)(IntegerNode(137...140)())
      ),
-     RationalNode(144...148)(IntegerNode(144...148)()),
-     ImaginaryNode(150...154)(IntegerNode(150...154)()),
+     RationalNode(144...148)(IntegerNode(144...147)()),
+     ImaginaryNode(150...154)(IntegerNode(150...153)()),
      ImaginaryNode(156...161)(
-       RationalNode(156...161)(IntegerNode(156...160)())
+       RationalNode(156...160)(IntegerNode(156...159)())
      )]
   )
 )

--- a/test/snapshots/patterns.rb
+++ b/test/snapshots/patterns.rb
@@ -58,7 +58,7 @@ ProgramNode(0...3655)(
          nil,
          "foo"
        ),
-       ImaginaryNode(38...40)(IntegerNode(38...40)()),
+       ImaginaryNode(38...40)(IntegerNode(38...39)()),
        (35...37)
      ),
      MatchRequiredNode(41...50)(
@@ -72,7 +72,7 @@ ProgramNode(0...3655)(
          nil,
          "foo"
        ),
-       RationalNode(48...50)(IntegerNode(48...50)()),
+       RationalNode(48...50)(IntegerNode(48...49)()),
        (45...47)
      ),
      MatchRequiredNode(51...62)(
@@ -507,8 +507,8 @@ ProgramNode(0...3655)(
          "foo"
        ),
        RangeNode(394...402)(
-         ImaginaryNode(394...396)(IntegerNode(394...396)()),
-         ImaginaryNode(400...402)(IntegerNode(400...402)()),
+         ImaginaryNode(394...396)(IntegerNode(394...395)()),
+         ImaginaryNode(400...402)(IntegerNode(400...401)()),
          (397...399)
        ),
        (391...393)
@@ -525,8 +525,8 @@ ProgramNode(0...3655)(
          "foo"
        ),
        RangeNode(410...418)(
-         RationalNode(410...412)(IntegerNode(410...412)()),
-         RationalNode(416...418)(IntegerNode(416...418)()),
+         RationalNode(410...412)(IntegerNode(410...411)()),
+         RationalNode(416...418)(IntegerNode(416...417)()),
          (413...415)
        ),
        (407...409)
@@ -2010,7 +2010,7 @@ ProgramNode(0...3655)(
          nil,
          "foo"
        ),
-       ImaginaryNode(1668...1670)(IntegerNode(1668...1670)()),
+       ImaginaryNode(1668...1670)(IntegerNode(1668...1669)()),
        (1665...1667)
      ),
      MatchPredicateNode(1671...1680)(
@@ -2024,7 +2024,7 @@ ProgramNode(0...3655)(
          nil,
          "foo"
        ),
-       RationalNode(1678...1680)(IntegerNode(1678...1680)()),
+       RationalNode(1678...1680)(IntegerNode(1678...1679)()),
        (1675...1677)
      ),
      MatchPredicateNode(1681...1692)(
@@ -2486,7 +2486,7 @@ ProgramNode(0...3655)(
          "foo"
        ),
        [InNode(2071...2081)(
-          ImaginaryNode(2074...2076)(IntegerNode(2074...2076)()),
+          ImaginaryNode(2074...2076)(IntegerNode(2074...2075)()),
           nil,
           (2071...2073),
           (2077...2081)
@@ -2507,7 +2507,7 @@ ProgramNode(0...3655)(
          "foo"
        ),
        [InNode(2096...2106)(
-          RationalNode(2099...2101)(IntegerNode(2099...2101)()),
+          RationalNode(2099...2101)(IntegerNode(2099...2100)()),
           nil,
           (2096...2098),
           (2102...2106)
@@ -3148,7 +3148,7 @@ ProgramNode(0...3655)(
             KEYWORD_IF_MODIFIER(2843...2845)("if"),
             LocalVariableReadNode(2846...2849)(0),
             StatementsNode(2840...2842)(
-              [ImaginaryNode(2840...2842)(IntegerNode(2840...2842)())]
+              [ImaginaryNode(2840...2842)(IntegerNode(2840...2841)())]
             ),
             nil,
             nil
@@ -3177,7 +3177,7 @@ ProgramNode(0...3655)(
             KEYWORD_IF_MODIFIER(2875...2877)("if"),
             LocalVariableReadNode(2878...2881)(0),
             StatementsNode(2872...2874)(
-              [RationalNode(2872...2874)(IntegerNode(2872...2874)())]
+              [RationalNode(2872...2874)(IntegerNode(2872...2873)())]
             ),
             nil,
             nil

--- a/test/snapshots/seattlerb/ruby21_numbers.rb
+++ b/test/snapshots/seattlerb/ruby21_numbers.rb
@@ -2,9 +2,9 @@ ProgramNode(0...13)(
   ScopeNode(0...0)([]),
   StatementsNode(0...13)(
     [ArrayNode(0...13)(
-       [ImaginaryNode(1...3)(IntegerNode(1...3)()),
-        RationalNode(5...7)(IntegerNode(5...7)()),
-        ImaginaryNode(9...12)(RationalNode(9...12)(IntegerNode(9...11)()))],
+       [ImaginaryNode(1...3)(IntegerNode(1...2)()),
+        RationalNode(5...7)(IntegerNode(5...6)()),
+        ImaginaryNode(9...12)(RationalNode(9...11)(IntegerNode(9...10)()))],
        BRACKET_LEFT_ARRAY(0...1)("["),
        BRACKET_RIGHT(12...13)("]")
      )]

--- a/test/snapshots/symbols.rb
+++ b/test/snapshots/symbols.rb
@@ -128,8 +128,8 @@ ProgramNode(0...345)(
      ArrayNode(97...113)(
        [IntegerNode(98...99)(),
         FloatNode(101...104)(),
-        RationalNode(106...108)(IntegerNode(106...108)()),
-        ImaginaryNode(110...112)(IntegerNode(110...112)())],
+        RationalNode(106...108)(IntegerNode(106...107)()),
+        ImaginaryNode(110...112)(IntegerNode(110...111)())],
        BRACKET_LEFT_ARRAY(97...98)("["),
        BRACKET_RIGHT(112...113)("]")
      ),

--- a/test/snapshots/unparser/corpus/literal/literal.rb
+++ b/test/snapshots/unparser/corpus/literal/literal.rb
@@ -268,12 +268,12 @@ ProgramNode(2...916)(
      ),
      IntegerNode(227...228)(),
      IntegerNode(229...230)(),
-     RationalNode(231...233)(IntegerNode(231...233)()),
-     RationalNode(234...238)(FloatNode(234...238)()),
-     RationalNode(239...243)(FloatNode(239...243)()),
-     ImaginaryNode(244...246)(IntegerNode(244...246)()),
+     RationalNode(231...233)(IntegerNode(231...232)()),
+     RationalNode(234...238)(FloatNode(234...237)()),
+     RationalNode(239...243)(FloatNode(239...242)()),
+     ImaginaryNode(244...246)(IntegerNode(244...245)()),
      CallNode(247...250)(
-       ImaginaryNode(248...250)(IntegerNode(248...250)()),
+       ImaginaryNode(248...250)(IntegerNode(248...249)()),
        nil,
        UMINUS_NUM(247...248)("-"),
        nil,
@@ -282,9 +282,9 @@ ProgramNode(2...916)(
        nil,
        "-@"
      ),
-     ImaginaryNode(251...255)(FloatNode(251...255)()),
+     ImaginaryNode(251...255)(FloatNode(251...254)()),
      CallNode(256...261)(
-       ImaginaryNode(257...261)(FloatNode(257...261)()),
+       ImaginaryNode(257...261)(FloatNode(257...260)()),
        nil,
        UMINUS_NUM(256...257)("-"),
        nil,
@@ -293,9 +293,9 @@ ProgramNode(2...916)(
        nil,
        "-@"
      ),
-     ImaginaryNode(262...294)(IntegerNode(262...294)()),
+     ImaginaryNode(262...294)(IntegerNode(262...293)()),
      ImaginaryNode(295...298)(
-       RationalNode(295...298)(IntegerNode(295...297)())
+       RationalNode(295...297)(IntegerNode(295...296)())
      ),
      StringConcatNode(299...310)(
        StringNode(299...304)(

--- a/test/snapshots/unparser/corpus/semantic/literal.rb
+++ b/test/snapshots/unparser/corpus/semantic/literal.rb
@@ -1,9 +1,9 @@
 ProgramNode(0...131)(
   ScopeNode(0...0)([]),
   StatementsNode(0...131)(
-    [RationalNode(0...4)(FloatNode(0...4)()),
+    [RationalNode(0...4)(FloatNode(0...3)()),
      CallNode(5...8)(
-       RationalNode(6...8)(IntegerNode(6...8)()),
+       RationalNode(6...8)(IntegerNode(6...7)()),
        nil,
        UMINUS_NUM(5...6)("-"),
        nil,

--- a/test/snapshots/whitequark/complex.rb
+++ b/test/snapshots/whitequark/complex.rb
@@ -1,9 +1,9 @@
 ProgramNode(0...24)(
   ScopeNode(0...0)([]),
   StatementsNode(0...24)(
-    [ImaginaryNode(0...5)(FloatNode(0...5)()),
-     ImaginaryNode(7...13)(RationalNode(7...13)(FloatNode(7...12)())),
-     ImaginaryNode(15...18)(IntegerNode(15...18)()),
-     ImaginaryNode(20...24)(RationalNode(20...24)(IntegerNode(20...23)()))]
+    [ImaginaryNode(0...5)(FloatNode(0...4)()),
+     ImaginaryNode(7...13)(RationalNode(7...12)(FloatNode(7...11)())),
+     ImaginaryNode(15...18)(IntegerNode(15...17)()),
+     ImaginaryNode(20...24)(RationalNode(20...23)(IntegerNode(20...22)()))]
   )
 )

--- a/test/snapshots/whitequark/rational.rb
+++ b/test/snapshots/whitequark/rational.rb
@@ -1,7 +1,7 @@
 ProgramNode(0...10)(
   ScopeNode(0...0)([]),
   StatementsNode(0...10)(
-    [RationalNode(0...5)(FloatNode(0...5)()),
-     RationalNode(7...10)(IntegerNode(7...10)())]
+    [RationalNode(0...5)(FloatNode(0...4)()),
+     RationalNode(7...10)(IntegerNode(7...9)())]
   )
 )

--- a/test/snapshots/whitequark/ruby_bug_11873_a.rb
+++ b/test/snapshots/whitequark/ruby_bug_11873_a.rb
@@ -139,7 +139,7 @@ ProgramNode(0...444)(
             nil,
             "b"
           ),
-          ImaginaryNode(52...56)(FloatNode(52...56)())]
+          ImaginaryNode(52...56)(FloatNode(52...55)())]
        ),
        nil,
        BlockNode(57...63)(
@@ -189,7 +189,7 @@ ProgramNode(0...444)(
             nil,
             "b"
           ),
-          RationalNode(75...79)(FloatNode(75...79)())]
+          RationalNode(75...79)(FloatNode(75...78)())]
        ),
        nil,
        BlockNode(80...86)(
@@ -394,7 +394,7 @@ ProgramNode(0...444)(
             nil,
             "b"
           ),
-          ImaginaryNode(164...168)(FloatNode(164...168)())]
+          ImaginaryNode(164...168)(FloatNode(164...167)())]
        ),
        nil,
        BlockNode(169...175)(
@@ -444,7 +444,7 @@ ProgramNode(0...444)(
             nil,
             "b"
           ),
-          RationalNode(188...192)(FloatNode(188...192)())]
+          RationalNode(188...192)(FloatNode(188...191)())]
        ),
        nil,
        BlockNode(193...199)(
@@ -667,7 +667,7 @@ ProgramNode(0...444)(
             ),
             "b"
           ),
-          ImaginaryNode(275...279)(FloatNode(275...279)())]
+          ImaginaryNode(275...279)(FloatNode(275...278)())]
        ),
        nil,
        BlockNode(280...286)(
@@ -723,7 +723,7 @@ ProgramNode(0...444)(
             ),
             "b"
           ),
-          RationalNode(298...302)(FloatNode(298...302)())]
+          RationalNode(298...302)(FloatNode(298...301)())]
        ),
        nil,
        BlockNode(303...309)(
@@ -952,7 +952,7 @@ ProgramNode(0...444)(
             ),
             "b"
           ),
-          ImaginaryNode(387...391)(FloatNode(387...391)())]
+          ImaginaryNode(387...391)(FloatNode(387...390)())]
        ),
        nil,
        BlockNode(392...398)(
@@ -1008,7 +1008,7 @@ ProgramNode(0...444)(
             ),
             "b"
           ),
-          RationalNode(411...415)(FloatNode(411...415)())]
+          RationalNode(411...415)(FloatNode(411...414)())]
        ),
        nil,
        BlockNode(416...422)(


### PR DESCRIPTION
A numeric node that is nested inside either a rational or imaginary node should have an end position that is smaller by 1.

This should be merged before #823 (if approved)