### PR TITLE
[rust] add flag accessors on nodes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -374,7 +374,7 @@ flags:
   - name: StringFlags
     values:
       - name: FROZEN
-        comment: "frozen by virtue of a frozen_string_literal comment"
+        comment: "frozen by virtue of a `frozen_string_literal` comment"
 nodes:
   - name: AliasGlobalVariableNode
     fields:

--- a/rust/prism-sys/build.rs
+++ b/rust/prism-sys/build.rs
@@ -75,8 +75,10 @@ fn generate_bindings(ruby_include_path: &Path) -> bindgen::Bindings {
         .allowlist_type("pm_parser_t")
         .allowlist_type("pm_string_t")
         .allowlist_type(r#"^pm_\w+_node_t"#)
+        .allowlist_type(r#"^pm_\w+_flags"#)
         // Enums
         .rustified_non_exhaustive_enum("pm_comment_type_t")
+        .rustified_non_exhaustive_enum(r#"pm_\w+_flags"#)
         .rustified_non_exhaustive_enum("pm_node_type")
         .rustified_non_exhaustive_enum("pm_pack_encoding")
         .rustified_non_exhaustive_enum("pm_pack_endian")

--- a/templates/include/prism/ast.h.erb
+++ b/templates/include/prism/ast.h.erb
@@ -104,7 +104,7 @@ typedef struct pm_<%= node.human %> {
 <%- flags.each do |flag| -%>
 
 // <%= flag.name %>
-typedef enum {
+typedef enum pm_<%= flag.human %> {
     <%- flag.values.each.with_index(Prism::COMMON_FLAGS) do |value, index| -%>
     PM_<%= flag.human.upcase %>_<%= value.name %> = 1 << <%= index %>,
     <%- end -%>


### PR DESCRIPTION
The raw `flags()` accessor that is currently exposed is functional, but seeing as how none of the relevant constants for the flag values are exported in `prism-sys`, `flags()` isn't very useful.  Let's write actual functions for each of the relevant flags, which will hopefully result in clearer code and make it so people don't have to worry about the bit-twiddliness of flag storage.