### PR TITLE
Use Method#arity instead of Method#parameters

### DIFF
--- a/templates/lib/prism/serialize.rb.erb
+++ b/templates/lib/prism/serialize.rb.erb
@@ -1,7 +1,7 @@
 require "stringio"
 
 # Polyfill for String#unpack1 with the offset parameter.
-if String.instance_method(:unpack1).parameters.none? { |_, name| name == :offset }
+if String.instance_method(:unpack1).arity == 1
   String.prepend(
     Module.new {
       def unpack1(format, offset: 0)


### PR DESCRIPTION
This has the benefit of creating fewer objects in memory just to check the method signature.

(Selfish reason for this PR is that Natalie doesn't have `Method#parameters` yet 😄)