### PR TITLE
Emit error for else nodes without rescue

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -9782,6 +9782,15 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
       begin_node->base.location.end = parser->previous.end;
       yp_begin_node_end_keyword_set(begin_node, &parser->previous);
 
+      if ((begin_node->else_clause != NULL) && (begin_node->rescue_clause == NULL)) {
+        yp_diagnostic_list_append(
+          &parser->error_list,
+          begin_node->else_clause->base.location.start,
+          begin_node->else_clause->base.location.end,
+          "else without rescue is useless"
+        );
+      }
+
       return (yp_node_t *) begin_node;
     }
     case YP_TOKEN_KEYWORD_BEGIN_UPCASE: {

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -52,8 +52,8 @@ module YARP
     test "BeginNode" do
       assert_location(BeginNode, "begin foo end")
       assert_location(BeginNode, "begin foo rescue bar end")
-      assert_location(BeginNode, "begin foo rescue bar\nelse baz end")
-      assert_location(BeginNode, "begin foo rescue bar\nelse baz\nensure qux end")
+      assert_location(BeginNode, "begin foo; rescue bar\nelse baz end")
+      assert_location(BeginNode, "begin foo; rescue bar\nelse baz\nensure qux end")
 
       assert_location(BeginNode, "class Foo\nrescue then end", &:statements)
       assert_location(BeginNode, "module Foo\nrescue then end", &:statements)
@@ -379,7 +379,7 @@ module YARP
       assert_location(StatementsNode, "begin; foo; end", 7...10, &:statements)
       assert_location(StatementsNode, "begin; rescue; foo; end", 15...18) { |node| node.rescue_clause.statements }
       assert_location(StatementsNode, "begin; ensure; foo; end", 15...18) { |node| node.ensure_clause.statements }
-      assert_location(StatementsNode, "begin; else; foo; end", 13...16) { |node| node.else_clause.statements }
+      assert_location(StatementsNode, "begin; rescue; else; foo; end", 21...24) { |node| node.else_clause.statements }
 
       assert_location(StatementsNode, "class Foo; foo; end", 11...14, &:statements)
       assert_location(StatementsNode, "module Foo; foo; end", 12...15, &:statements)


### PR DESCRIPTION
Emit error for:

```ruby
begin; 1; else bar; end
```

```
ruby -c -e "begin; 1; else bar; end"
-e:1: else without rescue is useless
begin; 1; else bar; end
-e: compile error (SyntaxError)
```

I unfortunately cannot add a test because `Ripper.sexp_raw` returns non-nil for the code.