### PR TITLE
Exclude comments when only serializing semantic fields

### DIFF
--- a/java/org/prism/ParseResult.java
+++ b/java/org/prism/ParseResult.java
@@ -2,27 +2,6 @@ package org.prism;
 
 public final class ParseResult {
 
-    public enum CommentType {
-        /** # comment */
-        INLINE,
-        /** =begin/=end */
-        EMBEDDED_DOCUMENT,
-        /** after __END__ */
-        __END__;
-
-        static final CommentType[] VALUES = values();
-    }
-
-    public static final class Comment {
-        public final CommentType type;
-        public final Nodes.Location location;
-
-        public Comment(CommentType type, Nodes.Location location) {
-            this.type = type;
-            this.location = location;
-        }
-    }
-
     public static final class MagicComment {
         public final Nodes.Location keyLocation;
         public final Nodes.Location valueLocation;
@@ -54,14 +33,12 @@ public final class ParseResult {
     }
 
     public final Nodes.Node value;
-    public final Comment[] comments;
     public final MagicComment[] magicComments;
     public final Error[] errors;
     public final Warning[] warnings;
 
-    public ParseResult(Nodes.Node value, Comment[] comments, MagicComment[] magicComments, Error[] errors, Warning[] warnings) {
+    public ParseResult(Nodes.Node value, MagicComment[] magicComments, Error[] errors, Warning[] warnings) {
         this.value = value;
-        this.comments = comments;
         this.magicComments = magicComments;
         this.errors = errors;
         this.warnings = warnings;

--- a/templates/java/org/prism/Loader.java.erb
+++ b/templates/java/org/prism/Loader.java.erb
@@ -108,7 +108,6 @@ public class Loader {
         this.encodingName = new String(encodingNameBytes, StandardCharsets.US_ASCII);
         this.encodingCharset = getEncodingCharset(this.encodingName);
 
-        ParseResult.Comment[] comments = loadComments();
         ParseResult.MagicComment[] magicComments = loadMagicComments();
         ParseResult.Error[] errors = loadSyntaxErrors();
         ParseResult.Warning[] warnings = loadWarnings();
@@ -128,7 +127,7 @@ public class Loader {
         MarkNewlinesVisitor visitor = new MarkNewlinesVisitor(source, newlineMarked);
         node.accept(visitor);
 
-        return new ParseResult(node, comments, magicComments, errors, warnings);
+        return new ParseResult(node, magicComments, errors, warnings);
     }
 
     private byte[] loadEmbeddedString() {
@@ -151,21 +150,6 @@ public class Loader {
             default:
                 throw new Error("Expected 0 or 1 but was " + buffer.get());
         }
-    }
-
-    private ParseResult.Comment[] loadComments() {
-        int count = loadVarInt();
-        ParseResult.Comment[] comments = new ParseResult.Comment[count];
-
-        for (int i = 0; i < count; i++) {
-            ParseResult.CommentType type = ParseResult.CommentType.VALUES[buffer.get()];
-            Nodes.Location location = loadLocation();
-
-            ParseResult.Comment comment = new ParseResult.Comment(type, location);
-            comments[i] = comment;
-        }
-
-        return comments;
     }
 
     private ParseResult.MagicComment[] loadMagicComments() {

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -200,7 +200,9 @@ pm_serialize_encoding(pm_encoding_t *encoding, pm_buffer_t *buffer) {
 void
 pm_serialize_content(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
     pm_serialize_encoding(&parser->encoding, buffer);
+<%- unless Prism::SERIALIZE_ONLY_SEMANTICS_FIELDS -%>
     pm_serialize_comment_list(parser, &parser->comment_list, buffer);
+<%- end -%>
     pm_serialize_magic_comment_list(parser, &parser->magic_comment_list, buffer);
     pm_serialize_diagnostic_list(parser, &parser->error_list, buffer);
     pm_serialize_diagnostic_list(parser, &parser->warning_list, buffer);


### PR DESCRIPTION
I don't think there is any value to have comments serialized for the Java Loader, it's just making the serialized size bigger.
Before:
```
be rake serialized_size:topgems
Total sizes for top 100 gems:
total source size:      90207647
total serialized size:  56131852
total serialized/total source: 0.622

Stats of ratio serialized/source per file:
average: 0.745
median:  0.724
1st quartile: 0.537
3rd quartile: 0.924
min - max: 0.036 - 3.532
```
After:
```
be rake serialized_size:topgems
Total sizes for top 100 gems:
total source size:      90207647
total serialized size:  53065393
total serialized/total source: 0.588

Stats of ratio serialized/source per file:
average: 0.716
median:  0.702
1st quartile: 0.496
3rd quartile: 0.913
min - max: 0.019 - 3.519
```

So that's quite a big saving in serialized size.

cc @enebo 