### PR TITLE
Fix parsing ** within hash patterns

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1356,9 +1356,9 @@ nodes:
     fields:
       - name: constant
         type: node?
-      - name: assocs
+      - name: elements
         type: node[]
-      - name: kwrest
+      - name: rest
         type: node?
       - name: opening_loc
         type: location?

--- a/lib/prism/pattern.rb
+++ b/lib/prism/pattern.rb
@@ -158,12 +158,12 @@ module Prism
     # in InstanceVariableReadNode[name: Symbol]
     # in { name: Symbol }
     def compile_hash_pattern_node(node)
-      compile_error(node) unless node.kwrest.nil?
+      compile_error(node) if node.rest
       compiled_constant = compile_node(node.constant) if node.constant
 
       preprocessed =
-        node.assocs.to_h do |assoc|
-          [assoc.key.unescaped.to_sym, compile_node(assoc.value)]
+        node.elements.to_h do |element|
+          [element.key.unescaped.to_sym, compile_node(element.value)]
         end
 
       compiled_keywords = ->(other) do

--- a/test/prism/snapshots/patterns.txt
+++ b/test/prism/snapshots/patterns.txt
@@ -4466,7 +4466,7 @@
             │   ├── constant:
             │   │   @ ConstantReadNode (location: (188,7)-(188,8))
             │   │   └── name: :A
-            │   ├── assocs: (length: 1)
+            │   ├── elements: (length: 1)
             │   │   └── @ AssocNode (location: (189,2)-(191,3))
             │   │       ├── key:
             │   │       │   @ SymbolNode (location: (189,2)-(189,6))
@@ -4479,7 +4479,7 @@
             │   │       │   ├── constant:
             │   │       │   │   @ ConstantReadNode (location: (189,7)-(189,8))
             │   │       │   │   └── name: :B
-            │   │       │   ├── assocs: (length: 1)
+            │   │       │   ├── elements: (length: 1)
             │   │       │   │   └── @ AssocNode (location: (190,4)-(190,12))
             │   │       │   │       ├── key:
             │   │       │   │       │   @ SymbolNode (location: (190,4)-(190,10))
@@ -4492,11 +4492,11 @@
             │   │       │   │       │   ├── name: :a
             │   │       │   │       │   └── depth: 0
             │   │       │   │       └── operator_loc: ∅
-            │   │       │   ├── kwrest: ∅
+            │   │       │   ├── rest: ∅
             │   │       │   ├── opening_loc: (189,8)-(189,9) = "["
             │   │       │   └── closing_loc: (191,2)-(191,3) = "]"
             │   │       └── operator_loc: ∅
-            │   ├── kwrest: ∅
+            │   ├── rest: ∅
             │   ├── opening_loc: (188,8)-(188,9) = "["
             │   └── closing_loc: (192,0)-(192,1) = "]"
             └── operator_loc: (188,4)-(188,6) = "in"

--- a/test/prism/snapshots/seattlerb/case_in.txt
+++ b/test/prism/snapshots/seattlerb/case_in.txt
@@ -15,7 +15,7 @@
         │   │       ├── pattern:
         │   │       │   @ HashPatternNode (location: (2,4)-(2,8))
         │   │       │   ├── constant: ∅
-        │   │       │   ├── assocs: (length: 1)
+        │   │       │   ├── elements: (length: 1)
         │   │       │   │   └── @ AssocNode (location: (2,4)-(2,8))
         │   │       │   │       ├── key:
         │   │       │   │       │   @ SymbolNode (location: (2,4)-(2,8))
@@ -25,7 +25,7 @@
         │   │       │   │       │   └── unescaped: "b"
         │   │       │   │       ├── value: ∅
         │   │       │   │       └── operator_loc: ∅
-        │   │       │   ├── kwrest: ∅
+        │   │       │   ├── rest: ∅
         │   │       │   ├── opening_loc: ∅
         │   │       │   └── closing_loc: ∅
         │   │       ├── statements: ∅
@@ -282,11 +282,11 @@
         │   │       ├── pattern:
         │   │       │   @ HashPatternNode (location: (42,3)-(42,8))
         │   │       │   ├── constant: ∅
