### PR TITLE
Use `cargo fmt`

### DIFF
--- a/.github/workflows/rust-bindings.yml
+++ b/.github/workflows/rust-bindings.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: rust/${{ matrix.crate }}
         run: cargo test
 
-  cargo-clippy:
+  lint:
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +67,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.71.1"
-          components: clippy
+          components: clippy, rustfmt
       - uses: actions/cache@v3
         with:
           path: |
@@ -83,6 +83,9 @@ jobs:
       - name: cargo clippy
         working-directory: rust/${{ matrix.crate }}
         run: cargo clippy --tests -- -W "clippy::pedantic"
+      - name: cargo fmt
+        working-directory: rust/${{ matrix.crate }}
+        run: cargo fmt --check
 
   sanitizer-test:
     name: Test with -Zsanitizer=${{ matrix.sanitizer }}

--- a/rust/prism-sys/build.rs
+++ b/rust/prism-sys/build.rs
@@ -8,10 +8,7 @@ fn main() {
     println!("cargo:rustc-link-lib=static=rubyparser");
 
     // Add `[root]/build/` to the search paths, so it can find `librubyparser.a`.
-    println!(
-        "cargo:rustc-link-search=native={}",
-        ruby_build_path.to_str().unwrap()
-    );
+    println!("cargo:rustc-link-search=native={}", ruby_build_path.to_str().unwrap());
 
     // This is where the magic happens.
     let bindings = generate_bindings(&ruby_include_path);
@@ -23,20 +20,14 @@ fn main() {
 /// Gets the path to project files (`librubyparser*`) at `[root]/build/`.
 ///
 fn ruby_build_path() -> PathBuf {
-    cargo_manifest_path()
-        .join("../../build/")
-        .canonicalize()
-        .unwrap()
+    cargo_manifest_path().join("../../build/").canonicalize().unwrap()
 }
 
 /// Gets the path to the header files that `bindgen` needs for doing code
 /// generation.
 ///
 fn ruby_include_path() -> PathBuf {
-    cargo_manifest_path()
-        .join("../../include/")
-        .canonicalize()
-        .unwrap()
+    cargo_manifest_path().join("../../include/").canonicalize().unwrap()
 }
 
 fn cargo_manifest_path() -> PathBuf {
@@ -74,11 +65,11 @@ fn generate_bindings(ruby_include_path: &Path) -> bindgen::Bindings {
         .allowlist_type("pm_pack_size")
         .allowlist_type("pm_parser_t")
         .allowlist_type("pm_string_t")
-        .allowlist_type(r#"^pm_\w+_node_t"#)
-        .allowlist_type(r#"^pm_\w+_flags"#)
+        .allowlist_type(r"^pm_\w+_node_t")
+        .allowlist_type(r"^pm_\w+_flags")
         // Enums
         .rustified_non_exhaustive_enum("pm_comment_type_t")
-        .rustified_non_exhaustive_enum(r#"pm_\w+_flags"#)
+        .rustified_non_exhaustive_enum(r"pm_\w+_flags")
         .rustified_non_exhaustive_enum("pm_node_type")
         .rustified_non_exhaustive_enum("pm_pack_encoding")
         .rustified_non_exhaustive_enum("pm_pack_endian")
@@ -102,7 +93,7 @@ fn generate_bindings(ruby_include_path: &Path) -> bindgen::Bindings {
         .allowlist_function("pm_string_source")
         .allowlist_function("pm_version")
         // Vars
-        .allowlist_var(r#"^pm_encoding\S+"#)
+        .allowlist_var(r"^pm_encoding\S+")
         .generate()
         .expect("Unable to generate prism bindings")
 }

--- a/rust/prism-sys/rustfmt.toml
+++ b/rust/prism-sys/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 120
+match_block_trailing_comma = true

--- a/rust/prism-sys/tests/node_tests.rs
+++ b/rust/prism-sys/tests/node_tests.rs
@@ -1,7 +1,7 @@
 use std::{ffi::CString, mem::MaybeUninit};
 
-use prism_sys::{pm_parser_t, pm_parser_init, pm_parse, pm_parser_free};
-use prism_sys::{pm_node_type, pm_node_destroy};
+use prism_sys::{pm_node_destroy, pm_node_type};
+use prism_sys::{pm_parse, pm_parser_free, pm_parser_init, pm_parser_t};
 
 #[test]
 fn node_test() {

--- a/rust/prism-sys/tests/pack_tests.rs
+++ b/rust/prism-sys/tests/pack_tests.rs
@@ -1,8 +1,8 @@
 use std::{ffi::CString, mem::MaybeUninit};
 
 use prism_sys::{
-    pm_pack_encoding, pm_pack_endian, pm_pack_length_type, pm_pack_parse, pm_pack_result,
-    pm_pack_signed, pm_pack_size, pm_pack_type, pm_pack_variant, pm_size_to_native,
+    pm_pack_encoding, pm_pack_endian, pm_pack_length_type, pm_pack_parse, pm_pack_result, pm_pack_signed, pm_pack_size,
+    pm_pack_type, pm_pack_variant, pm_size_to_native,
 };
 
 #[test]

--- a/rust/prism-sys/tests/parser_tests.rs
+++ b/rust/prism-sys/tests/parser_tests.rs
@@ -5,8 +5,7 @@ use std::{
 };
 
 use prism_sys::{
-    pm_comment_t, pm_comment_type_t, pm_diagnostic_t,
-    pm_node_destroy, pm_parse, pm_parser_free, pm_parser_init,
+    pm_comment_t, pm_comment_type_t, pm_diagnostic_t, pm_node_destroy, pm_parse, pm_parser_free, pm_parser_init,
     pm_parser_t,
 };
 
@@ -84,10 +83,7 @@ fn diagnostics_test() {
 
         let error = error_list.head as *const pm_diagnostic_t;
         let message = CStr::from_ptr((*error).message);
-        assert_eq!(
-            message.to_string_lossy(),
-            "Cannot parse the expression"
-        );
+        assert_eq!(message.to_string_lossy(), "Cannot parse the expression");
 
         let location = {
             let start = (*error).start.offset_from(parser.start);

--- a/rust/prism-sys/tests/utils_tests.rs
+++ b/rust/prism-sys/tests/utils_tests.rs
@@ -32,9 +32,8 @@ fn list_test() {
 
 mod string {
     use prism_sys::{
-        pm_string_free, pm_string_length, pm_string_source, pm_string_t,
-        pm_string_t__bindgen_ty_1, PM_STRING_SHARED, PM_STRING_OWNED,
-        PM_STRING_CONSTANT, PM_STRING_MAPPED
+        pm_string_free, pm_string_length, pm_string_source, pm_string_t, pm_string_t__bindgen_ty_1, PM_STRING_CONSTANT,
+        PM_STRING_MAPPED, PM_STRING_OWNED, PM_STRING_SHARED,
     };
 
     use super::*;
@@ -59,10 +58,7 @@ mod string {
             length: c_string.as_bytes().len(),
         };
 
-        S {
-            c_string,
-            pm_string,
-        }
+        S { c_string, pm_string }
     }
 
     #[test]

--- a/rust/prism/rustfmt.toml
+++ b/rust/prism/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 300
+match_block_trailing_comma = true


### PR DESCRIPTION
Consistent formatting is nice, so let's enable it. I tried to configure `rustfmt.toml` to minimize big diffs to keep the original struct of the code as much as possible, since the default settings made a very noisy diff.