### PR TITLE
Fix location for `InterpolatedStringNode`

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1893,8 +1893,16 @@ yp_interpolated_string_node_create(yp_parser_t *parser, const yp_token_t *openin
 
 // Append a part to an InterpolatedStringNode node.
 static inline void
-yp_interpolated_string_node_append(yp_parser_t *parser, yp_interpolated_string_node_t *node, yp_node_t *part) {
-  yp_node_list_append(parser, (yp_node_t *) node, &node->parts, part);
+yp_interpolated_string_node_append(yp_interpolated_string_node_t *node, yp_node_t *part) {
+  yp_node_list_append2(&node->parts, part);
+  node->base.location.end = part->location.end;
+}
+
+// Set the closing token of the given InterpolatedStringNode node.
+static void
+yp_interpolated_string_node_closing_set(yp_interpolated_string_node_t *node, const yp_token_t *closing) {
+  node->closing = *closing;
+  node->base.location.end = closing->end;
 }
 
 // Allocate and initialize a new InterpolatedSymbolNode node.
@@ -9569,7 +9577,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
         if (quote == YP_HEREDOC_QUOTE_BACKTICK) {
           yp_interpolated_xstring_node_append(parser, (yp_interpolated_x_string_node_t *) node, part);
         } else {
-          yp_interpolated_string_node_append(parser, (yp_interpolated_string_node_t *) node, part);
+          yp_interpolated_string_node_append((yp_interpolated_string_node_t *) node, part);
         }
       }
 
@@ -9580,7 +9588,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
         ((yp_interpolated_x_string_node_t *) node)->closing = parser->previous;
       } else {
         assert(node->type == YP_NODE_INTERPOLATED_STRING_NODE);
-        ((yp_interpolated_string_node_t *) node)->closing = parser->previous;
+        yp_interpolated_string_node_closing_set((yp_interpolated_string_node_t *) node, &parser->previous);
       }
 
       // If this is a heredoc that is indented with a ~, then we need to dedent
@@ -10675,7 +10683,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
               // interpolated string, then we need to append the string content
               // to the list of child nodes.
               yp_node_t *part = parse_string_part(parser);
-              yp_interpolated_string_node_append(parser, (yp_interpolated_string_node_t *) current, part);
+              yp_interpolated_string_node_append((yp_interpolated_string_node_t *) current, part);
             } else {
               assert(false && "unreachable");
             }
@@ -10697,7 +10705,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
               yp_token_t opening = not_provided(parser);
               yp_token_t closing = not_provided(parser);
               yp_interpolated_string_node_t *interpolated = yp_interpolated_string_node_create(parser, &opening, NULL, &closing);
-              yp_interpolated_string_node_append(parser, interpolated, current);
+              yp_interpolated_string_node_append(interpolated, current);
               current = (yp_node_t *) interpolated;
             } else {
               // If we hit an embedded variable and the current node is an
@@ -10705,7 +10713,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             }
 
             yp_node_t *part = parse_string_part(parser);
-            yp_interpolated_string_node_append(parser, (yp_interpolated_string_node_t *) current, part);
+            yp_interpolated_string_node_append((yp_interpolated_string_node_t *) current, part);
             break;
           }
           case YP_TOKEN_EMBEXPR_BEGIN: {
@@ -10724,7 +10732,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
               yp_token_t opening = not_provided(parser);
               yp_token_t closing = not_provided(parser);
               yp_interpolated_string_node_t *interpolated = yp_interpolated_string_node_create(parser, &opening, NULL, &closing);
-              yp_interpolated_string_node_append(parser, interpolated, current);
+              yp_interpolated_string_node_append(interpolated, current);
               current = (yp_node_t *) interpolated;
             } else if (current->type == YP_NODE_INTERPOLATED_STRING_NODE) {
               // If we hit an embedded expression and the current node is an
@@ -10734,7 +10742,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             }
 
             yp_node_t *part = parse_string_part(parser);
-            yp_interpolated_string_node_append(parser, (yp_interpolated_string_node_t *) current, part);
+            yp_interpolated_string_node_append((yp_interpolated_string_node_t *) current, part);
             break;
           }
           default:

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -250,6 +250,10 @@ module YARP
       assert_location(IntegerNode, "0o1_000")
     end
 
+    test "InterpolatedStringNode" do
+      assert_location(InterpolatedStringNode, "<<~A\nhello world\nA")
+    end
+
     test "NextNode" do
       assert_location(NextNode, "next")
       assert_location(NextNode, "next foo")

