### PR TITLE
Emit error when assigning to a numbered parameter

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -3444,10 +3444,19 @@ pm_local_variable_write_node_create(pm_parser_t *parser, pm_constant_id_t name, 
     return node;
 }
 
+static inline bool
+token_is_numbered_parameter(const uint8_t *start, const uint8_t *end) {
+    return (end - start == 2) && (start[0] == '_') && (start[1] != '0') && (pm_char_is_decimal_digit(start[1]));
+}
+
 // Allocate and initialize a new LocalVariableTargetNode node.
 static pm_local_variable_target_node_t *
 pm_local_variable_target_node_create(pm_parser_t *parser, const pm_token_t *name) {
     pm_local_variable_target_node_t *node = PM_ALLOC_NODE(parser, pm_local_variable_target_node_t);
+
+    if (token_is_numbered_parameter(name->start, name->end)) {
+        pm_parser_err_token(parser, name, PM_ERR_PARAMETER_NUMBERED_RESERVED);
+    }
 
     *node = (pm_local_variable_target_node_t) {
         {
@@ -4917,11 +4926,6 @@ static inline void
 pm_parser_local_add_owned(pm_parser_t *parser, const uint8_t *start, size_t length) {
     pm_constant_id_t constant_id = pm_parser_constant_id_owned(parser, start, length);
     if (constant_id != 0) pm_parser_local_add(parser, constant_id);
-}
-
-static inline bool
-token_is_numbered_parameter(const uint8_t *start, const uint8_t *end) {
-    return (end - start == 2) && (start[0] == '_') && (start[1] != '0') && (pm_char_is_decimal_digit(start[1]));
 }
 
 // Add a parameter name to the current scope and check whether the name of the

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -1389,6 +1389,21 @@ module Prism
       ], compare_ripper: compare_ripper
     end
 
+    def test_assign_to_numbered_parameter
+      source = "
+        a in _1
+        a => _1
+        1 => a, _1
+        1 in a, _1
+      "
+      assert_errors expression(source), source, [
+        ["Token reserved for a numbered parameter", 14..16],
+        ["Token reserved for a numbered parameter", 30..32],
+        ["Token reserved for a numbered parameter", 49..51],
+        ["Token reserved for a numbered parameter", 68..70],
+      ]
+    end
+
     private
 
     def assert_errors(expected, source, errors, compare_ripper: RUBY_ENGINE == "ruby")


### PR DESCRIPTION
Emit error for the following cases:

```ruby
a in _1
a => _1
1 => a, _1
1 in a, _1
```

Related #1580

This PR does not handle the case `/(?<_1>)/ =~ a` hence it is not closing the mentioned issue.