-        │   │       │   ├── assocs: (length: 1)
-        │   │       │   │   └── @ NoKeywordsParameterNode (location: (42,3)-(42,8))
-        │   │       │   │       ├── operator_loc: (42,3)-(42,5) = "**"
-        │   │       │   │       └── keyword_loc: (42,5)-(42,8) = "nil"
-        │   │       │   ├── kwrest: ∅
+        │   │       │   ├── elements: (length: 0)
+        │   │       │   ├── rest:
+        │   │       │   │   @ NoKeywordsParameterNode (location: (42,3)-(42,8))
+        │   │       │   │   ├── operator_loc: (42,3)-(42,5) = "**"
+        │   │       │   │   └── keyword_loc: (42,5)-(42,8) = "nil"
         │   │       │   ├── opening_loc: ∅
         │   │       │   └── closing_loc: ∅
         │   │       ├── statements: ∅
@@ -849,7 +849,7 @@
         │   │       ├── pattern:
         │   │       │   @ HashPatternNode (location: (106,3)-(106,11))
         │   │       │   ├── constant: ∅
-        │   │       │   ├── assocs: (length: 1)
+        │   │       │   ├── elements: (length: 1)
         │   │       │   │   └── @ AssocNode (location: (106,5)-(106,9))
         │   │       │   │       ├── key:
         │   │       │   │       │   @ SymbolNode (location: (106,5)-(106,9))
@@ -859,7 +859,7 @@
         │   │       │   │       │   └── unescaped: "b"
         │   │       │   │       ├── value: ∅
         │   │       │   │       └── operator_loc: ∅
-        │   │       │   ├── kwrest: ∅
+        │   │       │   ├── rest: ∅
         │   │       │   ├── opening_loc: (106,3)-(106,4) = "{"
         │   │       │   └── closing_loc: (106,10)-(106,11) = "}"
         │   │       ├── statements: ∅
@@ -880,8 +880,8 @@
             │       ├── pattern:
             │       │   @ HashPatternNode (location: (110,3)-(110,5))
             │       │   ├── constant: ∅
-            │       │   ├── assocs: (length: 0)
-            │       │   ├── kwrest: ∅
+            │       │   ├── elements: (length: 0)
+            │       │   ├── rest: ∅
             │       │   ├── opening_loc: (110,3)-(110,4) = "{"
             │       │   └── closing_loc: (110,4)-(110,5) = "}"
             │       ├── statements: ∅

--- a/test/prism/snapshots/seattlerb/case_in_37.txt
+++ b/test/prism/snapshots/seattlerb/case_in_37.txt
@@ -15,7 +15,7 @@
             │       ├── pattern:
             │       │   @ HashPatternNode (location: (2,3)-(2,19))
             │       │   ├── constant: ∅
-            │       │   ├── assocs: (length: 1)
+            │       │   ├── elements: (length: 1)
             │       │   │   └── @ AssocNode (location: (2,5)-(2,17))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,5)-(2,7))
@@ -37,7 +37,7 @@
             │       │   │       │   ├── opening_loc: (2,8)-(2,9) = "["
             │       │   │       │   └── closing_loc: (2,16)-(2,17) = "]"
             │       │   │       └── operator_loc: ∅
-            │       │   ├── kwrest: ∅
+            │       │   ├── rest: ∅
             │       │   ├── opening_loc: (2,3)-(2,4) = "{"
             │       │   └── closing_loc: (2,18)-(2,19) = "}"
             │       ├── statements:

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat.txt
@@ -15,7 +15,7 @@
             │       ├── pattern:
             │       │   @ HashPatternNode (location: (2,3)-(2,21))
             │       │   ├── constant: ∅
-            │       │   ├── assocs: (length: 2)
+            │       │   ├── elements: (length: 2)
             │       │   │   ├── @ AssocNode (location: (2,5)-(2,11))
             │       │   │   │   ├── key:
             │       │   │   │   │   @ SymbolNode (location: (2,5)-(2,7))
@@ -46,7 +46,7 @@
             │       │   │       │   ├── closing_loc: (2,18)-(2,19) = "\""
             │       │   │       │   └── unescaped: "e"
             │       │   │       └── operator_loc: ∅
