### PR TITLE
Remove trailing parenthesis in `Location#pretty_print`

### DIFF
--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -117,7 +117,7 @@ module Prism
     end
 
     def pretty_print(q)
-      q.text("(#{start_line},#{start_column})-(#{end_line},#{end_column}))")
+      q.text("(#{start_line},#{start_column})-(#{end_line},#{end_column})")
     end
 
     def ==(other)


### PR DESCRIPTION
Currently when calling `location` from a node, the class is called with a trailing parenthesis. This change was introduced in #1549.

## Before
```
[1] pry(main)> program_node.location
=> (1,0)-(2,6))
```

## After
```
[1] pry(main)> program_node.location
=> (1,0)-(2,6)
```
