### PR TITLE
[rust] fix lifetime for `ParseResult::node`

### DIFF
--- a/rust/prism/src/lib.rs
+++ b/rust/prism/src/lib.rs
@@ -186,7 +186,7 @@ impl<'pr> ParseResult<'pr> {
 
     /// Returns the root node of the parse result.
     #[must_use]
-    pub fn node(&self) -> Node<'pr> {
+    pub fn node(&self) -> Node<'_> {
         Node::new(self.parser, self.node.as_ptr())
     }
 }


### PR DESCRIPTION
`node` promised to return a `Node<'pr>`, but `'pr` is the lifetime for the slice that `ParseResult` holds.  In reality, the returned node should be bounded by the lifetime of the `ParseResult` itself, just like the return values for `errors`, `comments`, and `warnings`.

Since this code was wrong, Rust was perfectly happy to let `Node` references outlive the `ParseResult` so long as those `Node` references didn't outlive the slice being parsed.