-            │       │   ├── kwrest: ∅
+            │       │   ├── rest: ∅
             │       │   ├── opening_loc: (2,3)-(2,4) = "{"
             │       │   └── closing_loc: (2,20)-(2,21) = "}"
             │       ├── statements:

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_assign.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_assign.txt
@@ -15,7 +15,7 @@
             │       ├── pattern:
             │       │   @ HashPatternNode (location: (2,3)-(2,34))
             │       │   ├── constant: ∅
-            │       │   ├── assocs: (length: 3)
+            │       │   ├── elements: (length: 3)
             │       │   │   ├── @ AssocNode (location: (2,5)-(2,20))
             │       │   │   │   ├── key:
             │       │   │   │   │   @ SymbolNode (location: (2,5)-(2,7))
@@ -58,7 +58,7 @@
             │       │   │       │   └── unescaped: "f"
             │       │   │       ├── value: ∅
             │       │   │       └── operator_loc: ∅
-            │       │   ├── kwrest: ∅
+            │       │   ├── rest: ∅
             │       │   ├── opening_loc: (2,3)-(2,4) = "{"
             │       │   └── closing_loc: (2,33)-(2,34) = "}"
             │       ├── statements:

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_assign.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_assign.txt
@@ -17,7 +17,7 @@
             │       │   ├── constant:
             │       │   │   @ ConstantReadNode (location: (2,3)-(2,4))
             │       │   │   └── name: :B
-            │       │   ├── assocs: (length: 1)
+            │       │   ├── elements: (length: 1)
             │       │   │   └── @ AssocNode (location: (2,5)-(2,10))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,5)-(2,7))
@@ -29,7 +29,7 @@
             │       │   │       │   @ IntegerNode (location: (2,8)-(2,10))
             │       │   │       │   └── flags: decimal
             │       │   │       └── operator_loc: ∅
-            │       │   ├── kwrest: ∅
+            │       │   ├── rest: ∅
             │       │   ├── opening_loc: (2,4)-(2,5) = "("
             │       │   └── closing_loc: (2,10)-(2,11) = ")"
             │       ├── statements:

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_true.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_true.txt
@@ -15,7 +15,7 @@
             │       ├── pattern:
             │       │   @ HashPatternNode (location: (2,3)-(2,10))
             │       │   ├── constant: ∅
-            │       │   ├── assocs: (length: 1)
+            │       │   ├── elements: (length: 1)
             │       │   │   └── @ AssocNode (location: (2,3)-(2,10))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,3)-(2,5))
@@ -26,7 +26,7 @@
             │       │   │       ├── value:
             │       │   │       │   @ TrueNode (location: (2,6)-(2,10))
             │       │   │       └── operator_loc: ∅
-            │       │   ├── kwrest: ∅
+            │       │   ├── rest: ∅
             │       │   ├── opening_loc: ∅
             │       │   └── closing_loc: ∅
             │       ├── statements:

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_rest.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_rest.txt
@@ -15,7 +15,7 @@
             │       ├── pattern:
             │       │   @ HashPatternNode (location: (2,3)-(2,15))
             │       │   ├── constant: ∅
-            │       │   ├── assocs: (length: 2)
+            │       │   ├── elements: (length: 2)
             │       │   │   ├── @ AssocNode (location: (2,3)-(2,7))
             │       │   │   │   ├── key:
             │       │   │   │   │   @ SymbolNode (location: (2,3)-(2,5))
@@ -34,7 +34,7 @@
             │       │   │       │   ├── name: :rest
             │       │   │       │   └── depth: 0
             │       │   │       └── operator_loc: (2,9)-(2,11) = "**"
-            │       │   ├── kwrest: ∅
+            │       │   ├── rest: ∅
             │       │   ├── opening_loc: ∅
             │       │   └── closing_loc: ∅
             │       ├── statements:

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_rest_solo.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_rest_solo.txt
@@ -15,14 +15,14 @@
             │       ├── pattern:
             │       │   @ HashPatternNode (location: (2,3)-(2,9))
             │       │   ├── constant: ∅
