### PR TITLE
Check for duplicate names in shadow args

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -9785,6 +9785,7 @@ parse_block_parameters(
     if ((opening->type != PM_TOKEN_NOT_PROVIDED) && accept1(parser, PM_TOKEN_SEMICOLON)) {
         do {
             expect1(parser, PM_TOKEN_IDENTIFIER, PM_ERR_BLOCK_PARAM_LOCAL_VARIABLE);
+            pm_parser_parameter_name_check(parser, &parser->previous);
             pm_parser_local_add_token(parser, &parser->previous);
 
             pm_block_local_variable_node_t *local = pm_block_local_variable_node_create(parser, &parser->previous);

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -1373,6 +1373,13 @@ module Prism
       ]
     end
 
+    def test_shadow_args_in_block
+      source = "tap{|a;a|}"
+      assert_errors expression(source), source, [
+        ["Repeated parameter name", 7..8],
+      ]
+    end
+
     private
 
     def assert_errors(expected, source, errors, compare_ripper: RUBY_ENGINE == "ruby")


### PR DESCRIPTION
```
➜  prism git:(haldun/duplicated-shadow-arg) ✗ cat test.rb
tap{|a;a|}
➜  prism git:(haldun/duplicated-shadow-arg) ✗ ruby -c test.rb 
test.rb: test.rb:1: duplicated argument name (SyntaxError)
tap{|a;a|}
        ^

➜  prism git:(haldun/duplicated-shadow-arg) ✗ ./bin/parse test.rb 
Errors:
[#<Prism::ParseError @message="Repeated parameter name" @location=#<Prism::Location @start_offset=7 @length=1 start_line=1>>]
```