### PR TITLE
Avoid unnecessary delete_prefix in LibRubyParser.resolve_type

### DIFF
--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -25,8 +25,8 @@ module Prism
     #     void         -> :void
     #
     def self.resolve_type(type)
-      type = type.strip.delete_prefix("const ")
-      type.end_with?("*") ? :pointer : type.to_sym
+      type = type.strip
+      type.end_with?("*") ? :pointer : type.delete_prefix("const ").to_sym
     end
 
     # Read through the given header file and find the declaration of each of the


### PR DESCRIPTION
Only remove const prefix from non-pointer types.