### PR TITLE
Fix location for `HashNode`

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1594,8 +1594,12 @@ yp_hash_node_create(yp_parser_t *parser, const yp_token_t *opening, const yp_tok
 }
 
 static inline void
-yp_hash_node_elements_append(yp_parser_t *parser, yp_hash_node_t *hash, yp_node_t *element) {
-  yp_node_list_append(parser, (yp_node_t *)hash, &hash->elements, element);
+yp_hash_node_elements_append(yp_hash_node_t *hash, yp_node_t *element) {
+  yp_node_list_append2(&hash->elements, element);
+  if ((hash->opening.type == YP_TOKEN_NOT_PROVIDED) && (hash->elements.size == 1)) {
+    hash->base.location.start = element->location.start;
+  }
+  hash->base.location.end = element->location.end;
 }
 
 // Allocate a new IfNode node.
@@ -7236,7 +7240,7 @@ parse_assocs(yp_parser_t *parser, yp_hash_node_t *node) {
       }
     }
 
-    yp_node_list_append(parser, (yp_node_t *)node, &node->elements, element);
+    yp_hash_node_elements_append(node, element);
 
     // If there's no comma after the element, then we're done.
     if (!accept(parser, YP_TOKEN_COMMA)) return;
@@ -7381,7 +7385,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_node_t *arguments, bool accept
           yp_node_t *value = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected a value in the hash literal.");
 
           argument = (yp_node_t *) yp_assoc_node_create(parser, argument, &operator, value);
-          yp_hash_node_elements_append(parser, bare_hash, argument);
+          yp_hash_node_elements_append(bare_hash, argument);
           argument = (yp_node_t *) bare_hash;
 
           // Then parse more if we have a comma
@@ -9277,7 +9281,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
             yp_node_t *value = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected a value in the hash literal.");
             yp_node_t *assoc = (yp_node_t *) yp_assoc_node_create(parser, element, &operator, value);
-            yp_hash_node_elements_append(parser, hash, assoc);
+            yp_hash_node_elements_append(hash, assoc);
 
             element = (yp_node_t *)hash;
             if (accept(parser, YP_TOKEN_COMMA) && !match_type_p(parser, YP_TOKEN_BRACKET_RIGHT)) {
@@ -9404,6 +9408,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
       yp_accepts_block_stack_pop(parser);
       expect(parser, YP_TOKEN_BRACE_RIGHT, "Expected a closing delimiter for a hash literal.");
       node->closing = parser->previous;
+      node->base.location.end = parser->previous.end;
 
       return (yp_node_t *)node;
     }

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -221,6 +221,11 @@ module YARP
       assert_location(ForwardingSuperNode, "super {}")
     end
 
+    test "HashNode" do
+      assert_location(HashNode, "{ foo: 2 }")
+      assert_location(HashNode, "{ \nfoo: 2, \nbar: 3 \n}")
+    end
+
     test "IfNode" do
       assert_location(IfNode, "if type in 1;elsif type in B;end")
     end

