### PR TITLE
Attach the ast node node to the scope

### DIFF
--- a/include/prism/node.h
+++ b/include/prism/node.h
@@ -33,6 +33,7 @@ PRISM_EXPORTED_FUNCTION const char * pm_node_type_to_str(pm_node_type_t node_typ
 // declare them here to avoid generating them.
 typedef struct pm_scope_node {
     pm_node_t base;
+    pm_node_t *ast_node;
     struct pm_parameters_node *parameters;
     pm_node_t *body;
     pm_constant_id_list_t locals;

--- a/src/prism.c
+++ b/src/prism.c
@@ -669,6 +669,7 @@ pm_scope_node_init(pm_node_t *node, pm_scope_node_t *scope) {
     scope->base.location.start = node->location.start;
     scope->base.location.end = node->location.end;
 
+    scope->ast_node = node;
     scope->parameters = NULL;
     scope->body = NULL;
     pm_constant_id_list_init(&scope->locals);


### PR DESCRIPTION
So when building instruction sequences for a scope we can reference items from the parent. This is useful for for loops, where the local variable tables from the parent scope will need to be referenced.