### PR TITLE
Move common flags to top bits

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -361,6 +361,8 @@ flags:
         comment: "x - ignores whitespace and allows comments in regular expressions"
       - name: MULTI_LINE
         comment: "m - allows $ to match the end of lines within strings"
+      - name: ONCE
+        comment: "o - only interpolates values into the regular expression once"
       - name: EUC_JP
         comment: "e - forces the EUC-JP encoding"
       - name: ASCII_8BIT
@@ -369,8 +371,6 @@ flags:
         comment: "s - forces the Windows-31J encoding"
       - name: UTF_8
         comment: "u - forces the UTF-8 encoding"
-      - name: ONCE
-        comment: "o - only interpolates values into the regular expression once"
   - name: StringFlags
     values:
       - name: FROZEN

--- a/templates/ext/prism/api_node.c.erb
+++ b/templates/ext/prism/api_node.c.erb
@@ -176,7 +176,7 @@ pm_ast_new(pm_parser_t *parser, pm_node_t *node, rb_encoding *encoding) {
                     argv[<%= index %>] = ULONG2NUM(cast-><%= field.name %>);
                     <%- when Prism::FlagsField -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
-                    argv[<%= index %>] = ULONG2NUM(node->flags >> <%= Prism::COMMON_FLAGS %>);
+                    argv[<%= index %>] = ULONG2NUM(node->flags & ~PM_NODE_FLAG_COMMON_MASK);
                     <%- else -%>
                     <%- raise -%>
                     <%- end -%>

--- a/templates/include/prism/ast.h.erb
+++ b/templates/include/prism/ast.h.erb
@@ -52,8 +52,10 @@ typedef uint16_t pm_node_flags_t;
 
 // We store the flags enum in every node in the tree. Some flags are common to
 // all nodes (the ones listed below). Others are specific to certain node types.
-static const pm_node_flags_t PM_NODE_FLAG_NEWLINE = 0x1;
-static const pm_node_flags_t PM_NODE_FLAG_STATIC_LITERAL = 0x2;
+#define PM_NODE_FLAG_BITS (sizeof(pm_node_flags_t) * 8)
+static const pm_node_flags_t PM_NODE_FLAG_NEWLINE = (1 << (PM_NODE_FLAG_BITS - 1));
+static const pm_node_flags_t PM_NODE_FLAG_STATIC_LITERAL = (1 << (PM_NODE_FLAG_BITS - 2));
+static const pm_node_flags_t PM_NODE_FLAG_COMMON_MASK = PM_NODE_FLAG_NEWLINE | PM_NODE_FLAG_STATIC_LITERAL;
 
 // For easy access, we define some macros to check node type
 #define PM_NODE_TYPE(node) ((enum pm_node_type)node->type)
@@ -105,7 +107,7 @@ typedef struct pm_<%= node.human %> {
 
 // <%= flag.name %>
 typedef enum pm_<%= flag.human %> {
-    <%- flag.values.each.with_index(Prism::COMMON_FLAGS) do |value, index| -%>
+    <%- flag.values.each_with_index do |value, index| -%>
     PM_<%= flag.human.upcase %>_<%= value.name %> = 1 << <%= index %>,
     <%- end -%>
 } pm_<%= flag.human %>_t;

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -80,7 +80,7 @@ prettyprint_node(pm_buffer_t *buffer, pm_parser_t *parser, pm_node_t *node) {
             pm_buffer_append_str(buffer, <%= field.name %>_buffer, strlen(<%= field.name %>_buffer));
             <%- when Prism::FlagsField -%>
             char <%= field.name %>_buffer[12];
-            snprintf(<%= field.name %>_buffer, sizeof(<%= field.name %>_buffer), "+%d", node->flags >> <%= Prism::COMMON_FLAGS %>);
+            snprintf(<%= field.name %>_buffer, sizeof(<%= field.name %>_buffer), "+%d", (uint32_t)(node->flags & ~PM_NODE_FLAG_COMMON_MASK));
             pm_buffer_append_str(buffer, <%= field.name %>_buffer, strlen(<%= field.name %>_buffer));
             <%- else -%>
             <%- raise -%>

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -110,7 +110,7 @@ pm_serialize_node(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
             <%- when Prism::UInt32Field -%>
             pm_buffer_append_u32(buffer, ((pm_<%= node.human %>_t *)node)-><%= field.name %>);
             <%- when Prism::FlagsField -%>
-            pm_buffer_append_u32(buffer, node->flags >> <%= Prism::COMMON_FLAGS %>);
+            pm_buffer_append_u32(buffer, (uint32_t)(node->flags & ~PM_NODE_FLAG_COMMON_MASK));
             <%- else -%>
             <%- raise -%>
             <%- end -%>

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -5,8 +5,6 @@ require "fileutils"
 require "yaml"
 
 module Prism
-  COMMON_FLAGS = 2
-
   SERIALIZE_ONLY_SEMANTICS_FIELDS = ENV.fetch("PRISM_SERIALIZE_ONLY_SEMANTICS_FIELDS", false)
 
   JAVA_BACKEND = ENV["PRISM_JAVA_BACKEND"] || "truffleruby"


### PR DESCRIPTION
Moves the common flag bits to the top. This lets us eliminate the `COMMON` constant, and also allows us to group encoding flags on a nibble so we can more easily mask them.