### PR TITLE
Parse magic comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,6 @@ a.out
 
 compile_commands.json
 .cache/
+.vscode/
 
 tags

--- a/bin/parse
+++ b/bin/parse
@@ -22,6 +22,7 @@ value = value.accept(Prism::DesugarCompiler.new) if ENV["DESUGAR"]
 
 parts = {}
 parts["Comments"] = result.comments if result.comments.any?
+parts["Magic comments"] = result.magic_comments if result.magic_comments.any?
 parts["Warnings"] = result.warnings if result.warnings.any?
 parts["Errors"] = result.errors if result.errors.any?
 

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -31,6 +31,7 @@ This drastically cuts down on the size of the serialized string, especially when
 ### comment
 
 The comment type is one of:
+
 * 0=`INLINE` (`# comment`)
 * 1=`EMBEDDED_DOCUMENT` (`=begin`/`=end`)
 * 2=`__END__` (after `__END__`)
@@ -39,6 +40,13 @@ The comment type is one of:
 | --- | --- |
 | `1` | comment type |
 | location | the location in the source of this comment |
+
+### magic comment
+
+| # bytes | field |
+| --- | --- |
+| location | the location of the key of the magic comment |
+| location | the location of the value of the magic comment |
 
 ### diagnostic
 
@@ -66,6 +74,8 @@ The header is structured like the following table:
 | string | the encoding name |
 | varint | number of comments |
 | comment* | comments |
+| varint | number of magic comments |
+| magic comment* | magic comments |
 | varint | number of errors |
 | diagnostic* | errors |
 | varint | number of warnings |

--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -10,6 +10,7 @@ VALUE rb_cPrismToken;
 VALUE rb_cPrismLocation;
 
 VALUE rb_cPrismComment;
+VALUE rb_cPrismMagicComment;
 VALUE rb_cPrismParseError;
 VALUE rb_cPrismParseWarning;
 VALUE rb_cPrismParseResult;
@@ -151,6 +152,35 @@ parser_comments(pm_parser_t *parser, VALUE source) {
     }
 
     return comments;
+}
+
+// Extract the magic comments out of the parser into an array.
+static VALUE
+parser_magic_comments(pm_parser_t *parser, VALUE source) {
+    VALUE magic_comments = rb_ary_new();
+
+    for (pm_magic_comment_t *magic_comment = (pm_magic_comment_t *) parser->magic_comment_list.head; magic_comment != NULL; magic_comment = (pm_magic_comment_t *) magic_comment->node.next) {
+        VALUE key_loc_argv[] = {
+            source,
+            LONG2FIX(magic_comment->key_start - parser->start),
+            LONG2FIX(magic_comment->key_length)
+        };
+
+        VALUE value_loc_argv[] = {
+            source,
+            LONG2FIX(magic_comment->value_start - parser->start),
+            LONG2FIX(magic_comment->value_length)
+        };
+
+        VALUE magic_comment_argv[] = {
+            rb_class_new_instance(3, key_loc_argv, rb_cPrismLocation),
+            rb_class_new_instance(3, value_loc_argv, rb_cPrismLocation)
+        };
+
+        rb_ary_push(magic_comments, rb_class_new_instance(2, magic_comment_argv, rb_cPrismMagicComment));
+    }
+
+    return magic_comments;
 }
 
 // Extract the errors out of the parser into an array.