-            │       │   ├── assocs: (length: 1)
-            │       │   │   └── @ AssocSplatNode (location: (2,3)-(2,9))
-            │       │   │       ├── value:
-            │       │   │       │   @ LocalVariableTargetNode (location: (2,5)-(2,9))
-            │       │   │       │   ├── name: :rest
-            │       │   │       │   └── depth: 0
-            │       │   │       └── operator_loc: (2,3)-(2,5) = "**"
-            │       │   ├── kwrest: ∅
+            │       │   ├── elements: (length: 0)
+            │       │   ├── rest:
+            │       │   │   @ AssocSplatNode (location: (2,3)-(2,9))
+            │       │   │   ├── value:
+            │       │   │   │   @ LocalVariableTargetNode (location: (2,5)-(2,9))
+            │       │   │   │   ├── name: :rest
+            │       │   │   │   └── depth: 0
+            │       │   │   └── operator_loc: (2,3)-(2,5) = "**"
             │       │   ├── opening_loc: ∅
             │       │   └── closing_loc: ∅
             │       ├── statements:

--- a/test/prism/snapshots/seattlerb/parse_pattern_058.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_058.txt
@@ -25,7 +25,7 @@
             │       ├── pattern:
             │       │   @ HashPatternNode (location: (2,3)-(2,15))
             │       │   ├── constant: ∅
-            │       │   ├── assocs: (length: 2)
+            │       │   ├── elements: (length: 2)
             │       │   │   ├── @ AssocNode (location: (2,4)-(2,6))
             │       │   │   │   ├── key:
             │       │   │   │   │   @ SymbolNode (location: (2,4)-(2,6))
@@ -41,7 +41,7 @@
             │       │   │       │   ├── name: :rest
             │       │   │       │   └── depth: 0
             │       │   │       └── operator_loc: (2,8)-(2,10) = "**"
-            │       │   ├── kwrest: ∅
+            │       │   ├── rest: ∅
             │       │   ├── opening_loc: (2,3)-(2,4) = "{"
             │       │   └── closing_loc: (2,14)-(2,15) = "}"
             │       ├── statements:

--- a/test/prism/snapshots/seattlerb/parse_pattern_058_2.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_058_2.txt
@@ -25,7 +25,7 @@
             │       ├── pattern:
             │       │   @ HashPatternNode (location: (2,3)-(2,11))
             │       │   ├── constant: ∅
-            │       │   ├── assocs: (length: 2)
+            │       │   ├── elements: (length: 2)
             │       │   │   ├── @ AssocNode (location: (2,4)-(2,6))
             │       │   │   │   ├── key:
             │       │   │   │   │   @ SymbolNode (location: (2,4)-(2,6))
@@ -38,7 +38,7 @@
             │       │   │   └── @ AssocSplatNode (location: (2,8)-(2,10))
             │       │   │       ├── value: ∅
             │       │   │       └── operator_loc: (2,8)-(2,10) = "**"
-            │       │   ├── kwrest: ∅
+            │       │   ├── rest: ∅
             │       │   ├── opening_loc: (2,3)-(2,4) = "{"
             │       │   └── closing_loc: (2,10)-(2,11) = "}"
             │       ├── statements:

--- a/test/prism/snapshots/seattlerb/parse_pattern_069.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_069.txt
@@ -17,7 +17,7 @@
             │       │   ├── constant:
             │       │   │   @ ConstantReadNode (location: (2,3)-(2,9))
             │       │   │   └── name: :Object
-            │       │   ├── assocs: (length: 1)
+            │       │   ├── elements: (length: 1)
             │       │   │   └── @ AssocNode (location: (2,10)-(2,14))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,10)-(2,12))
@@ -29,7 +29,7 @@
             │       │   │       │   @ IntegerNode (location: (2,13)-(2,14))
             │       │   │       │   └── flags: decimal
             │       │   │       └── operator_loc: ∅
-            │       │   ├── kwrest: ∅
+            │       │   ├── rest: ∅
             │       │   ├── opening_loc: (2,9)-(2,10) = "["
             │       │   └── closing_loc: (2,14)-(2,15) = "]"
             │       ├── statements:

--- a/test/prism/snapshots/seattlerb/parse_pattern_076.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_076.txt
@@ -25,7 +25,7 @@
             │       ├── pattern:
             │       │   @ HashPatternNode (location: (2,3)-(2,16))
             │       │   ├── constant: ∅
-            │       │   ├── assocs: (length: 2)
+            │       │   ├── elements: (length: 2)
             │       │   │   ├── @ AssocNode (location: (2,4)-(2,8))
             │       │   │   │   ├── key:
             │       │   │   │   │   @ SymbolNode (location: (2,4)-(2,6))
