### PR TITLE
Increase the depth for the For node index variable

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -8583,8 +8583,10 @@ parse_target(pm_parser_t *parser, pm_node_t *target) {
                     pm_parser_local_add_location(parser, message.start, message.end);
                     pm_node_destroy(parser, target);
 
+                    uint32_t depth = 0;
+                    for (pm_scope_t *scope = parser->current_scope; scope && scope->transparent; depth++, scope = scope->previous);
                     const pm_token_t name = { .type = PM_TOKEN_IDENTIFIER, .start = message.start, .end = message.end };
-                    target = (pm_node_t *) pm_local_variable_read_node_create(parser, &name, 0);
+                    target = (pm_node_t *) pm_local_variable_read_node_create(parser, &name, depth);
 
                     assert(sizeof(pm_local_variable_target_node_t) == sizeof(pm_local_variable_read_node_t));
                     target->type = PM_LOCAL_VARIABLE_TARGET_NODE;
@@ -12746,6 +12748,7 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power) {
             parser_lex(parser);
             pm_token_t for_keyword = parser->previous;
             pm_node_t *index;
+            pm_parser_scope_push_transparent(parser);
 
             // First, parse out the first index expression.
             if (accept1(parser, PM_TOKEN_USTAR)) {
@@ -12771,6 +12774,7 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power) {
                 index = parse_target(parser, index);
             }
 
+            pm_parser_scope_pop(parser);
             pm_do_loop_stack_push(parser, true);
 
             expect1(parser, PM_TOKEN_KEYWORD_IN, PM_ERR_FOR_IN);

--- a/test/prism/snapshots/for.txt
+++ b/test/prism/snapshots/for.txt
@@ -7,7 +7,7 @@
         │   ├── index:
         │   │   @ LocalVariableTargetNode (location: (1,4)-(1,5))
         │   │   ├── name: :i
-        │   │   └── depth: 0
+        │   │   └── depth: 1
         │   ├── collection:
         │   │   @ RangeNode (location: (1,9)-(1,14))
         │   │   ├── left:
@@ -32,7 +32,7 @@
         │   ├── index:
         │   │   @ LocalVariableTargetNode (location: (5,4)-(5,5))
         │   │   ├── name: :i
-        │   │   └── depth: 0
+        │   │   └── depth: 1
         │   ├── collection:
         │   │   @ RangeNode (location: (5,9)-(5,14))
         │   │   ├── left:
@@ -59,10 +59,10 @@
         │   │   ├── targets: (length: 2)
         │   │   │   ├── @ LocalVariableTargetNode (location: (7,4)-(7,5))
         │   │   │   │   ├── name: :i
-        │   │   │   │   └── depth: 0
+        │   │   │   │   └── depth: 1
         │   │   │   └── @ LocalVariableTargetNode (location: (7,6)-(7,7))
         │   │   │       ├── name: :j
-        │   │   │       └── depth: 0
+        │   │   │       └── depth: 1
         │   │   ├── lparen_loc: ∅
         │   │   └── rparen_loc: ∅
         │   ├── collection:
@@ -91,13 +91,13 @@
         │   │   ├── targets: (length: 3)
         │   │   │   ├── @ LocalVariableTargetNode (location: (11,4)-(11,5))
         │   │   │   │   ├── name: :i
-        │   │   │   │   └── depth: 0
+        │   │   │   │   └── depth: 1
         │   │   │   ├── @ LocalVariableTargetNode (location: (11,6)-(11,7))
         │   │   │   │   ├── name: :j
-        │   │   │   │   └── depth: 0
+        │   │   │   │   └── depth: 1
         │   │   │   └── @ LocalVariableTargetNode (location: (11,8)-(11,9))
         │   │   │       ├── name: :k
-        │   │   │       └── depth: 0
+        │   │   │       └── depth: 1
         │   │   ├── lparen_loc: ∅
         │   │   └── rparen_loc: ∅
         │   ├── collection:
@@ -124,7 +124,7 @@
         │   ├── index:
         │   │   @ LocalVariableTargetNode (location: (15,4)-(15,5))
         │   │   ├── name: :i
-        │   │   └── depth: 0
+        │   │   └── depth: 1
         │   ├── collection:
         │   │   @ RangeNode (location: (15,9)-(15,14))
         │   │   ├── left:
@@ -149,7 +149,7 @@
             ├── index:
             │   @ LocalVariableTargetNode (location: (19,4)-(19,5))
             │   ├── name: :i
-            │   └── depth: 0
+            │   └── depth: 1
             ├── collection:
             │   @ RangeNode (location: (19,9)-(19,14))
             │   ├── left:

--- a/test/prism/snapshots/unparser/corpus/literal/for.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/for.txt
@@ -15,7 +15,7 @@
         │   │           ├── index:
         │   │           │   @ LocalVariableTargetNode (location: (1,8)-(1,9))
         │   │           │   ├── name: :a
-        │   │           │   └── depth: 0
+        │   │           │   └── depth: 1
         │   │           ├── collection:
         │   │           │   @ CallNode (location: (1,13)-(1,16))
         │   │           │   ├── receiver: ∅
@@ -52,7 +52,7 @@
         │   ├── index:
         │   │   @ LocalVariableTargetNode (location: (4,4)-(4,5))
         │   │   ├── name: :a
-        │   │   └── depth: 0
+        │   │   └── depth: 1
         │   ├── collection:
         │   │   @ CallNode (location: (4,9)-(4,12))
         │   │   ├── receiver: ∅
@@ -87,13 +87,13 @@
         │   │   ├── targets: (length: 2)
         │   │   │   ├── @ LocalVariableTargetNode (location: (7,5)-(7,6))
         │   │   │   │   ├── name: :a
-        │   │   │   │   └── depth: 0
+        │   │   │   │   └── depth: 1
         │   │   │   └── @ SplatNode (location: (7,8)-(7,10))
         │   │   │       ├── operator_loc: (7,8)-(7,9) = "*"
         │   │   │       └── expression:
         │   │   │           @ LocalVariableTargetNode (location: (7,9)-(7,10))
         │   │   │           ├── name: :b
-        │   │   │           └── depth: 0
+        │   │   │           └── depth: 1
         │   │   ├── lparen_loc: (7,4)-(7,5) = "("
         │   │   └── rparen_loc: (7,10)-(7,11) = ")"
         │   ├── collection:
@@ -130,10 +130,10 @@
             │   ├── targets: (length: 2)
             │   │   ├── @ LocalVariableTargetNode (location: (10,5)-(10,6))
             │   │   │   ├── name: :a
-            │   │   │   └── depth: 0
+            │   │   │   └── depth: 1
             │   │   └── @ LocalVariableTargetNode (location: (10,8)-(10,9))
             │   │       ├── name: :b
-            │   │       └── depth: 0
+            │   │       └── depth: 1
             │   ├── lparen_loc: (10,4)-(10,5) = "("
             │   └── rparen_loc: (10,9)-(10,10) = ")"
             ├── collection:

--- a/test/prism/snapshots/whitequark/for.txt
+++ b/test/prism/snapshots/whitequark/for.txt
@@ -7,7 +7,7 @@
         │   ├── index:
         │   │   @ LocalVariableTargetNode (location: (1,4)-(1,5))
         │   │   ├── name: :a
-        │   │   └── depth: 0
+        │   │   └── depth: 1
         │   ├── collection:
         │   │   @ CallNode (location: (1,9)-(1,12))
         │   │   ├── receiver: ∅
@@ -45,7 +45,7 @@
             ├── index:
             │   @ LocalVariableTargetNode (location: (3,4)-(3,5))
             │   ├── name: :a
-            │   └── depth: 0
+            │   └── depth: 1
             ├── collection:
             │   @ CallNode (location: (3,9)-(3,12))
             │   ├── receiver: ∅

--- a/test/prism/snapshots/whitequark/for_mlhs.txt
+++ b/test/prism/snapshots/whitequark/for_mlhs.txt
@@ -9,10 +9,10 @@
             │   ├── targets: (length: 2)
             │   │   ├── @ LocalVariableTargetNode (location: (1,4)-(1,5))
             │   │   │   ├── name: :a
-            │   │   │   └── depth: 0
+            │   │   │   └── depth: 1
             │   │   └── @ LocalVariableTargetNode (location: (1,7)-(1,8))
             │   │       ├── name: :b
-            │   │       └── depth: 0
+            │   │       └── depth: 1
             │   ├── lparen_loc: ∅
             │   └── rparen_loc: ∅
             ├── collection:


### PR DESCRIPTION
In CRuby's parser locals in for nodes appear deeper in the ast than they do in Prism, but we can fix that with a transparent scope