### PR TITLE
Fix location for `IfNode`

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1613,7 +1613,7 @@ yp_if_node_create(yp_parser_t *parser,
     end = end_keyword->end;
   } else if (consequent != NULL) {
     end = consequent->location.end;
-  } else if (statements != NULL) {
+  } else if ((statements != NULL) && (statements->body.size != 0)) {
     end = statements->base.location.end;
   } else {
     end = predicate->location.end;
@@ -8131,9 +8131,11 @@ parse_conditional(yp_parser_t *parser, yp_context_t context) {
     switch (context) {
       case YP_CONTEXT_IF:
         ((yp_if_node_t *) parent)->end_keyword = parser->previous;
+        parent->location.end = parser->previous.end;
         break;
       case YP_CONTEXT_UNLESS:
         ((yp_unless_node_t *) parent)->end_keyword = parser->previous;
+        parent->location.end = parser->previous.end;
         break;
       default:
         assert(false && "unreachable");

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -221,6 +221,10 @@ module YARP
       assert_location(ForwardingSuperNode, "super {}")
     end
 
+    test "IfNode" do
+      assert_location(IfNode, "if type in 1;elsif type in B;end")
+    end
+
     test "ImaginaryNode" do
       assert_location(ImaginaryNode, "1i")
       assert_location(ImaginaryNode, "1ri")

--- a/test/snapshots/if.rb
+++ b/test/snapshots/if.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...273)(
+ProgramNode(0...293)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...273)(
-    [IfNode(0...10)(
+  StatementsNode(0...293)(
+    [IfNode(0...15)(
        KEYWORD_IF(0...2)("if"),
        TrueNode(3...7)(),
        StatementsNode(9...10)([IntegerNode(9...10)()]),
@@ -72,7 +72,7 @@ ProgramNode(0...273)(
        nil,
        nil
      ),
-     IfNode(170...196)(
+     IfNode(170...200)(
        KEYWORD_IF(170...172)("if"),
        CallNode(173...182)(
          nil,
@@ -93,7 +93,7 @@ ProgramNode(0...273)(
        nil,
        KEYWORD_END(197...200)("end")
      ),
-     IfNode(202...217)(
+     IfNode(202...221)(
        KEYWORD_IF(202...204)("if"),
        CallNode(205...208)(
          nil,
@@ -201,7 +201,7 @@ ProgramNode(0...273)(
        ),
        KEYWORD_END(256...259)("end")
      ),
-     IfNode(261...273)(
+     IfNode(261...293)(
        KEYWORD_IF(261...263)("if"),
        MatchPredicateNode(264...273)(
          CallNode(264...268)(
@@ -218,7 +218,7 @@ ProgramNode(0...273)(
          (269...271)
        ),
        nil,
-       IfNode(274...0)(
+       IfNode(274...289)(
          KEYWORD_ELSIF(274...279)("elsif"),
          MatchPredicateNode(280...289)(
            CallNode(280...284)(

--- a/test/snapshots/method_calls.rb
+++ b/test/snapshots/method_calls.rb
@@ -1668,19 +1668,19 @@ ProgramNode(0...1187)(
        nil,
        "p"
      ),
-     CallNode(989...1034)(
+     CallNode(989...1040)(
        nil,
        nil,
        IDENTIFIER(989...992)("foo"),
        nil,
-       ArgumentsNode(993...1034)(
+       ArgumentsNode(993...1040)(
          [SymbolNode(993...995)(
             SYMBOL_BEGIN(993...994)(":"),
             IDENTIFIER(994...995)("a"),
             nil,
             "a"
           ),
-          IfNode(999...1034)(
+          IfNode(999...1040)(
             KEYWORD_IF(999...1001)("if"),
             CallNode(1002...1003)(
               nil,

--- a/test/snapshots/patterns.rb
+++ b/test/snapshots/patterns.rb
@@ -3881,7 +3881,7 @@ ProgramNode(0...3725)(
        (3616...3620),
        (3652...3655)
      ),
-     IfNode(3657...3667)(
+     IfNode(3657...3671)(
        KEYWORD_IF(3657...3659)("if"),
        MatchPredicateNode(3660...3667)(
          CallNode(3660...3661)(

--- a/test/snapshots/rescue.rb
+++ b/test/snapshots/rescue.rb
@@ -206,7 +206,7 @@ ProgramNode(0...316)(
        ),
        "foo"
      ),
-     IfNode(214...241)(
+     IfNode(214...245)(
        KEYWORD_IF(214...216)("if"),
        LocalVariableWriteNode(217...235)(
          (217...218),

--- a/test/snapshots/seattlerb/bug_comma.rb
+++ b/test/snapshots/seattlerb/bug_comma.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...15)(
+ProgramNode(0...24)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...15)(
-    [IfNode(0...15)(
+  StatementsNode(0...24)(
+    [IfNode(0...24)(
        KEYWORD_IF(0...2)("if"),
        CallNode(3...15)(
          nil,

--- a/test/snapshots/seattlerb/cond_unary_minus.rb
+++ b/test/snapshots/seattlerb/cond_unary_minus.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...5)(
+ProgramNode(0...10)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...5)(
-    [IfNode(0...5)(
+  StatementsNode(0...10)(
+    [IfNode(0...10)(
        KEYWORD_IF(0...2)("if"),
        CallNode(3...5)(
          IntegerNode(4...5)(),

--- a/test/snapshots/seattlerb/flip2_env_lvar.rb
+++ b/test/snapshots/seattlerb/flip2_env_lvar.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...7)(
+ProgramNode(0...16)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...7)(
-    [IfNode(0...7)(
+  StatementsNode(0...16)(
+    [IfNode(0...16)(
        KEYWORD_IF(0...2)("if"),
        RangeNode(3...7)(
          CallNode(3...4)(

--- a/test/snapshots/seattlerb/i_fucking_hate_line_numbers.rb
+++ b/test/snapshots/seattlerb/i_fucking_hate_line_numbers.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...100)(
+ProgramNode(0...104)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...100)(
-    [IfNode(0...100)(
+  StatementsNode(0...104)(
+    [IfNode(0...104)(
        KEYWORD_IF(0...2)("if"),
        TrueNode(3...7)(),
        StatementsNode(10...100)(

--- a/test/snapshots/seattlerb/i_fucking_hate_line_numbers2.rb
+++ b/test/snapshots/seattlerb/i_fucking_hate_line_numbers2.rb
@@ -1,7 +1,7 @@
 ProgramNode(0...48)(
   ScopeNode(0...0)([IDENTIFIER(24...25)("b"), IDENTIFIER(38...39)("c")]),
   StatementsNode(0...48)(
-    [IfNode(0...42)(
+    [IfNode(0...46)(
        KEYWORD_IF(0...2)("if"),
        TrueNode(3...7)(),
        StatementsNode(15...42)(

--- a/test/snapshots/seattlerb/if_elsif.rb
+++ b/test/snapshots/seattlerb/if_elsif.rb
@@ -1,11 +1,11 @@
-ProgramNode(0...4)(
+ProgramNode(0...18)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...4)(
-    [IfNode(0...4)(
+  StatementsNode(0...18)(
+    [IfNode(0...18)(
        KEYWORD_IF(0...2)("if"),
        IntegerNode(3...4)(),
        nil,
-       IfNode(6...0)(
+       IfNode(6...13)(
          KEYWORD_ELSIF(6...11)("elsif"),
          IntegerNode(12...13)(),
          StatementsNode(0...0)([]),

--- a/test/snapshots/seattlerb/if_symbol.rb
+++ b/test/snapshots/seattlerb/if_symbol.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...7)(
+ProgramNode(0...12)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...7)(
-    [IfNode(0...7)(
+  StatementsNode(0...12)(
+    [IfNode(0...12)(
        KEYWORD_IF(0...2)("if"),
        CallNode(3...7)(
          nil,

--- a/test/snapshots/seattlerb/parse_line_return.rb
+++ b/test/snapshots/seattlerb/parse_line_return.rb
@@ -5,8 +5,8 @@ ProgramNode(6...77)(
        IDENTIFIER(10...14)("blah"),
        nil,
        nil,
-       StatementsNode(23...55)(
-         [IfNode(23...55)(
+       StatementsNode(23...67)(
+         [IfNode(23...67)(
             KEYWORD_IF(23...25)("if"),
             TrueNode(26...30)(),
             StatementsNode(46...55)(

--- a/test/snapshots/unless.rb
+++ b/test/snapshots/unless.rb
@@ -1,7 +1,7 @@
 ProgramNode(0...141)(
   ScopeNode(0...0)([]),
   StatementsNode(0...141)(
-    [UnlessNode(0...14)(
+    [UnlessNode(0...19)(
        KEYWORD_UNLESS(0...6)("unless"),
        TrueNode(7...11)(),
        StatementsNode(13...14)([IntegerNode(13...14)()]),

--- a/test/snapshots/unparser/corpus/literal/dstr.rb
+++ b/test/snapshots/unparser/corpus/literal/dstr.rb
@@ -1,7 +1,7 @@
 ProgramNode(0...299)(
   ScopeNode(0...0)([]),
   StatementsNode(0...299)(
-    [IfNode(0...16)(
+    [IfNode(0...20)(
        KEYWORD_IF(0...2)("if"),
        TrueNode(3...7)(),
        StatementsNode(10...16)(
@@ -19,7 +19,7 @@ ProgramNode(0...299)(
        nil,
        KEYWORD_END(17...20)("end")
      ),
-     IfNode(21...64)(
+     IfNode(21...68)(
        KEYWORD_IF(21...23)("if"),
        TrueNode(24...28)(),
        StatementsNode(42...64)(
@@ -134,7 +134,7 @@ ProgramNode(0...299)(
         ClassVariableReadNode(169...172)()],
        STRING_END(172...173)("\"")
      ),
-     IfNode(174...212)(
+     IfNode(174...225)(
        KEYWORD_IF(174...176)("if"),
        TrueNode(177...181)(),
        StatementsNode(184...212)(

--- a/test/snapshots/unparser/corpus/literal/flipflop.rb
+++ b/test/snapshots/unparser/corpus/literal/flipflop.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...64)(
+ProgramNode(0...68)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...64)(
-    [IfNode(0...29)(
+  StatementsNode(0...68)(
+    [IfNode(0...33)(
        KEYWORD_IF(0...2)("if"),
        ParenthesesNode(3...23)(
          StatementsNode(4...22)(
@@ -77,7 +77,7 @@ ProgramNode(0...64)(
        nil,
        KEYWORD_END(30...33)("end")
      ),
-     IfNode(34...64)(
+     IfNode(34...68)(
        KEYWORD_IF(34...36)("if"),
        ParenthesesNode(37...58)(
          StatementsNode(38...57)(

--- a/test/snapshots/unparser/corpus/literal/if.rb
+++ b/test/snapshots/unparser/corpus/literal/if.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...242)(
+ProgramNode(0...246)(
   ScopeNode(0...0)(
     [IDENTIFIER(184...187)("foo"), IDENTIFIER(225...229)("pair")]
   ),
-  StatementsNode(0...242)(
-    [IfNode(0...14)(
+  StatementsNode(0...246)(
+    [IfNode(0...18)(
        KEYWORD_IF(0...2)("if"),
        RegularExpressionNode(3...8)(
          REGEXP_BEGIN(3...4)("/"),
@@ -26,7 +26,7 @@ ProgramNode(0...242)(
        nil,
        KEYWORD_END(15...18)("end")
      ),
-     IfNode(19...27)(
+     IfNode(19...31)(
        KEYWORD_IF(19...21)("if"),
        IntegerNode(22...23)(),
        StatementsNode(26...27)([IntegerNode(26...27)()]),
@@ -44,21 +44,21 @@ ProgramNode(0...242)(
        ),
        KEYWORD_END(50...53)("end")
      ),
-     UnlessNode(54...68)(
+     UnlessNode(54...72)(
        KEYWORD_UNLESS(54...60)("unless"),
        IntegerNode(61...62)(),
        StatementsNode(65...68)([NilNode(65...68)()]),
        nil,
        KEYWORD_END(69...72)("end")
      ),
-     UnlessNode(73...85)(
+     UnlessNode(73...89)(
        KEYWORD_UNLESS(73...79)("unless"),
        IntegerNode(80...81)(),
        StatementsNode(84...85)([IntegerNode(84...85)()]),
        nil,
        KEYWORD_END(86...89)("end")
      ),
-     IfNode(90...96)(
+     IfNode(90...100)(
        KEYWORD_IF(90...92)("if"),
        CallNode(93...96)(
          nil,
@@ -136,7 +136,7 @@ ProgramNode(0...242)(
        ),
        KEYWORD_END(167...170)("end")
      ),
-     UnlessNode(171...193)(
+     UnlessNode(171...197)(
        KEYWORD_UNLESS(171...177)("unless"),
        CallNode(178...181)(
          nil,
@@ -168,7 +168,7 @@ ProgramNode(0...242)(
        nil,
        KEYWORD_END(194...197)("end")
      ),
-     IfNode(198...242)(
+     IfNode(198...246)(
        KEYWORD_IF(198...200)("if"),
        CallNode(201...222)(
          nil,

--- a/test/snapshots/unparser/corpus/literal/send.rb
+++ b/test/snapshots/unparser/corpus/literal/send.rb
@@ -346,7 +346,7 @@ ProgramNode(0...991)(
        "bar"
      ),
      CallNode(304...318)(
-       IfNode(304...310)(
+       IfNode(304...314)(
          KEYWORD_IF(304...306)("if"),
          CallNode(307...310)(
            nil,

--- a/test/snapshots/unparser/corpus/semantic/and.rb
+++ b/test/snapshots/unparser/corpus/semantic/and.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...73)(
+ProgramNode(0...77)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...73)(
+  StatementsNode(0...77)(
     [OrNode(0...14)(
        RangeNode(0...5)(
          CallNode(0...1)(
@@ -99,7 +99,7 @@ ProgramNode(0...73)(
        ),
        KEYWORD_AND(21...24)("and")
      ),
-     IfNode(32...49)(
+     IfNode(32...53)(
        KEYWORD_IF(32...34)("if"),
        OrNode(35...49)(
          RangeNode(35...40)(
@@ -154,7 +154,7 @@ ProgramNode(0...73)(
        nil,
        KEYWORD_END(50...53)("end")
      ),
-     IfNode(55...73)(
+     IfNode(55...77)(
        KEYWORD_IF(55...57)("if"),
        AndNode(58...73)(
          RangeNode(58...63)(

--- a/test/snapshots/unparser/corpus/semantic/dstr.rb
+++ b/test/snapshots/unparser/corpus/semantic/dstr.rb
@@ -213,7 +213,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(310...314)("DOC\n")
      ),
-     IfNode(315...340)(
+     IfNode(315...349)(
        KEYWORD_IF(315...317)("if"),
        TrueNode(318...322)(),
        StatementsNode(332...340)(
@@ -242,7 +242,7 @@ ProgramNode(0...608)(
        nil,
        KEYWORD_END(346...349)("end")
      ),
-     IfNode(351...377)(
+     IfNode(351...386)(
        KEYWORD_IF(351...353)("if"),
        TrueNode(354...358)(),
        StatementsNode(368...377)(
@@ -271,7 +271,7 @@ ProgramNode(0...608)(
        nil,
        KEYWORD_END(383...386)("end")
      ),
-     IfNode(388...414)(
+     IfNode(388...423)(
        KEYWORD_IF(388...390)("if"),
        TrueNode(391...395)(),
        StatementsNode(405...414)(
@@ -300,7 +300,7 @@ ProgramNode(0...608)(
        nil,
        KEYWORD_END(420...423)("end")
      ),
-     IfNode(425...455)(
+     IfNode(425...464)(
        KEYWORD_IF(425...427)("if"),
        TrueNode(428...432)(),
        StatementsNode(444...455)(

--- a/test/snapshots/whitequark/cond_begin.rb
+++ b/test/snapshots/whitequark/cond_begin.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...13)(
+ProgramNode(0...18)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...13)(
-    [IfNode(0...13)(
+  StatementsNode(0...18)(
+    [IfNode(0...18)(
        KEYWORD_IF(0...2)("if"),
        ParenthesesNode(3...8)(
          StatementsNode(4...7)(

--- a/test/snapshots/whitequark/cond_begin_masgn.rb
+++ b/test/snapshots/whitequark/cond_begin_masgn.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...20)(
+ProgramNode(0...25)(
   ScopeNode(0...0)([IDENTIFIER(9...10)("a"), IDENTIFIER(12...13)("b")]),
-  StatementsNode(0...20)(
-    [IfNode(0...20)(
+  StatementsNode(0...25)(
+    [IfNode(0...25)(
        KEYWORD_IF(0...2)("if"),
        ParenthesesNode(3...20)(
          StatementsNode(4...19)(

--- a/test/snapshots/whitequark/cond_eflipflop.rb
+++ b/test/snapshots/whitequark/cond_eflipflop.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...26)(
+ProgramNode(0...31)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...26)(
+  StatementsNode(0...31)(
     [CallNode(0...12)(
        ParenthesesNode(1...12)(
          StatementsNode(2...11)(
@@ -39,7 +39,7 @@ ProgramNode(0...26)(
        nil,
        "!"
      ),
-     IfNode(14...26)(
+     IfNode(14...31)(
        KEYWORD_IF(14...16)("if"),
        RangeNode(17...26)(
          CallNode(17...20)(

--- a/test/snapshots/whitequark/cond_iflipflop.rb
+++ b/test/snapshots/whitequark/cond_iflipflop.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...24)(
+ProgramNode(0...29)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...24)(
+  StatementsNode(0...29)(
     [CallNode(0...11)(
        ParenthesesNode(1...11)(
          StatementsNode(2...10)(
@@ -39,7 +39,7 @@ ProgramNode(0...24)(
        nil,
        "!"
      ),
-     IfNode(13...24)(
+     IfNode(13...29)(
        KEYWORD_IF(13...15)("if"),
        RangeNode(16...24)(
          CallNode(16...19)(

--- a/test/snapshots/whitequark/cond_match_current_line.rb
+++ b/test/snapshots/whitequark/cond_match_current_line.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...16)(
+ProgramNode(0...21)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...16)(
+  StatementsNode(0...21)(
     [CallNode(0...6)(
        RegularExpressionNode(1...6)(
          REGEXP_BEGIN(1...2)("/"),
@@ -16,7 +16,7 @@ ProgramNode(0...16)(
        nil,
        "!"
      ),
-     IfNode(8...16)(
+     IfNode(8...21)(
        KEYWORD_IF(8...10)("if"),
        RegularExpressionNode(11...16)(
          REGEXP_BEGIN(11...12)("/"),

--- a/test/snapshots/whitequark/if.rb
+++ b/test/snapshots/whitequark/if.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...33)(
+ProgramNode(0...38)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...33)(
-    [IfNode(0...15)(
+  StatementsNode(0...38)(
+    [IfNode(0...20)(
        KEYWORD_IF(0...2)("if"),
        CallNode(3...6)(
          nil,
@@ -28,7 +28,7 @@ ProgramNode(0...33)(
        nil,
        KEYWORD_END(17...20)("end")
      ),
-     IfNode(22...33)(
+     IfNode(22...38)(
        KEYWORD_IF(22...24)("if"),
        CallNode(25...28)(
          nil,

--- a/test/snapshots/whitequark/if_masgn__24.rb
+++ b/test/snapshots/whitequark/if_masgn__24.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...15)(
+ProgramNode(0...20)(
   ScopeNode(0...0)([IDENTIFIER(4...5)("a"), IDENTIFIER(7...8)("b")]),
-  StatementsNode(0...15)(
-    [IfNode(0...15)(
+  StatementsNode(0...20)(
+    [IfNode(0...20)(
        KEYWORD_IF(0...2)("if"),
        ParenthesesNode(3...15)(
          StatementsNode(4...14)(

--- a/test/snapshots/whitequark/if_nl_then.rb
+++ b/test/snapshots/whitequark/if_nl_then.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...15)(
+ProgramNode(0...19)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...15)(
-    [IfNode(0...15)(
+  StatementsNode(0...19)(
+    [IfNode(0...19)(
        KEYWORD_IF(0...2)("if"),
        CallNode(3...6)(
          nil,

--- a/test/snapshots/whitequark/if_while_after_class__since_32.rb
+++ b/test/snapshots/whitequark/if_while_after_class__since_32.rb
@@ -5,7 +5,7 @@ ProgramNode(0...178)(
        ScopeNode(0...5)([]),
        KEYWORD_CLASS(0...5)("class"),
        ConstantPathNode(6...33)(
-         IfNode(6...21)(
+         IfNode(6...25)(
            KEYWORD_IF(6...8)("if"),
            TrueNode(9...13)(),
            StatementsNode(15...21)([ConstantReadNode(15...21)()]),
@@ -46,7 +46,7 @@ ProgramNode(0...178)(
        ScopeNode(89...95)([]),
        KEYWORD_MODULE(89...95)("module"),
        ConstantPathNode(96...123)(
-         IfNode(96...111)(
+         IfNode(96...115)(
            KEYWORD_IF(96...98)("if"),
            TrueNode(99...103)(),
            StatementsNode(105...111)([ConstantReadNode(105...111)()]),

--- a/test/snapshots/whitequark/ruby_bug_10279.rb
+++ b/test/snapshots/whitequark/ruby_bug_10279.rb
@@ -1,16 +1,16 @@
-ProgramNode(1...19)(
+ProgramNode(1...23)(
   ScopeNode(0...0)([]),
-  StatementsNode(1...19)(
-    [HashNode(1...19)(
+  StatementsNode(1...23)(
+    [HashNode(1...23)(
        BRACE_LEFT(0...1)("{"),
-       [AssocNode(1...19)(
+       [AssocNode(1...23)(
           SymbolNode(1...3)(
             nil,
             LABEL(1...2)("a"),
             LABEL_END(2...3)(":"),
             "a"
           ),
-          IfNode(4...19)(
+          IfNode(4...23)(
             KEYWORD_IF(4...6)("if"),
             TrueNode(7...11)(),
             StatementsNode(17...19)([IntegerNode(17...19)()]),

--- a/test/snapshots/whitequark/unless.rb
+++ b/test/snapshots/whitequark/unless.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...41)(
+ProgramNode(0...46)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...41)(
-    [UnlessNode(0...19)(
+  StatementsNode(0...46)(
+    [UnlessNode(0...24)(
        KEYWORD_UNLESS(0...6)("unless"),
        CallNode(7...10)(
          nil,
@@ -28,7 +28,7 @@ ProgramNode(0...41)(
        nil,
        KEYWORD_END(21...24)("end")
      ),
-     UnlessNode(26...41)(
+     UnlessNode(26...46)(
        KEYWORD_UNLESS(26...32)("unless"),
        CallNode(33...36)(
          nil,


### PR DESCRIPTION
- Set the `location.end` of an `IfNode` iff the statements are not empty.
- Set the `location.end` of an `IfNode` when we see the closing `end` keyword.