@@ -40,7 +40,7 @@
             │       │   │   └── @ NoKeywordsParameterNode (location: (2,10)-(2,15))
             │       │   │       ├── operator_loc: (2,10)-(2,12) = "**"
             │       │   │       └── keyword_loc: (2,12)-(2,15) = "nil"
-            │       │   ├── kwrest: ∅
+            │       │   ├── rest: ∅
             │       │   ├── opening_loc: (2,3)-(2,4) = "{"
             │       │   └── closing_loc: (2,15)-(2,16) = "}"
             │       ├── statements:

--- a/test/prism/snapshots/unparser/corpus/literal/pattern.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/pattern.txt
@@ -79,7 +79,7 @@
         │   │   │   │   ├── constant:
         │   │   │   │   │   @ ConstantReadNode (location: (6,3)-(6,4))
         │   │   │   │   │   └── name: :A
-        │   │   │   │   ├── assocs: (length: 1)
+        │   │   │   │   ├── elements: (length: 1)
         │   │   │   │   │   └── @ AssocNode (location: (6,5)-(6,7))
         │   │   │   │   │       ├── key:
         │   │   │   │   │       │   @ SymbolNode (location: (6,5)-(6,7))
@@ -89,7 +89,7 @@
         │   │   │   │   │       │   └── unescaped: "x"
         │   │   │   │   │       ├── value: ∅
         │   │   │   │   │       └── operator_loc: ∅
-        │   │   │   │   ├── kwrest: ∅
+        │   │   │   │   ├── rest: ∅
         │   │   │   │   ├── opening_loc: (6,4)-(6,5) = "("
         │   │   │   │   └── closing_loc: (6,7)-(6,8) = ")"
         │   │   │   ├── statements:
@@ -102,18 +102,14 @@
         │   │   │   ├── pattern:
         │   │   │   │   @ HashPatternNode (location: (8,3)-(8,8))
         │   │   │   │   ├── constant: ∅
-        │   │   │   │   ├── assocs: (length: 1)
-        │   │   │   │   │   └── @ AssocNode (location: (8,4)-(8,7))
-        │   │   │   │   │       ├── key:
-        │   │   │   │   │       │   @ AssocSplatNode (location: (8,4)-(8,7))
-        │   │   │   │   │       │   ├── value:
-        │   │   │   │   │       │   │   @ LocalVariableTargetNode (location: (8,6)-(8,7))
-        │   │   │   │   │       │   │   ├── name: :a
-        │   │   │   │   │       │   │   └── depth: 0
-        │   │   │   │   │       │   └── operator_loc: (8,4)-(8,6) = "**"
-        │   │   │   │   │       ├── value: ∅
-        │   │   │   │   │       └── operator_loc: ∅
-        │   │   │   │   ├── kwrest: ∅
+        │   │   │   │   ├── elements: (length: 0)
+        │   │   │   │   ├── rest:
+        │   │   │   │   │   @ AssocSplatNode (location: (8,4)-(8,7))
+        │   │   │   │   │   ├── value:
+        │   │   │   │   │   │   @ LocalVariableTargetNode (location: (8,6)-(8,7))
+        │   │   │   │   │   │   ├── name: :a
+        │   │   │   │   │   │   └── depth: 0
+        │   │   │   │   │   └── operator_loc: (8,4)-(8,6) = "**"
         │   │   │   │   ├── opening_loc: (8,3)-(8,4) = "{"
         │   │   │   │   └── closing_loc: (8,7)-(8,8) = "}"
         │   │   │   ├── statements:
@@ -133,8 +129,8 @@
         │   │   │   │   │   └── body: (length: 1)
         │   │   │   │   │       └── @ HashPatternNode (location: (10,3)-(10,5))
         │   │   │   │   │           ├── constant: ∅
-        │   │   │   │   │           ├── assocs: (length: 0)
-        │   │   │   │   │           ├── kwrest: ∅
+        │   │   │   │   │           ├── elements: (length: 0)
+        │   │   │   │   │           ├── rest: ∅
         │   │   │   │   │           ├── opening_loc: (10,3)-(10,4) = "{"
         │   │   │   │   │           └── closing_loc: (10,4)-(10,5) = "}"
         │   │   │   │   ├── consequent: ∅