--- a/test/snapshots/arrays.rb
+++ b/test/snapshots/arrays.rb
@@ -571,10 +571,10 @@ ProgramNode(0...502)(
        "[]="
      ),
      ArrayNode(261...267)(
-       [HashNode(262...265)(
+       [HashNode(262...266)(
           nil,
-          [AssocSplatNode(262...265)(
-             HashNode(264...265)(
+          [AssocSplatNode(262...266)(
+             HashNode(264...266)(
                BRACE_LEFT(264...265)("{"),
                [],
                BRACE_RIGHT(265...266)("}")
@@ -646,8 +646,8 @@ ProgramNode(0...502)(
              ),
              (292...294)
            ),
-           AssocSplatNode(298...301)(
-             HashNode(300...301)(
+           AssocSplatNode(298...302)(
+             HashNode(300...302)(
                BRACE_LEFT(300...301)("{"),
                [],
                BRACE_RIGHT(301...302)("}")

--- a/test/snapshots/hashes.rb
+++ b/test/snapshots/hashes.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...118)(
+ProgramNode(0...120)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...118)(
-    [HashNode(0...1)(BRACE_LEFT(0...1)("{"), [], BRACE_RIGHT(1...2)("}")),
-     HashNode(4...5)(BRACE_LEFT(4...5)("{"), [], BRACE_RIGHT(6...7)("}")),
-     HashNode(11...25)(
+  StatementsNode(0...120)(
+    [HashNode(0...2)(BRACE_LEFT(0...1)("{"), [], BRACE_RIGHT(1...2)("}")),
+     HashNode(4...7)(BRACE_LEFT(4...5)("{"), [], BRACE_RIGHT(6...7)("}")),
+     HashNode(9...27)(
        BRACE_LEFT(9...10)("{"),
        [AssocNode(11...17)(
           CallNode(11...12)(
@@ -53,7 +53,7 @@ ProgramNode(0...118)(
         )],
        BRACE_RIGHT(26...27)("}")
      ),
-     HashNode(31...42)(
+     HashNode(29...44)(
        BRACE_LEFT(29...30)("{"),
        [AssocNode(31...37)(
           CallNode(31...32)(
@@ -93,7 +93,7 @@ ProgramNode(0...118)(
         )],
        BRACE_RIGHT(43...44)("}")
      ),
-     HashNode(54...70)(
+     HashNode(46...79)(
        BRACE_LEFT(46...47)("{"),
        [AssocNode(54...58)(
           SymbolNode(54...56)(
@@ -135,7 +135,7 @@ ProgramNode(0...118)(
         )],
        BRACE_RIGHT(78...79)("}")
      ),
-     HashNode(83...104)(
+     HashNode(81...106)(
        BRACE_LEFT(81...82)("{"),
        [AssocNode(83...87)(
           SymbolNode(83...85)(
@@ -209,7 +209,7 @@ ProgramNode(0...118)(
         )],
        BRACE_RIGHT(105...106)("}")
      ),
-     HashNode(110...118)(
+     HashNode(108...120)(
        BRACE_LEFT(108...109)("{"),
        [AssocNode(110...118)(
           SymbolNode(110...114)(

--- a/test/snapshots/method_calls.rb
+++ b/test/snapshots/method_calls.rb
@@ -748,14 +748,14 @@ ProgramNode(0...1187)(
        nil,
        "foo"
      ),
-     CallNode(334...381)(
+     CallNode(334...383)(
        nil,
        nil,
        IDENTIFIER(334...336)("hi"),
        nil,
-       ArgumentsNode(337...381)(
+       ArgumentsNode(337...383)(
          [IntegerNode(337...340)(),
-          HashNode(344...381)(
+          HashNode(342...383)(
             BRACE_LEFT(342...343)("{"),
             [AssocNode(344...361)(
                SymbolNode(344...350)(
@@ -772,8 +772,8 @@ ProgramNode(0...1187)(
                ),
                EQUAL_GREATER(351...353)("=>")
              ),
-             AssocSplatNode(363...366)(
-               HashNode(365...366)(
+             AssocSplatNode(363...367)(
+               HashNode(365...367)(
                  BRACE_LEFT(365...366)("{"),
                  [],
                  BRACE_RIGHT(366...367)("}")
@@ -919,8 +919,8 @@ ProgramNode(0...1187)(
                ),
                EQUAL_GREATER(452...454)("=>")
              ),
-             AssocSplatNode(464...467)(
-               HashNode(466...467)(
+             AssocSplatNode(464...468)(
+               HashNode(466...468)(
                  BRACE_LEFT(466...467)("{"),
                  [],
                  BRACE_RIGHT(467...468)("}")
@@ -972,8 +972,8 @@ ProgramNode(0...1187)(
                ),
                EQUAL_GREATER(494...496)("=>")
              ),
-             AssocSplatNode(506...509)(
-               HashNode(508...509)(
+             AssocSplatNode(506...510)(
+               HashNode(508...510)(
                  BRACE_LEFT(508...509)("{"),
                  [],
                  BRACE_RIGHT(509...510)("}")
@@ -1007,8 +1007,8 @@ ProgramNode(0...1187)(
        nil,
        IDENTIFIER(527...530)("foo"),
        PARENTHESIS_LEFT(530...531)("("),
-       ArgumentsNode(533...562)(
-         [HashNode(533...550)(
+       ArgumentsNode(531...562)(
+         [HashNode(531...553)(
             BRACE_LEFT(531...532)("{"),
             [AssocNode(533...540)(
                SymbolNode(533...535)(
@@ -1370,22 +1370,22 @@ ProgramNode(0...1187)(
        nil,
        "foo"
      ),
-     CallNode(786...812)(
+     CallNode(786...814)(
        nil,
        nil,
        IDENTIFIER(786...789)("foo"),
        nil,
-       ArgumentsNode(790...812)(
-         [HashNode(790...812)(
+       ArgumentsNode(790...814)(
+         [HashNode(790...814)(
             nil,
-            [AssocNode(790...812)(
+            [AssocNode(790...814)(
                SymbolNode(790...794)(
                  nil,
                  LABEL(790...793)("bar"),
                  LABEL_END(793...794)(":"),
                  "bar"
                ),
-               HashNode(797...812)(
+               HashNode(795...814)(
                  BRACE_LEFT(795...796)("{"),
                  [AssocNode(797...812)(
                     SymbolNode(797...801)(
@@ -1423,22 +1423,22 @@ ProgramNode(0...1187)(
        nil,
        "foo"
      ),
-     CallNode(816...838)(
+     CallNode(816...840)(
        nil,
        nil,
        IDENTIFIER(816...819)("foo"),
        nil,
-       ArgumentsNode(820...838)(
-         [HashNode(820...838)(
+       ArgumentsNode(820...840)(
+         [HashNode(820...840)(
             nil,
-            [AssocNode(820...838)(
+            [AssocNode(820...840)(
                SymbolNode(820...824)(
                  nil,
                  LABEL(820...823)("bar"),
                  LABEL_END(823...824)(":"),
                  "bar"
                ),
-               HashNode(827...838)(
+               HashNode(825...840)(
                  BRACE_LEFT(825...826)("{"),
                  [AssocSplatNode(827...838)(
                     CallNode(829...838)(
@@ -1828,7 +1828,7 @@ ProgramNode(0...1187)(
        "foo"
      ),
      CallNode(1134...1143)(
-       HashNode(1134...1135)(
+       HashNode(1134...1136)(
          BRACE_LEFT(1134...1135)("{"),
          [],
          BRACE_RIGHT(1135...1136)("}")
@@ -1859,7 +1859,7 @@ ProgramNode(0...1187)(
        "+"
      ),
      CallNode(1145...1161)(
-       HashNode(1145...1146)(
+       HashNode(1145...1147)(
          BRACE_LEFT(1145...1146)("{"),
          [],
          BRACE_RIGHT(1146...1147)("}")

--- a/test/snapshots/methods.rb
+++ b/test/snapshots/methods.rb
@@ -1098,7 +1098,7 @@ ProgramNode(0...1167)(
        nil,
        StatementsNode(948...976)(
          [CallNode(948...976)(
-            HashNode(948...949)(
+            HashNode(948...950)(
               BRACE_LEFT(948...949)("{"),
               [],
               BRACE_RIGHT(949...950)("}")

--- a/test/snapshots/ranges.rb
+++ b/test/snapshots/ranges.rb
@@ -41,7 +41,7 @@ ProgramNode(0...85)(
        nil,
        "[]"
      ),
-     HashNode(35...46)(
+     HashNode(33...48)(
        BRACE_LEFT(33...34)("{"),
        [AssocNode(35...46)(
           SymbolNode(35...39)(
@@ -80,7 +80,7 @@ ProgramNode(0...85)(
        IntegerNode(61...62)(),
        (59...61)
      ),
-     HashNode(66...76)(
+     HashNode(64...78)(
        BRACE_LEFT(64...65)("{"),
        [AssocNode(66...76)(
           SymbolNode(66...70)(

--- a/test/snapshots/seattlerb/assoc__bare.rb
+++ b/test/snapshots/seattlerb/assoc__bare.rb
@@ -1,7 +1,7 @@
-ProgramNode(2...4)(
+ProgramNode(0...6)(
   ScopeNode(0...0)([]),
-  StatementsNode(2...4)(
-    [HashNode(2...4)(
+  StatementsNode(0...6)(
+    [HashNode(0...6)(
        BRACE_LEFT(0...1)("{"),
        [AssocNode(2...4)(
           SymbolNode(2...4)(

--- a/test/snapshots/seattlerb/bug_hash_interp_array.rb
+++ b/test/snapshots/seattlerb/bug_hash_interp_array.rb
@@ -1,7 +1,7 @@
-ProgramNode(2...11)(
+ProgramNode(0...13)(
   ScopeNode(0...0)([]),
-  StatementsNode(2...11)(
-    [HashNode(2...11)(
+  StatementsNode(0...13)(
+    [HashNode(0...13)(
        BRACE_LEFT(0...1)("{"),
        [AssocNode(2...11)(
           InterpolatedSymbolNode(2...8)(

--- a/test/snapshots/seattlerb/multiline_hash_declaration.rb
+++ b/test/snapshots/seattlerb/multiline_hash_declaration.rb
@@ -6,17 +6,17 @@ ProgramNode(0...43)(
        nil,
        IDENTIFIER(0...1)("f"),
        PARENTHESIS_LEFT(1...2)("("),
-       ArgumentsNode(2...11)(
-         [HashNode(2...11)(
+       ArgumentsNode(2...13)(
+         [HashNode(2...13)(
             nil,
-            [AssocNode(2...11)(
+            [AssocNode(2...13)(
                SymbolNode(2...8)(
                  nil,
                  LABEL(2...7)("state"),
                  LABEL_END(7...8)(":"),
                  "state"
                ),
-               HashNode(10...11)(
+               HashNode(10...13)(
                  BRACE_LEFT(10...11)("{"),
                  [],
                  BRACE_RIGHT(12...13)("}")
@@ -35,17 +35,17 @@ ProgramNode(0...43)(
        nil,
        IDENTIFIER(16...17)("f"),
        PARENTHESIS_LEFT(17...18)("("),
-       ArgumentsNode(18...26)(
-         [HashNode(18...26)(
+       ArgumentsNode(18...28)(
+         [HashNode(18...28)(
             nil,
-            [AssocNode(18...26)(
+            [AssocNode(18...28)(
                SymbolNode(18...24)(
                  nil,
                  LABEL(18...23)("state"),
                  LABEL_END(23...24)(":"),
                  "state"
                ),
-               HashNode(25...26)(
+               HashNode(25...28)(
                  BRACE_LEFT(25...26)("{"),
                  [],
                  BRACE_RIGHT(27...28)("}")
@@ -64,17 +64,17 @@ ProgramNode(0...43)(
        nil,
        IDENTIFIER(31...32)("f"),
        PARENTHESIS_LEFT(32...33)("("),
-       ArgumentsNode(33...41)(
-         [HashNode(33...41)(
+       ArgumentsNode(33...42)(
+         [HashNode(33...42)(
             nil,
-            [AssocNode(33...41)(
+            [AssocNode(33...42)(
                SymbolNode(33...39)(
                  nil,
                  LABEL(33...38)("state"),
                  LABEL_END(38...39)(":"),
                  "state"
                ),
-               HashNode(40...41)(
+               HashNode(40...42)(
                  BRACE_LEFT(40...41)("{"),
                  [],
                  BRACE_RIGHT(41...42)("}")

--- a/test/snapshots/seattlerb/parse_line_hash_lit.rb
+++ b/test/snapshots/seattlerb/parse_line_hash_lit.rb
@@ -1,7 +1,7 @@
-ProgramNode(2...10)(
+ProgramNode(0...13)(
   ScopeNode(0...0)([]),
-  StatementsNode(2...10)(
-    [HashNode(2...10)(
+  StatementsNode(0...13)(
+    [HashNode(0...13)(
        BRACE_LEFT(0...1)("{"),
        [AssocNode(2...10)(
           SymbolNode(2...5)(

--- a/test/snapshots/seattlerb/parse_pattern_058.rb
+++ b/test/snapshots/seattlerb/parse_pattern_058.rb
@@ -2,7 +2,7 @@ ProgramNode(0...43)(
   ScopeNode(0...0)([IDENTIFIER(22...26)("rest")]),
   StatementsNode(0...43)(
     [CaseNode(0...43)(
-       HashNode(6...10)(
+       HashNode(5...11)(
          BRACE_LEFT(5...6)("{"),
          [AssocNode(6...10)(
             SymbolNode(6...8)(

--- a/test/snapshots/seattlerb/parse_pattern_058_2.rb
+++ b/test/snapshots/seattlerb/parse_pattern_058_2.rb
@@ -2,7 +2,7 @@ ProgramNode(0...33)(
   ScopeNode(0...0)([]),
   StatementsNode(0...33)(
     [CaseNode(0...33)(
-       HashNode(6...10)(
+       HashNode(5...11)(
          BRACE_LEFT(5...6)("{"),
          [AssocNode(6...10)(
             SymbolNode(6...8)(

--- a/test/snapshots/seattlerb/parse_pattern_076.rb
+++ b/test/snapshots/seattlerb/parse_pattern_076.rb
@@ -2,7 +2,7 @@ ProgramNode(0...39)(
   ScopeNode(0...0)([]),
   StatementsNode(0...39)(
     [CaseNode(0...39)(
-       HashNode(6...10)(
+       HashNode(5...11)(
          BRACE_LEFT(5...6)("{"),
          [AssocNode(6...10)(
             SymbolNode(6...8)(

--- a/test/snapshots/seattlerb/quoted_symbol_hash_arg.rb
+++ b/test/snapshots/seattlerb/quoted_symbol_hash_arg.rb
@@ -1,22 +1,22 @@
-ProgramNode(0...11)(
+ProgramNode(0...12)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...11)(
-    [CallNode(0...11)(
+  StatementsNode(0...12)(
+    [CallNode(0...12)(
        nil,
        nil,
        IDENTIFIER(0...4)("puts"),
        nil,
-       ArgumentsNode(5...11)(
-         [HashNode(5...11)(
+       ArgumentsNode(5...12)(
+         [HashNode(5...12)(
             nil,
-            [AssocNode(5...11)(
+            [AssocNode(5...12)(
                SymbolNode(5...9)(
                  STRING_BEGIN(5...6)("'"),
                  STRING_CONTENT(6...7)("a"),
                  LABEL_END(7...9)("':"),
                  "a"
                ),
-               HashNode(10...11)(
+               HashNode(10...12)(
                  BRACE_LEFT(10...11)("{"),
                  [],
                  BRACE_RIGHT(11...12)("}")

--- a/test/snapshots/seattlerb/quoted_symbol_keys.rb
+++ b/test/snapshots/seattlerb/quoted_symbol_keys.rb
@@ -1,7 +1,7 @@
-ProgramNode(2...9)(
+ProgramNode(0...11)(
   ScopeNode(0...0)([]),
-  StatementsNode(2...9)(
-    [HashNode(2...9)(
+  StatementsNode(0...11)(
+    [HashNode(0...11)(
        BRACE_LEFT(0...1)("{"),
        [AssocNode(2...9)(
           SymbolNode(2...6)(

--- a/test/snapshots/seattlerb/zomg_sometimes_i_hate_this_project.rb
+++ b/test/snapshots/seattlerb/zomg_sometimes_i_hate_this_project.rb
@@ -1,7 +1,7 @@
-ProgramNode(16...57)(
+ProgramNode(6...66)(
   ScopeNode(0...0)([]),
-  StatementsNode(16...57)(
-    [HashNode(16...57)(
+  StatementsNode(6...66)(
+    [HashNode(6...66)(
        BRACE_LEFT(6...7)("{"),
        [AssocNode(16...41)(
           SymbolNode(16...18)(

--- a/test/snapshots/unparser/corpus/literal/literal.rb
+++ b/test/snapshots/unparser/corpus/literal/literal.rb
@@ -1,7 +1,7 @@
-ProgramNode(2...916)(
+ProgramNode(0...916)(
   ScopeNode(0...0)([]),
-  StatementsNode(2...916)(
-    [HashNode(2...36)(
+  StatementsNode(0...916)(
+    [HashNode(0...38)(
        BRACE_LEFT(0...1)("{"),
        [AssocNode(2...45)(
           StringNode(2...7)(
@@ -50,7 +50,7 @@ ProgramNode(2...916)(
         )],
        BRACE_RIGHT(37...38)("}")
      ),
-     HashNode(55...82)(
+     HashNode(53...84)(
        BRACE_LEFT(53...54)("{"),
        [AssocNode(55...67)(
           StringNode(55...60)(
@@ -167,7 +167,7 @@ ProgramNode(2...916)(
        nil,
        "a"
      ),
-     HashNode(139...165)(
+     HashNode(137...167)(
        BRACE_LEFT(137...138)("{"),
        [AssocNode(139...174)(
           StringNode(139...144)(
@@ -214,7 +214,7 @@ ProgramNode(2...916)(
         )],
        BRACE_RIGHT(166...167)("}")
      ),
-     HashNode(184...203)(
+     HashNode(182...205)(
        BRACE_LEFT(182...183)("{"),
        [AssocNode(184...196)(
           StringNode(184...189)(
@@ -775,12 +775,12 @@ ProgramNode(2...916)(
        BRACKET_LEFT_ARRAY(714...715)("["),
        BRACKET_RIGHT(727...728)("]")
      ),
-     HashNode(729...730)(
+     HashNode(729...731)(
        BRACE_LEFT(729...730)("{"),
        [],
        BRACE_RIGHT(730...731)("}")
      ),
-     HashNode(734...742)(
+     HashNode(732...744)(
        BRACE_LEFT(732...733)("{"),
        [AssocNode(734...742)(
           ParenthesesNode(734...736)(nil, (734...735), (735...736)),
@@ -789,7 +789,7 @@ ProgramNode(2...916)(
         )],
        BRACE_RIGHT(743...744)("}")
      ),
-     HashNode(747...753)(
+     HashNode(745...755)(
        BRACE_LEFT(745...746)("{"),
        [AssocNode(747...753)(
           IntegerNode(747...748)(),
@@ -798,7 +798,7 @@ ProgramNode(2...916)(
         )],
        BRACE_RIGHT(754...755)("}")
      ),
-     HashNode(758...772)(
+     HashNode(756...774)(
        BRACE_LEFT(756...757)("{"),
        [AssocNode(758...764)(
           IntegerNode(758...759)(),
@@ -812,7 +812,7 @@ ProgramNode(2...916)(
         )],
        BRACE_RIGHT(773...774)("}")
      ),
-     HashNode(777...800)(
+     HashNode(775...802)(
        BRACE_LEFT(775...776)("{"),
        [AssocNode(777...794)(
           SymbolNode(777...779)(
@@ -855,7 +855,7 @@ ProgramNode(2...916)(
         )],
        BRACE_RIGHT(801...802)("}")
      ),
-     HashNode(805...815)(
+     HashNode(803...817)(
        BRACE_LEFT(803...804)("{"),
        [AssocNode(805...809)(
           SymbolNode(805...807)(
@@ -879,7 +879,7 @@ ProgramNode(2...916)(
         )],
        BRACE_RIGHT(816...817)("}")
      ),
-     HashNode(820...825)(
+     HashNode(818...827)(
        BRACE_LEFT(818...819)("{"),
        [AssocNode(820...825)(
           SymbolNode(820...822)(
@@ -898,7 +898,7 @@ ProgramNode(2...916)(
         )],
        BRACE_RIGHT(826...827)("}")
      ),
-     HashNode(832...841)(
+     HashNode(828...843)(
        BRACE_LEFT(828...829)("{"),
        [AssocNode(832...841)(
           InterpolatedSymbolNode(832...835)(
@@ -916,7 +916,7 @@ ProgramNode(2...916)(
         )],
        BRACE_RIGHT(842...843)("}")
      ),
-     HashNode(846...854)(
+     HashNode(844...856)(
        BRACE_LEFT(844...845)("{"),
        [AssocNode(846...854)(
           SymbolNode(846...849)(

--- a/test/snapshots/unparser/corpus/literal/opasgn.rb
+++ b/test/snapshots/unparser/corpus/literal/opasgn.rb
@@ -67,10 +67,10 @@ ProgramNode(0...233)(
      ),
      CallNode(66...83)(
        ParenthesesNode(66...76)(
-         StatementsNode(67...74)(
-           [OperatorOrAssignmentNode(67...74)(
+         StatementsNode(67...75)(
+           [OperatorOrAssignmentNode(67...75)(
               LocalVariableWriteNode(67...68)((67...68), nil, nil, 0),
-              HashNode(73...74)(
+              HashNode(73...75)(
                 BRACE_LEFT(73...74)("{"),
                 [],
                 BRACE_RIGHT(74...75)("}")

--- a/test/snapshots/unparser/corpus/literal/send.rb
+++ b/test/snapshots/unparser/corpus/literal/send.rb
@@ -1325,7 +1325,7 @@ ProgramNode(0...991)(
        DOT(775...776)("."),
        IDENTIFIER(776...779)("bar"),
        PARENTHESIS_LEFT(779...780)("("),
-       ArgumentsNode(780...786)(
+       ArgumentsNode(780...787)(
          [CallNode(780...783)(
             nil,
             nil,
@@ -1336,7 +1336,7 @@ ProgramNode(0...991)(
             nil,
             "foo"
           ),
-          HashNode(785...786)(
+          HashNode(785...787)(
             BRACE_LEFT(785...786)("{"),
             [],
             BRACE_RIGHT(786...787)("}")
@@ -1360,8 +1360,8 @@ ProgramNode(0...991)(
        DOT(792...793)("."),
        IDENTIFIER(793...796)("bar"),
        PARENTHESIS_LEFT(796...797)("("),
-       ArgumentsNode(799...814)(
-         [HashNode(799...807)(
+       ArgumentsNode(797...814)(
+         [HashNode(797...809)(
             BRACE_LEFT(797...798)("{"),
             [AssocNode(799...807)(
                SymbolNode(799...803)(

--- a/test/snapshots/whitequark/bug_do_block_in_hash_brace.rb
+++ b/test/snapshots/whitequark/bug_do_block_in_hash_brace.rb
@@ -1,19 +1,19 @@
-ProgramNode(0...224)(
+ProgramNode(0...225)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...224)(
-    [CallNode(0...41)(
+  StatementsNode(0...225)(
+    [CallNode(0...42)(
        nil,
        nil,
        IDENTIFIER(0...1)("p"),
        nil,
-       ArgumentsNode(2...41)(
+       ArgumentsNode(2...42)(
          [SymbolNode(2...6)(
             SYMBOL_BEGIN(2...3)(":"),
             IDENTIFIER(3...6)("foo"),
             nil,
             "foo"
           ),
-          HashNode(9...41)(
+          HashNode(8...42)(
             BRACE_LEFT(8...9)("{"),
             [AssocNode(9...25)(
                SymbolNode(9...13)(
@@ -72,19 +72,19 @@ ProgramNode(0...224)(
        nil,
        "p"
      ),
-     CallNode(44...83)(
+     CallNode(44...84)(
        nil,
        nil,
        IDENTIFIER(44...45)("p"),
        nil,
-       ArgumentsNode(46...83)(
+       ArgumentsNode(46...84)(
          [SymbolNode(46...50)(
             SYMBOL_BEGIN(46...47)(":"),
             IDENTIFIER(47...50)("foo"),
             nil,
             "foo"
           ),
-          HashNode(53...83)(
+          HashNode(52...84)(
             BRACE_LEFT(52...53)("{"),
             [AssocSplatNode(53...67)(
                CallNode(56...67)(
@@ -137,19 +137,19 @@ ProgramNode(0...224)(
        nil,
        "p"
      ),
-     CallNode(86...128)(
+     CallNode(86...129)(
        nil,
        nil,
        IDENTIFIER(86...87)("p"),
        nil,
-       ArgumentsNode(88...128)(
+       ArgumentsNode(88...129)(
          [SymbolNode(88...92)(
             SYMBOL_BEGIN(88...89)(":"),
             IDENTIFIER(89...92)("foo"),
             nil,
             "foo"
           ),
-          HashNode(95...128)(
+          HashNode(94...129)(
             BRACE_LEFT(94...95)("{"),
             [AssocNode(95...112)(
                SymbolNode(95...97)(
@@ -208,19 +208,19 @@ ProgramNode(0...224)(
        nil,
        "p"
      ),
-     CallNode(131...170)(
+     CallNode(131...171)(
        nil,
        nil,
        IDENTIFIER(131...132)("p"),
        nil,
-       ArgumentsNode(133...170)(
+       ArgumentsNode(133...171)(
          [SymbolNode(133...137)(
             SYMBOL_BEGIN(133...134)(":"),
             IDENTIFIER(134...137)("foo"),
             nil,
             "foo"
           ),
-          HashNode(140...170)(
+          HashNode(139...171)(
             BRACE_LEFT(139...140)("{"),
             [AssocNode(140...154)(
                SymbolNode(140...142)(
@@ -279,19 +279,19 @@ ProgramNode(0...224)(
        nil,
        "p"
      ),
-     CallNode(173...224)(
+     CallNode(173...225)(
        nil,
        nil,
        IDENTIFIER(173...174)("p"),
        nil,
-       ArgumentsNode(175...224)(
+       ArgumentsNode(175...225)(
          [SymbolNode(175...179)(
             SYMBOL_BEGIN(175...176)(":"),
             IDENTIFIER(176...179)("foo"),
             nil,
             "foo"
           ),
-          HashNode(182...224)(
+          HashNode(181...225)(
             BRACE_LEFT(181...182)("{"),
             [AssocNode(182...208)(
                CallNode(182...193)(

--- a/test/snapshots/whitequark/hash_empty.rb
+++ b/test/snapshots/whitequark/hash_empty.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...1)(
+ProgramNode(0...3)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...1)(
-    [HashNode(0...1)(BRACE_LEFT(0...1)("{"), [], BRACE_RIGHT(2...3)("}"))]
+  StatementsNode(0...3)(
+    [HashNode(0...3)(BRACE_LEFT(0...1)("{"), [], BRACE_RIGHT(2...3)("}"))]
   )
 )

--- a/test/snapshots/whitequark/hash_hashrocket.rb
+++ b/test/snapshots/whitequark/hash_hashrocket.rb
@@ -1,7 +1,7 @@
-ProgramNode(2...35)(
+ProgramNode(0...37)(
   ScopeNode(0...0)([]),
-  StatementsNode(2...35)(
-    [HashNode(2...8)(
+  StatementsNode(0...37)(
+    [HashNode(0...10)(
        BRACE_LEFT(0...1)("{"),
        [AssocNode(2...8)(
           IntegerNode(2...3)(),
@@ -10,7 +10,7 @@ ProgramNode(2...35)(
         )],
        BRACE_RIGHT(9...10)("}")
      ),
-     HashNode(14...35)(
+     HashNode(12...37)(
        BRACE_LEFT(12...13)("{"),
        [AssocNode(14...20)(
           IntegerNode(14...15)(),

--- a/test/snapshots/whitequark/hash_kwsplat.rb
+++ b/test/snapshots/whitequark/hash_kwsplat.rb
@@ -1,7 +1,7 @@
-ProgramNode(2...15)(
+ProgramNode(0...17)(
   ScopeNode(0...0)([]),
-  StatementsNode(2...15)(
-    [HashNode(2...15)(
+  StatementsNode(0...17)(
+    [HashNode(0...17)(
        BRACE_LEFT(0...1)("{"),
        [AssocNode(2...8)(
           SymbolNode(2...6)(

--- a/test/snapshots/whitequark/hash_label.rb
+++ b/test/snapshots/whitequark/hash_label.rb
@@ -1,7 +1,7 @@
-ProgramNode(2...8)(
+ProgramNode(0...10)(
   ScopeNode(0...0)([]),
-  StatementsNode(2...8)(
-    [HashNode(2...8)(
+  StatementsNode(0...10)(
+    [HashNode(0...10)(
        BRACE_LEFT(0...1)("{"),
        [AssocNode(2...8)(
           SymbolNode(2...6)(

--- a/test/snapshots/whitequark/hash_label_end.rb
+++ b/test/snapshots/whitequark/hash_label_end.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...48)(
+ProgramNode(0...50)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...48)(
+  StatementsNode(0...50)(
     [CallNode(0...12)(
        nil,
        nil,
@@ -39,7 +39,7 @@ ProgramNode(0...48)(
        nil,
        "f"
      ),
-     HashNode(16...24)(
+     HashNode(14...26)(
        BRACE_LEFT(14...15)("{"),
        [AssocNode(16...24)(
           SymbolNode(16...22)(
@@ -53,7 +53,7 @@ ProgramNode(0...48)(
         )],
        BRACE_RIGHT(25...26)("}")
      ),
-     HashNode(30...48)(
+     HashNode(28...50)(
        BRACE_LEFT(28...29)("{"),
        [AssocNode(30...38)(
           SymbolNode(30...36)(
@@ -65,14 +65,14 @@ ProgramNode(0...48)(
           IntegerNode(37...38)(),
           nil
         ),
-        AssocNode(40...48)(
+        AssocNode(40...49)(
           SymbolNode(40...46)(
             STRING_BEGIN(40...41)("'"),
             STRING_CONTENT(41...44)("bar"),
             LABEL_END(44...46)("':"),
             "bar"
           ),
-          HashNode(47...48)(
+          HashNode(47...49)(
             BRACE_LEFT(47...48)("{"),
             [],
             BRACE_RIGHT(48...49)("}")

--- a/test/snapshots/whitequark/hash_pair_value_omission.rb
+++ b/test/snapshots/whitequark/hash_pair_value_omission.rb
@@ -1,7 +1,7 @@
-ProgramNode(1...24)(
+ProgramNode(0...25)(
   ScopeNode(0...0)([]),
-  StatementsNode(1...24)(
-    [HashNode(1...5)(
+  StatementsNode(0...25)(
+    [HashNode(0...6)(
        BRACE_LEFT(0...1)("{"),
        [AssocNode(1...5)(
           SymbolNode(1...5)(
@@ -15,7 +15,7 @@ ProgramNode(1...24)(
         )],
        BRACE_RIGHT(5...6)("}")
      ),
-     HashNode(9...15)(
+     HashNode(8...16)(
        BRACE_LEFT(8...9)("{"),
        [AssocNode(9...11)(
           SymbolNode(9...11)(
@@ -39,7 +39,7 @@ ProgramNode(1...24)(
         )],
        BRACE_RIGHT(15...16)("}")
      ),
-     HashNode(19...24)(
+     HashNode(18...25)(
        BRACE_LEFT(18...19)("{"),
        [AssocNode(19...24)(
           SymbolNode(19...24)(

--- a/test/snapshots/whitequark/multiple_pattern_matches.rb
+++ b/test/snapshots/whitequark/multiple_pattern_matches.rb
@@ -1,8 +1,8 @@
-ProgramNode(1...52)(
+ProgramNode(0...52)(
   ScopeNode(0...0)([]),
-  StatementsNode(1...52)(
-    [MatchRequiredNode(1...12)(
-       HashNode(1...5)(
+  StatementsNode(0...52)(
+    [MatchRequiredNode(0...12)(
+       HashNode(0...6)(
          BRACE_LEFT(0...1)("{"),
          [AssocNode(1...5)(
             SymbolNode(1...3)(
@@ -34,8 +34,8 @@ ProgramNode(1...52)(
        ),
        (7...9)
      ),
-     MatchRequiredNode(14...25)(
-       HashNode(14...18)(
+     MatchRequiredNode(13...25)(
+       HashNode(13...19)(
          BRACE_LEFT(13...14)("{"),
          [AssocNode(14...18)(
             SymbolNode(14...16)(
@@ -67,8 +67,8 @@ ProgramNode(1...52)(
        ),
        (20...22)
      ),
-     MatchPredicateNode(28...39)(
-       HashNode(28...32)(
+     MatchPredicateNode(27...39)(
+       HashNode(27...33)(
          BRACE_LEFT(27...28)("{"),
          [AssocNode(28...32)(
             SymbolNode(28...30)(
@@ -100,8 +100,8 @@ ProgramNode(1...52)(
        ),
        (34...36)
      ),
-     MatchPredicateNode(41...52)(
-       HashNode(41...45)(
+     MatchPredicateNode(40...52)(
+       HashNode(40...46)(
          BRACE_LEFT(40...41)("{"),
          [AssocNode(41...45)(
             SymbolNode(41...43)(

--- a/test/snapshots/whitequark/parser_bug_645.rb
+++ b/test/snapshots/whitequark/parser_bug_645.rb
@@ -5,12 +5,12 @@ ProgramNode(0...11)(
        ScopeNode(0...2)([IDENTIFIER(4...7)("arg")]),
        MINUS_GREATER(0...2)("->"),
        BlockParametersNode(3...11)(
-         ParametersNode(4...9)(
+         ParametersNode(4...10)(
            [],
-           [OptionalParameterNode(4...9)(
+           [OptionalParameterNode(4...10)(
               IDENTIFIER(4...7)("arg"),
               EQUAL(7...8)("="),
-              HashNode(8...9)(
+              HashNode(8...10)(
                 BRACE_LEFT(8...9)("{"),
                 [],
                 BRACE_RIGHT(9...10)("}")

--- a/test/snapshots/whitequark/pattern_matching_single_line_allowed_omission_of_parentheses.rb
+++ b/test/snapshots/whitequark/pattern_matching_single_line_allowed_omission_of_parentheses.rb
@@ -41,8 +41,8 @@ ProgramNode(0...142)(
        (26...28)
      ),
      LocalVariableReadNode(35...36)(0),
-     MatchRequiredNode(39...50)(
-       HashNode(39...43)(
+     MatchRequiredNode(38...50)(
+       HashNode(38...44)(
          BRACE_LEFT(38...39)("{"),
          [AssocNode(39...43)(
             SymbolNode(39...41)(
@@ -75,8 +75,8 @@ ProgramNode(0...142)(
        (45...47)
      ),
      LocalVariableReadNode(52...53)(0),
-     MatchPredicateNode(56...67)(
-       HashNode(56...60)(
+     MatchPredicateNode(55...67)(
+       HashNode(55...61)(
          BRACE_LEFT(55...56)("{"),
          [AssocNode(56...60)(
             SymbolNode(56...58)(
@@ -109,8 +109,8 @@ ProgramNode(0...142)(
        (62...64)
      ),
      LocalVariableReadNode(69...70)(0),
-     MatchRequiredNode(73...99)(
-       HashNode(73...84)(
+     MatchRequiredNode(72...99)(
+       HashNode(72...85)(
          BRACE_LEFT(72...73)("{"),
          [AssocNode(73...84)(
             SymbolNode(73...77)(
@@ -148,8 +148,8 @@ ProgramNode(0...142)(
        (86...88)
      ),
      LocalVariableReadNode(101...106)(0),
-     MatchPredicateNode(109...135)(
-       HashNode(109...120)(
+     MatchPredicateNode(108...135)(
+       HashNode(108...121)(
          BRACE_LEFT(108...109)("{"),
          [AssocNode(109...120)(
             SymbolNode(109...113)(

--- a/test/snapshots/whitequark/ruby_bug_10279.rb
+++ b/test/snapshots/whitequark/ruby_bug_10279.rb
@@ -1,7 +1,7 @@
-ProgramNode(1...23)(
+ProgramNode(0...24)(
   ScopeNode(0...0)([]),
-  StatementsNode(1...23)(
-    [HashNode(1...23)(
+  StatementsNode(0...24)(
+    [HashNode(0...24)(
        BRACE_LEFT(0...1)("{"),
        [AssocNode(1...23)(
           SymbolNode(1...3)(

--- a/test/snapshots/whitequark/ruby_bug_9669.rb
+++ b/test/snapshots/whitequark/ruby_bug_9669.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...31)(
+ProgramNode(0...33)(
   ScopeNode(0...0)([IDENTIFIER(21...22)("o")]),
-  StatementsNode(0...31)(
+  StatementsNode(0...33)(
     [DefNode(0...19)(
        IDENTIFIER(4...5)("a"),
        nil,
@@ -24,9 +24,9 @@ ProgramNode(0...31)(
        nil,
        (16...19)
      ),
-     LocalVariableWriteNode(21...31)(
+     LocalVariableWriteNode(21...33)(
        (21...22),
-       HashNode(27...31)(
+       HashNode(25...33)(
          BRACE_LEFT(25...26)("{"),
          [AssocNode(27...31)(
             SymbolNode(27...29)(


### PR DESCRIPTION
This PR changes the computation for the location of `HashNode`s. 

- Replaces `yp_node_list_append` with `yp_node_list_append2` when we append a new element to a `HashNode`. `yp_node_list_append` is mutating the location of the parent node unnecessarily.
- Sets the closing node's end location (if there is a closing node) to the end location of the parent `HashNode`.
