### PR TITLE
Add full_name to `ConstantPathNode` and `ConstantPathTargetNode`

### DIFF
--- a/lib/prism/node_ext.rb
+++ b/lib/prism/node_ext.rb
@@ -52,4 +52,48 @@ module Prism
       o
     end
   end
+
+  class ConstantReadNode < Node
+    # Returns the list of parts for the full name of this constant. For example: [:Foo]
+    def full_name_parts
+      [name]
+    end
+
+    # Returns the full name of this constant. For example: "Foo"
+    def full_name
+      name.name
+    end
+  end
+
+  class ConstantPathNode < Node
+    # Returns the list of parts for the full name of this constant path. For example: [:Foo, :Bar]
+    def full_name_parts
+      parts = [child.name]
+      current = parent
+
+      while current.is_a?(ConstantPathNode)
+        parts.unshift(current.child.name)
+        current = current.parent
+      end
+
+      parts.unshift(current&.name || :"")
+    end
+
+    # Returns the full name of this constant path. For example: "Foo::Bar"
+    def full_name
+      full_name_parts.join("::")
+    end
+  end
+
+  class ConstantPathTargetNode < Node
+    # Returns the list of parts for the full name of this constant path. For example: [:Foo, :Bar]
+    def full_name_parts
+      (parent&.full_name_parts || [:""]).push(child.name)
+    end
+
+    # Returns the full name of this constant path. For example: "Foo::Bar"
+    def full_name
+      full_name_parts.join("::")
+    end
+  end
 end

--- a/test/prism/constant_path_node_test.rb
+++ b/test/prism/constant_path_node_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+module Prism
+  class ConstantPathNodeTest < TestCase
+    def test_full_name_for_constant_path
+      source = <<~RUBY
+        Foo:: # comment
+          Bar::Baz::
+            Qux
+      RUBY
+
+      constant_path = Prism.parse(source).value.statements.body.first
+      assert_equal("Foo::Bar::Baz::Qux", constant_path.full_name)
+    end
+
+    def test_full_name_for_constant_path_target
+      source = <<~RUBY
+        Foo:: # comment
+          Bar::Baz::
+            Qux, Something = [1, 2]
+      RUBY
+
+      node = Prism.parse(source).value.statements.body.first
+      target = node.targets.first
+      assert_equal("Foo::Bar::Baz::Qux", target.full_name)
+    end
+  end
+end


### PR DESCRIPTION
Add `full_name` to both `ConstantPathNode` and `ConstantPathTargetNode`, so that one can easily figure out the complete name of the constant being referenced.