@@ -297,6 +327,7 @@ parse_lex_input(pm_string_t *input, const char *filepath, bool return_nodes) {
     VALUE result_argv[] = {
         value,
         parser_comments(&parser, source),
+        parser_magic_comments(&parser, source),
         parser_errors(&parser, parse_lex_data.encoding, source),
         parser_warnings(&parser, parse_lex_data.encoding, source),
         source
@@ -304,7 +335,7 @@ parse_lex_input(pm_string_t *input, const char *filepath, bool return_nodes) {
 
     pm_node_destroy(&parser, node);
     pm_parser_free(&parser);
-    return rb_class_new_instance(5, result_argv, rb_cPrismParseResult);
+    return rb_class_new_instance(6, result_argv, rb_cPrismParseResult);
 }
 
 // Return an array of tokens corresponding to the given string.
@@ -351,12 +382,13 @@ parse_input(pm_string_t *input, const char *filepath) {
     VALUE result_argv[] = {
         pm_ast_new(&parser, node, encoding),
         parser_comments(&parser, source),
+        parser_magic_comments(&parser, source),
         parser_errors(&parser, encoding, source),
         parser_warnings(&parser, encoding, source),
         source
     };
 
-    VALUE result = rb_class_new_instance(5, result_argv, rb_cPrismParseResult);
+    VALUE result = rb_class_new_instance(6, result_argv, rb_cPrismParseResult);
 
     pm_node_destroy(&parser, node);
     pm_parser_free(&parser);
@@ -547,6 +579,7 @@ Init_prism(void) {
     rb_cPrismToken = rb_define_class_under(rb_cPrism, "Token", rb_cObject);
     rb_cPrismLocation = rb_define_class_under(rb_cPrism, "Location", rb_cObject);
     rb_cPrismComment = rb_define_class_under(rb_cPrism, "Comment", rb_cObject);
+    rb_cPrismMagicComment = rb_define_class_under(rb_cPrism, "MagicComment", rb_cObject);
     rb_cPrismParseError = rb_define_class_under(rb_cPrism, "ParseError", rb_cObject);
     rb_cPrismParseWarning = rb_define_class_under(rb_cPrism, "ParseWarning", rb_cObject);
     rb_cPrismParseResult = rb_define_class_under(rb_cPrism, "ParseResult", rb_cObject);

--- a/include/prism/parser.h
+++ b/include/prism/parser.h
@@ -250,6 +250,16 @@ typedef struct pm_comment {
     pm_comment_type_t type;
 } pm_comment_t;
 
+// This is a node in the linked list of magic comments that we've found while
+// parsing.
+typedef struct {
+    pm_list_node_t node;
+    const uint8_t *key_start;
+    const uint8_t *value_start;
+    uint32_t key_length;
+    uint32_t value_length;
+} pm_magic_comment_t;
+
 // When the encoding that is being used to parse the source is changed by prism,
 // we provide the ability here to call out to a user-defined function.
 typedef void (*pm_encoding_changed_callback_t)(pm_parser_t *parser);
@@ -353,6 +363,7 @@ struct pm_parser {
     const uint8_t *heredoc_end;
 
     pm_list_t comment_list;             // the list of comments that have been found while parsing
+    pm_list_t magic_comment_list;       // the list of magic comments that have been found while parsing.
     pm_list_t warning_list;             // the list of warnings that have been found while parsing
     pm_list_t error_list;               // the list of errors that have been found while parsing
     pm_scope_t *current_scope;          // the current local scope

--- a/java/org/prism/ParseResult.java
+++ b/java/org/prism/ParseResult.java
@@ -23,6 +23,16 @@ public final class ParseResult {
         }
     }
 
+    public static final class MagicComment {
+        public final Nodes.Location keyLocation;
+        public final Nodes.Location valueLocation;
+
+        public MagicComment(Nodes.Location keyLocation, Nodes.Location valueLocation) {
+            this.keyLocation = keyLocation;
+            this.valueLocation = valueLocation;
+        }
+    }
+
     public static final class Error {
         public final String message;
         public final Nodes.Location location;
@@ -45,12 +55,14 @@ public final class ParseResult {
 
     public final Nodes.Node value;
     public final Comment[] comments;
+    public final MagicComment[] magicComments;
     public final Error[] errors;
     public final Warning[] warnings;
 
-    public ParseResult(Nodes.Node value, Comment[] comments, Error[] errors, Warning[] warnings) {
+    public ParseResult(Nodes.Node value, Comment[] comments, MagicComment[] magicComments, Error[] errors, Warning[] warnings) {
         this.value = value;
         this.comments = comments;
+        this.magicComments = magicComments;
         this.errors = errors;
         this.warnings = warnings;
     }

--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -234,11 +234,11 @@ module Prism
       loader = Serialize::Loader.new(source, buffer.read)
 
       tokens = loader.load_tokens
-      node, comments, errors, warnings = loader.load_nodes
+      node, comments, magic_comments, errors, warnings = loader.load_nodes
 
       tokens.each { |token,| token.value.force_encoding(loader.encoding) }
 
-      ParseResult.new([node, tokens], comments, errors, warnings, source)
+      ParseResult.new([node, tokens], comments, magic_comments, errors, warnings, source)
     end
   end
 

--- a/lib/prism/lex_compat.rb
+++ b/lib/prism/lex_compat.rb
@@ -825,7 +825,7 @@ module Prism
       # We sort by location to compare against Ripper's output
       tokens.sort_by!(&:location)
 
-      ParseResult.new(tokens, result.comments, result.errors, result.warnings, [])
+      ParseResult.new(tokens, result.comments, result.magic_comments, result.errors, result.warnings, [])
     end
   end
 

--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -137,7 +137,7 @@ module Prism
     end
 
     def self.null
-      new(0, 0)
+      new(nil, 0, 0)
     end
   end
 
@@ -163,6 +163,32 @@ module Prism
 
     def inspect
       "#<Prism::Comment @type=#{@type.inspect} @location=#{@location.inspect}>"
+    end
+  end
+
+  # This represents a magic comment that was encountered during parsing.
+  class MagicComment
+    attr_reader :key_loc, :value_loc
+
+    def initialize(key_loc, value_loc)
+      @key_loc = key_loc
+      @value_loc = value_loc
+    end
+
+    def key
+      key_loc.slice
+    end
+
+    def value
+      value_loc.slice
+    end
+
+    def deconstruct_keys(keys)
+      { key_loc: key_loc, value_loc: value_loc }
+    end
+
+    def inspect
+      "#<Prism::MagicComment @key=#{key.inspect} @value=#{value.inspect}>"
     end
   end
 
@@ -206,18 +232,19 @@ module Prism
   # the AST, any comments that were encounters, and any errors that were
   # encountered.
   class ParseResult
-    attr_reader :value, :comments, :errors, :warnings, :source
+    attr_reader :value, :comments, :magic_comments, :errors, :warnings, :source
 
-    def initialize(value, comments, errors, warnings, source)
+    def initialize(value, comments, magic_comments, errors, warnings, source)
       @value = value
       @comments = comments
+      @magic_comments = magic_comments
       @errors = errors
       @warnings = warnings
       @source = source
     end
 
     def deconstruct_keys(keys)
-      { value: value, comments: comments, errors: errors, warnings: warnings }
+      { value: value, comments: comments, magic_comments: magic_comments, errors: errors, warnings: warnings }
     end
 
     def success?

--- a/rakelib/check_manifest.rake
+++ b/rakelib/check_manifest.rake
@@ -9,6 +9,7 @@ task :check_manifest => [:templates] do
     .github
     .cache
     .ruby-lsp
+    .vscode
     autom4te.cache
     bin
     build

--- a/src/diagnostic.c
+++ b/src/diagnostic.c
@@ -265,7 +265,7 @@ pm_diagnostic_message(pm_diagnostic_id_t diag_id) {
 // Append an error to the given list of diagnostic.
 bool
 pm_diagnostic_list_append(pm_list_t *list, const uint8_t *start, const uint8_t *end, pm_diagnostic_id_t diag_id) {
-    pm_diagnostic_t *diagnostic = (pm_diagnostic_t *) malloc(sizeof(pm_diagnostic_t));
+    pm_diagnostic_t *diagnostic = (pm_diagnostic_t *) calloc(sizeof(pm_diagnostic_t), 1);
     if (diagnostic == NULL) return false;
 
     *diagnostic = (pm_diagnostic_t) { .start = start, .end = end, .message = pm_diagnostic_message(diag_id) };

--- a/src/prism.c
+++ b/src/prism.c
@@ -5448,7 +5448,8 @@ parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
         // Here, we need to do some processing on the key to swap out dashes for
         // underscores. We only need to do this if there _is_ a dash in the key.
         pm_string_t key;
-        const uint8_t *dash = pm_memchr(key_start, '-', (size_t) (key_end - key_start), parser->encoding_changed, &parser->encoding);
+        const size_t key_length = (size_t) (key_end - key_start);
+        const uint8_t *dash = pm_memchr(key_start, '-', (size_t) key_length, parser->encoding_changed, &parser->encoding);
 
         if (dash == NULL) {
             pm_string_shared_init(&key, key_start, key_end);
@@ -5470,7 +5471,6 @@ parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
         // Finally, we can start checking the key against the list of known
         // magic comment keys, and potentially change state based on that.
         const uint8_t *key_source = pm_string_source(&key);
-        const size_t key_length = pm_string_length(&key);
 
         // We only want to attempt to compare against encoding comments if it's
         // the first line in the file (or the second in the case of a shebang).
@@ -5497,7 +5497,7 @@ parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
 
         // Allocate a new magic comment node to append to the parser's list.
         pm_magic_comment_t *magic_comment;
-        if ((magic_comment = (pm_magic_comment_t *) malloc(sizeof(pm_magic_comment_t))) != NULL) {
+        if ((magic_comment = (pm_magic_comment_t *) calloc(sizeof(pm_magic_comment_t), 1)) != NULL) {
             magic_comment->key_start = key_start;
             magic_comment->value_start = value_start;
             magic_comment->key_length = (uint32_t) key_length;
@@ -6769,7 +6769,7 @@ parser_lex_callback(pm_parser_t *parser) {
 // Return a new comment node of the specified type.
 static inline pm_comment_t *
 parser_comment(pm_parser_t *parser, pm_comment_type_t type) {
-    pm_comment_t *comment = (pm_comment_t *) malloc(sizeof(pm_comment_t));
+    pm_comment_t *comment = (pm_comment_t *) calloc(sizeof(pm_comment_t), 1);
     if (comment == NULL) return NULL;
 
     *comment = (pm_comment_t) {

--- a/src/prism.c
+++ b/src/prism.c
@@ -5443,6 +5443,16 @@ parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
         // When we're done, we want to free the string in case we had to
         // allocate memory for it.
         pm_string_free(&key);
+
+        // Allocate a new magic comment node to append to the parser's list.
+        pm_magic_comment_t *magic_comment;
+        if ((magic_comment = (pm_magic_comment_t *) malloc(sizeof(pm_magic_comment_t))) != NULL) {
+            magic_comment->key_start = key_start;
+            magic_comment->value_start = value_start;
+            magic_comment->key_length = (uint32_t) key_length;
+            magic_comment->value_length = (uint32_t) (value_end - value_start);
+            pm_list_append(&parser->magic_comment_list, (pm_list_node_t *) magic_comment);
+        }
     }
 }
 
@@ -15257,6 +15267,7 @@ pm_parser_init(pm_parser_t *parser, const uint8_t *source, size_t size, const ch
         .next_start = NULL,
         .heredoc_end = NULL,
         .comment_list = PM_LIST_EMPTY,
+        .magic_comment_list = PM_LIST_EMPTY,
         .warning_list = PM_LIST_EMPTY,
         .error_list = PM_LIST_EMPTY,
         .current_scope = NULL,
@@ -15351,6 +15362,19 @@ pm_comment_list_free(pm_list_t *list) {
     }
 }
 
+// Free all of the memory associated with the magic comment list.
+static inline void
+pm_magic_comment_list_free(pm_list_t *list) {
+    pm_list_node_t *node, *next;
+
+    for (node = list->head; node != NULL; node = next) {
+        next = node->next;
+
+        pm_magic_comment_t *magic_comment = (pm_magic_comment_t *) node;
+        free(magic_comment);
+    }
+}
+
 // Free any memory associated with the given parser.
 PRISM_EXPORTED_FUNCTION void
 pm_parser_free(pm_parser_t *parser) {
@@ -15358,6 +15382,7 @@ pm_parser_free(pm_parser_t *parser) {
     pm_diagnostic_list_free(&parser->error_list);
     pm_diagnostic_list_free(&parser->warning_list);
     pm_comment_list_free(&parser->comment_list);
+    pm_magic_comment_list_free(&parser->magic_comment_list);
     pm_constant_pool_free(&parser->constant_pool);
     pm_newline_list_free(&parser->newline_list);
 

--- a/src/prism.c
+++ b/src/prism.c
@@ -5213,66 +5213,17 @@ next_newline(const uint8_t *cursor, ptrdiff_t length) {
     return memchr(cursor, '\n', (size_t) length);
 }
 
-// Find the start of the encoding comment. This is effectively an inlined
-// version of strnstr with some modifications.
-static inline const uint8_t *
-parser_lex_encoding_comment_start(pm_parser_t *parser, const uint8_t *cursor, ptrdiff_t remaining) {
-    assert(remaining >= 0);
-    size_t length = (size_t) remaining;
-
-    size_t key_length = strlen("coding:");
-    if (key_length > length) return NULL;
-
-    const uint8_t *cursor_limit = cursor + length - key_length + 1;
-    while ((cursor = pm_memchr(cursor, 'c', (size_t) (cursor_limit - cursor), parser->encoding_changed, &parser->encoding)) != NULL) {
-        if (memcmp(cursor, "coding", key_length - 1) == 0) {
-            size_t whitespace_after_coding = pm_strspn_inline_whitespace(cursor + key_length - 1, parser->end - (cursor + key_length - 1));
-            size_t cur_pos = key_length + whitespace_after_coding;
-
-            if (cursor[cur_pos - 1] == ':' || cursor[cur_pos - 1] == '=') {
-                return cursor + cur_pos;
-            }
-        }
-
-        cursor++;
-    }
-
-    return NULL;
-}
-
 // Here we're going to check if this is a "magic" comment, and perform whatever
 // actions are necessary for it here.
 static void
-parser_lex_encoding_comment(pm_parser_t *parser) {
-    const uint8_t *start = parser->current.start + 1;
-    const uint8_t *end = parser->current.end;
-
-    // These are the patterns we're going to match to find the encoding comment.
-    // This is definitely not complete or even really correct.
-    const uint8_t *encoding_start = parser_lex_encoding_comment_start(parser, start, end - start);
-
-    // If we didn't find anything that matched our patterns, then return. Note
-    // that this does a _very_ poor job of actually finding the encoding, and
-    // there is a lot of work to do here to better reflect actual magic comment
-    // parsing from CRuby, but this at least gets us part of the way there.
-    if (encoding_start == NULL) return;
-
-    // Skip any non-newline whitespace after the "coding:" or "coding=".
-    encoding_start += pm_strspn_inline_whitespace(encoding_start, end - encoding_start);
-
-    // Now determine the end of the encoding string. This is either the end of
-    // the line, the first whitespace character, or a punctuation mark.
-    const uint8_t *encoding_end = pm_strpbrk(parser, encoding_start, (const uint8_t *) " \t\f\r\v\n;,", end - encoding_start);
-    encoding_end = encoding_end == NULL ? end : encoding_end;
-
-    // Finally, we can determine the width of the encoding string.
-    size_t width = (size_t) (encoding_end - encoding_start);
+parser_lex_magic_comment_encoding(pm_parser_t *parser, const uint8_t *start, const uint8_t *end) {
+    size_t width = (size_t) (end - start);
 
     // First, we're going to call out to a user-defined callback if one was
     // provided. If they return an encoding struct that we can use, then we'll
     // use that here.
     if (parser->encoding_decode_callback != NULL) {
-        pm_encoding_t *encoding = parser->encoding_decode_callback(parser, encoding_start, width);
+        pm_encoding_t *encoding = parser->encoding_decode_callback(parser, start, width);
 
         if (encoding != NULL) {
             parser->encoding = *encoding;
@@ -5284,7 +5235,7 @@ parser_lex_encoding_comment(pm_parser_t *parser) {
     // Extensions like utf-8 can contain extra encoding details like,
     // utf-8-dos, utf-8-linux, utf-8-mac. We treat these all as utf-8 should
     // treat any encoding starting utf-8 as utf-8.
-    if ((encoding_start + 5 <= parser->end) && (pm_strncasecmp(encoding_start, (const uint8_t *) "utf-8", 5) == 0)) {
+    if ((start + 5 <= end) && (pm_strncasecmp(start, (const uint8_t *) "utf-8", 5) == 0)) {
         // We don't need to do anything here because the default encoding is
         // already UTF-8. We'll just return.
         return;
@@ -5293,7 +5244,7 @@ parser_lex_encoding_comment(pm_parser_t *parser) {
     // Next, we're going to loop through each of the encodings that we handle
     // explicitly. If we found one that we understand, we'll use that value.
 #define ENCODING(value, prebuilt) \
-    if (width == sizeof(value) - 1 && encoding_start + width <= parser->end && pm_strncasecmp(encoding_start, (const uint8_t *) value, width) == 0) { \
+    if (width == sizeof(value) - 1 && start + width <= end && pm_strncasecmp(start, (const uint8_t *) value, width) == 0) { \
         parser->encoding = prebuilt; \
         parser->encoding_changed |= true; \
         if (parser->encoding_changed_callback != NULL) parser->encoding_changed_callback(parser); \
@@ -5342,39 +5293,156 @@ parser_lex_encoding_comment(pm_parser_t *parser) {
     // didn't understand the encoding that the user was trying to use. In this
     // case we'll keep using the default encoding but add an error to the
     // parser to indicate an unsuccessful parse.
-    pm_parser_err(parser, encoding_start, encoding_end, PM_ERR_INVALID_ENCODING_MAGIC_COMMENT);
+    pm_parser_err(parser, start, end, PM_ERR_INVALID_ENCODING_MAGIC_COMMENT);
 }
 
 // Check if this is a magic comment that includes the frozen_string_literal
 // pragma. If it does, set that field on the parser.
 static void
-parser_lex_frozen_string_literal_comment(pm_parser_t *parser) {
-    const uint8_t *cursor = parser->current.start + 1;
+parser_lex_magic_comment_frozen_string_literal(pm_parser_t *parser, const uint8_t *start, const uint8_t *end) {
+    if (start + 4 <= end && pm_strncasecmp(start, (const uint8_t *) "true", 4) == 0) {
+        parser->frozen_string_literal = true;
+    }
+}
+
+static inline bool
+pm_char_is_magic_comment_key_delimiter(const uint8_t b) {
+    return b == '\'' || b == '"' || b == ':' || b == ';';
+}
+
+// Find an emacs magic comment marker (-*-) within the given bounds. If one is
+// found, it returns a pointer to the start of the marker. Otherwise it returns
+// NULL.
+static inline const uint8_t *
+parser_lex_magic_comment_emacs_marker(pm_parser_t *parser, const uint8_t *cursor, const uint8_t *end) {
+    while ((cursor + 3 <= end) && (cursor = pm_memchr(cursor, '-', (size_t) (end - cursor), parser->encoding_changed, &parser->encoding)) != NULL) {
+        if (cursor + 3 <= end && cursor[1] == '*' && cursor[2] == '-') {
+            return cursor;
+        }
+        cursor++;
+    }
+    return NULL;
+}
+
+// Parse the current token on the parser to see if it's a magic comment and
+// potentially perform some action based on that. A regular expression that this
+// function is effectively matching is:
+//
+//     %r"([^\\s\'\":;]+)\\s*:\\s*(\"(?:\\\\.|[^\"])*\"|[^\"\\s;]+)[\\s;]*"
+//
+static inline void
+parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
+    const uint8_t *start = parser->current.start + 1;
     const uint8_t *end = parser->current.end;
 
-    size_t key_length = strlen("frozen_string_literal");
-    if (key_length > (size_t) (end - cursor)) return;
+    const uint8_t *cursor;
+    bool indicator = false;
 
-    const uint8_t *cursor_limit = cursor + (end - cursor) - key_length + 1;
+    if ((cursor = parser_lex_magic_comment_emacs_marker(parser, start, end)) != NULL) {
+        start = cursor + 3;
 
-    while ((cursor = pm_memchr(cursor, 'f', (size_t) (cursor_limit - cursor), parser->encoding_changed, &parser->encoding)) != NULL) {
-        if (memcmp(cursor, "frozen_string_literal", key_length) == 0) {
-            cursor += key_length;
-            cursor += pm_strspn_inline_whitespace(cursor, end - cursor);
+        if ((cursor = parser_lex_magic_comment_emacs_marker(parser, start, end)) != NULL) {
+            end = cursor;
+            indicator = true;
+        } else {
+            // If we have a start marker but not an end marker, then we cannot
+            // have a magic comment.
+            return;
+        }
+    }
 
-            if (*cursor == ':' || *cursor == '=') {
-                cursor++;
-                cursor += pm_strspn_inline_whitespace(cursor, end - cursor);
+    cursor = start;
+    while (cursor < end) {
+        while (cursor < end && (pm_char_is_magic_comment_key_delimiter(*cursor) || pm_char_is_whitespace(*cursor))) cursor++;
 
-                if (cursor + 4 <= end && pm_strncasecmp(cursor, (const uint8_t *) "true", 4) == 0) {
-                    parser->frozen_string_literal = true;
-                }
+        const uint8_t *key_start = cursor;
+        while (cursor < end && (!pm_char_is_magic_comment_key_delimiter(*cursor) && !pm_char_is_whitespace(*cursor))) cursor++;
 
-                return;
+        const uint8_t *key_end = cursor;
+        while (cursor < end && pm_char_is_whitespace(*cursor)) cursor++;
+        if (cursor == end) return;
+
+        if (*cursor == ':') {
+            cursor++;
+        } else {
+            if (!indicator) return;
+            continue;
+        }
+
+        while (cursor < end && pm_char_is_whitespace(*cursor)) cursor++;
+        if (cursor == end) return;
+
+        const uint8_t *value_start;
+        const uint8_t *value_end;
+
+        if (*cursor == '"') {
+            value_start = ++cursor;
+            for (; cursor < end && *cursor != '"'; cursor++) {
+                if (*cursor == '\\' && (cursor + 1 < end)) cursor++;
+            }
+            value_end = cursor;
+        } else {
+            value_start = cursor;
+            while (cursor < end && *cursor != '"' && *cursor != ';' && !pm_char_is_whitespace(*cursor)) cursor++;
+            value_end = cursor;
+        }
+
+        if (indicator) {
+            while (cursor < end && (*cursor == ';' || pm_char_is_whitespace(*cursor))) cursor++;
+        } else {
+            while (cursor < end && pm_char_is_whitespace(*cursor)) cursor++;
+            if (cursor != end) return;
+        }
+
+        // Here, we need to do some processing on the key to swap out dashes for
+        // underscores. We only need to do this if there _is_ a dash in the key.
+        pm_string_t key;
+        const uint8_t *dash = pm_memchr(key_start, '-', (size_t) (key_end - key_start), parser->encoding_changed, &parser->encoding);
+
+        if (dash == NULL) {
+            pm_string_shared_init(&key, key_start, key_end);
+        } else {
+            size_t width = (size_t) (key_end - key_start);
+            uint8_t *buffer = malloc(width);
+            if (buffer == NULL) return;
+
+            memcpy(buffer, key_start, width);
+            buffer[dash - key_start] = '_';
+
+            while ((dash = pm_memchr(dash + 1, '-', (size_t) (key_end - dash - 1), parser->encoding_changed, &parser->encoding)) != NULL) {
+                buffer[dash - key_start] = '_';
+            }
+
+            pm_string_owned_init(&key, buffer, width);
+        }
+
+        // Finally, we can start checking the key against the list of known
+        // magic comment keys, and potentially change state based on that.
+        const char *key_source = (const char *) pm_string_source(&key);
+        const size_t key_length = pm_string_length(&key);
+
+        // We only want to attempt to compare against encoding comments if it's
+        // the first line in the file (or the second in the case of a shebang).
+        if (parser->current.start == parser->encoding_comment_start) {
+            if (
+                (key_length == 8 && strncasecmp(key_source, "encoding", 8) == 0) ||
+                (key_length == 6 && strncasecmp(key_source, "coding", 6) == 0)
+            ) {
+                parser_lex_magic_comment_encoding(parser, value_start, value_end);
             }
         }
 
-        cursor++;
+        // We only want to handle frozen string literal comments if it's before
+        // any semantic tokens have been seen.
+        if (!semantic_token_seen) {
+            if (key_length == 21 && strncasecmp(key_source, "frozen_string_literal", 21) == 0) {
+                parser_lex_magic_comment_frozen_string_literal(parser, value_start, value_end);
+            }
+        }
+
+        // When we're done, we want to free the string in case we had to
+        // allocate memory for it.
+        pm_string_free(&key);
     }
 }
 
@@ -6976,13 +7044,9 @@ parser_lex(pm_parser_t *parser) {
                     parser->current.type = PM_TOKEN_COMMENT;
                     parser_lex_callback(parser);
 
-                    if (parser->current.start == parser->encoding_comment_start) {
-                        parser_lex_encoding_comment(parser);
-                    }
-
-                    if (!semantic_token_seen) {
-                        parser_lex_frozen_string_literal_comment(parser);
-                    }
+                    // Here, parse the comment to see if it's a magic comment
+                    // and potentially change state on the parser.
+                    parser_lex_magic_comment(parser, semantic_token_seen);
 
                     lexed_comment = true;
                 }

--- a/src/prism.c
+++ b/src/prism.c
@@ -5216,7 +5216,7 @@ next_newline(const uint8_t *cursor, ptrdiff_t length) {
 // Here we're going to check if this is a "magic" comment, and perform whatever
 // actions are necessary for it here.
 static void
-parser_lex_magic_comment_encoding(pm_parser_t *parser, const uint8_t *start, const uint8_t *end) {
+parser_lex_magic_comment_encoding_value(pm_parser_t *parser, const uint8_t *start, const uint8_t *end) {
     size_t width = (size_t) (end - start);
 
     // First, we're going to call out to a user-defined callback if one was
@@ -5296,10 +5296,58 @@ parser_lex_magic_comment_encoding(pm_parser_t *parser, const uint8_t *start, con
     pm_parser_err(parser, start, end, PM_ERR_INVALID_ENCODING_MAGIC_COMMENT);
 }
 
+// Look for a specific pattern of "coding" and potentially set the encoding on
+// the parser.
+static void
+parser_lex_magic_comment_encoding(pm_parser_t *parser) {
+    const uint8_t *cursor = parser->current.start + 1;
+    const uint8_t *end = parser->current.end;
+
+    bool separator = false;
+    while (true) {
+        if (end - cursor <= 6) return;
+        switch (cursor[6]) {
+            case 'C': case 'c': cursor += 6; continue;
+            case 'O': case 'o': cursor += 5; continue;
+            case 'D': case 'd': cursor += 4; continue;
+            case 'I': case 'i': cursor += 3; continue;
+            case 'N': case 'n': cursor += 2; continue;
+            case 'G': case 'g': cursor += 1; continue;
+            case '=': case ':':
+                separator = true;
+                cursor += 6;
+                break;
+            default:
+                cursor += 6;
+                if (pm_char_is_whitespace(*cursor)) break;
+                continue;
+        }
+        if (pm_strncasecmp(cursor - 6, (const uint8_t *) "coding", 6) == 0) break;
+        separator = false;
+    }
+
+    while (true) {
+        do {
+            if (++cursor >= end) return;
+        } while (pm_char_is_whitespace(*cursor));
+
+        if (separator) break;
+        if (*cursor != '=' && *cursor != ':') return;
+
+        separator = true;
+        cursor++;
+    }
+
+    const uint8_t *value_start = cursor;
+    while ((*cursor == '-' || *cursor == '_' || parser->encoding.alnum_char(cursor, 1)) && ++cursor < end);
+
+    parser_lex_magic_comment_encoding_value(parser, value_start, cursor);
+}
+
 // Check if this is a magic comment that includes the frozen_string_literal
 // pragma. If it does, set that field on the parser.
 static void
-parser_lex_magic_comment_frozen_string_literal(pm_parser_t *parser, const uint8_t *start, const uint8_t *end) {
+parser_lex_magic_comment_frozen_string_literal_value(pm_parser_t *parser, const uint8_t *start, const uint8_t *end) {
     if (start + 4 <= end && pm_strncasecmp(start, (const uint8_t *) "true", 4) == 0) {
         parser->frozen_string_literal = true;
     }
@@ -5330,10 +5378,13 @@ parser_lex_magic_comment_emacs_marker(pm_parser_t *parser, const uint8_t *cursor
 //
 //     %r"([^\\s\'\":;]+)\\s*:\\s*(\"(?:\\\\.|[^\"])*\"|[^\"\\s;]+)[\\s;]*"
 //
-static inline void
+// It returns true if it consumes the entire comment. Otherwise it returns
+// false.
+static inline bool
 parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
     const uint8_t *start = parser->current.start + 1;
     const uint8_t *end = parser->current.end;
+    if (end - start <= 7) return false;
 
     const uint8_t *cursor;
     bool indicator = false;
@@ -5347,7 +5398,7 @@ parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
         } else {
             // If we have a start marker but not an end marker, then we cannot
             // have a magic comment.
-            return;
+            return false;
         }
     }
 
@@ -5360,17 +5411,17 @@ parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
 
         const uint8_t *key_end = cursor;
         while (cursor < end && pm_char_is_whitespace(*cursor)) cursor++;
-        if (cursor == end) return;
+        if (cursor == end) break;
 
         if (*cursor == ':') {
             cursor++;
         } else {
-            if (!indicator) return;
+            if (!indicator) return false;
             continue;
         }
 
         while (cursor < end && pm_char_is_whitespace(*cursor)) cursor++;
-        if (cursor == end) return;
+        if (cursor == end) break;
 
         const uint8_t *value_start;
         const uint8_t *value_end;
@@ -5391,7 +5442,7 @@ parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
             while (cursor < end && (*cursor == ';' || pm_char_is_whitespace(*cursor))) cursor++;
         } else {
             while (cursor < end && pm_char_is_whitespace(*cursor)) cursor++;
-            if (cursor != end) return;
+            if (cursor != end) return false;
         }
 
         // Here, we need to do some processing on the key to swap out dashes for
@@ -5404,7 +5455,7 @@ parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
         } else {
             size_t width = (size_t) (key_end - key_start);
             uint8_t *buffer = malloc(width);
-            if (buffer == NULL) return;
+            if (buffer == NULL) break;
 
             memcpy(buffer, key_start, width);
             buffer[dash - key_start] = '_';
@@ -5418,25 +5469,25 @@ parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
 
         // Finally, we can start checking the key against the list of known
         // magic comment keys, and potentially change state based on that.
-        const char *key_source = (const char *) pm_string_source(&key);
+        const uint8_t *key_source = pm_string_source(&key);
         const size_t key_length = pm_string_length(&key);
 
         // We only want to attempt to compare against encoding comments if it's
         // the first line in the file (or the second in the case of a shebang).
         if (parser->current.start == parser->encoding_comment_start) {
             if (
-                (key_length == 8 && strncasecmp(key_source, "encoding", 8) == 0) ||
-                (key_length == 6 && strncasecmp(key_source, "coding", 6) == 0)
+                (key_length == 8 && pm_strncasecmp(key_source, (const uint8_t *) "encoding", 8) == 0) ||
+                (key_length == 6 && pm_strncasecmp(key_source, (const uint8_t *) "coding", 6) == 0)
             ) {
-                parser_lex_magic_comment_encoding(parser, value_start, value_end);
+                parser_lex_magic_comment_encoding_value(parser, value_start, value_end);
             }
         }
 
         // We only want to handle frozen string literal comments if it's before
         // any semantic tokens have been seen.
         if (!semantic_token_seen) {
-            if (key_length == 21 && strncasecmp(key_source, "frozen_string_literal", 21) == 0) {
-                parser_lex_magic_comment_frozen_string_literal(parser, value_start, value_end);
+            if (key_length == 21 && pm_strncasecmp(key_source, (const uint8_t *) "frozen_string_literal", 21) == 0) {
+                parser_lex_magic_comment_frozen_string_literal_value(parser, value_start, value_end);
             }
         }
 
@@ -5454,6 +5505,8 @@ parser_lex_magic_comment(pm_parser_t *parser, bool semantic_token_seen) {
             pm_list_append(&parser->magic_comment_list, (pm_list_node_t *) magic_comment);
         }
     }
+
+    return true;
 }
 
 /******************************************************************************/
@@ -7056,7 +7109,15 @@ parser_lex(pm_parser_t *parser) {
 
                     // Here, parse the comment to see if it's a magic comment
                     // and potentially change state on the parser.
-                    parser_lex_magic_comment(parser, semantic_token_seen);
+                    if (!parser_lex_magic_comment(parser, semantic_token_seen) && (parser->current.start == parser->encoding_comment_start)) {
+                        ptrdiff_t length = parser->current.end - parser->current.start;
+
+                        // If we didn't find a magic comment within the first
+                        // pass and we're at the start of the file, then we need
+                        // to do another pass to potentially find other patterns
+                        // for encoding comments.
+                        if (length >= 10) parser_lex_magic_comment_encoding(parser);
+                    }
 
                     lexed_comment = true;
                 }

--- a/templates/java/org/prism/Loader.java.erb
+++ b/templates/java/org/prism/Loader.java.erb
@@ -109,6 +109,7 @@ public class Loader {
         this.encodingCharset = getEncodingCharset(this.encodingName);
 
         ParseResult.Comment[] comments = loadComments();
+        ParseResult.MagicComment[] magicComments = loadMagicComments();
         ParseResult.Error[] errors = loadSyntaxErrors();
         ParseResult.Warning[] warnings = loadWarnings();
 
@@ -127,7 +128,7 @@ public class Loader {
         MarkNewlinesVisitor visitor = new MarkNewlinesVisitor(source, newlineMarked);
         node.accept(visitor);
 
-        return new ParseResult(node, comments, errors, warnings);
+        return new ParseResult(node, comments, magicComments, errors, warnings);
     }
 
     private byte[] loadEmbeddedString() {
@@ -165,6 +166,21 @@ public class Loader {
         }
 
         return comments;
+    }
+
+    private ParseResult.MagicComment[] loadMagicComments() {
+        int count = loadVarInt();
+        ParseResult.MagicComment[] magicComments = new ParseResult.MagicComment[count];
+
+        for (int i = 0; i < count; i++) {
+            Nodes.Location keyLocation = loadLocation();
+            Nodes.Location valueLocation = loadLocation();
+
+            ParseResult.MagicComment magicComment = new ParseResult.MagicComment(keyLocation, valueLocation);
+            magicComments[i] = magicComment;
+        }
+
+        return magicComments;
     }
 
     private ParseResult.Error[] loadSyntaxErrors() {

--- a/templates/lib/prism/serialize.rb.erb
+++ b/templates/lib/prism/serialize.rb.erb
@@ -55,9 +55,10 @@ module Prism
 
       def load_metadata
         comments = load_varint.times.map { Comment.new(Comment::TYPES.fetch(load_varint), load_location) }
+        magic_comments = load_varint.times.map { MagicComment.new(load_location, load_location) }
         errors = load_varint.times.map { ParseError.new(load_embedded_string, load_location) }
         warnings = load_varint.times.map { ParseWarning.new(load_embedded_string, load_location) }
-        [comments, errors, warnings]
+        [comments, magic_comments, errors, warnings]
       end
 
       def load_tokens
@@ -76,14 +77,14 @@ module Prism
       def load_tokens_result
         tokens = load_tokens
         encoding = load_encoding
-        comments, errors, warnings = load_metadata
+        comments, magic_comments, errors, warnings = load_metadata
 
         if encoding != @encoding
           tokens.each { |token,| token.value.force_encoding(encoding) }
         end
 
         raise "Expected to consume all bytes while deserializing" unless @io.eof?
-        Prism::ParseResult.new(tokens, comments, errors, warnings, @source)
+        Prism::ParseResult.new(tokens, comments, magic_comments, errors, warnings, @source)
       end
 
       def load_nodes
@@ -97,17 +98,17 @@ module Prism
         @encoding = load_encoding
         @input = input.force_encoding(@encoding).freeze
 
-        comments, errors, warnings = load_metadata
+        comments, magic_comments, errors, warnings = load_metadata
 
         @constant_pool_offset = io.read(4).unpack1("L")
         @constant_pool = Array.new(load_varint, nil)
 
-        [load_node, comments, errors, warnings]
+        [load_node, comments, magic_comments, errors, warnings]
       end
 
       def load_result
-        node, comments, errors, warnings = load_nodes
-        Prism::ParseResult.new(node, comments, errors, warnings, @source)
+        node, comments, magic_comments, errors, warnings = load_nodes
+        Prism::ParseResult.new(node, comments, magic_comments, errors, warnings, @source)
       end
 
       private

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -147,6 +147,27 @@ pm_serialize_comment_list(pm_parser_t *parser, pm_list_t *list, pm_buffer_t *buf
 }
 
 static void
+pm_serialize_magic_comment(pm_parser_t *parser, pm_magic_comment_t *magic_comment, pm_buffer_t *buffer) {
+    // serialize key location
+    pm_buffer_append_u32(buffer, pm_ptrdifft_to_u32(magic_comment->key_start - parser->start));
+    pm_buffer_append_u32(buffer, pm_ptrdifft_to_u32(magic_comment->key_length));
+
+    // serialize value location
+    pm_buffer_append_u32(buffer, pm_ptrdifft_to_u32(magic_comment->value_start - parser->start));
+    pm_buffer_append_u32(buffer, pm_ptrdifft_to_u32(magic_comment->value_length));
+}
+
+static void
+pm_serialize_magic_comment_list(pm_parser_t *parser, pm_list_t *list, pm_buffer_t *buffer) {
+    pm_buffer_append_u32(buffer, pm_sizet_to_u32(pm_list_size(list)));
+
+    pm_magic_comment_t *magic_comment;
+    for (magic_comment = (pm_magic_comment_t *) list->head; magic_comment != NULL; magic_comment = (pm_magic_comment_t *) magic_comment->node.next) {
+        pm_serialize_magic_comment(parser, magic_comment, buffer);
+    }
+}
+
+static void
 pm_serialize_diagnostic(pm_parser_t *parser, pm_diagnostic_t *diagnostic, pm_buffer_t *buffer) {
     // serialize message
     size_t message_length = strlen(diagnostic->message);
@@ -180,6 +201,7 @@ void
 pm_serialize_content(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
     pm_serialize_encoding(&parser->encoding, buffer);
     pm_serialize_comment_list(parser, &parser->comment_list, buffer);
+    pm_serialize_magic_comment_list(parser, &parser->magic_comment_list, buffer);
     pm_serialize_diagnostic_list(parser, &parser->error_list, buffer);
     pm_serialize_diagnostic_list(parser, &parser->warning_list, buffer);
 
@@ -268,6 +290,7 @@ pm_lex_serialize(const uint8_t *source, size_t size, const char *filepath, pm_bu
 
     pm_serialize_encoding(&parser.encoding, buffer);
     pm_serialize_comment_list(&parser, &parser.comment_list, buffer);
+    pm_serialize_magic_comment_list(&parser, &parser.magic_comment_list, buffer);
     pm_serialize_diagnostic_list(&parser, &parser.error_list, buffer);
     pm_serialize_diagnostic_list(&parser, &parser.warning_list, buffer);
 

--- a/test/prism/magic_comment_test.rb
+++ b/test/prism/magic_comment_test.rb
@@ -16,7 +16,8 @@ module Prism
       "# -*- CoDiNg: ascii -*-",
       "# -*- \s\t\v encoding \s\t\v : \s\t\v ascii \s\t\v -*-",
       "# -*- foo: bar; encoding: ascii -*-",
-      "# coding \t \r  \v   :     \t \v    \r   ascii-8bit\n"
+      "# coding \t \r  \v   :     \t \v    \r   ascii-8bit\n",
+      "# vim: filetype=ruby, fileencoding=big5, tabsize=3, shiftwidth=3\n"
     ]
 
     examples.each do |example|

--- a/test/prism/magic_comment_test.rb
+++ b/test/prism/magic_comment_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+module Prism
+  class MagicCommentTest < TestCase
+    examples = [
+      "# encoding: ascii",
+      "# coding: ascii",
+      "# eNcOdInG: ascii",
+      "# CoDiNg: ascii",
+      "# \s\t\v encoding \s\t\v : \s\t\v ascii \s\t\v",
+      "# -*- encoding: ascii -*-",
+      "# -*- coding: ascii -*-",
+      "# -*- eNcOdInG: ascii -*-",
+      "# -*- CoDiNg: ascii -*-",
+      "# -*- \s\t\v encoding \s\t\v : \s\t\v ascii \s\t\v -*-",
+      "# -*- foo: bar; encoding: ascii -*-",
+      "# coding \t \r  \v   :     \t \v    \r   ascii-8bit\n"
+    ]
+
+    examples.each do |example|
+      define_method(:"test_magic_comment_#{example}") do
+        assert_magic_comment(example)
+      end
+    end
+
+    private
+
+    def assert_magic_comment(example)
+      expected = Ripper.new(example).tap(&:parse).encoding
+      actual = Prism.parse(example).source.source.encoding
+      assert_equal expected, actual
+    end
+  end
+end


### PR DESCRIPTION
* Magic comments now get attached to the parse result object
* We now support the emacs and vim syntax, so to my knowledge we are now 1:1 with CRuby

We still don't properly support:

* The `warn_indent` magic comment
* The `shareable_constant_value` magic comment

But now that we are handling the syntax all in one place, adding these should be much easier.

Fixes #574