### PR TITLE
Cast constant pool default bucket type

### DIFF
--- a/src/util/pm_constant_pool.c
+++ b/src/util/pm_constant_pool.c
@@ -197,7 +197,7 @@ pm_constant_pool_insert(pm_constant_pool_t *pool, const uint8_t *start, size_t l
                 // constant and replace it with the shared constant.
                 free((void *) constant->start);
                 constant->start = start;
-                bucket->type = PM_CONSTANT_POOL_BUCKET_DEFAULT;
+                bucket->type = (pm_constant_pool_bucket_type_t)PM_CONSTANT_POOL_BUCKET_DEFAULT;
             }
 
             return bucket->id;


### PR DESCRIPTION
Compilation is failing with

```
src/util/pm_constant_pool.c:200:32: error: conversion to ‘unsigned char:2’ from
‘pm_constant_pool_bucket_type_t {aka const unsigned int}’ may alter its value
[-Werror=conversion]
                 bucket->type = PM_CONSTANT_POOL_BUCKET_DEFAULT;
```