### PR TITLE
{Compiler,Visitor}#visit_with

### DIFF
--- a/templates/lib/prism/compiler.rb.erb
+++ b/templates/lib/prism/compiler.rb.erb
@@ -22,9 +22,19 @@ module Prism
       node&.accept(self)
     end
 
+    # Visit an individual node with a value.
+    def visit_with(node, value)
+      node&.accept_with(self, value)
+    end
+
     # Visit a list of nodes.
     def visit_all(nodes)
       nodes.map { |node| node&.accept(self) }
+    end
+
+    # Visit a list of nodes with a value.
+    def visit_all_with(nodes, value)
+      nodes.map { |node| node&.accept_with(self, value) }
     end
 
     # Visit the child nodes of the given node.
@@ -32,10 +42,17 @@ module Prism
       node.compact_child_nodes.map { |node| node.accept(self) }
     end
 
+    # Visit the child nodes of the given node with a value.
+    def visit_child_nodes_with(node, value)
+      node.compact_child_nodes.map { |node| node.accept_with(self, value) }
+    end
     <%- nodes.each_with_index do |node, index| -%>
-<%= "\n" if index != 0 -%>
+
     # Compile a <%= node.name %> node
     alias visit_<%= node.human %> visit_child_nodes
+
+    # Compile a <%= node.name %> node with a value
+    alias visit_<%= node.human %>_with visit_child_nodes_with
     <%- end -%>
   end
 end

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -46,9 +46,14 @@ module Prism
       @location = location
     end
 
-    # def accept: (visitor: Visitor) -> void
+    # def accept: (visitor: Visitor) -> untyped
     def accept(visitor)
       visitor.visit_<%= node.human %>(self)
+    end
+
+    # def accept_with: (visitor: Visitor, value: untyped) -> untyped
+    def accept_with(visitor, value)
+      visitor.visit_<%= node.human %>_with(self, value)
     end
     <%- if node.newline == false -%>
 

--- a/templates/lib/prism/visitor.rb.erb
+++ b/templates/lib/prism/visitor.rb.erb
@@ -8,12 +8,24 @@ module Prism
       node&.accept(self)
     end
 
+    def visit_with(node, value)
+      node&.accept_with(self, value)
+    end
+
     def visit_all(nodes)
       nodes.each { |node| node&.accept(self) }
     end
 
+    def visit_all_with(nodes, value)
+      nodes.each { |node| node&.accept_with(self, value) }
+    end
+
     def visit_child_nodes(node)
       node.compact_child_nodes.each { |node| node.accept(self) }
+    end
+
+    def visit_child_nodes_with(node)
+      node.compact_child_nodes.each { |node| node.accept_with(self, value) }
     end
   end
 
@@ -41,6 +53,9 @@ module Prism
 <%= "\n" if index != 0 -%>
     # Visit a <%= node.name %> node
     alias visit_<%= node.human %> visit_child_nodes
+
+    # Visit a <%= node.name %> node with a value
+    alias visit_<%= node.human %>_with visit_child_nodes_with
     <%- end -%>
   end
 end


### PR DESCRIPTION
There are many times when you need to pass data down the tree as you are compiling/visiting it. For example, in the CRuby compiler we need to pass `popped` and the current `iseq` that is being compiled, in parser-prism we need to pass down the local table, etc.

This new API allows you to do that without having to store stacks of values like we were previously doing. It would look something like:

```ruby
class MyCompiler < Prism::Compiler
  def visit_program_node(node)
    visit_with(node.statements, top_iseq)
  end

  def visit_statements_node_with(node, iseq)
    visit_all_with(node.body, iseq)
  end

  def visit_integer_node_with(node, iseq)
    iseq.putobject(node.value)
  end
end
```

`visit`, `visit_all`, and `visit_child_nodes` now all have `_with` equivalents, and all nodes have `accept_with` equivalents that forward along the data.

If you would like to forward multiple data points, it's recommended to create your own custom object or to use a data structure like an array or hash.