@@ -173,7 +169,7 @@
         │   │   │   ├── pattern:
         │   │   │   │   @ HashPatternNode (location: (14,3)-(14,16))
         │   │   │   │   ├── constant: ∅
-        │   │   │   │   ├── assocs: (length: 2)
+        │   │   │   │   ├── elements: (length: 2)
         │   │   │   │   │   ├── @ AssocNode (location: (14,4)-(14,8))
         │   │   │   │   │   │   ├── key:
         │   │   │   │   │   │   │   @ SymbolNode (location: (14,4)-(14,6))
@@ -196,7 +192,7 @@
         │   │   │   │   │       │   @ IntegerNode (location: (14,14)-(14,15))
         │   │   │   │   │       │   └── flags: decimal
         │   │   │   │   │       └── operator_loc: ∅
-        │   │   │   │   ├── kwrest: ∅
+        │   │   │   │   ├── rest: ∅
         │   │   │   │   ├── opening_loc: (14,3)-(14,4) = "{"
         │   │   │   │   └── closing_loc: (14,15)-(14,16) = "}"
         │   │   │   ├── statements:
@@ -209,8 +205,8 @@
         │   │   │   ├── pattern:
         │   │   │   │   @ HashPatternNode (location: (16,3)-(16,5))
         │   │   │   │   ├── constant: ∅
-        │   │   │   │   ├── assocs: (length: 0)
-        │   │   │   │   ├── kwrest: ∅
+        │   │   │   │   ├── elements: (length: 0)
+        │   │   │   │   ├── rest: ∅
         │   │   │   │   ├── opening_loc: (16,3)-(16,4) = "{"
         │   │   │   │   └── closing_loc: (16,4)-(16,5) = "}"
         │   │   │   ├── statements:
@@ -223,15 +219,11 @@
         │   │   │   ├── pattern:
         │   │   │   │   @ HashPatternNode (location: (18,3)-(18,10))
         │   │   │   │   ├── constant: ∅
-        │   │   │   │   ├── assocs: (length: 1)
-        │   │   │   │   │   └── @ AssocNode (location: (18,4)-(18,9))
-        │   │   │   │   │       ├── key:
-        │   │   │   │   │       │   @ NoKeywordsParameterNode (location: (18,4)-(18,9))
-        │   │   │   │   │       │   ├── operator_loc: (18,4)-(18,6) = "**"
-        │   │   │   │   │       │   └── keyword_loc: (18,6)-(18,9) = "nil"
-        │   │   │   │   │       ├── value: ∅
-        │   │   │   │   │       └── operator_loc: ∅
-        │   │   │   │   ├── kwrest: ∅
+        │   │   │   │   ├── elements: (length: 0)
+        │   │   │   │   ├── rest:
+        │   │   │   │   │   @ NoKeywordsParameterNode (location: (18,4)-(18,9))
+        │   │   │   │   │   ├── operator_loc: (18,4)-(18,6) = "**"
+        │   │   │   │   │   └── keyword_loc: (18,6)-(18,9) = "nil"
         │   │   │   │   ├── opening_loc: (18,3)-(18,4) = "{"
         │   │   │   │   └── closing_loc: (18,9)-(18,10) = "}"
         │   │   │   ├── statements:
@@ -244,7 +236,7 @@
         │   │   │   ├── pattern:
         │   │   │   │   @ HashPatternNode (location: (20,3)-(20,11))
         │   │   │   │   ├── constant: ∅
-        │   │   │   │   ├── assocs: (length: 1)
+        │   │   │   │   ├── elements: (length: 1)
         │   │   │   │   │   └── @ AssocNode (location: (20,4)-(20,10))
         │   │   │   │   │       ├── key:
         │   │   │   │   │       │   @ SymbolNode (location: (20,4)-(20,8))
@@ -256,7 +248,7 @@
         │   │   │   │   │       │   @ IntegerNode (location: (20,9)-(20,10))
         │   │   │   │   │       │   └── flags: decimal
         │   │   │   │   │       └── operator_loc: ∅
-        │   │   │   │   ├── kwrest: ∅
+        │   │   │   │   ├── rest: ∅
         │   │   │   │   ├── opening_loc: (20,3)-(20,4) = "{"
         │   │   │   │   └── closing_loc: (20,10)-(20,11) = "}"
         │   │   │   ├── statements:

--- a/test/prism/snapshots/whitequark/multiple_pattern_matches.txt
+++ b/test/prism/snapshots/whitequark/multiple_pattern_matches.txt
@@ -23,7 +23,7 @@
         │   ├── pattern:
         │   │   @ HashPatternNode (location: (1,10)-(1,12))
         │   │   ├── constant: ∅
-        │   │   ├── assocs: (length: 1)
+        │   │   ├── elements: (length: 1)
         │   │   │   └── @ AssocNode (location: (1,10)-(1,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (1,10)-(1,12))
@@ -33,7 +33,7 @@
         │   │   │       │   └── unescaped: "a"
         │   │   │       ├── value: ∅
         │   │   │       └── operator_loc: ∅
-        │   │   ├── kwrest: ∅
+        │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅
         │   │   └── closing_loc: ∅
         │   └── operator_loc: (1,7)-(1,9) = "=>"
@@ -57,7 +57,7 @@
         │   ├── pattern:
         │   │   @ HashPatternNode (location: (2,10)-(2,12))
         │   │   ├── constant: ∅
-        │   │   ├── assocs: (length: 1)
+        │   │   ├── elements: (length: 1)
         │   │   │   └── @ AssocNode (location: (2,10)-(2,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (2,10)-(2,12))
@@ -67,7 +67,7 @@
         │   │   │       │   └── unescaped: "a"
         │   │   │       ├── value: ∅
         │   │   │       └── operator_loc: ∅
-        │   │   ├── kwrest: ∅
+        │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅
         │   │   └── closing_loc: ∅
         │   └── operator_loc: (2,7)-(2,9) = "=>"
@@ -91,7 +91,7 @@
         │   ├── pattern:
         │   │   @ HashPatternNode (location: (4,10)-(4,12))
         │   │   ├── constant: ∅
-        │   │   ├── assocs: (length: 1)
+        │   │   ├── elements: (length: 1)
         │   │   │   └── @ AssocNode (location: (4,10)-(4,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (4,10)-(4,12))
@@ -101,7 +101,7 @@
         │   │   │       │   └── unescaped: "a"
         │   │   │       ├── value: ∅
         │   │   │       └── operator_loc: ∅
-        │   │   ├── kwrest: ∅
+        │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅
         │   │   └── closing_loc: ∅
         │   └── operator_loc: (4,7)-(4,9) = "in"
@@ -125,7 +125,7 @@
             ├── pattern:
             │   @ HashPatternNode (location: (5,10)-(5,12))
             │   ├── constant: ∅
-            │   ├── assocs: (length: 1)
+            │   ├── elements: (length: 1)
             │   │   └── @ AssocNode (location: (5,10)-(5,12))
             │   │       ├── key:
             │   │       │   @ SymbolNode (location: (5,10)-(5,12))
@@ -135,7 +135,7 @@
             │   │       │   └── unescaped: "a"
             │   │       ├── value: ∅
             │   │       └── operator_loc: ∅
-            │   ├── kwrest: ∅
+            │   ├── rest: ∅
             │   ├── opening_loc: ∅
             │   └── closing_loc: ∅
             └── operator_loc: (5,7)-(5,9) = "in"

--- a/test/prism/snapshots/whitequark/newline_in_hash_argument.txt
+++ b/test/prism/snapshots/whitequark/newline_in_hash_argument.txt
@@ -20,7 +20,7 @@
         │   │   │   ├── pattern:
         │   │   │   │   @ HashPatternNode (location: (2,3)-(2,5))
         │   │   │   │   ├── constant: ∅
-        │   │   │   │   ├── assocs: (length: 1)
+        │   │   │   │   ├── elements: (length: 1)
         │   │   │   │   │   └── @ AssocNode (location: (2,3)-(2,5))
         │   │   │   │   │       ├── key:
         │   │   │   │   │       │   @ SymbolNode (location: (2,3)-(2,5))
@@ -30,7 +30,7 @@
         │   │   │   │   │       │   └── unescaped: "a"
         │   │   │   │   │       ├── value: ∅
         │   │   │   │   │       └── operator_loc: ∅
-        │   │   │   │   ├── kwrest: ∅
+        │   │   │   │   ├── rest: ∅
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   └── closing_loc: ∅
         │   │   │   ├── statements:
@@ -45,7 +45,7 @@
         │   │       ├── pattern:
         │   │       │   @ HashPatternNode (location: (5,3)-(5,7))
         │   │       │   ├── constant: ∅
-        │   │       │   ├── assocs: (length: 1)
+        │   │       │   ├── elements: (length: 1)
         │   │       │   │   └── @ AssocNode (location: (5,3)-(5,7))
         │   │       │   │       ├── key:
         │   │       │   │       │   @ SymbolNode (location: (5,3)-(5,7))
@@ -55,7 +55,7 @@
         │   │       │   │       │   └── unescaped: "b"
         │   │       │   │       ├── value: ∅
         │   │       │   │       └── operator_loc: ∅
-        │   │       │   ├── kwrest: ∅
+        │   │       │   ├── rest: ∅
         │   │       │   ├── opening_loc: ∅
         │   │       │   └── closing_loc: ∅
         │   │       ├── statements:

--- a/test/prism/snapshots/whitequark/pattern_matching_single_line_allowed_omission_of_parentheses.txt
+++ b/test/prism/snapshots/whitequark/pattern_matching_single_line_allowed_omission_of_parentheses.txt
@@ -79,7 +79,7 @@
         │   ├── pattern:
         │   │   @ HashPatternNode (location: (5,10)-(5,12))
         │   │   ├── constant: ∅
-        │   │   ├── assocs: (length: 1)
+        │   │   ├── elements: (length: 1)
         │   │   │   └── @ AssocNode (location: (5,10)-(5,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (5,10)-(5,12))
@@ -89,7 +89,7 @@
         │   │   │       │   └── unescaped: "a"
         │   │   │       ├── value: ∅
         │   │   │       └── operator_loc: ∅
-        │   │   ├── kwrest: ∅
+        │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅
         │   │   └── closing_loc: ∅
         │   └── operator_loc: (5,7)-(5,9) = "=>"
@@ -116,7 +116,7 @@
         │   ├── pattern:
         │   │   @ HashPatternNode (location: (7,10)-(7,12))
         │   │   ├── constant: ∅
-        │   │   ├── assocs: (length: 1)
+        │   │   ├── elements: (length: 1)
         │   │   │   └── @ AssocNode (location: (7,10)-(7,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (7,10)-(7,12))
@@ -126,7 +126,7 @@
         │   │   │       │   └── unescaped: "a"
         │   │   │       ├── value: ∅
         │   │   │       └── operator_loc: ∅
-        │   │   ├── kwrest: ∅
+        │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅
         │   │   └── closing_loc: ∅
         │   └── operator_loc: (7,7)-(7,9) = "in"
@@ -156,7 +156,7 @@
         │   ├── pattern:
         │   │   @ HashPatternNode (location: (9,17)-(9,27))
         │   │   ├── constant: ∅
-        │   │   ├── assocs: (length: 1)
+        │   │   ├── elements: (length: 1)
         │   │   │   └── @ AssocNode (location: (9,17)-(9,27))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (9,17)-(9,21))
@@ -169,7 +169,7 @@
         │   │   │       │   ├── name: :value
         │   │   │       │   └── depth: 0
         │   │   │       └── operator_loc: ∅
-        │   │   ├── kwrest: ∅
+        │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅
         │   │   └── closing_loc: ∅
         │   └── operator_loc: (9,14)-(9,16) = "=>"
@@ -199,7 +199,7 @@
         │   ├── pattern:
         │   │   @ HashPatternNode (location: (11,17)-(11,27))
         │   │   ├── constant: ∅
-        │   │   ├── assocs: (length: 1)
+        │   │   ├── elements: (length: 1)
         │   │   │   └── @ AssocNode (location: (11,17)-(11,27))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (11,17)-(11,21))
@@ -212,7 +212,7 @@
         │   │   │       │   ├── name: :value
         │   │   │       │   └── depth: 0
         │   │   │       └── operator_loc: ∅
-        │   │   ├── kwrest: ∅
+        │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅
         │   │   └── closing_loc: ∅
         │   └── operator_loc: (11,14)-(11,16) = "in"


### PR DESCRIPTION
Previously `kwrest` was never used and ** got dumped into the regular assoc list when it was the first element in the list.