### PR TITLE
Fix segfault for invalid `frozen_string_literals` magic comment

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -5277,10 +5277,10 @@ parser_lex_frozen_string_literal_comment(pm_parser_t *parser) {
     const uint8_t *cursor = parser->current.start + 1;
     const uint8_t *end = parser->current.end;
 
-    size_t key_length = strlen("frozen_string_literal");
+    size_t key_length = strlen("frozen_string_literal:");
     if (key_length > (size_t) (end - cursor)) return;
 
-    const uint8_t *cursor_limit = cursor + (end - cursor) - key_length + 1;
+    const uint8_t *cursor_limit = cursor + (end - cursor) - key_length;
 
     while ((cursor = pm_memchr(cursor, 'f', (size_t) (cursor_limit - cursor), parser->encoding_changed, &parser->encoding)) != NULL) {
         if (memcmp(cursor, "frozen_string_literal", key_length) == 0) {

--- a/src/prism.c
+++ b/src/prism.c
@@ -5280,11 +5280,11 @@ parser_lex_frozen_string_literal_comment(pm_parser_t *parser) {
     size_t key_length = strlen("frozen_string_literal:");
     if (key_length > (size_t) (end - cursor)) return;
 
-    const uint8_t *cursor_limit = cursor + (end - cursor) - key_length;
+    const uint8_t *cursor_limit = cursor + (end - cursor) - key_length + 1;
 
     while ((cursor = pm_memchr(cursor, 'f', (size_t) (cursor_limit - cursor), parser->encoding_changed, &parser->encoding)) != NULL) {
-        if (memcmp(cursor, "frozen_string_literal", key_length) == 0) {
-            cursor += key_length;
+        if (memcmp(cursor, "frozen_string_literal:", key_length) == 0) {
+            cursor += key_length - 1;
             cursor += pm_strspn_inline_whitespace(cursor, end - cursor);
 
             if (*cursor == ':' || *cursor == '=') {

--- a/test/prism/fixtures/magic_comments.txt
+++ b/test/prism/fixtures/magic_comments.txt
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+# frozen_string_literals: true

--- a/test/prism/snapshots/magic_comments.txt
+++ b/test/prism/snapshots/magic_comments.txt
@@ -1,0 +1,5 @@
+@ ProgramNode (location: (1,0)-(0,0))
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (1,0)-(0,0))
+    └── body: (length: 0)


### PR DESCRIPTION
Closes https://github.com/ruby/prism/issues/1629