### PR TITLE
Run memcheck on CRuby 3.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,6 +169,10 @@ jobs:
       run: bundle exec rake serialized_size:topgems
 
   memcheck:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.2", "head"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -196,7 +200,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - name: Run Ruby tests with valgrind
       run: bundle exec rake test:valgrind


### PR DESCRIPTION
* memcheck on ruby-head regularly fails due to regressions in ruby-head. This makes it clear whether the failure is due to ruby-head or to the changes in prism.

Alternatively we could skip running memcheck on ruby-head?