--- a/test/snapshots/dash_heredocs.rb
+++ b/test/snapshots/dash_heredocs.rb
@@ -1,7 +1,7 @@
-ProgramNode(7...219)(
+ProgramNode(0...223)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...219)(
-    [InterpolatedStringNode(7...11)(
+  StatementsNode(0...223)(
+    [InterpolatedStringNode(0...15)(
        HEREDOC_START(0...6)("<<-EOF"),
        [StringNode(7...11)(
           nil,
@@ -11,8 +11,8 @@ ProgramNode(7...219)(
         )],
        HEREDOC_END(11...15)("EOF\n")
      ),
-     CallNode(37...51)(
-       InterpolatedStringNode(37...41)(
+     CallNode(16...58)(
+       InterpolatedStringNode(16...47)(
          HEREDOC_START(16...24)("<<-FIRST"),
          [StringNode(37...41)(
             nil,
@@ -25,8 +25,8 @@ ProgramNode(7...219)(
        nil,
        PLUS(25...26)("+"),
        nil,
-       ArgumentsNode(47...51)(
-         [InterpolatedStringNode(47...51)(
+       ArgumentsNode(27...58)(
+         [InterpolatedStringNode(27...58)(
             HEREDOC_START(27...36)("<<-SECOND"),
             [StringNode(47...51)(
                nil,
@@ -68,7 +68,7 @@ ProgramNode(7...219)(
         StringNode(76...77)(nil, STRING_CONTENT(76...77)("\n"), nil, "\n")],
        HEREDOC_END(77...81)("EOF\n")
      ),
-     InterpolatedStringNode(98...102)(
+     InterpolatedStringNode(82...106)(
        HEREDOC_START(82...88)("<<-EOF"),
        [StringNode(98...102)(
           nil,
@@ -78,7 +78,7 @@ ProgramNode(7...219)(
         )],
        HEREDOC_END(102...106)("EOF\n")
      ),
-     InterpolatedStringNode(114...122)(
+     InterpolatedStringNode(107...128)(
        HEREDOC_START(107...113)("<<-EOF"),
        [StringNode(114...122)(
           nil,
@@ -88,7 +88,7 @@ ProgramNode(7...219)(
         )],
        HEREDOC_END(122...128)("  EOF\n")
      ),
-     InterpolatedStringNode(138...147)(
+     InterpolatedStringNode(129...151)(
        HEREDOC_START(129...137)("<<-\"EOF\""),
        [StringNode(138...142)(
           nil,
@@ -120,7 +120,7 @@ ProgramNode(7...219)(
         )],
        HEREDOC_END(147...151)("EOF\n")
      ),
-     InterpolatedStringNode(159...168)(
+     InterpolatedStringNode(152...172)(
        HEREDOC_START(152...158)("<<-EOF"),
        [StringNode(159...163)(
           nil,
@@ -158,7 +158,7 @@ ProgramNode(7...219)(
        STRING_END(178...179)("#"),
        "abc"
      ),
-     InterpolatedStringNode(188...196)(
+     InterpolatedStringNode(181...200)(
        HEREDOC_START(181...187)("<<-EOF"),
        [StringNode(188...196)(
           nil,
@@ -168,7 +168,7 @@ ProgramNode(7...219)(
         )],
        HEREDOC_END(196...200)("EOF\n")
      ),
-     InterpolatedStringNode(210...219)(
+     InterpolatedStringNode(201...223)(
        HEREDOC_START(201...209)("<<-'EOF'"),
        [StringNode(210...219)(
           nil,

--- a/test/snapshots/dos_endings.rb
+++ b/test/snapshots/dos_endings.rb
@@ -36,7 +36,7 @@ ProgramNode(0...108)(
        PERCENT_UPPER_I(28...31)("%I{"),
        STRING_END(36...37)("}")
      ),
-     InterpolatedStringNode(47...70)(
+     InterpolatedStringNode(41...73)(
        HEREDOC_START(41...45)("<<-E"),
        [StringNode(47...70)(
           nil,
@@ -64,9 +64,9 @@ ProgramNode(0...108)(
          nil,
          IDENTIFIER(92...95)("foo"),
          PARENTHESIS_LEFT(95...96)("("),
-         ArgumentsNode(110...107)(
-           [CallNode(110...107)(
-              InterpolatedStringNode(110...121)(
+         ArgumentsNode(96...107)(
+           [CallNode(96...107)(
+              InterpolatedStringNode(96...128)(
                 HEREDOC_START(96...102)("<<~EOF"),
                 [StringNode(110...121)(
                    nil,

--- a/test/snapshots/heredoc_with_trailing_newline.rb
+++ b/test/snapshots/heredoc_with_trailing_newline.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...6)(
+ProgramNode(0...10)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...6)(
-    [InterpolatedStringNode(0...6)(
+  StatementsNode(0...10)(
+    [InterpolatedStringNode(0...10)(
        HEREDOC_START(0...6)("<<-END"),
        [],
        HEREDOC_END(7...10)("END")

--- a/test/snapshots/heredocs_nested.rb
+++ b/test/snapshots/heredocs_nested.rb
@@ -1,13 +1,13 @@
-ProgramNode(8...42)(
+ProgramNode(0...47)(
   ScopeNode(0...0)([]),
-  StatementsNode(8...42)(
-    [InterpolatedStringNode(8...42)(
+  StatementsNode(0...47)(
+    [InterpolatedStringNode(0...47)(
        HEREDOC_START(0...7)("<<~RUBY"),
        [StringNode(8...12)(nil, STRING_CONTENT(8...12)("pre\n"), nil, "pre\n"),
         StringInterpolatedNode(12...36)(
           EMBEXPR_BEGIN(12...14)("\#{"),
-          StatementsNode(22...30)(
-            [InterpolatedStringNode(22...30)(
+          StatementsNode(15...35)(
+            [InterpolatedStringNode(15...35)(
                HEREDOC_START(15...21)("<<RUBY"),
                [StringNode(22...30)(
                   nil,

--- a/test/snapshots/heredocs_with_ignored_newlines.rb
+++ b/test/snapshots/heredocs_with_ignored_newlines.rb
@@ -1,12 +1,12 @@
-ProgramNode(0...100)(
+ProgramNode(0...106)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...100)(
-    [InterpolatedStringNode(0...7)(
+  StatementsNode(0...106)(
+    [InterpolatedStringNode(0...14)(
        HEREDOC_START(0...7)("<<-HERE"),
        [],
        HEREDOC_END(9...14)("HERE\n")
      ),
-     InterpolatedStringNode(25...100)(
+     InterpolatedStringNode(15...106)(
        HEREDOC_START(15...23)("<<~THERE"),
        [StringNode(25...100)(
           nil,

--- a/test/snapshots/heredocs_with_ignored_newlines_and_non_empty.rb
+++ b/test/snapshots/heredocs_with_ignored_newlines_and_non_empty.rb
@@ -1,7 +1,7 @@
-ProgramNode(7...23)(
+ProgramNode(0...26)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...23)(
-    [InterpolatedStringNode(7...23)(
+  StatementsNode(0...26)(
+    [InterpolatedStringNode(0...26)(
        HEREDOC_START(0...6)("<<-EOE"),
        [StringNode(7...23)(
           nil,

--- a/test/snapshots/seattlerb/heredoc__backslash_dos_format.rb
+++ b/test/snapshots/seattlerb/heredoc__backslash_dos_format.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...30)(
+ProgramNode(0...35)(
   ScopeNode(0...0)([IDENTIFIER(0...3)("str")]),
-  StatementsNode(0...30)(
-    [LocalVariableWriteNode(0...30)(
+  StatementsNode(0...35)(
+    [LocalVariableWriteNode(0...35)(
        (0...3),
-       InterpolatedStringNode(14...30)(
+       InterpolatedStringNode(6...35)(
          HEREDOC_START(6...12)("<<-XXX"),
          [StringNode(14...30)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_backslash_nl.rb
+++ b/test/snapshots/seattlerb/heredoc_backslash_nl.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...88)(
+ProgramNode(0...93)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...88)(
+  StatementsNode(0...93)(
     [StringNode(0...40)(
        STRING_BEGIN(0...1)("\""),
        STRING_CONTENT(1...39)(
@@ -9,7 +9,7 @@ ProgramNode(0...88)(
        STRING_END(39...40)("\""),
        "  why would someone do this? \n" + "  blah\n"
      ),
-     InterpolatedStringNode(50...88)(
+     InterpolatedStringNode(42...93)(
        HEREDOC_START(42...49)("<<-DESC"),
        [StringNode(50...88)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_bad_hex_escape.rb
+++ b/test/snapshots/seattlerb/heredoc_bad_hex_escape.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...17)(
+ProgramNode(0...21)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("s")]),
-  StatementsNode(0...17)(
-    [LocalVariableWriteNode(0...17)(
+  StatementsNode(0...21)(
+    [LocalVariableWriteNode(0...21)(
        (0...1),
-       InterpolatedStringNode(10...17)(
+       InterpolatedStringNode(4...21)(
          HEREDOC_START(4...9)("<<eos"),
          [StringNode(10...17)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_bad_oct_escape.rb
+++ b/test/snapshots/seattlerb/heredoc_bad_oct_escape.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...23)(
+ProgramNode(0...27)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("s")]),
-  StatementsNode(0...23)(
-    [LocalVariableWriteNode(0...23)(
+  StatementsNode(0...27)(
+    [LocalVariableWriteNode(0...27)(
        (0...1),
-       InterpolatedStringNode(11...23)(
+       InterpolatedStringNode(4...27)(
          HEREDOC_START(4...10)("<<-EOS"),
          [StringNode(11...23)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_comma_arg.rb
+++ b/test/snapshots/seattlerb/heredoc_comma_arg.rb
@@ -12,7 +12,7 @@ ProgramNode(0...47)(
        BRACKET_RIGHT(16...17)("]")
      ),
      ArrayNode(19...47)(
-       [InterpolatedStringNode(29...41)(
+       [InterpolatedStringNode(20...46)(
           HEREDOC_START(20...27)("<<-FILE"),
           [StringNode(29...41)(
              nil,

--- a/test/snapshots/seattlerb/heredoc_lineno.rb
+++ b/test/snapshots/seattlerb/heredoc_lineno.rb
@@ -1,9 +1,9 @@
 ProgramNode(0...41)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("c"), IDENTIFIER(35...36)("d")]),
   StatementsNode(0...41)(
-    [LocalVariableWriteNode(0...30)(
+    [LocalVariableWriteNode(0...34)(
        (0...1),
-       InterpolatedStringNode(12...30)(
+       InterpolatedStringNode(4...34)(
          HEREDOC_START(4...11)("<<'CCC'"),
          [StringNode(12...30)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_squiggly.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...25)(
+ProgramNode(0...31)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("a")]),
-  StatementsNode(0...25)(
-    [LocalVariableWriteNode(0...25)(
+  StatementsNode(0...31)(
+    [LocalVariableWriteNode(0...31)(
        (0...1),
-       InterpolatedStringNode(13...25)(
+       InterpolatedStringNode(4...31)(
          HEREDOC_START(4...12)("<<~\"EOF\""),
          [StringNode(13...25)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.rb
@@ -8,9 +8,9 @@ ProgramNode(0...20)(
          nil,
          IDENTIFIER(4...7)("foo"),
          PARENTHESIS_LEFT(7...8)("("),
-         ArgumentsNode(21...19)(
-           [CallNode(21...19)(
-              InterpolatedStringNode(21...36)(
+         ArgumentsNode(8...19)(
+           [CallNode(8...19)(
+              InterpolatedStringNode(8...42)(
                 HEREDOC_START(8...14)("<<~EOF"),
                 [StringNode(21...26)(
                    nil,

--- a/test/snapshots/seattlerb/heredoc_squiggly_blank_lines.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_blank_lines.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...20)(
+ProgramNode(0...24)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("a")]),
-  StatementsNode(0...20)(
-    [LocalVariableWriteNode(0...20)(
+  StatementsNode(0...24)(
+    [LocalVariableWriteNode(0...24)(
        (0...1),
-       InterpolatedStringNode(11...20)(
+       InterpolatedStringNode(4...24)(
          HEREDOC_START(4...10)("<<~EOF"),
          [StringNode(11...20)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_squiggly_empty.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_empty.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...4)(
+ProgramNode(0...7)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...4)(
-    [InterpolatedStringNode(0...4)(
+  StatementsNode(0...7)(
+    [InterpolatedStringNode(0...7)(
        HEREDOC_START(0...4)("<<~A"),
        [],
        HEREDOC_END(5...7)("A\n")

--- a/test/snapshots/seattlerb/heredoc_squiggly_interp.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_interp.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...36)(
+ProgramNode(0...42)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("a")]),
-  StatementsNode(0...36)(
-    [LocalVariableWriteNode(0...36)(
+  StatementsNode(0...42)(
+    [LocalVariableWriteNode(0...42)(
        (0...1),
-       InterpolatedStringNode(11...36)(
+       InterpolatedStringNode(4...42)(
          HEREDOC_START(4...10)("<<~EOF"),
          [StringNode(11...22)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_squiggly_no_indent.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_no_indent.rb
@@ -1,7 +1,7 @@
-ProgramNode(5...7)(
+ProgramNode(0...9)(
   ScopeNode(0...0)([]),
-  StatementsNode(5...7)(
-    [InterpolatedStringNode(5...7)(
+  StatementsNode(0...9)(
+    [InterpolatedStringNode(0...9)(
        HEREDOC_START(0...4)("<<~A"),
        [StringNode(5...7)(nil, STRING_CONTENT(5...7)("a\n"), nil, "a\n")],
        HEREDOC_END(7...9)("A\n")

--- a/test/snapshots/seattlerb/heredoc_squiggly_tabs.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_tabs.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...43)(
+ProgramNode(0...49)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("a")]),
-  StatementsNode(0...43)(
-    [LocalVariableWriteNode(0...43)(
+  StatementsNode(0...49)(
+    [LocalVariableWriteNode(0...49)(
        (0...1),
-       InterpolatedStringNode(13...43)(
+       InterpolatedStringNode(4...49)(
          HEREDOC_START(4...12)("<<~\"EOF\""),
          [StringNode(13...43)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_squiggly_tabs_extra.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_tabs_extra.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...37)(
+ProgramNode(0...43)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("a")]),
-  StatementsNode(0...37)(
-    [LocalVariableWriteNode(0...37)(
+  StatementsNode(0...43)(
+    [LocalVariableWriteNode(0...43)(
        (0...1),
-       InterpolatedStringNode(13...37)(
+       InterpolatedStringNode(4...43)(
          HEREDOC_START(4...12)("<<~\"EOF\""),
          [StringNode(13...37)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_squiggly_visually_blank_lines.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_visually_blank_lines.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...21)(
+ProgramNode(0...25)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("a")]),
-  StatementsNode(0...21)(
-    [LocalVariableWriteNode(0...21)(
+  StatementsNode(0...25)(
+    [LocalVariableWriteNode(0...25)(
        (0...1),
-       InterpolatedStringNode(11...21)(
+       InterpolatedStringNode(4...25)(
          HEREDOC_START(4...10)("<<~EOF"),
          [StringNode(11...21)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_trailing_slash_continued_call.rb
+++ b/test/snapshots/seattlerb/heredoc_trailing_slash_continued_call.rb
@@ -1,8 +1,8 @@
-ProgramNode(7...22)(
+ProgramNode(0...22)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...22)(
-    [CallNode(7...22)(
-       InterpolatedStringNode(7...12)(
+  StatementsNode(0...22)(
+    [CallNode(0...22)(
+       InterpolatedStringNode(0...16)(
          HEREDOC_START(0...5)("<<END"),
          [StringNode(7...12)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_unicode.rb
+++ b/test/snapshots/seattlerb/heredoc_unicode.rb
@@ -1,7 +1,7 @@
-ProgramNode(10...12)(
+ProgramNode(0...20)(
   ScopeNode(0...0)([]),
-  StatementsNode(10...12)(
-    [InterpolatedStringNode(10...12)(
+  StatementsNode(0...20)(
+    [InterpolatedStringNode(0...20)(
        HEREDOC_START(0...9)("<<OOTPÜT"),
        [StringNode(10...12)(nil, STRING_CONTENT(10...12)(".\n"), nil, ".\n")],
        HEREDOC_END(12...20)("OOTPÜT\n")

--- a/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes.rb
+++ b/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes.rb
@@ -1,7 +1,7 @@
-ProgramNode(6...21)(
+ProgramNode(0...25)(
   ScopeNode(0...0)([]),
-  StatementsNode(6...21)(
-    [InterpolatedStringNode(6...21)(
+  StatementsNode(0...25)(
+    [InterpolatedStringNode(0...25)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(6...21)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes_windows.rb
+++ b/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes_windows.rb
@@ -1,7 +1,7 @@
-ProgramNode(7...24)(
+ProgramNode(0...29)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...24)(
-    [InterpolatedStringNode(7...24)(
+  StatementsNode(0...29)(
+    [InterpolatedStringNode(0...29)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(7...24)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_with_extra_carriage_horrible_mix?.rb
+++ b/test/snapshots/seattlerb/heredoc_with_extra_carriage_horrible_mix?.rb
@@ -1,7 +1,7 @@
-ProgramNode(9...15)(
+ProgramNode(0...19)(
   ScopeNode(0...0)([]),
-  StatementsNode(9...15)(
-    [InterpolatedStringNode(9...15)(
+  StatementsNode(0...19)(
+    [InterpolatedStringNode(0...19)(
        HEREDOC_START(0...7)("<<'eot'"),
        [StringNode(9...15)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns.rb
+++ b/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns.rb
@@ -1,7 +1,7 @@
-ProgramNode(6...19)(
+ProgramNode(0...23)(
   ScopeNode(0...0)([]),
-  StatementsNode(6...19)(
-    [InterpolatedStringNode(6...19)(
+  StatementsNode(0...23)(
+    [InterpolatedStringNode(0...23)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(6...19)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns_windows.rb
+++ b/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns_windows.rb
@@ -1,7 +1,7 @@
-ProgramNode(7...22)(
+ProgramNode(0...27)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...22)(
-    [InterpolatedStringNode(7...22)(
+  StatementsNode(0...27)(
+    [InterpolatedStringNode(0...27)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(7...22)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes.rb
+++ b/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes.rb
@@ -1,7 +1,7 @@
-ProgramNode(6...17)(
+ProgramNode(0...21)(
   ScopeNode(0...0)([]),
-  StatementsNode(6...17)(
-    [InterpolatedStringNode(6...17)(
+  StatementsNode(0...21)(
+    [InterpolatedStringNode(0...21)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(6...11)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes_windows.rb
+++ b/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes_windows.rb
@@ -1,7 +1,7 @@
-ProgramNode(7...19)(
+ProgramNode(0...24)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...19)(
-    [InterpolatedStringNode(7...19)(
+  StatementsNode(0...24)(
+    [InterpolatedStringNode(0...24)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(7...12)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_with_not_global_interpolation.rb
+++ b/test/snapshots/seattlerb/heredoc_with_not_global_interpolation.rb
@@ -1,7 +1,7 @@
-ProgramNode(11...15)(
+ProgramNode(0...23)(
   ScopeNode(0...0)([]),
-  StatementsNode(11...15)(
-    [InterpolatedStringNode(11...15)(
+  StatementsNode(0...23)(
+    [InterpolatedStringNode(0...23)(
        HEREDOC_START(0...10)("<<-HEREDOC"),
        [StringNode(11...15)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_with_only_carriage_returns.rb
+++ b/test/snapshots/seattlerb/heredoc_with_only_carriage_returns.rb
@@ -1,7 +1,7 @@
-ProgramNode(6...14)(
+ProgramNode(0...18)(
   ScopeNode(0...0)([]),
-  StatementsNode(6...14)(
-    [InterpolatedStringNode(6...14)(
+  StatementsNode(0...18)(
+    [InterpolatedStringNode(0...18)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(6...14)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_with_only_carriage_returns_windows.rb
+++ b/test/snapshots/seattlerb/heredoc_with_only_carriage_returns_windows.rb
@@ -1,7 +1,7 @@
-ProgramNode(7...18)(
+ProgramNode(0...23)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...18)(
-    [InterpolatedStringNode(7...18)(
+  StatementsNode(0...23)(
+    [InterpolatedStringNode(0...23)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(7...18)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_wtf_I_hate_you.rb
+++ b/test/snapshots/seattlerb/heredoc_wtf_I_hate_you.rb
@@ -6,10 +6,10 @@ ProgramNode(0...30)(
        nil,
        IDENTIFIER(0...1)("p"),
        nil,
-       ArgumentsNode(12...30)(
-         [CallNode(12...30)(
-            CallNode(12...26)(
-              InterpolatedStringNode(12...16)(
+       ArgumentsNode(2...30)(
+         [CallNode(2...30)(
+            CallNode(2...26)(
+              InterpolatedStringNode(2...22)(
                 HEREDOC_START(2...8)("<<-END"),
                 [StringNode(12...16)(
                    nil,

--- a/test/snapshots/seattlerb/parse_line_heredoc.rb
+++ b/test/snapshots/seattlerb/parse_line_heredoc.rb
@@ -3,8 +3,8 @@ ProgramNode(6...88)(
   StatementsNode(6...88)(
     [LocalVariableWriteNode(6...31)(
        (6...12),
-       CallNode(32...31)(
-         InterpolatedStringNode(32...57)(
+       CallNode(15...31)(
+         InterpolatedStringNode(15...71)(
            HEREDOC_START(15...25)("<<-HEREDOC"),
            [StringNode(32...57)(
               nil,

--- a/test/snapshots/seattlerb/parse_line_heredoc_evstr.rb
+++ b/test/snapshots/seattlerb/parse_line_heredoc_evstr.rb
@@ -1,7 +1,7 @@
-ProgramNode(5...12)(
+ProgramNode(0...14)(
   ScopeNode(0...0)([]),
-  StatementsNode(5...12)(
-    [InterpolatedStringNode(5...12)(
+  StatementsNode(0...14)(
+    [InterpolatedStringNode(0...14)(
        HEREDOC_START(0...4)("<<-A"),
        [StringNode(5...7)(nil, STRING_CONTENT(5...7)("a\n"), nil, "a\n"),
         StringInterpolatedNode(7...11)(

--- a/test/snapshots/seattlerb/parse_line_heredoc_hardnewline.rb
+++ b/test/snapshots/seattlerb/parse_line_heredoc_hardnewline.rb
@@ -1,7 +1,7 @@
-ProgramNode(9...48)(
+ProgramNode(0...48)(
   ScopeNode(0...0)([]),
-  StatementsNode(9...48)(
-    [InterpolatedStringNode(9...28)(
+  StatementsNode(0...48)(
+    [InterpolatedStringNode(0...34)(
        HEREDOC_START(0...8)("<<-EOFOO"),
        [StringNode(9...28)(
           nil,

--- a/test/snapshots/seattlerb/parse_line_heredoc_regexp_chars.rb
+++ b/test/snapshots/seattlerb/parse_line_heredoc_regexp_chars.rb
@@ -1,9 +1,9 @@
 ProgramNode(6...74)(
   ScopeNode(0...0)([IDENTIFIER(6...12)("string")]),
   StatementsNode(6...74)(
-    [LocalVariableWriteNode(6...48)(
+    [LocalVariableWriteNode(6...57)(
        (6...12),
-       InterpolatedStringNode(23...48)(
+       InterpolatedStringNode(15...57)(
          HEREDOC_START(15...22)("<<-\"^D\""),
          [StringNode(23...48)(
             nil,

--- a/test/snapshots/seattlerb/str_heredoc_interp.rb
+++ b/test/snapshots/seattlerb/str_heredoc_interp.rb
@@ -1,7 +1,7 @@
-ProgramNode(5...16)(
+ProgramNode(0...17)(
   ScopeNode(0...0)([]),
-  StatementsNode(5...16)(
-    [InterpolatedStringNode(5...16)(
+  StatementsNode(0...17)(
+    [InterpolatedStringNode(0...17)(
        HEREDOC_START(0...4)("<<\"\""),
        [StringInterpolatedNode(5...9)(
           EMBEXPR_BEGIN(5...7)("\#{"),

--- a/test/snapshots/seattlerb/words_interp.rb
+++ b/test/snapshots/seattlerb/words_interp.rb
@@ -2,7 +2,7 @@ ProgramNode(0...9)(
   ScopeNode(0...0)([]),
   StatementsNode(0...9)(
     [ArrayNode(0...9)(
-       [InterpolatedStringNode(3...8)(
+       [InterpolatedStringNode(0...8)(
           nil,
           [StringInterpolatedNode(3...7)(
              EMBEXPR_BEGIN(3...5)("\#{"),

--- a/test/snapshots/strings.rb
+++ b/test/snapshots/strings.rb
@@ -298,7 +298,7 @@ ProgramNode(0...497)(
      ),
      ArrayNode(324...338)(
        [StringNode(327...328)(nil, STRING_CONTENT(327...328)("a"), nil, "a"),
-        InterpolatedStringNode(329...335)(
+        InterpolatedStringNode(0...335)(
           nil,
           [StringNode(329...330)(
              nil,

--- a/test/snapshots/tilde_heredocs.rb
+++ b/test/snapshots/tilde_heredocs.rb
@@ -1,12 +1,12 @@
-ProgramNode(7...383)(
+ProgramNode(0...387)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...383)(
-    [InterpolatedStringNode(7...11)(
+  StatementsNode(0...387)(
+    [InterpolatedStringNode(0...15)(
        HEREDOC_START(0...6)("<<~EOF"),
        [StringNode(7...11)(nil, STRING_CONTENT(7...11)("  a\n"), nil, "a\n")],
        HEREDOC_END(11...15)("EOF\n")
      ),
-     InterpolatedStringNode(23...34)(
+     InterpolatedStringNode(16...38)(
        HEREDOC_START(16...22)("<<~EOF"),
        [StringNode(23...34)(
           nil,
@@ -16,7 +16,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(34...38)("EOF\n")
      ),
-     InterpolatedStringNode(46...55)(
+     InterpolatedStringNode(39...59)(
        HEREDOC_START(39...45)("<<~EOF"),
        [StringNode(46...48)(nil, STRING_CONTENT(46...48)("  "), nil, ""),
         StringInterpolatedNode(48...52)(
@@ -32,7 +32,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(55...59)("EOF\n")
      ),
-     InterpolatedStringNode(67...76)(
+     InterpolatedStringNode(60...80)(
        HEREDOC_START(60...66)("<<~EOF"),
        [StringNode(67...71)(nil, STRING_CONTENT(67...71)("  a "), nil, "a "),
         StringInterpolatedNode(71...75)(
@@ -43,7 +43,7 @@ ProgramNode(7...383)(
         StringNode(75...76)(nil, STRING_CONTENT(75...76)("\n"), nil, "\n")],
        HEREDOC_END(76...80)("EOF\n")
      ),
-     InterpolatedStringNode(88...98)(
+     InterpolatedStringNode(81...102)(
        HEREDOC_START(81...87)("<<~EOF"),
        [StringNode(88...93)(
           nil,
@@ -59,7 +59,7 @@ ProgramNode(7...383)(
         StringNode(97...98)(nil, STRING_CONTENT(97...98)("\n"), nil, "\n")],
        HEREDOC_END(98...102)("EOF\n")
      ),
-     InterpolatedStringNode(110...121)(
+     InterpolatedStringNode(103...125)(
        HEREDOC_START(103...109)("<<~EOF"),
        [StringNode(110...116)(
           nil,
@@ -80,7 +80,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(121...125)("EOF\n")
      ),
-     InterpolatedStringNode(133...141)(
+     InterpolatedStringNode(126...145)(
        HEREDOC_START(126...132)("<<~EOF"),
        [StringNode(133...141)(
           nil,
@@ -90,7 +90,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(141...145)("EOF\n")
      ),
-     InterpolatedStringNode(153...162)(
+     InterpolatedStringNode(146...166)(
        HEREDOC_START(146...152)("<<~EOF"),
        [StringNode(153...162)(
           nil,
@@ -100,7 +100,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(162...166)("EOF\n")
      ),
-     InterpolatedStringNode(174...183)(
+     InterpolatedStringNode(167...187)(
        HEREDOC_START(167...173)("<<~EOF"),
        [StringNode(174...183)(
           nil,
@@ -110,7 +110,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(183...187)("EOF\n")
      ),
-     InterpolatedStringNode(197...206)(
+     InterpolatedStringNode(188...210)(
        HEREDOC_START(188...196)("<<~'EOF'"),
        [StringNode(197...206)(
           nil,
@@ -120,7 +120,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(206...210)("EOF\n")
      ),
-     InterpolatedStringNode(218...225)(
+     InterpolatedStringNode(211...229)(
        HEREDOC_START(211...217)("<<~EOF"),
        [StringNode(218...225)(
           nil,
@@ -130,7 +130,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(225...229)("EOF\n")
      ),
-     InterpolatedStringNode(237...244)(
+     InterpolatedStringNode(230...248)(
        HEREDOC_START(230...236)("<<~EOF"),
        [StringNode(237...244)(
           nil,
@@ -140,7 +140,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(244...248)("EOF\n")
      ),
-     InterpolatedStringNode(256...271)(
+     InterpolatedStringNode(249...275)(
        HEREDOC_START(249...255)("<<~EOF"),
        [StringNode(256...271)(
           nil,
@@ -150,7 +150,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(271...275)("EOF\n")
      ),
-     InterpolatedStringNode(283...292)(
+     InterpolatedStringNode(276...296)(
        HEREDOC_START(276...282)("<<~EOF"),
        [StringNode(283...292)(
           nil,
@@ -160,7 +160,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(292...296)("EOF\n")
      ),
-     InterpolatedStringNode(304...313)(
+     InterpolatedStringNode(297...317)(
        HEREDOC_START(297...303)("<<~EOF"),
        [StringNode(304...313)(
           nil,
@@ -170,7 +170,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(313...317)("EOF\n")
      ),
-     InterpolatedStringNode(325...336)(
+     InterpolatedStringNode(318...340)(
        HEREDOC_START(318...324)("<<~EOF"),
        [StringNode(325...336)(
           nil,
@@ -180,7 +180,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(336...340)("EOF\n")
      ),
-     InterpolatedStringNode(348...357)(
+     InterpolatedStringNode(341...365)(
        HEREDOC_START(341...347)("<<~EOF"),
        [StringNode(348...351)(
           nil,
@@ -201,7 +201,7 @@ ProgramNode(7...383)(
         )],
        HEREDOC_END(357...365)("    EOF\n")
      ),
-     InterpolatedStringNode(373...383)(
+     InterpolatedStringNode(366...387)(
        HEREDOC_START(366...372)("<<~EOT"),
        [StringNode(373...375)(nil, STRING_CONTENT(373...375)("  "), nil, ""),
         StringInterpolatedNode(375...379)(

--- a/test/snapshots/unescaping.rb
+++ b/test/snapshots/unescaping.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...50)(
+ProgramNode(0...55)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...50)(
+  StatementsNode(0...55)(
     [ArrayNode(0...10)(
        [StringNode(1...9)(
           STRING_BEGIN(1...2)("\""),
@@ -23,7 +23,7 @@ ProgramNode(0...50)(
        STRING_END(29...30)("\""),
        "\u0003{1}"
      ),
-     InterpolatedStringNode(40...50)(
+     InterpolatedStringNode(32...55)(
        HEREDOC_START(32...39)("<<~HERE"),
        [StringNode(40...50)(
           nil,

--- a/test/snapshots/unparser/corpus/literal/assignment.rb
+++ b/test/snapshots/unparser/corpus/literal/assignment.rb
@@ -1,4 +1,4 @@
-ProgramNode(0...711)(
+ProgramNode(0...719)(
   ScopeNode(0...0)(
     [IDENTIFIER(27...28)("a"),
      IDENTIFIER(32...33)("b"),
@@ -6,7 +6,7 @@ ProgramNode(0...711)(
      IDENTIFIER(111...112)("c"),
      IDENTIFIER(507...508)("x")]
   ),
-  StatementsNode(0...711)(
+  StatementsNode(0...719)(
     [GlobalVariableWriteNode(0...6)(
        GLOBAL_VARIABLE(0...2)("$a"),
        EQUAL(3...4)("="),
@@ -624,9 +624,9 @@ ProgramNode(0...711)(
        ),
        (554...557)
      ),
-     LocalVariableWriteNode(562...583)(
+     LocalVariableWriteNode(562...591)(
        (562...563),
-       InterpolatedStringNode(577...583)(
+       InterpolatedStringNode(566...591)(
          HEREDOC_START(566...576)("<<-HEREDOC"),
          [StringNode(577...579)(
             nil,
@@ -655,8 +655,8 @@ ProgramNode(0...711)(
        DOT(592...593)("."),
        IDENTIFIER(593...594)("x"),
        nil,
-       ArgumentsNode(606...612)(
-         [InterpolatedStringNode(606...612)(
+       ArgumentsNode(595...620)(
+         [InterpolatedStringNode(595...620)(
             HEREDOC_START(595...605)("<<-HEREDOC"),
             [StringNode(606...608)(
                nil,
@@ -682,13 +682,13 @@ ProgramNode(0...711)(
        nil,
        "x="
      ),
-     CallNode(620...643)(
+     CallNode(620...651)(
        LocalVariableReadNode(620...621)(0),
        nil,
        BRACKET_LEFT_RIGHT_EQUAL(621...622)("["),
        BRACKET_LEFT(621...622)("["),
-       ArgumentsNode(637...643)(
-         [InterpolatedStringNode(637...643)(
+       ArgumentsNode(626...651)(
+         [InterpolatedStringNode(626...651)(
             HEREDOC_START(626...636)("<<-HEREDOC"),
             [StringNode(637...639)(
                nil,
@@ -720,8 +720,8 @@ ProgramNode(0...711)(
          nil,
          BRACKET_LEFT_RIGHT_EQUAL(652...653)("["),
          BRACKET_LEFT(652...653)("["),
-         ArgumentsNode(673...679)(
-           [InterpolatedStringNode(673...679)(
+         ArgumentsNode(653...687)(
+           [InterpolatedStringNode(653...687)(
               HEREDOC_START(653...663)("<<-HEREDOC"),
               [StringNode(673...675)(
                  nil,
@@ -759,9 +759,9 @@ ProgramNode(0...711)(
        ),
        (665...668)
      ),
-     OperatorOrAssignmentNode(687...711)(
+     OperatorOrAssignmentNode(687...719)(
        InstanceVariableWriteNode(687...689)((687...689), nil, nil),
-       InterpolatedStringNode(705...711)(
+       InterpolatedStringNode(694...719)(
          HEREDOC_START(694...704)("<<-HEREDOC"),
          [StringNode(705...707)(
             nil,

--- a/test/snapshots/unparser/corpus/literal/def.rb
+++ b/test/snapshots/unparser/corpus/literal/def.rb
@@ -1006,8 +1006,8 @@ ProgramNode(0...913)(
        IDENTIFIER(860...861)("f"),
        nil,
        nil,
-       StatementsNode(875...883)(
-         [InterpolatedStringNode(875...883)(
+       StatementsNode(864...893)(
+         [InterpolatedStringNode(864...893)(
             HEREDOC_START(864...874)("<<-HEREDOC"),
             [StringNode(875...879)(
                nil,

--- a/test/snapshots/unparser/corpus/literal/dstr.rb
+++ b/test/snapshots/unparser/corpus/literal/dstr.rb
@@ -22,8 +22,8 @@ ProgramNode(0...299)(
      IfNode(21...68)(
        KEYWORD_IF(21...23)("if"),
        TrueNode(24...28)(),
-       StatementsNode(42...64)(
-         [InterpolatedStringNode(42...51)(
+       StatementsNode(31...64)(
+         [InterpolatedStringNode(31...61)(
             HEREDOC_START(31...41)("<<-HEREDOC"),
             [StringNode(42...44)(
                nil,
@@ -58,7 +58,7 @@ ProgramNode(0...299)(
        nil,
        KEYWORD_END(65...68)("end")
      ),
-     InterpolatedStringNode(80...101)(
+     InterpolatedStringNode(69...109)(
        HEREDOC_START(69...79)("<<-HEREDOC"),
        [StringNode(80...89)(
           nil,
@@ -91,8 +91,8 @@ ProgramNode(0...299)(
         )],
        HEREDOC_END(101...109)("HEREDOC\n")
      ),
-     RescueModifierNode(131...130)(
-       InterpolatedStringNode(131...137)(
+     RescueModifierNode(109...130)(
+       InterpolatedStringNode(109...145)(
          HEREDOC_START(109...119)("<<-HEREDOC"),
          [StringInterpolatedNode(131...134)(
             EMBEXPR_BEGIN(131...133)("\#{"),
@@ -137,11 +137,11 @@ ProgramNode(0...299)(
      IfNode(174...225)(
        KEYWORD_IF(174...176)("if"),
        TrueNode(177...181)(),
-       StatementsNode(184...212)(
-         [ReturnNode(184...212)(
+       StatementsNode(184...222)(
+         [ReturnNode(184...222)(
             KEYWORD_RETURN(184...190)("return"),
-            ArgumentsNode(202...212)(
-              [InterpolatedStringNode(202...212)(
+            ArgumentsNode(191...222)(
+              [InterpolatedStringNode(191...222)(
                  HEREDOC_START(191...201)("<<-HEREDOC"),
                  [StringNode(202...206)(
                     nil,
@@ -173,8 +173,8 @@ ProgramNode(0...299)(
        nil,
        IDENTIFIER(226...229)("foo"),
        PARENTHESIS_LEFT(229...230)("("),
-       ArgumentsNode(242...251)(
-         [InterpolatedStringNode(242...251)(
+       ArgumentsNode(230...259)(
+         [InterpolatedStringNode(230...259)(
             HEREDOC_START(230...240)("<<-HEREDOC"),
             [StringNode(242...244)(
                nil,
@@ -216,8 +216,8 @@ ProgramNode(0...299)(
        nil,
        IDENTIFIER(259...262)("foo"),
        PARENTHESIS_LEFT(262...263)("("),
-       ArgumentsNode(281...290)(
-         [InterpolatedStringNode(281...290)(
+       ArgumentsNode(263...298)(
+         [InterpolatedStringNode(263...298)(
             HEREDOC_START(263...273)("<<-HEREDOC"),
             [StringNode(281...283)(
                nil,

--- a/test/snapshots/unparser/corpus/literal/literal.rb
+++ b/test/snapshots/unparser/corpus/literal/literal.rb
@@ -3,14 +3,14 @@ ProgramNode(2...916)(
   StatementsNode(2...916)(
     [HashNode(2...36)(
        BRACE_LEFT(0...1)("{"),
-       [AssocNode(2...45)(
+       [AssocNode(2...53)(
           StringNode(2...7)(
             STRING_BEGIN(2...3)("\""),
             STRING_CONTENT(3...6)("foo"),
             STRING_END(6...7)("\""),
             "foo"
           ),
-          InterpolatedStringNode(39...45)(
+          InterpolatedStringNode(11...53)(
             HEREDOC_START(11...21)("<<-HEREDOC"),
             [StringNode(39...41)(
                nil,
@@ -106,8 +106,8 @@ ProgramNode(2...916)(
          nil,
          IDENTIFIER(98...99)("a"),
          PARENTHESIS_LEFT(99...100)("("),
-         ArgumentsNode(114...120)(
-           [InterpolatedStringNode(114...120)(
+         ArgumentsNode(100...128)(
+           [InterpolatedStringNode(100...128)(
               HEREDOC_START(100...110)("<<-HEREDOC"),
               [StringNode(114...116)(
                  nil,
@@ -169,14 +169,14 @@ ProgramNode(2...916)(
      ),
      HashNode(139...165)(
        BRACE_LEFT(137...138)("{"),
-       [AssocNode(139...174)(
+       [AssocNode(139...182)(
           StringNode(139...144)(
             STRING_BEGIN(139...140)("\""),
             STRING_CONTENT(140...143)("foo"),
             STRING_END(143...144)("\""),
             "foo"
           ),
-          InterpolatedStringNode(168...174)(
+          InterpolatedStringNode(148...182)(
             HEREDOC_START(148...158)("<<-HEREDOC"),
             [StringNode(168...170)(
                nil,

--- a/test/snapshots/unparser/corpus/semantic/block.rb
+++ b/test/snapshots/unparser/corpus/semantic/block.rb
@@ -98,8 +98,8 @@ ProgramNode(0...148)(
        nil,
        IDENTIFIER(82...85)("foo"),
        PARENTHESIS_LEFT(85...86)("("),
-       ArgumentsNode(101...105)(
-         [InterpolatedStringNode(101...105)(
+       ArgumentsNode(86...109)(
+         [InterpolatedStringNode(86...109)(
             HEREDOC_START(86...92)("<<-DOC"),
             [StringNode(101...105)(
                nil,
@@ -138,8 +138,8 @@ ProgramNode(0...148)(
        nil,
        IDENTIFIER(118...121)("foo"),
        PARENTHESIS_LEFT(121...122)("("),
-       ArgumentsNode(133...137)(
-         [InterpolatedStringNode(133...137)(
+       ArgumentsNode(122...141)(
+         [InterpolatedStringNode(122...141)(
             HEREDOC_START(122...128)("<<-DOC"),
             [StringNode(133...137)(
                nil,

--- a/test/snapshots/unparser/corpus/semantic/dstr.rb
+++ b/test/snapshots/unparser/corpus/semantic/dstr.rb
@@ -1,27 +1,27 @@
 ProgramNode(0...608)(
   ScopeNode(0...0)([]),
   StatementsNode(0...608)(
-    [InterpolatedStringNode(0...5)(
+    [InterpolatedStringNode(0...10)(
        HEREDOC_START(0...5)("<<DOC"),
        [],
        HEREDOC_END(6...10)("DOC\n")
      ),
-     InterpolatedStringNode(11...18)(
+     InterpolatedStringNode(11...23)(
        HEREDOC_START(11...18)("<<'DOC'"),
        [],
        HEREDOC_END(19...23)("DOC\n")
      ),
-     InterpolatedStringNode(24...30)(
+     InterpolatedStringNode(24...35)(
        HEREDOC_START(24...30)("<<~DOC"),
        [],
        HEREDOC_END(31...35)("DOC\n")
      ),
-     InterpolatedStringNode(36...44)(
+     InterpolatedStringNode(36...49)(
        HEREDOC_START(36...44)("<<~'DOC'"),
        [],
        HEREDOC_END(45...49)("DOC\n")
      ),
-     InterpolatedStringNode(56...60)(
+     InterpolatedStringNode(50...64)(
        HEREDOC_START(50...55)("<<DOC"),
        [StringNode(56...60)(
           nil,
@@ -31,7 +31,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(60...64)("DOC\n")
      ),
-     InterpolatedStringNode(73...77)(
+     InterpolatedStringNode(65...81)(
        HEREDOC_START(65...72)("<<'DOC'"),
        [StringNode(73...77)(
           nil,
@@ -41,7 +41,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(77...81)("DOC\n")
      ),
-     InterpolatedStringNode(88...98)(
+     InterpolatedStringNode(82...102)(
        HEREDOC_START(82...87)("<<DOC"),
        [StringNode(88...94)(
           nil,
@@ -57,7 +57,7 @@ ProgramNode(0...608)(
         StringNode(97...98)(nil, STRING_CONTENT(97...98)("\n"), nil, "\n")],
        HEREDOC_END(98...102)("DOC\n")
      ),
-     InterpolatedStringNode(110...120)(
+     InterpolatedStringNode(103...124)(
        HEREDOC_START(103...109)("<<~DOC"),
        [StringNode(110...116)(
           nil,
@@ -78,7 +78,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(120...124)("DOC\n")
      ),
-     InterpolatedStringNode(132...146)(
+     InterpolatedStringNode(125...150)(
        HEREDOC_START(125...131)("<<~DOC"),
        [StringNode(132...138)(
           nil,
@@ -99,7 +99,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(146...150)("DOC\n")
      ),
-     InterpolatedStringNode(158...168)(
+     InterpolatedStringNode(151...172)(
        HEREDOC_START(151...157)("<<~DOC"),
        [StringNode(158...168)(
           nil,
@@ -109,7 +109,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(168...172)("DOC\n")
      ),
-     InterpolatedStringNode(181...186)(
+     InterpolatedStringNode(173...190)(
        HEREDOC_START(173...180)("<<'DOC'"),
        [StringNode(181...186)(
           nil,
@@ -119,7 +119,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(186...190)("DOC\n")
      ),
-     InterpolatedStringNode(199...206)(
+     InterpolatedStringNode(191...210)(
        HEREDOC_START(191...198)("<<'DOC'"),
        [StringNode(199...206)(
           nil,
@@ -129,7 +129,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(206...210)("DOC\n")
      ),
-     InterpolatedStringNode(219...225)(
+     InterpolatedStringNode(211...229)(
        HEREDOC_START(211...218)("<<'DOC'"),
        [StringNode(219...225)(
           nil,
@@ -139,7 +139,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(225...229)("DOC\n")
      ),
-     InterpolatedStringNode(236...247)(
+     InterpolatedStringNode(230...251)(
        HEREDOC_START(230...235)("<<DOC"),
        [StringInterpolatedNode(236...239)(
           EMBEXPR_BEGIN(236...238)("\#{"),
@@ -165,7 +165,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(247...251)("DOC\n")
      ),
-     InterpolatedStringNode(258...271)(
+     InterpolatedStringNode(252...275)(
        HEREDOC_START(252...257)("<<DOC"),
        [StringNode(258...260)(nil, STRING_CONTENT(258...260)("  "), nil, "  "),
         StringInterpolatedNode(260...263)(
@@ -181,7 +181,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(271...275)("DOC\n")
      ),
-     InterpolatedStringNode(282...292)(
+     InterpolatedStringNode(276...296)(
        HEREDOC_START(276...281)("<<DOC"),
        [StringNode(282...284)(nil, STRING_CONTENT(282...284)(" a"), nil, " a"),
         StringInterpolatedNode(284...287)(
@@ -197,7 +197,7 @@ ProgramNode(0...608)(
         )],
        HEREDOC_END(292...296)("DOC\n")
      ),
-     InterpolatedStringNode(304...310)(
+     InterpolatedStringNode(297...314)(
        HEREDOC_START(297...303)("<<~DOC"),
        [StringNode(304...306)(nil, STRING_CONTENT(304...306)("  "), nil, ""),
         StringInterpolatedNode(306...309)(
@@ -216,8 +216,8 @@ ProgramNode(0...608)(
      IfNode(315...349)(
        KEYWORD_IF(315...317)("if"),
        TrueNode(318...322)(),
-       StatementsNode(332...340)(
-         [InterpolatedStringNode(332...340)(
+       StatementsNode(325...346)(
+         [InterpolatedStringNode(325...346)(
             HEREDOC_START(325...331)("<<~DOC"),
             [StringNode(332...336)(
                nil,
@@ -245,8 +245,8 @@ ProgramNode(0...608)(
      IfNode(351...386)(
        KEYWORD_IF(351...353)("if"),
        TrueNode(354...358)(),
-       StatementsNode(368...377)(
-         [InterpolatedStringNode(368...377)(
+       StatementsNode(361...383)(
+         [InterpolatedStringNode(361...383)(
             HEREDOC_START(361...367)("<<~DOC"),
             [StringNode(368...373)(
                nil,
@@ -274,8 +274,8 @@ ProgramNode(0...608)(
      IfNode(388...423)(
        KEYWORD_IF(388...390)("if"),
        TrueNode(391...395)(),
-       StatementsNode(405...414)(
-         [InterpolatedStringNode(405...414)(
+       StatementsNode(398...420)(
+         [InterpolatedStringNode(398...420)(
             HEREDOC_START(398...404)("<<~DOC"),
             [StringNode(405...409)(
                nil,
@@ -303,8 +303,8 @@ ProgramNode(0...608)(
      IfNode(425...464)(
        KEYWORD_IF(425...427)("if"),
        TrueNode(428...432)(),
-       StatementsNode(444...455)(
-         [InterpolatedStringNode(444...455)(
+       StatementsNode(435...461)(
+         [InterpolatedStringNode(435...461)(
             HEREDOC_START(435...443)("<<-'DOC'"),
             [StringNode(444...455)(
                nil,

--- a/test/snapshots/unparser/corpus/semantic/while.rb
+++ b/test/snapshots/unparser/corpus/semantic/while.rb
@@ -154,8 +154,8 @@ ProgramNode(2...188)(
          nil,
          IDENTIFIER(106...107)("b"),
          PARENTHESIS_LEFT(107...108)("("),
-         ArgumentsNode(108...114)(
-           [InterpolatedStringNode(108...114)(
+         ArgumentsNode(108...123)(
+           [InterpolatedStringNode(108...123)(
               HEREDOC_START(108...114)("<<-FOO"),
               [],
               HEREDOC_END(119...123)("FOO\n")

--- a/test/snapshots/whitequark/array_words_interp.rb
+++ b/test/snapshots/whitequark/array_words_interp.rb
@@ -3,7 +3,7 @@ ProgramNode(0...38)(
   StatementsNode(0...38)(
     [ArrayNode(0...14)(
        [StringNode(3...6)(nil, STRING_CONTENT(3...6)("foo"), nil, "foo"),
-        InterpolatedStringNode(7...13)(
+        InterpolatedStringNode(0...13)(
           nil,
           [StringInterpolatedNode(7...13)(
              EMBEXPR_BEGIN(7...9)("\#{"),
@@ -28,7 +28,7 @@ ProgramNode(0...38)(
      ),
      ArrayNode(16...38)(
        [StringNode(19...22)(nil, STRING_CONTENT(19...22)("foo"), nil, "foo"),
-        InterpolatedStringNode(23...37)(
+        InterpolatedStringNode(0...37)(
           nil,
           [StringInterpolatedNode(23...29)(
              EMBEXPR_BEGIN(23...25)("\#{"),

--- a/test/snapshots/whitequark/bug_heredoc_do.rb
+++ b/test/snapshots/whitequark/bug_heredoc_do.rb
@@ -6,8 +6,8 @@ ProgramNode(0...23)(
        nil,
        IDENTIFIER(0...1)("f"),
        nil,
-       ArgumentsNode(2...10)(
-         [InterpolatedStringNode(2...10)(
+       ArgumentsNode(2...20)(
+         [InterpolatedStringNode(2...20)(
             HEREDOC_START(2...10)("<<-TABLE"),
             [],
             HEREDOC_END(14...20)("TABLE\n")

--- a/test/snapshots/whitequark/bug_interp_single.rb
+++ b/test/snapshots/whitequark/bug_interp_single.rb
@@ -11,7 +11,7 @@ ProgramNode(0...16)(
        STRING_END(5...6)("\"")
      ),
      ArrayNode(8...16)(
-       [InterpolatedStringNode(11...15)(
+       [InterpolatedStringNode(0...15)(
           nil,
           [StringInterpolatedNode(11...15)(
              EMBEXPR_BEGIN(11...13)("\#{"),

--- a/test/snapshots/whitequark/dedenting_heredoc.rb
+++ b/test/snapshots/whitequark/dedenting_heredoc.rb
@@ -1,13 +1,13 @@
 ProgramNode(0...329)(
   ScopeNode(0...0)([]),
   StatementsNode(0...329)(
-    [CallNode(0...26)(
+    [CallNode(0...28)(
        nil,
        nil,
        IDENTIFIER(0...1)("p"),
        nil,
-       ArgumentsNode(9...26)(
-         [InterpolatedStringNode(9...26)(
+       ArgumentsNode(2...28)(
+         [InterpolatedStringNode(2...28)(
             HEREDOC_START(2...8)("<<~\"E\""),
             [StringNode(9...17)(
                nil,
@@ -40,13 +40,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(29...53)(
+     CallNode(29...55)(
        nil,
        nil,
        IDENTIFIER(29...30)("p"),
        nil,
-       ArgumentsNode(38...53)(
-         [InterpolatedStringNode(38...53)(
+       ArgumentsNode(31...55)(
+         [InterpolatedStringNode(31...55)(
             HEREDOC_START(31...37)("<<~\"E\""),
             [StringNode(38...46)(
                nil,
@@ -83,13 +83,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(56...76)(
+     CallNode(56...78)(
        nil,
        nil,
        IDENTIFIER(56...57)("p"),
        nil,
-       ArgumentsNode(63...76)(
-         [InterpolatedStringNode(63...76)(
+       ArgumentsNode(58...78)(
+         [InterpolatedStringNode(58...78)(
             HEREDOC_START(58...62)("<<~E"),
             [StringNode(63...76)(
                nil,
@@ -104,13 +104,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(79...95)(
+     CallNode(79...97)(
        nil,
        nil,
        IDENTIFIER(79...80)("p"),
        nil,
-       ArgumentsNode(86...95)(
-         [InterpolatedStringNode(86...95)(
+       ArgumentsNode(81...97)(
+         [InterpolatedStringNode(81...97)(
             HEREDOC_START(81...85)("<<~E"),
             [StringNode(86...95)(
                nil,
@@ -125,13 +125,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(98...122)(
+     CallNode(98...124)(
        nil,
        nil,
        IDENTIFIER(98...99)("p"),
        nil,
-       ArgumentsNode(105...122)(
-         [InterpolatedStringNode(105...122)(
+       ArgumentsNode(100...124)(
+         [InterpolatedStringNode(100...124)(
             HEREDOC_START(100...104)("<<~E"),
             [StringNode(105...122)(
                nil,
@@ -146,13 +146,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(125...146)(
+     CallNode(125...148)(
        nil,
        nil,
        IDENTIFIER(125...126)("p"),
        nil,
-       ArgumentsNode(132...146)(
-         [InterpolatedStringNode(132...146)(
+       ArgumentsNode(127...148)(
+         [InterpolatedStringNode(127...148)(
             HEREDOC_START(127...131)("<<~E"),
             [StringNode(132...146)(
                nil,
@@ -167,13 +167,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(149...168)(
+     CallNode(149...170)(
        nil,
        nil,
        IDENTIFIER(149...150)("p"),
        nil,
-       ArgumentsNode(156...168)(
-         [InterpolatedStringNode(156...168)(
+       ArgumentsNode(151...170)(
+         [InterpolatedStringNode(151...170)(
             HEREDOC_START(151...155)("<<~E"),
             [StringNode(156...168)(
                nil,
@@ -188,13 +188,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(171...191)(
+     CallNode(171...193)(
        nil,
        nil,
        IDENTIFIER(171...172)("p"),
        nil,
-       ArgumentsNode(178...191)(
-         [InterpolatedStringNode(178...191)(
+       ArgumentsNode(173...193)(
+         [InterpolatedStringNode(173...193)(
             HEREDOC_START(173...177)("<<~E"),
             [StringNode(178...191)(
                nil,
@@ -209,13 +209,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(194...200)(
+     CallNode(194...205)(
        nil,
        nil,
        IDENTIFIER(194...195)("p"),
        nil,
-       ArgumentsNode(196...200)(
-         [InterpolatedStringNode(196...200)(
+       ArgumentsNode(196...205)(
+         [InterpolatedStringNode(196...205)(
             HEREDOC_START(196...200)("<<~E"),
             [],
             HEREDOC_END(201...205)("  E\n")
@@ -225,13 +225,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(206...220)(
+     CallNode(206...222)(
        nil,
        nil,
        IDENTIFIER(206...207)("p"),
        nil,
-       ArgumentsNode(213...220)(
-         [InterpolatedStringNode(213...220)(
+       ArgumentsNode(208...222)(
+         [InterpolatedStringNode(208...222)(
             HEREDOC_START(208...212)("<<~E"),
             [StringNode(213...220)(
                nil,
@@ -246,13 +246,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(223...243)(
+     CallNode(223...245)(
        nil,
        nil,
        IDENTIFIER(223...224)("p"),
        nil,
-       ArgumentsNode(230...243)(
-         [InterpolatedStringNode(230...243)(
+       ArgumentsNode(225...245)(
+         [InterpolatedStringNode(225...245)(
             HEREDOC_START(225...229)("<<~E"),
             [StringNode(230...243)(
                nil,
@@ -267,13 +267,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(246...263)(
+     CallNode(246...265)(
        nil,
        nil,
        IDENTIFIER(246...247)("p"),
        nil,
-       ArgumentsNode(253...263)(
-         [InterpolatedStringNode(253...263)(
+       ArgumentsNode(248...265)(
+         [InterpolatedStringNode(248...265)(
             HEREDOC_START(248...252)("<<~E"),
             [StringNode(253...263)(
                nil,
@@ -288,13 +288,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(266...277)(
+     CallNode(266...279)(
        nil,
        nil,
        IDENTIFIER(266...267)("p"),
        nil,
-       ArgumentsNode(273...277)(
-         [InterpolatedStringNode(273...277)(
+       ArgumentsNode(268...279)(
+         [InterpolatedStringNode(268...279)(
             HEREDOC_START(268...272)("<<~E"),
             [StringNode(273...277)(
                nil,
@@ -309,13 +309,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(280...292)(
+     CallNode(280...294)(
        nil,
        nil,
        IDENTIFIER(280...281)("p"),
        nil,
-       ArgumentsNode(287...292)(
-         [InterpolatedStringNode(287...292)(
+       ArgumentsNode(282...294)(
+         [InterpolatedStringNode(282...294)(
             HEREDOC_START(282...286)("<<~E"),
             [StringNode(287...292)(
                nil,
@@ -330,13 +330,13 @@ ProgramNode(0...329)(
        nil,
        "p"
      ),
-     CallNode(295...301)(
+     CallNode(295...304)(
        nil,
        nil,
        IDENTIFIER(295...296)("p"),
        nil,
-       ArgumentsNode(297...301)(
-         [InterpolatedStringNode(297...301)(
+       ArgumentsNode(297...304)(
+         [InterpolatedStringNode(297...304)(
             HEREDOC_START(297...301)("<<~E"),
             [],
             HEREDOC_END(302...304)("E\n")

--- a/test/snapshots/whitequark/dedenting_interpolating_heredoc_fake_line_continuation.rb
+++ b/test/snapshots/whitequark/dedenting_interpolating_heredoc_fake_line_continuation.rb
@@ -1,7 +1,7 @@
-ProgramNode(9...23)(
+ProgramNode(0...27)(
   ScopeNode(0...0)([]),
-  StatementsNode(9...23)(
-    [InterpolatedStringNode(9...23)(
+  StatementsNode(0...27)(
+    [InterpolatedStringNode(0...27)(
        HEREDOC_START(0...8)("<<~'FOO'"),
        [StringNode(9...23)(
           nil,

--- a/test/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.rb
+++ b/test/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.rb
@@ -1,7 +1,7 @@
-ProgramNode(9...22)(
+ProgramNode(0...26)(
   ScopeNode(0...0)([]),
-  StatementsNode(9...22)(
-    [InterpolatedStringNode(9...22)(
+  StatementsNode(0...26)(
+    [InterpolatedStringNode(0...26)(
        HEREDOC_START(0...8)("<<~'FOO'"),
        [StringNode(9...22)(
           nil,

--- a/test/snapshots/whitequark/heredoc.rb
+++ b/test/snapshots/whitequark/heredoc.rb
@@ -1,7 +1,7 @@
-ProgramNode(9...61)(
+ProgramNode(0...61)(
   ScopeNode(0...0)([]),
-  StatementsNode(9...61)(
-    [InterpolatedStringNode(9...17)(
+  StatementsNode(0...61)(
+    [InterpolatedStringNode(0...22)(
        HEREDOC_START(0...8)("<<'HERE'"),
        [StringNode(9...17)(
           nil,
@@ -11,7 +11,7 @@ ProgramNode(9...61)(
         )],
        HEREDOC_END(17...22)("HERE\n")
      ),
-     InterpolatedStringNode(30...38)(
+     InterpolatedStringNode(23...43)(
        HEREDOC_START(23...29)("<<HERE"),
        [StringNode(30...38)(
           nil,

--- a/test/snapshots/whitequark/interp_digit_var.rb
+++ b/test/snapshots/whitequark/interp_digit_var.rb
@@ -233,7 +233,7 @@ ProgramNode(1...471)(
        STRING_END(350...351)("`"),
        "\#@@1"
      ),
-     InterpolatedStringNode(364...368)(
+     InterpolatedStringNode(354...373)(
        HEREDOC_START(354...363)("<<-\"HERE\""),
        [StringNode(364...368)(
           nil,
@@ -243,7 +243,7 @@ ProgramNode(1...471)(
         )],
        HEREDOC_END(368...373)("HERE\n")
      ),
-     InterpolatedStringNode(384...389)(
+     InterpolatedStringNode(374...394)(
        HEREDOC_START(374...383)("<<-\"HERE\""),
        [StringNode(384...389)(
           nil,
@@ -253,7 +253,7 @@ ProgramNode(1...471)(
         )],
        HEREDOC_END(389...394)("HERE\n")
      ),
-     InterpolatedStringNode(405...409)(
+     InterpolatedStringNode(395...414)(
        HEREDOC_START(395...404)("<<-'HERE'"),
        [StringNode(405...409)(
           nil,
@@ -263,7 +263,7 @@ ProgramNode(1...471)(
         )],
        HEREDOC_END(409...414)("HERE\n")
      ),
-     InterpolatedStringNode(425...430)(
+     InterpolatedStringNode(415...435)(
        HEREDOC_START(415...424)("<<-'HERE'"),
        [StringNode(425...430)(
           nil,

--- a/test/snapshots/whitequark/parser_bug_640.rb
+++ b/test/snapshots/whitequark/parser_bug_640.rb
@@ -1,7 +1,7 @@
-ProgramNode(7...20)(
+ProgramNode(0...24)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...20)(
-    [InterpolatedStringNode(7...20)(
+  StatementsNode(0...24)(
+    [InterpolatedStringNode(0...24)(
        HEREDOC_START(0...6)("<<~FOO"),
        [StringNode(7...20)(
           nil,

--- a/test/snapshots/whitequark/parser_drops_truncated_parts_of_squiggly_heredoc.rb
+++ b/test/snapshots/whitequark/parser_drops_truncated_parts_of_squiggly_heredoc.rb
@@ -1,7 +1,7 @@
-ProgramNode(8...14)(
+ProgramNode(0...19)(
   ScopeNode(0...0)([]),
-  StatementsNode(8...14)(
-    [InterpolatedStringNode(8...14)(
+  StatementsNode(0...19)(
+    [InterpolatedStringNode(0...19)(
        HEREDOC_START(0...7)("<<~HERE"),
        [StringNode(8...10)(nil, STRING_CONTENT(8...10)("  "), nil, ""),
         StringInterpolatedNode(10...13)(

--- a/test/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.rb
+++ b/test/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.rb
@@ -111,7 +111,7 @@ ProgramNode(0...210)(
        STRING_END(138...139)("'"),
        "a\n" + "b"
      ),
-     InterpolatedStringNode(151...156)(
+     InterpolatedStringNode(141...161)(
        HEREDOC_START(141...150)("<<-\"HERE\""),
        [StringNode(151...156)(
           nil,
@@ -121,7 +121,7 @@ ProgramNode(0...210)(
         )],
        HEREDOC_END(156...161)("HERE\n")
      ),
-     InterpolatedStringNode(172...177)(
+     InterpolatedStringNode(162...182)(
        HEREDOC_START(162...171)("<<-'HERE'"),
        [StringNode(172...177)(
           nil,

--- a/test/snapshots/whitequark/ruby_bug_11989.rb
+++ b/test/snapshots/whitequark/ruby_bug_11989.rb
@@ -1,13 +1,13 @@
-ProgramNode(0...19)(
+ProgramNode(0...21)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...19)(
-    [CallNode(0...19)(
+  StatementsNode(0...21)(
+    [CallNode(0...21)(
        nil,
        nil,
        IDENTIFIER(0...1)("p"),
        nil,
-       ArgumentsNode(9...19)(
-         [InterpolatedStringNode(9...19)(
+       ArgumentsNode(2...21)(
+         [InterpolatedStringNode(2...21)(
             HEREDOC_START(2...8)("<<~\"E\""),
             [StringNode(9...19)(
                nil,

--- a/test/snapshots/whitequark/ruby_bug_11990.rb
+++ b/test/snapshots/whitequark/ruby_bug_11990.rb
@@ -6,9 +6,9 @@ ProgramNode(0...12)(
        nil,
        IDENTIFIER(0...1)("p"),
        nil,
-       ArgumentsNode(13...12)(
-         [StringConcatNode(13...12)(
-            InterpolatedStringNode(13...17)(
+       ArgumentsNode(2...12)(
+         [StringConcatNode(2...12)(
+            InterpolatedStringNode(2...19)(
               HEREDOC_START(2...6)("<<~E"),
               [StringNode(13...17)(
                  nil,

--- a/test/snapshots/whitequark/slash_newline_in_heredocs.rb
+++ b/test/snapshots/whitequark/slash_newline_in_heredocs.rb
@@ -1,7 +1,7 @@
-ProgramNode(5...54)(
+ProgramNode(0...56)(
   ScopeNode(0...0)([]),
-  StatementsNode(5...54)(
-    [InterpolatedStringNode(5...25)(
+  StatementsNode(0...56)(
+    [InterpolatedStringNode(0...27)(
        HEREDOC_START(0...4)("<<-E"),
        [StringNode(5...25)(
           nil,
@@ -11,7 +11,7 @@ ProgramNode(5...54)(
         )],
        HEREDOC_END(25...27)("E\n")
      ),
-     InterpolatedStringNode(34...54)(
+     InterpolatedStringNode(29...56)(
        HEREDOC_START(29...33)("<<~E"),
        [StringNode(34...54)(
           nil,


### PR DESCRIPTION
`InterpolatedStringNode` now starts at its opening's start and ends with its closing's end.