### PR TITLE
make `yp_constant_id_t`s useful for constant pool indexing

### DIFF
--- a/include/yarp/util/yp_constant_pool.h
+++ b/include/yarp/util/yp_constant_pool.h
@@ -42,9 +42,9 @@ void yp_constant_id_list_free(yp_constant_id_list_t *list);
 typedef struct {
     unsigned int id: 31;
     bool owned: 1;
+    uint32_t hash;
     const uint8_t *start;
     size_t length;
-    uint32_t hash;
 } yp_constant_t;
 
 typedef struct {

--- a/include/yarp/util/yp_constant_pool.h
+++ b/include/yarp/util/yp_constant_pool.h
@@ -43,18 +43,22 @@ typedef struct {
     unsigned int id: 31;
     bool owned: 1;
     uint32_t hash;
+} yp_constant_pool_bucket_t;
+
+typedef struct {
     const uint8_t *start;
     size_t length;
 } yp_constant_t;
 
 typedef struct {
+    yp_constant_pool_bucket_t *buckets;
     yp_constant_t *constants;
     uint32_t size;
     uint32_t capacity;
 } yp_constant_pool_t;
 
 // Define an empty constant pool.
-#define YP_CONSTANT_POOL_EMPTY ((yp_constant_pool_t) { .constants = NULL, .size = 0, .capacity = 0 })
+#define YP_CONSTANT_POOL_EMPTY ((yp_constant_pool_t) { .buckets = NULL, .constants = NULL, .size = 0, .capacity = 0 })
 
 // Initialize a new constant pool with a given capacity.
 bool yp_constant_pool_init(yp_constant_pool_t *pool, uint32_t capacity);

--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -551,13 +551,8 @@ impl<'pr> ConstantId<'pr> {{
     pub fn as_slice(&self) -> &'pr [u8] {{
         unsafe {{
             let pool = &(*self.parser.as_ptr()).constant_pool;
-            for i in 0..pool.capacity {{
-                let constant = &(*pool.constants.add(i.try_into().unwrap()));
-                if constant.id() == self.id {{
-                    return std::slice::from_raw_parts(constant.start, constant.length);
-                }}
-            }}
-            panic!("Unable to locate constant id");
+            let constant = &(*pool.constants.add((self.id - 1).try_into().unwrap()));
+            std::slice::from_raw_parts(constant.start, constant.length)
         }}
     }}
 }}

--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -81,12 +81,10 @@ yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
     VALUE source = yp_source_new(parser, encoding);
     ID *constants = calloc(parser->constant_pool.size, sizeof(ID));
 
-    for (uint32_t index = 0; index < parser->constant_pool.capacity; index++) {
-        yp_constant_t constant = parser->constant_pool.constants[index];
+    for (uint32_t index = 0; index < parser->constant_pool.size; index++) {
+        yp_constant_t *constant = &parser->constant_pool.constants[index];
 
-        if (constant.id != 0) {
-            constants[constant.id - 1] = rb_intern3((const char *) constant.start, constant.length, encoding);
-        }
+        constants[index] = rb_intern3((const char *) constant->start, constant->length, encoding);
     }
 
     yp_node_stack_node_t *node_stack = NULL;

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -199,16 +199,16 @@ yp_serialize_content(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) 
     offset = buffer->length;
     yp_buffer_append_zeroes(buffer, parser->constant_pool.size * 8);
 
-    yp_constant_t *constant;
     for (uint32_t index = 0; index < parser->constant_pool.capacity; index++) {
-        constant = &parser->constant_pool.constants[index];
+        yp_constant_pool_bucket_t *bucket = &parser->constant_pool.buckets[index];
 
         // If we find a constant at this index, serialize it at the correct
         // index in the buffer.
-        if (constant->id != 0) {
-            size_t buffer_offset = offset + ((((size_t) constant->id) - 1) * 8);
+        if (bucket->id != 0) {
+            yp_constant_t *constant = &parser->constant_pool.constants[bucket->id - 1];
+            size_t buffer_offset = offset + ((((size_t)bucket->id) - 1) * 8);
 
-            if (constant->owned) {
+            if (bucket->owned) {
                 // Since this is an owned constant, we are going to write its
                 // contents into the buffer after the constant pool. So
                 // effectively in place of the source offset, we have a buffer


### PR DESCRIPTION
This turns out to be really useful (#1537, #1533, #1449, etc.), and we can make everything smaller while doing so.