### PR TITLE
Add KeywordSplat flag to ArgumentsNode

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -329,6 +329,10 @@ tokens:
   - name: __END__
     comment: "marker for the point in the file at which the parser should stop"
 flags:
+  - name: ArgumentsNodeFlags
+    values:
+      - name: KEYWORD_SPLAT
+        comment: "if arguments contain keyword splat"
   - name: CallNodeFlags
     values:
       - name: SAFE_NAVIGATION
@@ -432,6 +436,9 @@ nodes:
     fields:
       - name: arguments
         type: node[]
+      - name: flags
+        type: flags
+        kind: ArgumentsNodeFlags
     comment: |
       Represents a set of arguments to a method or a keyword.
 
@@ -1924,8 +1931,8 @@ nodes:
     comment: |
       Represents a multi-target expression.
 
-          a, b, c = 1, 2, 3
-          ^^^^^^^
+          a, (b, c) = 1, 2, 3
+             ^^^^^^
   - name: MultiWriteNode
     fields:
       - name: targets

--- a/lib/prism/desugar_compiler.rb
+++ b/lib/prism/desugar_compiler.rb
@@ -161,7 +161,7 @@ module Prism
           nil,
           node.operator_loc.copy(length: node.operator_loc.length - 1),
           nil,
-          ArgumentsNode.new([node.value], node.value.location),
+          ArgumentsNode.new([node.value], 0, node.value.location),
           nil,
           nil,
           0,

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -85,7 +85,7 @@ module Prism
             nil,
             Location(),
             nil,
-            ArgumentsNode([MissingNode()]),
+            ArgumentsNode([MissingNode()], 0),
             nil,
             nil,
             0,
@@ -346,7 +346,7 @@ module Prism
         ArgumentsNode([
           KeywordHashNode([AssocSplatNode(expression("kwargs"), Location())]),
           SplatNode(Location(), expression("args"))
-        ]),
+        ], 1),
         Location(),
         nil,
         0,
@@ -364,7 +364,7 @@ module Prism
         nil,
         Location(),
         Location(),
-        ArgumentsNode([expression("foo")]),
+        ArgumentsNode([expression("foo")], 0),
         Location(),
         BlockArgumentNode(expression("block"), Location()),
         0,
@@ -399,7 +399,7 @@ module Prism
             )]
           ),
           SplatNode(Location(), expression("args"))
-        ]),
+        ], 0),
         Location(),
         nil,
         0,

--- a/test/prism/snapshots/arithmetic.txt
+++ b/test/prism/snapshots/arithmetic.txt
@@ -10,27 +10,28 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,4)-(1,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (1,4)-(1,8))
-        │   │           ├── receiver:
-        │   │           │   @ CallNode (location: (1,5)-(1,8))
-        │   │           │   ├── receiver: ∅
-        │   │           │   ├── call_operator_loc: ∅
-        │   │           │   ├── message_loc: (1,5)-(1,8) = "bar"
-        │   │           │   ├── opening_loc: ∅
-        │   │           │   ├── arguments: ∅
-        │   │           │   ├── closing_loc: ∅
-        │   │           │   ├── block: ∅
-        │   │           │   ├── flags: variable_call
-        │   │           │   └── name: :bar
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (1,4)-(1,5) = "!"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :!
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (1,4)-(1,8))
+        │   │   │       ├── receiver:
+        │   │   │       │   @ CallNode (location: (1,5)-(1,8))
+        │   │   │       │   ├── receiver: ∅
+        │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │       │   ├── message_loc: (1,5)-(1,8) = "bar"
+        │   │   │       │   ├── opening_loc: ∅
+        │   │   │       │   ├── arguments: ∅
+        │   │   │       │   ├── closing_loc: ∅
+        │   │   │       │   ├── block: ∅
+        │   │   │       │   ├── flags: variable_call
+        │   │   │       │   └── name: :bar
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (1,4)-(1,5) = "!"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :!
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -62,17 +63,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,5)-(3,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (3,5)-(3,8))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (3,5)-(3,8) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (3,5)-(3,8))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (3,5)-(3,8) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -104,17 +106,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,6)-(5,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (5,6)-(5,9))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (5,6)-(5,9) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (5,6)-(5,9))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (5,6)-(5,9) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -126,27 +129,28 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,4)-(7,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (7,4)-(7,8))
-        │   │           ├── receiver:
-        │   │           │   @ CallNode (location: (7,5)-(7,8))
-        │   │           │   ├── receiver: ∅
-        │   │           │   ├── call_operator_loc: ∅
-        │   │           │   ├── message_loc: (7,5)-(7,8) = "bar"
-        │   │           │   ├── opening_loc: ∅
-        │   │           │   ├── arguments: ∅
-        │   │           │   ├── closing_loc: ∅
-        │   │           │   ├── block: ∅
-        │   │           │   ├── flags: variable_call
-        │   │           │   └── name: :bar
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (7,4)-(7,5) = "~"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :~
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (7,4)-(7,8))
+        │   │   │       ├── receiver:
+        │   │   │       │   @ CallNode (location: (7,5)-(7,8))
+        │   │   │       │   ├── receiver: ∅
+        │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │       │   ├── message_loc: (7,5)-(7,8) = "bar"
+        │   │   │       │   ├── opening_loc: ∅
+        │   │   │       │   ├── arguments: ∅
+        │   │   │       │   ├── closing_loc: ∅
+        │   │   │       │   ├── block: ∅
+        │   │   │       │   ├── flags: variable_call
+        │   │   │       │   └── name: :bar
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (7,4)-(7,5) = "~"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :~
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -170,17 +174,18 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (9,7)-(9,10))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ CallNode (location: (9,7)-(9,10))
-        │   │   │           ├── receiver: ∅
-        │   │   │           ├── call_operator_loc: ∅
-        │   │   │           ├── message_loc: (9,7)-(9,10) = "bar"
-        │   │   │           ├── opening_loc: ∅
-        │   │   │           ├── arguments: ∅
-        │   │   │           ├── closing_loc: ∅
-        │   │   │           ├── block: ∅
-        │   │   │           ├── flags: variable_call
-        │   │   │           └── name: :bar
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ CallNode (location: (9,7)-(9,10))
+        │   │   │   │       ├── receiver: ∅
+        │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │       ├── message_loc: (9,7)-(9,10) = "bar"
+        │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │       ├── arguments: ∅
+        │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │       ├── block: ∅
+        │   │   │   │       ├── flags: variable_call
+        │   │   │   │       └── name: :bar
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block: ∅
         │   │   ├── flags: ∅
@@ -190,17 +195,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (9,14)-(9,17))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (9,14)-(9,17))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (9,14)-(9,17) = "baz"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :baz
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (9,14)-(9,17))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (9,14)-(9,17) = "baz"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :baz
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -216,9 +222,10 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (11,4)-(11,5))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ IntegerNode (location: (11,4)-(11,5))
-        │   │   │           └── flags: decimal
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ IntegerNode (location: (11,4)-(11,5))
+        │   │   │   │       └── flags: decimal
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block: ∅
         │   │   ├── flags: ∅

--- a/test/prism/snapshots/arrays.txt
+++ b/test/prism/snapshots/arrays.txt
@@ -37,37 +37,38 @@
         │   ├── opening_loc: (3,3)-(3,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,4)-(3,23))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ CallNode (location: (3,4)-(3,7))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (3,4)-(3,7) = "bar"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :bar
-        │   │       ├── @ CallNode (location: (3,9)-(3,12))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (3,9)-(3,12) = "baz"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :baz
-        │   │       └── @ ArrayNode (location: (3,16)-(3,23))
-        │   │           ├── elements: (length: 3)
-        │   │           │   ├── @ IntegerNode (location: (3,16)-(3,17))
-        │   │           │   │   └── flags: decimal
-        │   │           │   ├── @ IntegerNode (location: (3,19)-(3,20))
-        │   │           │   │   └── flags: decimal
-        │   │           │   └── @ IntegerNode (location: (3,22)-(3,23))
-        │   │           │       └── flags: decimal
-        │   │           ├── opening_loc: ∅
-        │   │           └── closing_loc: ∅
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ CallNode (location: (3,4)-(3,7))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (3,4)-(3,7) = "bar"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :bar
+        │   │   │   ├── @ CallNode (location: (3,9)-(3,12))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (3,9)-(3,12) = "baz"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :baz
+        │   │   │   └── @ ArrayNode (location: (3,16)-(3,23))
+        │   │   │       ├── elements: (length: 3)
+        │   │   │       │   ├── @ IntegerNode (location: (3,16)-(3,17))
+        │   │   │       │   │   └── flags: decimal
+        │   │   │       │   ├── @ IntegerNode (location: (3,19)-(3,20))
+        │   │   │       │   │   └── flags: decimal
+        │   │   │       │   └── @ IntegerNode (location: (3,22)-(3,23))
+        │   │   │       │       └── flags: decimal
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       └── closing_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: (3,12)-(3,13) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -202,17 +203,18 @@
         │   │   ├── opening_loc: (30,3)-(30,4) = "["
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (30,4)-(30,7))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ CallNode (location: (30,4)-(30,7))
-        │   │   │           ├── receiver: ∅
-        │   │   │           ├── call_operator_loc: ∅
-        │   │   │           ├── message_loc: (30,4)-(30,7) = "bar"
-        │   │   │           ├── opening_loc: ∅
-        │   │   │           ├── arguments: ∅
-        │   │   │           ├── closing_loc: ∅
-        │   │   │           ├── block: ∅
-        │   │   │           ├── flags: variable_call
-        │   │   │           └── name: :bar
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ CallNode (location: (30,4)-(30,7))
+        │   │   │   │       ├── receiver: ∅
+        │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │       ├── message_loc: (30,4)-(30,7) = "bar"
+        │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │       ├── arguments: ∅
+        │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │       ├── block: ∅
+        │   │   │   │       ├── flags: variable_call
+        │   │   │   │       └── name: :bar
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: (30,7)-(30,8) = "]"
         │   │   ├── block: ∅
         │   │   ├── flags: ∅
@@ -222,27 +224,28 @@
         │   ├── opening_loc: (30,8)-(30,9) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (30,9)-(30,19))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (30,9)-(30,12))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (30,9)-(30,12) = "baz"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :baz
-        │   │       └── @ CallNode (location: (30,16)-(30,19))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (30,16)-(30,19) = "qux"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :qux
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (30,9)-(30,12))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (30,9)-(30,12) = "baz"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :baz
+        │   │   │   └── @ CallNode (location: (30,16)-(30,19))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (30,16)-(30,19) = "qux"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :qux
+        │   │   └── flags: ∅
         │   ├── closing_loc: (30,12)-(30,13) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -266,17 +269,18 @@
         │   │   ├── opening_loc: (32,3)-(32,4) = "["
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (32,4)-(32,7))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ CallNode (location: (32,4)-(32,7))
-        │   │   │           ├── receiver: ∅
-        │   │   │           ├── call_operator_loc: ∅
-        │   │   │           ├── message_loc: (32,4)-(32,7) = "bar"
-        │   │   │           ├── opening_loc: ∅
-        │   │   │           ├── arguments: ∅
-        │   │   │           ├── closing_loc: ∅
-        │   │   │           ├── block: ∅
-        │   │   │           ├── flags: variable_call
-        │   │   │           └── name: :bar
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ CallNode (location: (32,4)-(32,7))
+        │   │   │   │       ├── receiver: ∅
+        │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │       ├── message_loc: (32,4)-(32,7) = "bar"
+        │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │       ├── arguments: ∅
+        │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │       ├── block: ∅
+        │   │   │   │       ├── flags: variable_call
+        │   │   │   │       └── name: :bar
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: (32,7)-(32,8) = "]"
         │   │   ├── block: ∅
         │   │   ├── flags: ∅
@@ -286,17 +290,18 @@
         │   ├── opening_loc: (32,8)-(32,9) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (32,9)-(32,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (32,9)-(32,12))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (32,9)-(32,12) = "baz"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :baz
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (32,9)-(32,12))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (32,9)-(32,12) = "baz"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :baz
+        │   │   └── flags: ∅
         │   ├── closing_loc: (32,12)-(32,13) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -322,27 +327,28 @@
         │   ├── opening_loc: (37,3)-(37,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (37,4)-(37,12))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (37,4)-(37,7))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (37,4)-(37,7) = "bar"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :bar
-        │   │       └── @ CallNode (location: (37,9)-(37,12))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (37,9)-(37,12) = "baz"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :baz
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (37,4)-(37,7))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (37,4)-(37,7) = "bar"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :bar
+        │   │   │   └── @ CallNode (location: (37,9)-(37,12))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (37,9)-(37,12) = "baz"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :baz
+        │   │   └── flags: ∅
         │   ├── closing_loc: (37,12)-(37,13) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -364,37 +370,38 @@
         │   ├── opening_loc: (39,3)-(39,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (39,4)-(39,19))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ CallNode (location: (39,4)-(39,7))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (39,4)-(39,7) = "bar"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :bar
-        │   │       ├── @ CallNode (location: (39,9)-(39,12))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (39,9)-(39,12) = "baz"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :baz
-        │   │       └── @ CallNode (location: (39,16)-(39,19))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (39,16)-(39,19) = "qux"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :qux
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ CallNode (location: (39,4)-(39,7))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (39,4)-(39,7) = "bar"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :bar
+        │   │   │   ├── @ CallNode (location: (39,9)-(39,12))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (39,9)-(39,12) = "baz"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :baz
+        │   │   │   └── @ CallNode (location: (39,16)-(39,19))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (39,16)-(39,19) = "qux"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :qux
+        │   │   └── flags: ∅
         │   ├── closing_loc: (39,12)-(39,13) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -418,9 +425,10 @@
         │   │   │   ├── opening_loc: (41,3)-(41,4) = "["
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (41,4)-(41,5))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ IntegerNode (location: (41,4)-(41,5))
-        │   │   │   │           └── flags: decimal
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ IntegerNode (location: (41,4)-(41,5))
+        │   │   │   │   │       └── flags: decimal
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: (41,5)-(41,6) = "]"
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅
@@ -442,9 +450,10 @@
         │   │       ├── opening_loc: (41,11)-(41,12) = "["
         │   │       ├── arguments:
         │   │       │   @ ArgumentsNode (location: (41,12)-(41,13))
-        │   │       │   └── arguments: (length: 1)
-        │   │       │       └── @ IntegerNode (location: (41,12)-(41,13))
-        │   │       │           └── flags: decimal
+        │   │       │   ├── arguments: (length: 1)
+        │   │       │   │   └── @ IntegerNode (location: (41,12)-(41,13))
+        │   │       │   │       └── flags: decimal
+        │   │       │   └── flags: ∅
         │   │       ├── closing_loc: (41,13)-(41,14) = "]"
         │   │       ├── block: ∅
         │   │       ├── flags: ∅
@@ -478,49 +487,51 @@
         │   ├── opening_loc: (43,3)-(43,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (43,4)-(43,18))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (43,4)-(43,18))
-        │   │           ├── receiver:
-        │   │           │   @ CallNode (location: (43,4)-(43,7))
-        │   │           │   ├── receiver: ∅
-        │   │           │   ├── call_operator_loc: ∅
-        │   │           │   ├── message_loc: (43,4)-(43,7) = "bar"
-        │   │           │   ├── opening_loc: ∅
-        │   │           │   ├── arguments: ∅
-        │   │           │   ├── closing_loc: ∅
-        │   │           │   ├── block: ∅
-        │   │           │   ├── flags: variable_call
-        │   │           │   └── name: :bar
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (43,7)-(43,12) = "[baz]"
-        │   │           ├── opening_loc: (43,7)-(43,8) = "["
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (43,8)-(43,18))
-        │   │           │   └── arguments: (length: 2)
-        │   │           │       ├── @ CallNode (location: (43,8)-(43,11))
-        │   │           │       │   ├── receiver: ∅
-        │   │           │       │   ├── call_operator_loc: ∅
-        │   │           │       │   ├── message_loc: (43,8)-(43,11) = "baz"
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── arguments: ∅
-        │   │           │       │   ├── closing_loc: ∅
-        │   │           │       │   ├── block: ∅
-        │   │           │       │   ├── flags: variable_call
-        │   │           │       │   └── name: :baz
-        │   │           │       └── @ CallNode (location: (43,15)-(43,18))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (43,15)-(43,18) = "qux"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block: ∅
-        │   │           │           ├── flags: variable_call
-        │   │           │           └── name: :qux
-        │   │           ├── closing_loc: (43,11)-(43,12) = "]"
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :[]=
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (43,4)-(43,18))
+        │   │   │       ├── receiver:
+        │   │   │       │   @ CallNode (location: (43,4)-(43,7))
+        │   │   │       │   ├── receiver: ∅
+        │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │       │   ├── message_loc: (43,4)-(43,7) = "bar"
+        │   │   │       │   ├── opening_loc: ∅
+        │   │   │       │   ├── arguments: ∅
+        │   │   │       │   ├── closing_loc: ∅
+        │   │   │       │   ├── block: ∅
+        │   │   │       │   ├── flags: variable_call
+        │   │   │       │   └── name: :bar
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (43,7)-(43,12) = "[baz]"
+        │   │   │       ├── opening_loc: (43,7)-(43,8) = "["
+        │   │   │       ├── arguments:
+        │   │   │       │   @ ArgumentsNode (location: (43,8)-(43,18))
+        │   │   │       │   ├── arguments: (length: 2)
+        │   │   │       │   │   ├── @ CallNode (location: (43,8)-(43,11))
+        │   │   │       │   │   │   ├── receiver: ∅
+        │   │   │       │   │   │   ├── call_operator_loc: ∅
+        │   │   │       │   │   │   ├── message_loc: (43,8)-(43,11) = "baz"
+        │   │   │       │   │   │   ├── opening_loc: ∅
+        │   │   │       │   │   │   ├── arguments: ∅
+        │   │   │       │   │   │   ├── closing_loc: ∅
+        │   │   │       │   │   │   ├── block: ∅
+        │   │   │       │   │   │   ├── flags: variable_call
+        │   │   │       │   │   │   └── name: :baz
+        │   │   │       │   │   └── @ CallNode (location: (43,15)-(43,18))
+        │   │   │       │   │       ├── receiver: ∅
+        │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │       │   │       ├── message_loc: (43,15)-(43,18) = "qux"
+        │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │       │   │       ├── arguments: ∅
+        │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │       │   │       ├── block: ∅
+        │   │   │       │   │       ├── flags: variable_call
+        │   │   │       │   │       └── name: :qux
+        │   │   │       │   └── flags: ∅
+        │   │   │       ├── closing_loc: (43,11)-(43,12) = "]"
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :[]=
+        │   │   └── flags: ∅
         │   ├── closing_loc: (43,18)-(43,19) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -542,17 +553,18 @@
         │   ├── opening_loc: (45,3)-(45,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (45,4)-(45,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (45,4)-(45,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (45,4)-(45,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (45,4)-(45,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (45,4)-(45,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (45,7)-(45,8) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -574,27 +586,28 @@
         │   ├── opening_loc: (47,3)-(47,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (47,4)-(47,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (47,4)-(47,7))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (47,4)-(47,7) = "bar"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :bar
-        │   │       └── @ CallNode (location: (47,11)-(47,14))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (47,11)-(47,14) = "baz"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :baz
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (47,4)-(47,7))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (47,4)-(47,7) = "bar"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :bar
+        │   │   │   └── @ CallNode (location: (47,11)-(47,14))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (47,11)-(47,14) = "baz"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :baz
+        │   │   └── flags: ∅
         │   ├── closing_loc: (47,7)-(47,8) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1051,17 +1064,18 @@
         │   ├── opening_loc: (96,3)-(96,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (96,4)-(96,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (96,4)-(96,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (96,4)-(96,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (96,4)-(96,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (96,4)-(96,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (96,7)-(96,8) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1086,17 +1100,18 @@
         │   ├── opening_loc: (98,3)-(98,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (98,4)-(98,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (98,4)-(98,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (98,4)-(98,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (98,4)-(98,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (98,4)-(98,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (98,7)-(98,8) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1120,17 +1135,18 @@
         │   ├── opening_loc: (100,3)-(100,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (100,4)-(100,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (100,4)-(100,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (100,4)-(100,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (100,4)-(100,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (100,4)-(100,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (100,7)-(100,8) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1164,17 +1180,18 @@
         │   ├── opening_loc: (102,7)-(102,8) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (102,8)-(102,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (102,8)-(102,11))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (102,8)-(102,11) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (102,8)-(102,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (102,8)-(102,11) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (102,11)-(102,12) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1209,17 +1226,18 @@
         │   ├── opening_loc: (104,7)-(104,8) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (104,8)-(104,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (104,8)-(104,11))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (104,8)-(104,11) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (104,8)-(104,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (104,8)-(104,11) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (104,11)-(104,12) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1253,17 +1271,18 @@
         │   ├── opening_loc: (106,7)-(106,8) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (106,8)-(106,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (106,8)-(106,11))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (106,8)-(106,11) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (106,8)-(106,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (106,8)-(106,11) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (106,11)-(106,12) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1287,17 +1306,18 @@
         │   ├── opening_loc: (108,3)-(108,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (108,4)-(108,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (108,4)-(108,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (108,4)-(108,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (108,4)-(108,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (108,4)-(108,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (108,13)-(108,14) = "]"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (108,9)-(108,13))
@@ -1335,17 +1355,18 @@
         │   ├── opening_loc: (110,3)-(110,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (110,4)-(110,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (110,4)-(110,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (110,4)-(110,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (110,4)-(110,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (110,4)-(110,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (110,13)-(110,14) = "]"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (110,9)-(110,13))
@@ -1382,17 +1403,18 @@
         │   ├── opening_loc: (112,3)-(112,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (112,4)-(112,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (112,4)-(112,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (112,4)-(112,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (112,4)-(112,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (112,4)-(112,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (112,13)-(112,14) = "]"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (112,9)-(112,13))
@@ -1439,17 +1461,18 @@
         │   ├── opening_loc: (114,7)-(114,8) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (114,8)-(114,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (114,8)-(114,11))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (114,8)-(114,11) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (114,8)-(114,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (114,8)-(114,11) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (114,17)-(114,18) = "]"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (114,13)-(114,17))
@@ -1497,17 +1520,18 @@
         │   ├── opening_loc: (116,7)-(116,8) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (116,8)-(116,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (116,8)-(116,11))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (116,8)-(116,11) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (116,8)-(116,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (116,8)-(116,11) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (116,17)-(116,18) = "]"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (116,13)-(116,17))
@@ -1554,17 +1578,18 @@
             ├── opening_loc: (118,7)-(118,8) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (118,8)-(118,11))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (118,8)-(118,11))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (118,8)-(118,11) = "bar"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :bar
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (118,8)-(118,11))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (118,8)-(118,11) = "bar"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :bar
+            │   └── flags: ∅
             ├── closing_loc: (118,17)-(118,18) = "]"
             ├── block:
             │   @ BlockArgumentNode (location: (118,13)-(118,17))

--- a/test/prism/snapshots/begin_ensure.txt
+++ b/test/prism/snapshots/begin_ensure.txt
@@ -165,76 +165,77 @@
             │           │           ├── opening_loc: ∅
             │           │           ├── arguments:
             │           │           │   @ ArgumentsNode (location: (15,16)-(21,7))
-            │           │           │   └── arguments: (length: 1)
-            │           │           │       └── @ BeginNode (location: (15,16)-(21,7))
-            │           │           │           ├── begin_keyword_loc: (15,16)-(15,21) = "begin"
-            │           │           │           ├── statements: ∅
-            │           │           │           ├── rescue_clause: ∅
-            │           │           │           ├── else_clause: ∅
-            │           │           │           ├── ensure_clause:
-            │           │           │           │   @ EnsureNode (location: (15,22)-(21,7))
-            │           │           │           │   ├── ensure_keyword_loc: (15,22)-(15,28) = "ensure"
-            │           │           │           │   ├── statements:
-            │           │           │           │   │   @ StatementsNode (location: (15,29)-(21,3))
-            │           │           │           │   │   └── body: (length: 1)
-            │           │           │           │   │       └── @ CallNode (location: (15,29)-(21,3))
-            │           │           │           │   │           ├── receiver:
-            │           │           │           │   │           │   @ ConstantReadNode (location: (15,29)-(15,35))
-            │           │           │           │   │           │   └── name: :Module
-            │           │           │           │   │           ├── call_operator_loc: (15,35)-(15,36) = "."
-            │           │           │           │   │           ├── message_loc: (15,36)-(15,39) = "new"
-            │           │           │           │   │           ├── opening_loc: ∅
-            │           │           │           │   │           ├── arguments: ∅
-            │           │           │           │   │           ├── closing_loc: ∅
-            │           │           │           │   │           ├── block:
-            │           │           │           │   │           │   @ BlockNode (location: (15,40)-(21,3))
-            │           │           │           │   │           │   ├── locals: []
-            │           │           │           │   │           │   ├── parameters: ∅
-            │           │           │           │   │           │   ├── body:
-            │           │           │           │   │           │   │   @ StatementsNode (location: (16,2)-(20,5))
-            │           │           │           │   │           │   │   └── body: (length: 1)
-            │           │           │           │   │           │   │       └── @ BeginNode (location: (16,2)-(20,5))
-            │           │           │           │   │           │   │           ├── begin_keyword_loc: (16,2)-(16,7) = "begin"
-            │           │           │           │   │           │   │           ├── statements:
-            │           │           │           │   │           │   │           │   @ StatementsNode (location: (17,4)-(17,9))
-            │           │           │           │   │           │   │           │   └── body: (length: 1)
-            │           │           │           │   │           │   │           │       └── @ BreakNode (location: (17,4)-(17,9))
-            │           │           │           │   │           │   │           │           ├── arguments: ∅
-            │           │           │           │   │           │   │           │           └── keyword_loc: (17,4)-(17,9) = "break"
-            │           │           │           │   │           │   │           ├── rescue_clause: ∅
-            │           │           │           │   │           │   │           ├── else_clause: ∅
-            │           │           │           │   │           │   │           ├── ensure_clause:
-            │           │           │           │   │           │   │           │   @ EnsureNode (location: (18,4)-(20,5))
-            │           │           │           │   │           │   │           │   ├── ensure_keyword_loc: (18,4)-(18,10) = "ensure"
-            │           │           │           │   │           │   │           │   ├── statements:
-            │           │           │           │   │           │   │           │   │   @ StatementsNode (location: (18,11)-(19,7))
-            │           │           │           │   │           │   │           │   │   └── body: (length: 1)
-            │           │           │           │   │           │   │           │   │       └── @ CallNode (location: (18,11)-(19,7))
-            │           │           │           │   │           │   │           │   │           ├── receiver:
-            │           │           │           │   │           │   │           │   │           │   @ ConstantReadNode (location: (18,11)-(18,17))
-            │           │           │           │   │           │   │           │   │           │   └── name: :Module
-            │           │           │           │   │           │   │           │   │           ├── call_operator_loc: (18,17)-(18,18) = "."
-            │           │           │           │   │           │   │           │   │           ├── message_loc: (18,18)-(18,21) = "new"
-            │           │           │           │   │           │   │           │   │           ├── opening_loc: ∅
-            │           │           │           │   │           │   │           │   │           ├── arguments: ∅
-            │           │           │           │   │           │   │           │   │           ├── closing_loc: ∅
-            │           │           │           │   │           │   │           │   │           ├── block:
-            │           │           │           │   │           │   │           │   │           │   @ BlockNode (location: (18,22)-(19,7))
-            │           │           │           │   │           │   │           │   │           │   ├── locals: []
-            │           │           │           │   │           │   │           │   │           │   ├── parameters: ∅
-            │           │           │           │   │           │   │           │   │           │   ├── body: ∅
-            │           │           │           │   │           │   │           │   │           │   ├── opening_loc: (18,22)-(18,24) = "do"
-            │           │           │           │   │           │   │           │   │           │   └── closing_loc: (19,4)-(19,7) = "end"
-            │           │           │           │   │           │   │           │   │           ├── flags: ∅
-            │           │           │           │   │           │   │           │   │           └── name: :new
-            │           │           │           │   │           │   │           │   └── end_keyword_loc: (20,2)-(20,5) = "end"
-            │           │           │           │   │           │   │           └── end_keyword_loc: (20,2)-(20,5) = "end"
-            │           │           │           │   │           │   ├── opening_loc: (15,40)-(15,42) = "do"
-            │           │           │           │   │           │   └── closing_loc: (21,0)-(21,3) = "end"
-            │           │           │           │   │           ├── flags: ∅
-            │           │           │           │   │           └── name: :new
-            │           │           │           │   └── end_keyword_loc: (21,4)-(21,7) = "end"
-            │           │           │           └── end_keyword_loc: (21,4)-(21,7) = "end"
+            │           │           │   ├── arguments: (length: 1)
+            │           │           │   │   └── @ BeginNode (location: (15,16)-(21,7))
+            │           │           │   │       ├── begin_keyword_loc: (15,16)-(15,21) = "begin"
+            │           │           │   │       ├── statements: ∅
+            │           │           │   │       ├── rescue_clause: ∅
+            │           │           │   │       ├── else_clause: ∅
+            │           │           │   │       ├── ensure_clause:
+            │           │           │   │       │   @ EnsureNode (location: (15,22)-(21,7))
+            │           │           │   │       │   ├── ensure_keyword_loc: (15,22)-(15,28) = "ensure"
+            │           │           │   │       │   ├── statements:
+            │           │           │   │       │   │   @ StatementsNode (location: (15,29)-(21,3))
+            │           │           │   │       │   │   └── body: (length: 1)
+            │           │           │   │       │   │       └── @ CallNode (location: (15,29)-(21,3))
+            │           │           │   │       │   │           ├── receiver:
+            │           │           │   │       │   │           │   @ ConstantReadNode (location: (15,29)-(15,35))
+            │           │           │   │       │   │           │   └── name: :Module
+            │           │           │   │       │   │           ├── call_operator_loc: (15,35)-(15,36) = "."
+            │           │           │   │       │   │           ├── message_loc: (15,36)-(15,39) = "new"
+            │           │           │   │       │   │           ├── opening_loc: ∅
+            │           │           │   │       │   │           ├── arguments: ∅
+            │           │           │   │       │   │           ├── closing_loc: ∅
+            │           │           │   │       │   │           ├── block:
+            │           │           │   │       │   │           │   @ BlockNode (location: (15,40)-(21,3))
+            │           │           │   │       │   │           │   ├── locals: []
+            │           │           │   │       │   │           │   ├── parameters: ∅
+            │           │           │   │       │   │           │   ├── body:
+            │           │           │   │       │   │           │   │   @ StatementsNode (location: (16,2)-(20,5))
+            │           │           │   │       │   │           │   │   └── body: (length: 1)
+            │           │           │   │       │   │           │   │       └── @ BeginNode (location: (16,2)-(20,5))
+            │           │           │   │       │   │           │   │           ├── begin_keyword_loc: (16,2)-(16,7) = "begin"
+            │           │           │   │       │   │           │   │           ├── statements:
+            │           │           │   │       │   │           │   │           │   @ StatementsNode (location: (17,4)-(17,9))
+            │           │           │   │       │   │           │   │           │   └── body: (length: 1)
+            │           │           │   │       │   │           │   │           │       └── @ BreakNode (location: (17,4)-(17,9))
+            │           │           │   │       │   │           │   │           │           ├── arguments: ∅
+            │           │           │   │       │   │           │   │           │           └── keyword_loc: (17,4)-(17,9) = "break"
+            │           │           │   │       │   │           │   │           ├── rescue_clause: ∅
+            │           │           │   │       │   │           │   │           ├── else_clause: ∅
+            │           │           │   │       │   │           │   │           ├── ensure_clause:
+            │           │           │   │       │   │           │   │           │   @ EnsureNode (location: (18,4)-(20,5))
+            │           │           │   │       │   │           │   │           │   ├── ensure_keyword_loc: (18,4)-(18,10) = "ensure"
+            │           │           │   │       │   │           │   │           │   ├── statements:
+            │           │           │   │       │   │           │   │           │   │   @ StatementsNode (location: (18,11)-(19,7))
+            │           │           │   │       │   │           │   │           │   │   └── body: (length: 1)
+            │           │           │   │       │   │           │   │           │   │       └── @ CallNode (location: (18,11)-(19,7))
+            │           │           │   │       │   │           │   │           │   │           ├── receiver:
+            │           │           │   │       │   │           │   │           │   │           │   @ ConstantReadNode (location: (18,11)-(18,17))
+            │           │           │   │       │   │           │   │           │   │           │   └── name: :Module
+            │           │           │   │       │   │           │   │           │   │           ├── call_operator_loc: (18,17)-(18,18) = "."
+            │           │           │   │       │   │           │   │           │   │           ├── message_loc: (18,18)-(18,21) = "new"
+            │           │           │   │       │   │           │   │           │   │           ├── opening_loc: ∅
+            │           │           │   │       │   │           │   │           │   │           ├── arguments: ∅
+            │           │           │   │       │   │           │   │           │   │           ├── closing_loc: ∅
+            │           │           │   │       │   │           │   │           │   │           ├── block:
+            │           │           │   │       │   │           │   │           │   │           │   @ BlockNode (location: (18,22)-(19,7))
+            │           │           │   │       │   │           │   │           │   │           │   ├── locals: []
+            │           │           │   │       │   │           │   │           │   │           │   ├── parameters: ∅
+            │           │           │   │       │   │           │   │           │   │           │   ├── body: ∅
+            │           │           │   │       │   │           │   │           │   │           │   ├── opening_loc: (18,22)-(18,24) = "do"
+            │           │           │   │       │   │           │   │           │   │           │   └── closing_loc: (19,4)-(19,7) = "end"
+            │           │           │   │       │   │           │   │           │   │           ├── flags: ∅
+            │           │           │   │       │   │           │   │           │   │           └── name: :new
+            │           │           │   │       │   │           │   │           │   └── end_keyword_loc: (20,2)-(20,5) = "end"
+            │           │           │   │       │   │           │   │           └── end_keyword_loc: (20,2)-(20,5) = "end"
+            │           │           │   │       │   │           │   ├── opening_loc: (15,40)-(15,42) = "do"
+            │           │           │   │       │   │           │   └── closing_loc: (21,0)-(21,3) = "end"
+            │           │           │   │       │   │           ├── flags: ∅
+            │           │           │   │       │   │           └── name: :new
+            │           │           │   │       │   └── end_keyword_loc: (21,4)-(21,7) = "end"
+            │           │           │   │       └── end_keyword_loc: (21,4)-(21,7) = "end"
+            │           │           │   └── flags: ∅
             │           │           ├── closing_loc: ∅
             │           │           ├── block: ∅
             │           │           ├── flags: ∅

--- a/test/prism/snapshots/blocks.txt
+++ b/test/prism/snapshots/blocks.txt
@@ -20,17 +20,18 @@
         │   ├── opening_loc: (1,3)-(1,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,4)-(1,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (1,4)-(1,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (1,4)-(1,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (1,4)-(1,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (1,4)-(1,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (1,7)-(1,8) = "]"
         │   ├── block:
         │   │   @ BlockNode (location: (1,9)-(1,16))
@@ -70,17 +71,18 @@
         │   ├── opening_loc: (3,3)-(3,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,4)-(3,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (3,4)-(3,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (3,4)-(3,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (3,4)-(3,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (3,4)-(3,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (3,7)-(3,8) = "]"
         │   ├── block:
         │   │   @ BlockNode (location: (3,9)-(5,3))
@@ -120,9 +122,10 @@
         │   ├── opening_loc: (7,8)-(7,9) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,9)-(7,10))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (7,9)-(7,10))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (7,9)-(7,10))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (7,10)-(7,11) = ")"
         │   ├── block:
         │   │   @ BlockNode (location: (7,12)-(7,35))
@@ -185,39 +188,40 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (11,4)-(11,21))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (11,4)-(11,7))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (11,4)-(11,7) = "bar"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :bar
-        │   │       └── @ ParenthesesNode (location: (11,9)-(11,21))
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (11,10)-(11,20))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (11,10)-(11,20))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (11,10)-(11,13) = "baz"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block:
-        │   │           │           │   @ BlockNode (location: (11,14)-(11,20))
-        │   │           │           │   ├── locals: []
-        │   │           │           │   ├── parameters: ∅
-        │   │           │           │   ├── body: ∅
-        │   │           │           │   ├── opening_loc: (11,14)-(11,16) = "do"
-        │   │           │           │   └── closing_loc: (11,17)-(11,20) = "end"
-        │   │           │           ├── flags: ∅
-        │   │           │           └── name: :baz
-        │   │           ├── opening_loc: (11,9)-(11,10) = "("
-        │   │           └── closing_loc: (11,20)-(11,21) = ")"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (11,4)-(11,7))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (11,4)-(11,7) = "bar"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :bar
+        │   │   │   └── @ ParenthesesNode (location: (11,9)-(11,21))
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (11,10)-(11,20))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (11,10)-(11,20))
+        │   │   │       │           ├── receiver: ∅
+        │   │   │       │           ├── call_operator_loc: ∅
+        │   │   │       │           ├── message_loc: (11,10)-(11,13) = "baz"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block:
+        │   │   │       │           │   @ BlockNode (location: (11,14)-(11,20))
+        │   │   │       │           │   ├── locals: []
+        │   │   │       │           │   ├── parameters: ∅
+        │   │   │       │           │   ├── body: ∅
+        │   │   │       │           │   ├── opening_loc: (11,14)-(11,16) = "do"
+        │   │   │       │           │   └── closing_loc: (11,17)-(11,20) = "end"
+        │   │   │       │           ├── flags: ∅
+        │   │   │       │           └── name: :baz
+        │   │   │       ├── opening_loc: (11,9)-(11,10) = "("
+        │   │   │       └── closing_loc: (11,20)-(11,21) = ")"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -229,17 +233,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (13,4)-(13,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (13,4)-(13,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (13,4)-(13,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (13,4)-(13,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (13,4)-(13,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (13,8)-(13,14))
@@ -257,29 +262,31 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (15,4)-(15,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (15,4)-(15,11))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (15,4)-(15,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (15,8)-(15,11))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ CallNode (location: (15,8)-(15,11))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (15,8)-(15,11) = "baz"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block: ∅
-        │   │           │           ├── flags: variable_call
-        │   │           │           └── name: :baz
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (15,4)-(15,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (15,4)-(15,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments:
+        │   │   │       │   @ ArgumentsNode (location: (15,8)-(15,11))
+        │   │   │       │   ├── arguments: (length: 1)
+        │   │   │       │   │   └── @ CallNode (location: (15,8)-(15,11))
+        │   │   │       │   │       ├── receiver: ∅
+        │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │       │   │       ├── message_loc: (15,8)-(15,11) = "baz"
+        │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │       │   │       ├── arguments: ∅
+        │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │       │   │       ├── block: ∅
+        │   │   │       │   │       ├── flags: variable_call
+        │   │   │       │   │       └── name: :baz
+        │   │   │       │   └── flags: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (15,12)-(15,18))
@@ -328,9 +335,10 @@
         │   │   │   │   │           ├── opening_loc: (17,13)-(17,14) = "["
         │   │   │   │   │           ├── arguments:
         │   │   │   │   │           │   @ ArgumentsNode (location: (17,14)-(17,15))
-        │   │   │   │   │           │   └── arguments: (length: 1)
-        │   │   │   │   │           │       └── @ IntegerNode (location: (17,14)-(17,15))
-        │   │   │   │   │           │           └── flags: decimal
+        │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │           │   │   └── @ IntegerNode (location: (17,14)-(17,15))
+        │   │   │   │   │           │   │       └── flags: decimal
+        │   │   │   │   │           │   └── flags: ∅
         │   │   │   │   │           ├── closing_loc: (17,15)-(17,16) = "]"
         │   │   │   │   │           ├── block: ∅
         │   │   │   │   │           ├── flags: ∅
@@ -447,17 +455,18 @@
         │   ├── opening_loc: (31,3)-(31,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (31,4)-(31,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (31,4)-(31,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (31,4)-(31,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (31,4)-(31,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (31,4)-(31,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (31,7)-(31,8) = "]"
         │   ├── block:
         │   │   @ BlockNode (location: (31,9)-(31,16))
@@ -667,48 +676,49 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (48,4)-(52,1))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (48,4)-(52,1))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (48,4)-(48,10) = "lambda"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block:
-        │   │           │   @ BlockNode (location: (48,11)-(52,1))
-        │   │           │   ├── locals: [:a, :b]
-        │   │           │   ├── parameters:
-        │   │           │   │   @ BlockParametersNode (location: (48,13)-(51,3))
-        │   │           │   │   ├── parameters:
-        │   │           │   │   │   @ ParametersNode (location: (49,2)-(50,6))
-        │   │           │   │   │   ├── requireds: (length: 0)
-        │   │           │   │   │   ├── optionals: (length: 0)
-        │   │           │   │   │   ├── rest: ∅
-        │   │           │   │   │   ├── posts: (length: 0)
-        │   │           │   │   │   ├── keywords: (length: 2)
-        │   │           │   │   │   │   ├── @ KeywordParameterNode (location: (49,2)-(49,6))
-        │   │           │   │   │   │   │   ├── name: :a
-        │   │           │   │   │   │   │   ├── name_loc: (49,2)-(49,4) = "a:"
-        │   │           │   │   │   │   │   └── value:
-        │   │           │   │   │   │   │       @ IntegerNode (location: (49,5)-(49,6))
-        │   │           │   │   │   │   │       └── flags: decimal
-        │   │           │   │   │   │   └── @ KeywordParameterNode (location: (50,2)-(50,6))
-        │   │           │   │   │   │       ├── name: :b
-        │   │           │   │   │   │       ├── name_loc: (50,2)-(50,4) = "b:"
-        │   │           │   │   │   │       └── value:
-        │   │           │   │   │   │           @ IntegerNode (location: (50,5)-(50,6))
-        │   │           │   │   │   │           └── flags: decimal
-        │   │           │   │   │   ├── keyword_rest: ∅
-        │   │           │   │   │   └── block: ∅
-        │   │           │   │   ├── locals: (length: 0)
-        │   │           │   │   ├── opening_loc: (48,13)-(48,14) = "|"
-        │   │           │   │   └── closing_loc: (51,2)-(51,3) = "|"
-        │   │           │   ├── body: ∅
-        │   │           │   ├── opening_loc: (48,11)-(48,12) = "{"
-        │   │           │   └── closing_loc: (52,0)-(52,1) = "}"
-        │   │           ├── flags: ∅
-        │   │           └── name: :lambda
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (48,4)-(52,1))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (48,4)-(48,10) = "lambda"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block:
+        │   │   │       │   @ BlockNode (location: (48,11)-(52,1))
+        │   │   │       │   ├── locals: [:a, :b]
+        │   │   │       │   ├── parameters:
+        │   │   │       │   │   @ BlockParametersNode (location: (48,13)-(51,3))
+        │   │   │       │   │   ├── parameters:
+        │   │   │       │   │   │   @ ParametersNode (location: (49,2)-(50,6))
+        │   │   │       │   │   │   ├── requireds: (length: 0)
+        │   │   │       │   │   │   ├── optionals: (length: 0)
+        │   │   │       │   │   │   ├── rest: ∅
+        │   │   │       │   │   │   ├── posts: (length: 0)
+        │   │   │       │   │   │   ├── keywords: (length: 2)
+        │   │   │       │   │   │   │   ├── @ KeywordParameterNode (location: (49,2)-(49,6))
+        │   │   │       │   │   │   │   │   ├── name: :a
+        │   │   │       │   │   │   │   │   ├── name_loc: (49,2)-(49,4) = "a:"
+        │   │   │       │   │   │   │   │   └── value:
+        │   │   │       │   │   │   │   │       @ IntegerNode (location: (49,5)-(49,6))
+        │   │   │       │   │   │   │   │       └── flags: decimal
+        │   │   │       │   │   │   │   └── @ KeywordParameterNode (location: (50,2)-(50,6))
+        │   │   │       │   │   │   │       ├── name: :b
+        │   │   │       │   │   │   │       ├── name_loc: (50,2)-(50,4) = "b:"
+        │   │   │       │   │   │   │       └── value:
+        │   │   │       │   │   │   │           @ IntegerNode (location: (50,5)-(50,6))
+        │   │   │       │   │   │   │           └── flags: decimal
+        │   │   │       │   │   │   ├── keyword_rest: ∅
+        │   │   │       │   │   │   └── block: ∅
+        │   │   │       │   │   ├── locals: (length: 0)
+        │   │   │       │   │   ├── opening_loc: (48,13)-(48,14) = "|"
+        │   │   │       │   │   └── closing_loc: (51,2)-(51,3) = "|"
+        │   │   │       │   ├── body: ∅
+        │   │   │       │   ├── opening_loc: (48,11)-(48,12) = "{"
+        │   │   │       │   └── closing_loc: (52,0)-(52,1) = "}"
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :lambda
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/break.txt
+++ b/test/prism/snapshots/break.txt
@@ -9,112 +9,120 @@
         ├── @ BreakNode (location: (3,0)-(3,19))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,6)-(3,19))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ ParenthesesNode (location: (3,6)-(3,9))
-        │   │       │   ├── body:
-        │   │       │   │   @ StatementsNode (location: (3,7)-(3,8))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ IntegerNode (location: (3,7)-(3,8))
-        │   │       │   │           └── flags: decimal
-        │   │       │   ├── opening_loc: (3,6)-(3,7) = "("
-        │   │       │   └── closing_loc: (3,8)-(3,9) = ")"
-        │   │       ├── @ ParenthesesNode (location: (3,11)-(3,14))
-        │   │       │   ├── body:
-        │   │       │   │   @ StatementsNode (location: (3,12)-(3,13))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ IntegerNode (location: (3,12)-(3,13))
-        │   │       │   │           └── flags: decimal
-        │   │       │   ├── opening_loc: (3,11)-(3,12) = "("
-        │   │       │   └── closing_loc: (3,13)-(3,14) = ")"
-        │   │       └── @ ParenthesesNode (location: (3,16)-(3,19))
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (3,17)-(3,18))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (3,17)-(3,18))
-        │   │           │           └── flags: decimal
-        │   │           ├── opening_loc: (3,16)-(3,17) = "("
-        │   │           └── closing_loc: (3,18)-(3,19) = ")"
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ ParenthesesNode (location: (3,6)-(3,9))
+        │   │   │   │   ├── body:
+        │   │   │   │   │   @ StatementsNode (location: (3,7)-(3,8))
+        │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │       └── @ IntegerNode (location: (3,7)-(3,8))
+        │   │   │   │   │           └── flags: decimal
+        │   │   │   │   ├── opening_loc: (3,6)-(3,7) = "("
+        │   │   │   │   └── closing_loc: (3,8)-(3,9) = ")"
+        │   │   │   ├── @ ParenthesesNode (location: (3,11)-(3,14))
+        │   │   │   │   ├── body:
+        │   │   │   │   │   @ StatementsNode (location: (3,12)-(3,13))
+        │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │       └── @ IntegerNode (location: (3,12)-(3,13))
+        │   │   │   │   │           └── flags: decimal
+        │   │   │   │   ├── opening_loc: (3,11)-(3,12) = "("
+        │   │   │   │   └── closing_loc: (3,13)-(3,14) = ")"
+        │   │   │   └── @ ParenthesesNode (location: (3,16)-(3,19))
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (3,17)-(3,18))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ IntegerNode (location: (3,17)-(3,18))
+        │   │   │       │           └── flags: decimal
+        │   │   │       ├── opening_loc: (3,16)-(3,17) = "("
+        │   │   │       └── closing_loc: (3,18)-(3,19) = ")"
+        │   │   └── flags: ∅
         │   └── keyword_loc: (3,0)-(3,5) = "break"
         ├── @ BreakNode (location: (5,0)-(5,7))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,6)-(5,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (5,6)-(5,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (5,6)-(5,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   └── keyword_loc: (5,0)-(5,5) = "break"
         ├── @ BreakNode (location: (7,0)-(8,1))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,6)-(8,1))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ IntegerNode (location: (7,6)-(7,7))
-        │   │       │   └── flags: decimal
-        │   │       ├── @ IntegerNode (location: (7,9)-(7,10))
-        │   │       │   └── flags: decimal
-        │   │       └── @ IntegerNode (location: (8,0)-(8,1))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ IntegerNode (location: (7,6)-(7,7))
+        │   │   │   │   └── flags: decimal
+        │   │   │   ├── @ IntegerNode (location: (7,9)-(7,10))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ IntegerNode (location: (8,0)-(8,1))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   └── keyword_loc: (7,0)-(7,5) = "break"
         ├── @ BreakNode (location: (10,0)-(10,13))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (10,6)-(10,13))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ IntegerNode (location: (10,6)-(10,7))
-        │   │       │   └── flags: decimal
-        │   │       ├── @ IntegerNode (location: (10,9)-(10,10))
-        │   │       │   └── flags: decimal
-        │   │       └── @ IntegerNode (location: (10,12)-(10,13))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ IntegerNode (location: (10,6)-(10,7))
+        │   │   │   │   └── flags: decimal
+        │   │   │   ├── @ IntegerNode (location: (10,9)-(10,10))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ IntegerNode (location: (10,12)-(10,13))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   └── keyword_loc: (10,0)-(10,5) = "break"
         ├── @ BreakNode (location: (12,0)-(12,15))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (12,6)-(12,15))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ArrayNode (location: (12,6)-(12,15))
-        │   │           ├── elements: (length: 3)
-        │   │           │   ├── @ IntegerNode (location: (12,7)-(12,8))
-        │   │           │   │   └── flags: decimal
-        │   │           │   ├── @ IntegerNode (location: (12,10)-(12,11))
-        │   │           │   │   └── flags: decimal
-        │   │           │   └── @ IntegerNode (location: (12,13)-(12,14))
-        │   │           │       └── flags: decimal
-        │   │           ├── opening_loc: (12,6)-(12,7) = "["
-        │   │           └── closing_loc: (12,14)-(12,15) = "]"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ArrayNode (location: (12,6)-(12,15))
+        │   │   │       ├── elements: (length: 3)
+        │   │   │       │   ├── @ IntegerNode (location: (12,7)-(12,8))
+        │   │   │       │   │   └── flags: decimal
+        │   │   │       │   ├── @ IntegerNode (location: (12,10)-(12,11))
+        │   │   │       │   │   └── flags: decimal
+        │   │   │       │   └── @ IntegerNode (location: (12,13)-(12,14))
+        │   │   │       │       └── flags: decimal
+        │   │   │       ├── opening_loc: (12,6)-(12,7) = "["
+        │   │   │       └── closing_loc: (12,14)-(12,15) = "]"
+        │   │   └── flags: ∅
         │   └── keyword_loc: (12,0)-(12,5) = "break"
         ├── @ BreakNode (location: (14,0)-(17,1))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (14,5)-(17,1))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (14,5)-(17,1))
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (15,2)-(16,3))
-        │   │           │   └── body: (length: 2)
-        │   │           │       ├── @ IntegerNode (location: (15,2)-(15,3))
-        │   │           │       │   └── flags: decimal
-        │   │           │       └── @ IntegerNode (location: (16,2)-(16,3))
-        │   │           │           └── flags: decimal
-        │   │           ├── opening_loc: (14,5)-(14,6) = "("
-        │   │           └── closing_loc: (17,0)-(17,1) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (14,5)-(17,1))
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (15,2)-(16,3))
+        │   │   │       │   └── body: (length: 2)
+        │   │   │       │       ├── @ IntegerNode (location: (15,2)-(15,3))
+        │   │   │       │       │   └── flags: decimal
+        │   │   │       │       └── @ IntegerNode (location: (16,2)-(16,3))
+        │   │   │       │           └── flags: decimal
+        │   │   │       ├── opening_loc: (14,5)-(14,6) = "("
+        │   │   │       └── closing_loc: (17,0)-(17,1) = ")"
+        │   │   └── flags: ∅
         │   └── keyword_loc: (14,0)-(14,5) = "break"
         ├── @ BreakNode (location: (19,0)-(19,7))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (19,5)-(19,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (19,5)-(19,7))
-        │   │           ├── body: ∅
-        │   │           ├── opening_loc: (19,5)-(19,6) = "("
-        │   │           └── closing_loc: (19,6)-(19,7) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (19,5)-(19,7))
+        │   │   │       ├── body: ∅
+        │   │   │       ├── opening_loc: (19,5)-(19,6) = "("
+        │   │   │       └── closing_loc: (19,6)-(19,7) = ")"
+        │   │   └── flags: ∅
         │   └── keyword_loc: (19,0)-(19,5) = "break"
         ├── @ BreakNode (location: (21,0)-(21,8))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (21,5)-(21,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (21,5)-(21,8))
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (21,6)-(21,7))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (21,6)-(21,7))
-        │   │           │           └── flags: decimal
-        │   │           ├── opening_loc: (21,5)-(21,6) = "("
-        │   │           └── closing_loc: (21,7)-(21,8) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (21,5)-(21,8))
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (21,6)-(21,7))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ IntegerNode (location: (21,6)-(21,7))
+        │   │   │       │           └── flags: decimal
+        │   │   │       ├── opening_loc: (21,5)-(21,6) = "("
+        │   │   │       └── closing_loc: (21,7)-(21,8) = ")"
+        │   │   └── flags: ∅
         │   └── keyword_loc: (21,0)-(21,5) = "break"
         ├── @ CallNode (location: (23,0)-(23,22))
         │   ├── receiver:
@@ -135,9 +143,10 @@
         │   │   │   │       └── @ BreakNode (location: (23,6)-(23,14))
         │   │   │   │           ├── arguments:
         │   │   │   │           │   @ ArgumentsNode (location: (23,12)-(23,14))
-        │   │   │   │           │   └── arguments: (length: 1)
-        │   │   │   │           │       └── @ IntegerNode (location: (23,12)-(23,14))
-        │   │   │   │           │           └── flags: decimal
+        │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │           │   │   └── @ IntegerNode (location: (23,12)-(23,14))
+        │   │   │   │           │   │       └── flags: decimal
+        │   │   │   │           │   └── flags: ∅
         │   │   │   │           └── keyword_loc: (23,6)-(23,11) = "break"
         │   │   │   ├── opening_loc: (23,4)-(23,5) = "{"
         │   │   │   └── closing_loc: (23,15)-(23,16) = "}"
@@ -148,9 +157,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (23,20)-(23,22))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (23,20)-(23,22))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (23,20)-(23,22))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -198,9 +208,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (25,21)-(25,23))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (25,21)-(25,23))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (25,21)-(25,23))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/case.txt
+++ b/test/prism/snapshots/case.txt
@@ -41,12 +41,13 @@
         │   │   │               ├── opening_loc: ∅
         │   │   │               ├── arguments:
         │   │   │               │   @ ArgumentsNode (location: (5,27)-(5,30))
-        │   │   │               │   └── arguments: (length: 1)
-        │   │   │               │       └── @ SymbolNode (location: (5,27)-(5,30))
-        │   │   │               │           ├── opening_loc: (5,27)-(5,28) = ":"
-        │   │   │               │           ├── value_loc: (5,28)-(5,30) = "hi"
-        │   │   │               │           ├── closing_loc: ∅
-        │   │   │               │           └── unescaped: "hi"
+        │   │   │               │   ├── arguments: (length: 1)
+        │   │   │               │   │   └── @ SymbolNode (location: (5,27)-(5,30))
+        │   │   │               │   │       ├── opening_loc: (5,27)-(5,28) = ":"
+        │   │   │               │   │       ├── value_loc: (5,28)-(5,30) = "hi"
+        │   │   │               │   │       ├── closing_loc: ∅
+        │   │   │               │   │       └── unescaped: "hi"
+        │   │   │               │   └── flags: ∅
         │   │   │               ├── closing_loc: ∅
         │   │   │               ├── block: ∅
         │   │   │               ├── flags: ∅
@@ -65,12 +66,13 @@
         │   │                   ├── opening_loc: ∅
         │   │                   ├── arguments:
         │   │                   │   @ ArgumentsNode (location: (5,49)-(5,53))
-        │   │                   │   └── arguments: (length: 1)
-        │   │                   │       └── @ SymbolNode (location: (5,49)-(5,53))
-        │   │                   │           ├── opening_loc: (5,49)-(5,50) = ":"
-        │   │                   │           ├── value_loc: (5,50)-(5,53) = "bye"
-        │   │                   │           ├── closing_loc: ∅
-        │   │                   │           └── unescaped: "bye"
+        │   │                   │   ├── arguments: (length: 1)
+        │   │                   │   │   └── @ SymbolNode (location: (5,49)-(5,53))
+        │   │                   │   │       ├── opening_loc: (5,49)-(5,50) = ":"
+        │   │                   │   │       ├── value_loc: (5,50)-(5,53) = "bye"
+        │   │                   │   │       ├── closing_loc: ∅
+        │   │                   │   │       └── unescaped: "bye"
+        │   │                   │   └── flags: ∅
         │   │                   ├── closing_loc: ∅
         │   │                   ├── block: ∅
         │   │                   ├── flags: ∅
@@ -179,17 +181,18 @@
         │   │       │       ├── opening_loc: ∅
         │   │       │       ├── arguments:
         │   │       │       │   @ ArgumentsNode (location: (18,12)-(18,15))
-        │   │       │       │   └── arguments: (length: 1)
-        │   │       │       │       └── @ CallNode (location: (18,12)-(18,15))
-        │   │       │       │           ├── receiver: ∅
-        │   │       │       │           ├── call_operator_loc: ∅
-        │   │       │       │           ├── message_loc: (18,12)-(18,15) = "bar"
-        │   │       │       │           ├── opening_loc: ∅
-        │   │       │       │           ├── arguments: ∅
-        │   │       │       │           ├── closing_loc: ∅
-        │   │       │       │           ├── block: ∅
-        │   │       │       │           ├── flags: variable_call
-        │   │       │       │           └── name: :bar
+        │   │       │       │   ├── arguments: (length: 1)
+        │   │       │       │   │   └── @ CallNode (location: (18,12)-(18,15))
+        │   │       │       │   │       ├── receiver: ∅
+        │   │       │       │   │       ├── call_operator_loc: ∅
+        │   │       │       │   │       ├── message_loc: (18,12)-(18,15) = "bar"
+        │   │       │       │   │       ├── opening_loc: ∅
+        │   │       │       │   │       ├── arguments: ∅
+        │   │       │       │   │       ├── closing_loc: ∅
+        │   │       │       │   │       ├── block: ∅
+        │   │       │       │   │       ├── flags: variable_call
+        │   │       │       │   │       └── name: :bar
+        │   │       │       │   └── flags: ∅
         │   │       │       ├── closing_loc: ∅
         │   │       │       ├── block: ∅
         │   │       │       ├── flags: ∅

--- a/test/prism/snapshots/classes.txt
+++ b/test/prism/snapshots/classes.txt
@@ -292,9 +292,10 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (29,4)-(29,5))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (29,4)-(29,5))
-        │   │           │           └── flags: decimal
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ IntegerNode (location: (29,4)-(29,5))
+        │   │           │   │       └── flags: decimal
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -318,9 +319,10 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (32,18)-(32,19))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (32,18)-(32,19))
-        │   │           │           └── flags: decimal
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ IntegerNode (location: (32,18)-(32,19))
+        │   │           │   │       └── flags: decimal
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -343,9 +345,10 @@
             │   ├── opening_loc: (34,11)-(34,12) = "["
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (34,12)-(34,13))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ IntegerNode (location: (34,12)-(34,13))
-            │   │           └── flags: decimal
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ IntegerNode (location: (34,12)-(34,13))
+            │   │   │       └── flags: decimal
+            │   │   └── flags: ∅
             │   ├── closing_loc: (34,13)-(34,14) = "]"
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/constants.txt
+++ b/test/prism/snapshots/constants.txt
@@ -71,9 +71,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (13,4)-(13,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (13,4)-(13,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (13,4)-(13,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -85,20 +86,21 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (15,4)-(15,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SplatNode (location: (15,4)-(15,8))
-        │   │           ├── operator_loc: (15,4)-(15,5) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (15,5)-(15,8))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (15,5)-(15,8) = "bar"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SplatNode (location: (15,4)-(15,8))
+        │   │   │       ├── operator_loc: (15,4)-(15,5) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (15,5)-(15,8))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (15,5)-(15,8) = "bar"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -110,22 +112,23 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (17,4)-(17,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (17,4)-(17,9))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocSplatNode (location: (17,4)-(17,9))
-        │   │                   ├── value:
-        │   │                   │   @ CallNode (location: (17,6)-(17,9))
-        │   │                   │   ├── receiver: ∅
-        │   │                   │   ├── call_operator_loc: ∅
-        │   │                   │   ├── message_loc: (17,6)-(17,9) = "bar"
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── arguments: ∅
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   ├── block: ∅
-        │   │                   │   ├── flags: variable_call
-        │   │                   │   └── name: :bar
-        │   │                   └── operator_loc: (17,4)-(17,6) = "**"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (17,4)-(17,9))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocSplatNode (location: (17,4)-(17,9))
+        │   │   │               ├── value:
+        │   │   │               │   @ CallNode (location: (17,6)-(17,9))
+        │   │   │               │   ├── receiver: ∅
+        │   │   │               │   ├── call_operator_loc: ∅
+        │   │   │               │   ├── message_loc: (17,6)-(17,9) = "bar"
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── arguments: ∅
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   ├── block: ∅
+        │   │   │               │   ├── flags: variable_call
+        │   │   │               │   └── name: :bar
+        │   │   │               └── operator_loc: (17,4)-(17,6) = "**"
+        │   │   └── flags: keyword_splat
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -162,20 +165,21 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (21,9)-(21,13))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SplatNode (location: (21,9)-(21,13))
-        │   │           ├── operator_loc: (21,9)-(21,10) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (21,10)-(21,13))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (21,10)-(21,13) = "baz"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :baz
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SplatNode (location: (21,9)-(21,13))
+        │   │   │       ├── operator_loc: (21,9)-(21,10) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (21,10)-(21,13))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (21,10)-(21,13) = "baz"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :baz
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -189,22 +193,23 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (23,9)-(23,14))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (23,9)-(23,14))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocSplatNode (location: (23,9)-(23,14))
-        │   │                   ├── value:
-        │   │                   │   @ CallNode (location: (23,11)-(23,14))
-        │   │                   │   ├── receiver: ∅
-        │   │                   │   ├── call_operator_loc: ∅
-        │   │                   │   ├── message_loc: (23,11)-(23,14) = "baz"
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── arguments: ∅
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   ├── block: ∅
-        │   │                   │   ├── flags: variable_call
-        │   │                   │   └── name: :baz
-        │   │                   └── operator_loc: (23,9)-(23,11) = "**"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (23,9)-(23,14))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocSplatNode (location: (23,9)-(23,14))
+        │   │   │               ├── value:
+        │   │   │               │   @ CallNode (location: (23,11)-(23,14))
+        │   │   │               │   ├── receiver: ∅
+        │   │   │               │   ├── call_operator_loc: ∅
+        │   │   │               │   ├── message_loc: (23,11)-(23,14) = "baz"
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── arguments: ∅
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   ├── block: ∅
+        │   │   │               │   ├── flags: variable_call
+        │   │   │               │   └── name: :baz
+        │   │   │               └── operator_loc: (23,9)-(23,11) = "**"
+        │   │   └── flags: keyword_splat
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1009,17 +1014,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (157,4)-(157,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (157,4)-(157,5))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (157,4)-(157,5) = "i"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :i
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (157,4)-(157,5))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (157,4)-(157,5) = "i"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :i
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1033,17 +1039,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (159,4)-(159,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (159,4)-(159,5))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (159,4)-(159,5) = "w"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :w
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (159,4)-(159,5))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (159,4)-(159,5) = "w"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :w
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1057,17 +1064,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (161,4)-(161,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (161,4)-(161,5))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (161,4)-(161,5) = "x"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :x
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (161,4)-(161,5))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (161,4)-(161,5) = "x"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :x
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1081,9 +1089,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (163,4)-(163,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ConstantReadNode (location: (163,4)-(163,5))
-        │   │           └── name: :I
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ConstantReadNode (location: (163,4)-(163,5))
+        │   │   │       └── name: :I
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1097,9 +1106,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (165,4)-(165,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ConstantReadNode (location: (165,4)-(165,5))
-        │   │           └── name: :W
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ConstantReadNode (location: (165,4)-(165,5))
+        │   │   │       └── name: :W
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/dash_heredocs.txt
+++ b/test/prism/snapshots/dash_heredocs.txt
@@ -22,13 +22,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,11)-(5,20))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (5,11)-(5,20))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (5,11)-(5,20) = "<<-SECOND"
-        │   │           ├── content_loc: (8,0)-(8,0) = "  b\n"
-        │   │           ├── closing_loc: (9,0)-(9,0) = "SECOND\n"
-        │   │           └── unescaped: "  b\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (5,11)-(5,20))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (5,11)-(5,20) = "<<-SECOND"
+        │   │   │       ├── content_loc: (8,0)-(8,0) = "  b\n"
+        │   │   │       ├── closing_loc: (9,0)-(9,0) = "SECOND\n"
+        │   │   │       └── unescaped: "  b\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -178,31 +179,32 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (49,7)-(49,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (49,7)-(49,11))
-        │   │           ├── opening_loc: (49,7)-(49,11) = "<<-B"
-        │   │           ├── parts: (length: 3)
-        │   │           │   ├── @ StringNode (location: (52,0)-(53,2))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (52,0)-(53,2) = "  b\n  "
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "  b\n  "
-        │   │           │   ├── @ EmbeddedStatementsNode (location: (53,2)-(54,3))
-        │   │           │   │   ├── opening_loc: (53,2)-(53,4) = "\#{"
-        │   │           │   │   ├── statements:
-        │   │           │   │   │   @ StatementsNode (location: (53,4)-(53,5))
-        │   │           │   │   │   └── body: (length: 1)
-        │   │           │   │   │       └── @ IntegerNode (location: (53,4)-(53,5))
-        │   │           │   │   │           └── flags: decimal
-        │   │           │   │   └── closing_loc: (54,2)-(54,3) = "}"
-        │   │           │   └── @ StringNode (location: (54,3)-(54,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (54,3)-(54,0) = "\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "\n"
-        │   │           └── closing_loc: (55,0)-(55,0) = "B\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (49,7)-(49,11))
+        │   │   │       ├── opening_loc: (49,7)-(49,11) = "<<-B"
+        │   │   │       ├── parts: (length: 3)
+        │   │   │       │   ├── @ StringNode (location: (52,0)-(53,2))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (52,0)-(53,2) = "  b\n  "
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "  b\n  "
+        │   │   │       │   ├── @ EmbeddedStatementsNode (location: (53,2)-(54,3))
+        │   │   │       │   │   ├── opening_loc: (53,2)-(53,4) = "\#{"
+        │   │   │       │   │   ├── statements:
+        │   │   │       │   │   │   @ StatementsNode (location: (53,4)-(53,5))
+        │   │   │       │   │   │   └── body: (length: 1)
+        │   │   │       │   │   │       └── @ IntegerNode (location: (53,4)-(53,5))
+        │   │   │       │   │   │           └── flags: decimal
+        │   │   │       │   │   └── closing_loc: (54,2)-(54,3) = "}"
+        │   │   │       │   └── @ StringNode (location: (54,3)-(54,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (54,3)-(54,0) = "\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "\n"
+        │   │   │       └── closing_loc: (55,0)-(55,0) = "B\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -220,31 +222,32 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (57,7)-(57,11))
-            │   └── arguments: (length: 1)
-            │       └── @ InterpolatedStringNode (location: (57,7)-(57,11))
-            │           ├── opening_loc: (57,7)-(57,11) = "<<-B"
-            │           ├── parts: (length: 3)
-            │           │   ├── @ StringNode (location: (60,0)-(61,2))
-            │           │   │   ├── flags: ∅
-            │           │   │   ├── opening_loc: ∅
-            │           │   │   ├── content_loc: (60,0)-(61,2) = "  b\n  "
-            │           │   │   ├── closing_loc: ∅
-            │           │   │   └── unescaped: "  b\n  "
-            │           │   ├── @ EmbeddedStatementsNode (location: (61,2)-(62,4))
-            │           │   │   ├── opening_loc: (61,2)-(61,4) = "\#{"
-            │           │   │   ├── statements:
-            │           │   │   │   @ StatementsNode (location: (62,2)-(62,3))
-            │           │   │   │   └── body: (length: 1)
-            │           │   │   │       └── @ IntegerNode (location: (62,2)-(62,3))
-            │           │   │   │           └── flags: decimal
-            │           │   │   └── closing_loc: (62,3)-(62,4) = "}"
-            │           │   └── @ StringNode (location: (62,4)-(62,0))
-            │           │       ├── flags: ∅
-            │           │       ├── opening_loc: ∅
-            │           │       ├── content_loc: (62,4)-(62,0) = "\n"
-            │           │       ├── closing_loc: ∅
-            │           │       └── unescaped: "\n"
-            │           └── closing_loc: (63,0)-(63,0) = "B\n"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ InterpolatedStringNode (location: (57,7)-(57,11))
+            │   │       ├── opening_loc: (57,7)-(57,11) = "<<-B"
+            │   │       ├── parts: (length: 3)
+            │   │       │   ├── @ StringNode (location: (60,0)-(61,2))
+            │   │       │   │   ├── flags: ∅
+            │   │       │   │   ├── opening_loc: ∅
+            │   │       │   │   ├── content_loc: (60,0)-(61,2) = "  b\n  "
+            │   │       │   │   ├── closing_loc: ∅
+            │   │       │   │   └── unescaped: "  b\n  "
+            │   │       │   ├── @ EmbeddedStatementsNode (location: (61,2)-(62,4))
+            │   │       │   │   ├── opening_loc: (61,2)-(61,4) = "\#{"
+            │   │       │   │   ├── statements:
+            │   │       │   │   │   @ StatementsNode (location: (62,2)-(62,3))
+            │   │       │   │   │   └── body: (length: 1)
+            │   │       │   │   │       └── @ IntegerNode (location: (62,2)-(62,3))
+            │   │       │   │   │           └── flags: decimal
+            │   │       │   │   └── closing_loc: (62,3)-(62,4) = "}"
+            │   │       │   └── @ StringNode (location: (62,4)-(62,0))
+            │   │       │       ├── flags: ∅
+            │   │       │       ├── opening_loc: ∅
+            │   │       │       ├── content_loc: (62,4)-(62,0) = "\n"
+            │   │       │       ├── closing_loc: ∅
+            │   │       │       └── unescaped: "\n"
+            │   │       └── closing_loc: (63,0)-(63,0) = "B\n"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/dos_endings.txt
+++ b/test/prism/snapshots/dos_endings.txt
@@ -10,22 +10,23 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,5)-(2,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringConcatNode (location: (1,5)-(2,12))
-        │   │           ├── left:
-        │   │           │   @ StringNode (location: (1,5)-(1,9))
-        │   │           │   ├── flags: ∅
-        │   │           │   ├── opening_loc: (1,5)-(1,6) = "\""
-        │   │           │   ├── content_loc: (1,6)-(1,8) = "hi"
-        │   │           │   ├── closing_loc: (1,8)-(1,9) = "\""
-        │   │           │   └── unescaped: "hi"
-        │   │           └── right:
-        │   │               @ StringNode (location: (2,5)-(2,12))
-        │   │               ├── flags: ∅
-        │   │               ├── opening_loc: (2,5)-(2,6) = "\""
-        │   │               ├── content_loc: (2,6)-(2,11) = "there"
-        │   │               ├── closing_loc: (2,11)-(2,12) = "\""
-        │   │               └── unescaped: "there"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringConcatNode (location: (1,5)-(2,12))
+        │   │   │       ├── left:
+        │   │   │       │   @ StringNode (location: (1,5)-(1,9))
+        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── opening_loc: (1,5)-(1,6) = "\""
+        │   │   │       │   ├── content_loc: (1,6)-(1,8) = "hi"
+        │   │   │       │   ├── closing_loc: (1,8)-(1,9) = "\""
+        │   │   │       │   └── unescaped: "hi"
+        │   │   │       └── right:
+        │   │   │           @ StringNode (location: (2,5)-(2,12))
+        │   │   │           ├── flags: ∅
+        │   │   │           ├── opening_loc: (2,5)-(2,6) = "\""
+        │   │   │           ├── content_loc: (2,6)-(2,11) = "there"
+        │   │   │           ├── closing_loc: (2,11)-(2,12) = "\""
+        │   │   │           └── unescaped: "there"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -69,33 +70,34 @@
             │   ├── opening_loc: (17,7)-(17,8) = "("
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (17,8)-(17,19))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ CallNode (location: (17,8)-(17,19))
-            │   │           ├── receiver:
-            │   │           │   @ InterpolatedStringNode (location: (17,8)-(17,14))
-            │   │           │   ├── opening_loc: (17,8)-(17,14) = "<<~EOF"
-            │   │           │   ├── parts: (length: 2)
-            │   │           │   │   ├── @ StringNode (location: (18,0)-(18,0))
-            │   │           │   │   │   ├── flags: ∅
-            │   │           │   │   │   ├── opening_loc: ∅
-            │   │           │   │   │   ├── content_loc: (18,0)-(18,0) = "\r\n"
-            │   │           │   │   │   ├── closing_loc: ∅
-            │   │           │   │   │   └── unescaped: "\n"
-            │   │           │   │   └── @ StringNode (location: (19,0)-(19,0))
-            │   │           │   │       ├── flags: ∅
-            │   │           │   │       ├── opening_loc: ∅
-            │   │           │   │       ├── content_loc: (19,0)-(19,0) = "    baz\r\n"
-            │   │           │   │       ├── closing_loc: ∅
-            │   │           │   │       └── unescaped: "baz\r\n"
-            │   │           │   └── closing_loc: (20,0)-(20,0) = "  EOF\r\n"
-            │   │           ├── call_operator_loc: (17,14)-(17,15) = "."
-            │   │           ├── message_loc: (17,15)-(17,19) = "chop"
-            │   │           ├── opening_loc: ∅
-            │   │           ├── arguments: ∅
-            │   │           ├── closing_loc: ∅
-            │   │           ├── block: ∅
-            │   │           ├── flags: ∅
-            │   │           └── name: :chop
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ CallNode (location: (17,8)-(17,19))
+            │   │   │       ├── receiver:
+            │   │   │       │   @ InterpolatedStringNode (location: (17,8)-(17,14))
+            │   │   │       │   ├── opening_loc: (17,8)-(17,14) = "<<~EOF"
+            │   │   │       │   ├── parts: (length: 2)
+            │   │   │       │   │   ├── @ StringNode (location: (18,0)-(18,0))
+            │   │   │       │   │   │   ├── flags: ∅
+            │   │   │       │   │   │   ├── opening_loc: ∅
+            │   │   │       │   │   │   ├── content_loc: (18,0)-(18,0) = "\r\n"
+            │   │   │       │   │   │   ├── closing_loc: ∅
+            │   │   │       │   │   │   └── unescaped: "\n"
+            │   │   │       │   │   └── @ StringNode (location: (19,0)-(19,0))
+            │   │   │       │   │       ├── flags: ∅
+            │   │   │       │   │       ├── opening_loc: ∅
+            │   │   │       │   │       ├── content_loc: (19,0)-(19,0) = "    baz\r\n"
+            │   │   │       │   │       ├── closing_loc: ∅
+            │   │   │       │   │       └── unescaped: "baz\r\n"
+            │   │   │       │   └── closing_loc: (20,0)-(20,0) = "  EOF\r\n"
+            │   │   │       ├── call_operator_loc: (17,14)-(17,15) = "."
+            │   │   │       ├── message_loc: (17,15)-(17,19) = "chop"
+            │   │   │       ├── opening_loc: ∅
+            │   │   │       ├── arguments: ∅
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       ├── block: ∅
+            │   │   │       ├── flags: ∅
+            │   │   │       └── name: :chop
+            │   │   └── flags: ∅
             │   ├── closing_loc: (17,19)-(17,20) = ")"
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/endless_methods.txt
+++ b/test/prism/snapshots/endless_methods.txt
@@ -35,13 +35,14 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (3,12)-(3,14))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ StringNode (location: (3,12)-(3,14))
-        │   │           │           ├── flags: ∅
-        │   │           │           ├── opening_loc: (3,12)-(3,13) = "\""
-        │   │           │           ├── content_loc: (3,13)-(3,13) = ""
-        │   │           │           ├── closing_loc: (3,13)-(3,14) = "\""
-        │   │           │           └── unescaped: ""
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ StringNode (location: (3,12)-(3,14))
+        │   │           │   │       ├── flags: ∅
+        │   │           │   │       ├── opening_loc: (3,12)-(3,13) = "\""
+        │   │           │   │       ├── content_loc: (3,13)-(3,13) = ""
+        │   │           │   │       ├── closing_loc: (3,13)-(3,14) = "\""
+        │   │           │   │       └── unescaped: ""
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -72,9 +73,10 @@
             │           │   ├── opening_loc: ∅
             │           │   ├── arguments:
             │           │   │   @ ArgumentsNode (location: (5,17)-(5,18))
-            │           │   │   └── arguments: (length: 1)
-            │           │   │       └── @ IntegerNode (location: (5,17)-(5,18))
-            │           │   │           └── flags: decimal
+            │           │   │   ├── arguments: (length: 1)
+            │           │   │   │   └── @ IntegerNode (location: (5,17)-(5,18))
+            │           │   │   │       └── flags: decimal
+            │           │   │   └── flags: ∅
             │           │   ├── closing_loc: ∅
             │           │   ├── block: ∅
             │           │   ├── flags: ∅
@@ -84,9 +86,10 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (5,21)-(5,22))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ IntegerNode (location: (5,21)-(5,22))
-            │           │           └── flags: decimal
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ IntegerNode (location: (5,21)-(5,22))
+            │           │   │       └── flags: decimal
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/heredoc_with_escaped_newline_at_start.txt
+++ b/test/prism/snapshots/heredoc_with_escaped_newline_at_start.txt
@@ -16,19 +16,20 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,15)-(1,25))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ RegularExpressionNode (location: (1,15)-(1,21))
-        │   │       │   ├── opening_loc: (1,15)-(1,16) = "/"
-        │   │       │   ├── content_loc: (1,16)-(1,20) = "^\\s{"
-        │   │       │   ├── closing_loc: (1,20)-(1,21) = "/"
-        │   │       │   ├── unescaped: "^\\s{"
-        │   │       │   └── flags: ∅
-        │   │       └── @ StringNode (location: (1,23)-(1,25))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (1,23)-(1,24) = "'"
-        │   │           ├── content_loc: (1,24)-(1,24) = ""
-        │   │           ├── closing_loc: (1,24)-(1,25) = "'"
-        │   │           └── unescaped: ""
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ RegularExpressionNode (location: (1,15)-(1,21))
+        │   │   │   │   ├── opening_loc: (1,15)-(1,16) = "/"
+        │   │   │   │   ├── content_loc: (1,16)-(1,20) = "^\\s{"
+        │   │   │   │   ├── closing_loc: (1,20)-(1,21) = "/"
+        │   │   │   │   ├── unescaped: "^\\s{"
+        │   │   │   │   └── flags: ∅
+        │   │   │   └── @ StringNode (location: (1,23)-(1,25))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (1,23)-(1,24) = "'"
+        │   │   │       ├── content_loc: (1,24)-(1,24) = ""
+        │   │   │       ├── closing_loc: (1,24)-(1,25) = "'"
+        │   │   │       └── unescaped: ""
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -46,19 +47,20 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (5,15)-(5,25))
-            │   └── arguments: (length: 2)
-            │       ├── @ RegularExpressionNode (location: (5,15)-(5,21))
-            │       │   ├── opening_loc: (5,15)-(5,16) = "/"
-            │       │   ├── content_loc: (5,16)-(5,20) = "^\\s{"
-            │       │   ├── closing_loc: (5,20)-(5,21) = "/"
-            │       │   ├── unescaped: "^\\s{"
-            │       │   └── flags: ∅
-            │       └── @ StringNode (location: (5,23)-(5,25))
-            │           ├── flags: ∅
-            │           ├── opening_loc: (5,23)-(5,24) = "'"
-            │           ├── content_loc: (5,24)-(5,24) = ""
-            │           ├── closing_loc: (5,24)-(5,25) = "'"
-            │           └── unescaped: ""
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ RegularExpressionNode (location: (5,15)-(5,21))
+            │   │   │   ├── opening_loc: (5,15)-(5,16) = "/"
+            │   │   │   ├── content_loc: (5,16)-(5,20) = "^\\s{"
+            │   │   │   ├── closing_loc: (5,20)-(5,21) = "/"
+            │   │   │   ├── unescaped: "^\\s{"
+            │   │   │   └── flags: ∅
+            │   │   └── @ StringNode (location: (5,23)-(5,25))
+            │   │       ├── flags: ∅
+            │   │       ├── opening_loc: (5,23)-(5,24) = "'"
+            │   │       ├── content_loc: (5,24)-(5,24) = ""
+            │   │       ├── closing_loc: (5,24)-(5,25) = "'"
+            │   │       └── unescaped: ""
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/if.txt
+++ b/test/prism/snapshots/if.txt
@@ -136,9 +136,10 @@
         │   │       └── @ BreakNode (location: (16,18)-(16,26))
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (16,24)-(16,26))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (16,24)-(16,26))
-        │   │           │           └── flags: decimal
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ IntegerNode (location: (16,24)-(16,26))
+        │   │           │   │       └── flags: decimal
+        │   │           │   └── flags: ∅
         │   │           └── keyword_loc: (16,18)-(16,23) = "break"
         │   ├── consequent: ∅
         │   └── end_keyword_loc: (16,27)-(16,30) = "end"
@@ -230,30 +231,31 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (25,4)-(25,6))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ KeywordHashNode (location: (25,4)-(25,6))
-        │   │           │           └── elements: (length: 1)
-        │   │           │               └── @ AssocNode (location: (25,4)-(25,6))
-        │   │           │                   ├── key:
-        │   │           │                   │   @ SymbolNode (location: (25,4)-(25,6))
-        │   │           │                   │   ├── opening_loc: ∅
-        │   │           │                   │   ├── value_loc: (25,4)-(25,5) = "b"
-        │   │           │                   │   ├── closing_loc: (25,5)-(25,6) = ":"
-        │   │           │                   │   └── unescaped: "b"
-        │   │           │                   ├── value:
-        │   │           │                   │   @ ImplicitNode (location: (25,4)-(25,6))
-        │   │           │                   │   └── value:
-        │   │           │                   │       @ CallNode (location: (25,4)-(25,6))
-        │   │           │                   │       ├── receiver: ∅
-        │   │           │                   │       ├── call_operator_loc: ∅
-        │   │           │                   │       ├── message_loc: (25,4)-(25,5) = "b"
-        │   │           │                   │       ├── opening_loc: ∅
-        │   │           │                   │       ├── arguments: ∅
-        │   │           │                   │       ├── closing_loc: ∅
-        │   │           │                   │       ├── block: ∅
-        │   │           │                   │       ├── flags: ∅
-        │   │           │                   │       └── name: :b
-        │   │           │                   └── operator_loc: ∅
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ KeywordHashNode (location: (25,4)-(25,6))
+        │   │           │   │       └── elements: (length: 1)
+        │   │           │   │           └── @ AssocNode (location: (25,4)-(25,6))
+        │   │           │   │               ├── key:
+        │   │           │   │               │   @ SymbolNode (location: (25,4)-(25,6))
+        │   │           │   │               │   ├── opening_loc: ∅
+        │   │           │   │               │   ├── value_loc: (25,4)-(25,5) = "b"
+        │   │           │   │               │   ├── closing_loc: (25,5)-(25,6) = ":"
+        │   │           │   │               │   └── unescaped: "b"
+        │   │           │   │               ├── value:
+        │   │           │   │               │   @ ImplicitNode (location: (25,4)-(25,6))
+        │   │           │   │               │   └── value:
+        │   │           │   │               │       @ CallNode (location: (25,4)-(25,6))
+        │   │           │   │               │       ├── receiver: ∅
+        │   │           │   │               │       ├── call_operator_loc: ∅
+        │   │           │   │               │       ├── message_loc: (25,4)-(25,5) = "b"
+        │   │           │   │               │       ├── opening_loc: ∅
+        │   │           │   │               │       ├── arguments: ∅
+        │   │           │   │               │       ├── closing_loc: ∅
+        │   │           │   │               │       ├── block: ∅
+        │   │           │   │               │       ├── flags: ∅
+        │   │           │   │               │       └── name: :b
+        │   │           │   │               └── operator_loc: ∅
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅

--- a/test/prism/snapshots/integer_operations.txt
+++ b/test/prism/snapshots/integer_operations.txt
@@ -36,9 +36,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,5)-(5,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (5,5)-(5,6))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (5,5)-(5,6))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -52,9 +53,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,5)-(7,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (7,5)-(7,6))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (7,5)-(7,6))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -68,9 +70,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (9,4)-(9,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (9,4)-(9,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (9,4)-(9,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -84,9 +87,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (11,4)-(11,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (11,4)-(11,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (11,4)-(11,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -100,9 +104,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (13,4)-(13,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (13,4)-(13,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (13,4)-(13,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -116,9 +121,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (15,3)-(15,4))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (15,3)-(15,4))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (15,3)-(15,4))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -132,9 +138,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (17,4)-(17,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (17,4)-(17,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (17,4)-(17,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -148,9 +155,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (19,4)-(19,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (19,4)-(19,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (19,4)-(19,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -164,9 +172,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (21,4)-(21,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (21,4)-(21,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (21,4)-(21,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -182,9 +191,10 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (23,2)-(23,3))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ IntegerNode (location: (23,2)-(23,3))
-        │   │   │           └── flags: decimal
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ IntegerNode (location: (23,2)-(23,3))
+        │   │   │   │       └── flags: decimal
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block: ∅
         │   │   ├── flags: ∅
@@ -194,9 +204,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (23,4)-(23,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (23,4)-(23,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (23,4)-(23,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -210,9 +221,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (25,4)-(25,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (25,4)-(25,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (25,4)-(25,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -226,9 +238,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (27,5)-(27,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (27,5)-(27,6))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (27,5)-(27,6))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -242,9 +255,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (29,5)-(29,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (29,5)-(29,6))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (29,5)-(29,6))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -258,9 +272,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (31,6)-(31,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (31,6)-(31,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (31,6)-(31,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -274,9 +289,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (33,5)-(33,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (33,5)-(33,6))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (33,5)-(33,6))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -290,9 +306,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (35,6)-(35,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (35,6)-(35,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (35,6)-(35,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -306,9 +323,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (37,5)-(37,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (37,5)-(37,6))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (37,5)-(37,6))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -322,9 +340,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (39,4)-(39,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (39,4)-(39,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (39,4)-(39,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -338,9 +357,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (41,5)-(41,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (41,5)-(41,6))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (41,5)-(41,6))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -354,9 +374,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (43,5)-(43,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (43,5)-(43,6))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (43,5)-(43,6))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -370,9 +391,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (45,4)-(45,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (45,4)-(45,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (45,4)-(45,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -386,9 +408,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (47,4)-(47,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (47,4)-(47,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (47,4)-(47,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -418,23 +441,25 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (53,4)-(53,10))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (53,4)-(53,10))
-        │   │           ├── receiver:
-        │   │           │   @ IntegerNode (location: (53,4)-(53,5))
-        │   │           │   └── flags: decimal
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (53,6)-(53,8) = "**"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (53,9)-(53,10))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (53,9)-(53,10))
-        │   │           │           └── flags: decimal
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :**
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (53,4)-(53,10))
+        │   │   │       ├── receiver:
+        │   │   │       │   @ IntegerNode (location: (53,4)-(53,5))
+        │   │   │       │   └── flags: decimal
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (53,6)-(53,8) = "**"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments:
+        │   │   │       │   @ ArgumentsNode (location: (53,9)-(53,10))
+        │   │   │       │   ├── arguments: (length: 1)
+        │   │   │       │   │   └── @ IntegerNode (location: (53,9)-(53,10))
+        │   │   │       │   │       └── flags: decimal
+        │   │   │       │   └── flags: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :**
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -450,9 +475,10 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (55,4)-(55,5))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ IntegerNode (location: (55,4)-(55,5))
-        │   │   │           └── flags: decimal
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ IntegerNode (location: (55,4)-(55,5))
+        │   │   │   │       └── flags: decimal
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block: ∅
         │   │   ├── flags: ∅
@@ -462,9 +488,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (55,8)-(55,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (55,8)-(55,9))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (55,8)-(55,9))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -494,23 +521,25 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (61,4)-(61,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (61,4)-(61,9))
-        │   │           ├── receiver:
-        │   │           │   @ IntegerNode (location: (61,4)-(61,5))
-        │   │           │   └── flags: decimal
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (61,6)-(61,7) = "*"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (61,8)-(61,9))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (61,8)-(61,9))
-        │   │           │           └── flags: decimal
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :*
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (61,4)-(61,9))
+        │   │   │       ├── receiver:
+        │   │   │       │   @ IntegerNode (location: (61,4)-(61,5))
+        │   │   │       │   └── flags: decimal
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (61,6)-(61,7) = "*"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments:
+        │   │   │       │   @ ArgumentsNode (location: (61,8)-(61,9))
+        │   │   │       │   ├── arguments: (length: 1)
+        │   │   │       │   │   └── @ IntegerNode (location: (61,8)-(61,9))
+        │   │   │       │   │       └── flags: decimal
+        │   │   │       │   └── flags: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :*
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -528,9 +557,10 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (63,5)-(63,6))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ IntegerNode (location: (63,5)-(63,6))
-            │           │           └── flags: decimal
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ IntegerNode (location: (63,5)-(63,6))
+            │           │   │       └── flags: decimal
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/keyword_method_names.txt
+++ b/test/prism/snapshots/keyword_method_names.txt
@@ -37,38 +37,39 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,8)-(10,3))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ DefNode (location: (7,8)-(10,3))
-        │   │           ├── name: :foo
-        │   │           ├── name_loc: (7,12)-(7,15) = "foo"
-        │   │           ├── receiver: ∅
-        │   │           ├── parameters: ∅
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (8,2)-(9,5))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (8,2)-(9,5))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (8,2)-(8,5) = "bar"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block:
-        │   │           │           │   @ BlockNode (location: (8,6)-(9,5))
-        │   │           │           │   ├── locals: []
-        │   │           │           │   ├── parameters: ∅
-        │   │           │           │   ├── body: ∅
-        │   │           │           │   ├── opening_loc: (8,6)-(8,8) = "do"
-        │   │           │           │   └── closing_loc: (9,2)-(9,5) = "end"
-        │   │           │           ├── flags: ∅
-        │   │           │           └── name: :bar
-        │   │           ├── locals: []
-        │   │           ├── def_keyword_loc: (7,8)-(7,11) = "def"
-        │   │           ├── operator_loc: ∅
-        │   │           ├── lparen_loc: ∅
-        │   │           ├── rparen_loc: ∅
-        │   │           ├── equal_loc: ∅
-        │   │           └── end_keyword_loc: (10,0)-(10,3) = "end"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ DefNode (location: (7,8)-(10,3))
+        │   │   │       ├── name: :foo
+        │   │   │       ├── name_loc: (7,12)-(7,15) = "foo"
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── parameters: ∅
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (8,2)-(9,5))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (8,2)-(9,5))
+        │   │   │       │           ├── receiver: ∅
+        │   │   │       │           ├── call_operator_loc: ∅
+        │   │   │       │           ├── message_loc: (8,2)-(8,5) = "bar"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block:
+        │   │   │       │           │   @ BlockNode (location: (8,6)-(9,5))
+        │   │   │       │           │   ├── locals: []
+        │   │   │       │           │   ├── parameters: ∅
+        │   │   │       │           │   ├── body: ∅
+        │   │   │       │           │   ├── opening_loc: (8,6)-(8,8) = "do"
+        │   │   │       │           │   └── closing_loc: (9,2)-(9,5) = "end"
+        │   │   │       │           ├── flags: ∅
+        │   │   │       │           └── name: :bar
+        │   │   │       ├── locals: []
+        │   │   │       ├── def_keyword_loc: (7,8)-(7,11) = "def"
+        │   │   │       ├── operator_loc: ∅
+        │   │   │       ├── lparen_loc: ∅
+        │   │   │       ├── rparen_loc: ∅
+        │   │   │       ├── equal_loc: ∅
+        │   │   │       └── end_keyword_loc: (10,0)-(10,3) = "end"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/lambda.txt
+++ b/test/prism/snapshots/lambda.txt
@@ -110,9 +110,10 @@
         │   │   │   │           ├── opening_loc: ∅
         │   │   │   │           ├── arguments:
         │   │   │   │           │   @ ArgumentsNode (location: (7,10)-(7,11))
-        │   │   │   │           │   └── arguments: (length: 1)
-        │   │   │   │           │       └── @ IntegerNode (location: (7,10)-(7,11))
-        │   │   │   │           │           └── flags: decimal
+        │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │           │   │   └── @ IntegerNode (location: (7,10)-(7,11))
+        │   │   │   │           │   │       └── flags: decimal
+        │   │   │   │           │   └── flags: ∅
         │   │   │   │           ├── closing_loc: ∅
         │   │   │   │           ├── block: ∅
         │   │   │   │           ├── flags: ∅

--- a/test/prism/snapshots/method_calls.txt
+++ b/test/prism/snapshots/method_calls.txt
@@ -20,13 +20,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,8)-(1,14))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (1,8)-(1,14))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (1,8)-(1,10) = "%{"
-        │   │           ├── content_loc: (1,10)-(1,13) = "baz"
-        │   │           ├── closing_loc: (1,13)-(1,14) = "}"
-        │   │           └── unescaped: "baz"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (1,8)-(1,14))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (1,8)-(1,10) = "%{"
+        │   │   │       ├── content_loc: (1,10)-(1,13) = "baz"
+        │   │   │       ├── closing_loc: (1,13)-(1,14) = "}"
+        │   │   │       └── unescaped: "baz"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -48,27 +49,28 @@
         │   ├── opening_loc: (3,3)-(3,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,4)-(3,8))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (3,4)-(3,5))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (3,4)-(3,5) = "c"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :c
-        │   │       └── @ CallNode (location: (3,7)-(3,8))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (3,7)-(3,8) = "d"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :d
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (3,4)-(3,5))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (3,4)-(3,5) = "c"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :c
+        │   │   │   └── @ CallNode (location: (3,7)-(3,8))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (3,7)-(3,8) = "d"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :d
+        │   │   └── flags: ∅
         │   ├── closing_loc: (3,8)-(3,9) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -170,13 +172,14 @@
         │   ├── opening_loc: (15,2)-(15,3) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (15,3)-(15,10))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ IntegerNode (location: (15,3)-(15,4))
-        │   │       │   └── flags: decimal
-        │   │       ├── @ IntegerNode (location: (15,6)-(15,7))
-        │   │       │   └── flags: decimal
-        │   │       └── @ IntegerNode (location: (15,9)-(15,10))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ IntegerNode (location: (15,3)-(15,4))
+        │   │   │   │   └── flags: decimal
+        │   │   │   ├── @ IntegerNode (location: (15,6)-(15,7))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ IntegerNode (location: (15,9)-(15,10))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (15,10)-(15,11) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -218,17 +221,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (19,5)-(19,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (19,5)-(19,6))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (19,5)-(19,6) = "c"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :c
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (19,5)-(19,6))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (19,5)-(19,6) = "c"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :c
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -250,9 +254,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (21,10)-(21,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (21,10)-(21,11))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (21,10)-(21,11))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -297,22 +302,23 @@
         │   ├── opening_loc: (27,1)-(27,2) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (27,2)-(27,10))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (27,2)-(27,10))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocSplatNode (location: (27,2)-(27,10))
-        │   │                   ├── value:
-        │   │                   │   @ CallNode (location: (27,4)-(27,10))
-        │   │                   │   ├── receiver: ∅
-        │   │                   │   ├── call_operator_loc: ∅
-        │   │                   │   ├── message_loc: (27,4)-(27,10) = "kwargs"
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── arguments: ∅
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   ├── block: ∅
-        │   │                   │   ├── flags: variable_call
-        │   │                   │   └── name: :kwargs
-        │   │                   └── operator_loc: (27,2)-(27,4) = "**"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (27,2)-(27,10))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocSplatNode (location: (27,2)-(27,10))
+        │   │   │               ├── value:
+        │   │   │               │   @ CallNode (location: (27,4)-(27,10))
+        │   │   │               │   ├── receiver: ∅
+        │   │   │               │   ├── call_operator_loc: ∅
+        │   │   │               │   ├── message_loc: (27,4)-(27,10) = "kwargs"
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── arguments: ∅
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   ├── block: ∅
+        │   │   │               │   ├── flags: variable_call
+        │   │   │               │   └── name: :kwargs
+        │   │   │               └── operator_loc: (27,2)-(27,4) = "**"
+        │   │   └── flags: keyword_splat
         │   ├── closing_loc: (27,10)-(27,11) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -354,27 +360,28 @@
         │   ├── opening_loc: (31,1)-(31,2) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (31,2)-(31,6))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (31,2)-(31,3))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (31,2)-(31,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :b
-        │   │       └── @ CallNode (location: (31,5)-(31,6))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (31,5)-(31,6) = "c"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :c
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (31,2)-(31,3))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (31,2)-(31,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ CallNode (location: (31,5)-(31,6))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (31,5)-(31,6) = "c"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :c
+        │   │   └── flags: ∅
         │   ├── closing_loc: (31,6)-(31,7) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -396,20 +403,21 @@
         │   ├── opening_loc: (35,1)-(35,2) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (35,2)-(35,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SplatNode (location: (35,2)-(35,7))
-        │   │           ├── operator_loc: (35,2)-(35,3) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (35,3)-(35,7))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (35,3)-(35,7) = "args"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :args
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SplatNode (location: (35,2)-(35,7))
+        │   │   │       ├── operator_loc: (35,2)-(35,3) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (35,3)-(35,7))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (35,3)-(35,7) = "args"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :args
+        │   │   └── flags: ∅
         │   ├── closing_loc: (35,7)-(35,8) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -421,27 +429,28 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (37,2)-(37,6))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (37,2)-(37,3))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (37,2)-(37,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :b
-        │   │       └── @ CallNode (location: (37,5)-(37,6))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (37,5)-(37,6) = "c"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :c
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (37,2)-(37,3))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (37,2)-(37,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ CallNode (location: (37,5)-(37,6))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (37,5)-(37,6) = "c"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :c
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -463,27 +472,28 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (39,4)-(39,8))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (39,4)-(39,5))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (39,4)-(39,5) = "c"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :c
-        │   │       └── @ CallNode (location: (39,7)-(39,8))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (39,7)-(39,8) = "d"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :d
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (39,4)-(39,5))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (39,4)-(39,5) = "c"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :c
+        │   │   │   └── @ CallNode (location: (39,7)-(39,8))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (39,7)-(39,8) = "d"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :d
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -599,17 +609,18 @@
         │   ├── opening_loc: (47,4)-(47,5) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (47,5)-(47,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (47,5)-(47,6))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (47,5)-(47,6) = "c"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :c
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (47,5)-(47,6))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (47,5)-(47,6) = "c"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :c
+        │   │   └── flags: ∅
         │   ├── closing_loc: (47,6)-(47,7) = ")"
         │   ├── block: ∅
         │   ├── flags: safe_navigation
@@ -685,17 +696,18 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (51,4)-(51,10))
-        │   │           │   └── arguments: (length: 2)
-        │   │           │       ├── @ SymbolNode (location: (51,4)-(51,6))
-        │   │           │       │   ├── opening_loc: (51,4)-(51,5) = ":"
-        │   │           │       │   ├── value_loc: (51,5)-(51,6) = "a"
-        │   │           │       │   ├── closing_loc: ∅
-        │   │           │       │   └── unescaped: "a"
-        │   │           │       └── @ SymbolNode (location: (51,8)-(51,10))
-        │   │           │           ├── opening_loc: (51,8)-(51,9) = ":"
-        │   │           │           ├── value_loc: (51,9)-(51,10) = "b"
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           └── unescaped: "b"
+        │   │           │   ├── arguments: (length: 2)
+        │   │           │   │   ├── @ SymbolNode (location: (51,4)-(51,6))
+        │   │           │   │   │   ├── opening_loc: (51,4)-(51,5) = ":"
+        │   │           │   │   │   ├── value_loc: (51,5)-(51,6) = "a"
+        │   │           │   │   │   ├── closing_loc: ∅
+        │   │           │   │   │   └── unescaped: "a"
+        │   │           │   │   └── @ SymbolNode (location: (51,8)-(51,10))
+        │   │           │   │       ├── opening_loc: (51,8)-(51,9) = ":"
+        │   │           │   │       ├── value_loc: (51,9)-(51,10) = "b"
+        │   │           │   │       ├── closing_loc: ∅
+        │   │           │   │       └── unescaped: "b"
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -709,17 +721,18 @@
         │   ├── opening_loc: (53,3)-(53,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (53,4)-(55,4))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SymbolNode (location: (53,4)-(53,6))
-        │   │       │   ├── opening_loc: (53,4)-(53,5) = ":"
-        │   │       │   ├── value_loc: (53,5)-(53,6) = "a"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "a"
-        │   │       └── @ SymbolNode (location: (55,2)-(55,4))
-        │   │           ├── opening_loc: (55,2)-(55,3) = ":"
-        │   │           ├── value_loc: (55,3)-(55,4) = "b"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "b"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SymbolNode (location: (53,4)-(53,6))
+        │   │   │   │   ├── opening_loc: (53,4)-(53,5) = ":"
+        │   │   │   │   ├── value_loc: (53,5)-(53,6) = "a"
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── unescaped: "a"
+        │   │   │   └── @ SymbolNode (location: (55,2)-(55,4))
+        │   │   │       ├── opening_loc: (55,2)-(55,3) = ":"
+        │   │   │       ├── value_loc: (55,3)-(55,4) = "b"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "b"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (56,0)-(56,1) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -731,20 +744,21 @@
         │   ├── opening_loc: (58,3)-(58,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (58,4)-(58,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SplatNode (location: (58,4)-(58,9))
-        │   │           ├── operator_loc: (58,4)-(58,5) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (58,5)-(58,9))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (58,5)-(58,9) = "rest"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :rest
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SplatNode (location: (58,4)-(58,9))
+        │   │   │       ├── operator_loc: (58,4)-(58,5) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (58,5)-(58,9))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (58,5)-(58,9) = "rest"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :rest
+        │   │   └── flags: ∅
         │   ├── closing_loc: (58,9)-(58,10) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -756,51 +770,52 @@
         │   ├── opening_loc: (60,3)-(60,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (60,4)-(60,32))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SymbolNode (location: (60,4)-(60,6))
-        │   │       │   ├── opening_loc: (60,4)-(60,5) = ":"
-        │   │       │   ├── value_loc: (60,5)-(60,6) = "a"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "a"
-        │   │       └── @ KeywordHashNode (location: (60,8)-(60,32))
-        │   │           └── elements: (length: 2)
-        │   │               ├── @ AssocNode (location: (60,8)-(60,22))
-        │   │               │   ├── key:
-        │   │               │   │   @ SymbolNode (location: (60,8)-(60,10))
-        │   │               │   │   ├── opening_loc: (60,8)-(60,9) = ":"
-        │   │               │   │   ├── value_loc: (60,9)-(60,10) = "h"
-        │   │               │   │   ├── closing_loc: ∅
-        │   │               │   │   └── unescaped: "h"
-        │   │               │   ├── value:
-        │   │               │   │   @ ArrayNode (location: (60,14)-(60,22))
-        │   │               │   │   ├── elements: (length: 2)
-        │   │               │   │   │   ├── @ SymbolNode (location: (60,15)-(60,17))
-        │   │               │   │   │   │   ├── opening_loc: (60,15)-(60,16) = ":"
-        │   │               │   │   │   │   ├── value_loc: (60,16)-(60,17) = "x"
-        │   │               │   │   │   │   ├── closing_loc: ∅
-        │   │               │   │   │   │   └── unescaped: "x"
-        │   │               │   │   │   └── @ SymbolNode (location: (60,19)-(60,21))
-        │   │               │   │   │       ├── opening_loc: (60,19)-(60,20) = ":"
-        │   │               │   │   │       ├── value_loc: (60,20)-(60,21) = "y"
-        │   │               │   │   │       ├── closing_loc: ∅
-        │   │               │   │   │       └── unescaped: "y"
-        │   │               │   │   ├── opening_loc: (60,14)-(60,15) = "["
-        │   │               │   │   └── closing_loc: (60,21)-(60,22) = "]"
-        │   │               │   └── operator_loc: (60,11)-(60,13) = "=>"
-        │   │               └── @ AssocNode (location: (60,24)-(60,32))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (60,24)-(60,26))
-        │   │                   │   ├── opening_loc: (60,24)-(60,25) = ":"
-        │   │                   │   ├── value_loc: (60,25)-(60,26) = "a"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "a"
-        │   │                   ├── value:
-        │   │                   │   @ SymbolNode (location: (60,30)-(60,32))
-        │   │                   │   ├── opening_loc: (60,30)-(60,31) = ":"
-        │   │                   │   ├── value_loc: (60,31)-(60,32) = "b"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "b"
-        │   │                   └── operator_loc: (60,27)-(60,29) = "=>"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SymbolNode (location: (60,4)-(60,6))
+        │   │   │   │   ├── opening_loc: (60,4)-(60,5) = ":"
+        │   │   │   │   ├── value_loc: (60,5)-(60,6) = "a"
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── unescaped: "a"
+        │   │   │   └── @ KeywordHashNode (location: (60,8)-(60,32))
+        │   │   │       └── elements: (length: 2)
+        │   │   │           ├── @ AssocNode (location: (60,8)-(60,22))
+        │   │   │           │   ├── key:
+        │   │   │           │   │   @ SymbolNode (location: (60,8)-(60,10))
+        │   │   │           │   │   ├── opening_loc: (60,8)-(60,9) = ":"
+        │   │   │           │   │   ├── value_loc: (60,9)-(60,10) = "h"
+        │   │   │           │   │   ├── closing_loc: ∅
+        │   │   │           │   │   └── unescaped: "h"
+        │   │   │           │   ├── value:
+        │   │   │           │   │   @ ArrayNode (location: (60,14)-(60,22))
+        │   │   │           │   │   ├── elements: (length: 2)
+        │   │   │           │   │   │   ├── @ SymbolNode (location: (60,15)-(60,17))
+        │   │   │           │   │   │   │   ├── opening_loc: (60,15)-(60,16) = ":"
+        │   │   │           │   │   │   │   ├── value_loc: (60,16)-(60,17) = "x"
+        │   │   │           │   │   │   │   ├── closing_loc: ∅
+        │   │   │           │   │   │   │   └── unescaped: "x"
+        │   │   │           │   │   │   └── @ SymbolNode (location: (60,19)-(60,21))
+        │   │   │           │   │   │       ├── opening_loc: (60,19)-(60,20) = ":"
+        │   │   │           │   │   │       ├── value_loc: (60,20)-(60,21) = "y"
+        │   │   │           │   │   │       ├── closing_loc: ∅
+        │   │   │           │   │   │       └── unescaped: "y"
+        │   │   │           │   │   ├── opening_loc: (60,14)-(60,15) = "["
+        │   │   │           │   │   └── closing_loc: (60,21)-(60,22) = "]"
+        │   │   │           │   └── operator_loc: (60,11)-(60,13) = "=>"
+        │   │   │           └── @ AssocNode (location: (60,24)-(60,32))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (60,24)-(60,26))
+        │   │   │               │   ├── opening_loc: (60,24)-(60,25) = ":"
+        │   │   │               │   ├── value_loc: (60,25)-(60,26) = "a"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "a"
+        │   │   │               ├── value:
+        │   │   │               │   @ SymbolNode (location: (60,30)-(60,32))
+        │   │   │               │   ├── opening_loc: (60,30)-(60,31) = ":"
+        │   │   │               │   ├── value_loc: (60,31)-(60,32) = "b"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "b"
+        │   │   │               └── operator_loc: (60,27)-(60,29) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (60,39)-(60,40) = ")"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (60,34)-(60,39))
@@ -820,48 +835,49 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (62,3)-(62,49))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ IntegerNode (location: (62,3)-(62,6))
-        │   │       │   └── flags: decimal
-        │   │       └── @ HashNode (location: (62,8)-(62,49))
-        │   │           ├── opening_loc: (62,8)-(62,9) = "{"
-        │   │           ├── elements: (length: 3)
-        │   │           │   ├── @ AssocNode (location: (62,10)-(62,27))
-        │   │           │   │   ├── key:
-        │   │           │   │   │   @ SymbolNode (location: (62,10)-(62,16))
-        │   │           │   │   │   ├── opening_loc: (62,10)-(62,11) = ":"
-        │   │           │   │   │   ├── value_loc: (62,11)-(62,16) = "there"
-        │   │           │   │   │   ├── closing_loc: ∅
-        │   │           │   │   │   └── unescaped: "there"
-        │   │           │   │   ├── value:
-        │   │           │   │   │   @ SymbolNode (location: (62,20)-(62,27))
-        │   │           │   │   │   ├── opening_loc: (62,20)-(62,21) = ":"
-        │   │           │   │   │   ├── value_loc: (62,21)-(62,27) = "friend"
-        │   │           │   │   │   ├── closing_loc: ∅
-        │   │           │   │   │   └── unescaped: "friend"
-        │   │           │   │   └── operator_loc: (62,17)-(62,19) = "=>"
-        │   │           │   ├── @ AssocSplatNode (location: (62,29)-(62,33))
-        │   │           │   │   ├── value:
-        │   │           │   │   │   @ HashNode (location: (62,31)-(62,33))
-        │   │           │   │   │   ├── opening_loc: (62,31)-(62,32) = "{"
-        │   │           │   │   │   ├── elements: (length: 0)
-        │   │           │   │   │   └── closing_loc: (62,32)-(62,33) = "}"
-        │   │           │   │   └── operator_loc: (62,29)-(62,31) = "**"
-        │   │           │   └── @ AssocNode (location: (62,35)-(62,47))
-        │   │           │       ├── key:
-        │   │           │       │   @ SymbolNode (location: (62,35)-(62,42))
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── value_loc: (62,35)-(62,41) = "whatup"
-        │   │           │       │   ├── closing_loc: (62,41)-(62,42) = ":"
-        │   │           │       │   └── unescaped: "whatup"
-        │   │           │       ├── value:
-        │   │           │       │   @ SymbolNode (location: (62,43)-(62,47))
-        │   │           │       │   ├── opening_loc: (62,43)-(62,44) = ":"
-        │   │           │       │   ├── value_loc: (62,44)-(62,47) = "dog"
-        │   │           │       │   ├── closing_loc: ∅
-        │   │           │       │   └── unescaped: "dog"
-        │   │           │       └── operator_loc: ∅
-        │   │           └── closing_loc: (62,48)-(62,49) = "}"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ IntegerNode (location: (62,3)-(62,6))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ HashNode (location: (62,8)-(62,49))
+        │   │   │       ├── opening_loc: (62,8)-(62,9) = "{"
+        │   │   │       ├── elements: (length: 3)
+        │   │   │       │   ├── @ AssocNode (location: (62,10)-(62,27))
+        │   │   │       │   │   ├── key:
+        │   │   │       │   │   │   @ SymbolNode (location: (62,10)-(62,16))
+        │   │   │       │   │   │   ├── opening_loc: (62,10)-(62,11) = ":"
+        │   │   │       │   │   │   ├── value_loc: (62,11)-(62,16) = "there"
+        │   │   │       │   │   │   ├── closing_loc: ∅
+        │   │   │       │   │   │   └── unescaped: "there"
+        │   │   │       │   │   ├── value:
+        │   │   │       │   │   │   @ SymbolNode (location: (62,20)-(62,27))
+        │   │   │       │   │   │   ├── opening_loc: (62,20)-(62,21) = ":"
+        │   │   │       │   │   │   ├── value_loc: (62,21)-(62,27) = "friend"
+        │   │   │       │   │   │   ├── closing_loc: ∅
+        │   │   │       │   │   │   └── unescaped: "friend"
+        │   │   │       │   │   └── operator_loc: (62,17)-(62,19) = "=>"
+        │   │   │       │   ├── @ AssocSplatNode (location: (62,29)-(62,33))
+        │   │   │       │   │   ├── value:
+        │   │   │       │   │   │   @ HashNode (location: (62,31)-(62,33))
+        │   │   │       │   │   │   ├── opening_loc: (62,31)-(62,32) = "{"
+        │   │   │       │   │   │   ├── elements: (length: 0)
+        │   │   │       │   │   │   └── closing_loc: (62,32)-(62,33) = "}"
+        │   │   │       │   │   └── operator_loc: (62,29)-(62,31) = "**"
+        │   │   │       │   └── @ AssocNode (location: (62,35)-(62,47))
+        │   │   │       │       ├── key:
+        │   │   │       │       │   @ SymbolNode (location: (62,35)-(62,42))
+        │   │   │       │       │   ├── opening_loc: ∅
+        │   │   │       │       │   ├── value_loc: (62,35)-(62,41) = "whatup"
+        │   │   │       │       │   ├── closing_loc: (62,41)-(62,42) = ":"
+        │   │   │       │       │   └── unescaped: "whatup"
+        │   │   │       │       ├── value:
+        │   │   │       │       │   @ SymbolNode (location: (62,43)-(62,47))
+        │   │   │       │       │   ├── opening_loc: (62,43)-(62,44) = ":"
+        │   │   │       │       │   ├── value_loc: (62,44)-(62,47) = "dog"
+        │   │   │       │       │   ├── closing_loc: ∅
+        │   │   │       │       │   └── unescaped: "dog"
+        │   │   │       │       └── operator_loc: ∅
+        │   │   │       └── closing_loc: (62,48)-(62,49) = "}"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -873,24 +889,25 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (64,4)-(64,15))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SymbolNode (location: (64,4)-(64,6))
-        │   │       │   ├── opening_loc: (64,4)-(64,5) = ":"
-        │   │       │   ├── value_loc: (64,5)-(64,6) = "a"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "a"
-        │   │       └── @ KeywordHashNode (location: (64,8)-(64,15))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (64,8)-(64,15))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (64,8)-(64,10))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (64,8)-(64,9) = "b"
-        │   │                   │   ├── closing_loc: (64,9)-(64,10) = ":"
-        │   │                   │   └── unescaped: "b"
-        │   │                   ├── value:
-        │   │                   │   @ TrueNode (location: (64,11)-(64,15))
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SymbolNode (location: (64,4)-(64,6))
+        │   │   │   │   ├── opening_loc: (64,4)-(64,5) = ":"
+        │   │   │   │   ├── value_loc: (64,5)-(64,6) = "a"
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── unescaped: "a"
+        │   │   │   └── @ KeywordHashNode (location: (64,8)-(64,15))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (64,8)-(64,15))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (64,8)-(64,10))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (64,8)-(64,9) = "b"
+        │   │   │               │   ├── closing_loc: (64,9)-(64,10) = ":"
+        │   │   │               │   └── unescaped: "b"
+        │   │   │               ├── value:
+        │   │   │               │   @ TrueNode (location: (64,11)-(64,15))
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (64,16)-(64,36))
@@ -923,10 +940,11 @@
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (64,31)-(64,32))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ LocalVariableReadNode (location: (64,31)-(64,32))
-        │   │   │           │           ├── name: :a
-        │   │   │           │           └── depth: 0
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ LocalVariableReadNode (location: (64,31)-(64,32))
+        │   │   │           │   │       ├── name: :a
+        │   │   │           │   │       └── depth: 0
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅
@@ -942,23 +960,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (66,3)-(66,17))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (66,3)-(66,17))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (66,3)-(66,17))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (66,3)-(66,9))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (66,3)-(66,8) = "there"
-        │   │                   │   ├── closing_loc: (66,8)-(66,9) = ":"
-        │   │                   │   └── unescaped: "there"
-        │   │                   ├── value:
-        │   │                   │   @ SymbolNode (location: (66,10)-(66,17))
-        │   │                   │   ├── opening_loc: (66,10)-(66,11) = ":"
-        │   │                   │   ├── value_loc: (66,11)-(66,17) = "friend"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "friend"
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (66,3)-(66,17))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (66,3)-(66,17))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (66,3)-(66,9))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (66,3)-(66,8) = "there"
+        │   │   │               │   ├── closing_loc: (66,8)-(66,9) = ":"
+        │   │   │               │   └── unescaped: "there"
+        │   │   │               ├── value:
+        │   │   │               │   @ SymbolNode (location: (66,10)-(66,17))
+        │   │   │               │   ├── opening_loc: (66,10)-(66,11) = ":"
+        │   │   │               │   ├── value_loc: (66,11)-(66,17) = "friend"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "friend"
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -970,44 +989,45 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (68,3)-(68,40))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (68,3)-(68,40))
-        │   │           └── elements: (length: 3)
-        │   │               ├── @ AssocNode (location: (68,3)-(68,20))
-        │   │               │   ├── key:
-        │   │               │   │   @ SymbolNode (location: (68,3)-(68,9))
-        │   │               │   │   ├── opening_loc: (68,3)-(68,4) = ":"
-        │   │               │   │   ├── value_loc: (68,4)-(68,9) = "there"
-        │   │               │   │   ├── closing_loc: ∅
-        │   │               │   │   └── unescaped: "there"
-        │   │               │   ├── value:
-        │   │               │   │   @ SymbolNode (location: (68,13)-(68,20))
-        │   │               │   │   ├── opening_loc: (68,13)-(68,14) = ":"
-        │   │               │   │   ├── value_loc: (68,14)-(68,20) = "friend"
-        │   │               │   │   ├── closing_loc: ∅
-        │   │               │   │   └── unescaped: "friend"
-        │   │               │   └── operator_loc: (68,10)-(68,12) = "=>"
-        │   │               ├── @ AssocSplatNode (location: (68,22)-(68,26))
-        │   │               │   ├── value:
-        │   │               │   │   @ HashNode (location: (68,24)-(68,26))
-        │   │               │   │   ├── opening_loc: (68,24)-(68,25) = "{"
-        │   │               │   │   ├── elements: (length: 0)
-        │   │               │   │   └── closing_loc: (68,25)-(68,26) = "}"
-        │   │               │   └── operator_loc: (68,22)-(68,24) = "**"
-        │   │               └── @ AssocNode (location: (68,28)-(68,40))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (68,28)-(68,35))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (68,28)-(68,34) = "whatup"
-        │   │                   │   ├── closing_loc: (68,34)-(68,35) = ":"
-        │   │                   │   └── unescaped: "whatup"
-        │   │                   ├── value:
-        │   │                   │   @ SymbolNode (location: (68,36)-(68,40))
-        │   │                   │   ├── opening_loc: (68,36)-(68,37) = ":"
-        │   │                   │   ├── value_loc: (68,37)-(68,40) = "dog"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "dog"
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (68,3)-(68,40))
+        │   │   │       └── elements: (length: 3)
+        │   │   │           ├── @ AssocNode (location: (68,3)-(68,20))
+        │   │   │           │   ├── key:
+        │   │   │           │   │   @ SymbolNode (location: (68,3)-(68,9))
+        │   │   │           │   │   ├── opening_loc: (68,3)-(68,4) = ":"
+        │   │   │           │   │   ├── value_loc: (68,4)-(68,9) = "there"
+        │   │   │           │   │   ├── closing_loc: ∅
+        │   │   │           │   │   └── unescaped: "there"
+        │   │   │           │   ├── value:
+        │   │   │           │   │   @ SymbolNode (location: (68,13)-(68,20))
+        │   │   │           │   │   ├── opening_loc: (68,13)-(68,14) = ":"
+        │   │   │           │   │   ├── value_loc: (68,14)-(68,20) = "friend"
+        │   │   │           │   │   ├── closing_loc: ∅
+        │   │   │           │   │   └── unescaped: "friend"
+        │   │   │           │   └── operator_loc: (68,10)-(68,12) = "=>"
+        │   │   │           ├── @ AssocSplatNode (location: (68,22)-(68,26))
+        │   │   │           │   ├── value:
+        │   │   │           │   │   @ HashNode (location: (68,24)-(68,26))
+        │   │   │           │   │   ├── opening_loc: (68,24)-(68,25) = "{"
+        │   │   │           │   │   ├── elements: (length: 0)
+        │   │   │           │   │   └── closing_loc: (68,25)-(68,26) = "}"
+        │   │   │           │   └── operator_loc: (68,22)-(68,24) = "**"
+        │   │   │           └── @ AssocNode (location: (68,28)-(68,40))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (68,28)-(68,35))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (68,28)-(68,34) = "whatup"
+        │   │   │               │   ├── closing_loc: (68,34)-(68,35) = ":"
+        │   │   │               │   └── unescaped: "whatup"
+        │   │   │               ├── value:
+        │   │   │               │   @ SymbolNode (location: (68,36)-(68,40))
+        │   │   │               │   ├── opening_loc: (68,36)-(68,37) = ":"
+        │   │   │               │   ├── value_loc: (68,37)-(68,40) = "dog"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "dog"
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: keyword_splat
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1019,44 +1039,45 @@
         │   ├── opening_loc: (70,2)-(70,3) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (70,3)-(70,40))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (70,3)-(70,40))
-        │   │           └── elements: (length: 3)
-        │   │               ├── @ AssocNode (location: (70,3)-(70,20))
-        │   │               │   ├── key:
-        │   │               │   │   @ SymbolNode (location: (70,3)-(70,9))
-        │   │               │   │   ├── opening_loc: (70,3)-(70,4) = ":"
-        │   │               │   │   ├── value_loc: (70,4)-(70,9) = "there"
-        │   │               │   │   ├── closing_loc: ∅
-        │   │               │   │   └── unescaped: "there"
-        │   │               │   ├── value:
-        │   │               │   │   @ SymbolNode (location: (70,13)-(70,20))
-        │   │               │   │   ├── opening_loc: (70,13)-(70,14) = ":"
-        │   │               │   │   ├── value_loc: (70,14)-(70,20) = "friend"
-        │   │               │   │   ├── closing_loc: ∅
-        │   │               │   │   └── unescaped: "friend"
-        │   │               │   └── operator_loc: (70,10)-(70,12) = "=>"
-        │   │               ├── @ AssocSplatNode (location: (70,22)-(70,26))
-        │   │               │   ├── value:
-        │   │               │   │   @ HashNode (location: (70,24)-(70,26))
-        │   │               │   │   ├── opening_loc: (70,24)-(70,25) = "{"
-        │   │               │   │   ├── elements: (length: 0)
-        │   │               │   │   └── closing_loc: (70,25)-(70,26) = "}"
-        │   │               │   └── operator_loc: (70,22)-(70,24) = "**"
-        │   │               └── @ AssocNode (location: (70,28)-(70,40))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (70,28)-(70,35))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (70,28)-(70,34) = "whatup"
-        │   │                   │   ├── closing_loc: (70,34)-(70,35) = ":"
-        │   │                   │   └── unescaped: "whatup"
-        │   │                   ├── value:
-        │   │                   │   @ SymbolNode (location: (70,36)-(70,40))
-        │   │                   │   ├── opening_loc: (70,36)-(70,37) = ":"
-        │   │                   │   ├── value_loc: (70,37)-(70,40) = "dog"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "dog"
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (70,3)-(70,40))
+        │   │   │       └── elements: (length: 3)
+        │   │   │           ├── @ AssocNode (location: (70,3)-(70,20))
+        │   │   │           │   ├── key:
+        │   │   │           │   │   @ SymbolNode (location: (70,3)-(70,9))
+        │   │   │           │   │   ├── opening_loc: (70,3)-(70,4) = ":"
+        │   │   │           │   │   ├── value_loc: (70,4)-(70,9) = "there"
+        │   │   │           │   │   ├── closing_loc: ∅
+        │   │   │           │   │   └── unescaped: "there"
+        │   │   │           │   ├── value:
+        │   │   │           │   │   @ SymbolNode (location: (70,13)-(70,20))
+        │   │   │           │   │   ├── opening_loc: (70,13)-(70,14) = ":"
+        │   │   │           │   │   ├── value_loc: (70,14)-(70,20) = "friend"
+        │   │   │           │   │   ├── closing_loc: ∅
+        │   │   │           │   │   └── unescaped: "friend"
+        │   │   │           │   └── operator_loc: (70,10)-(70,12) = "=>"
+        │   │   │           ├── @ AssocSplatNode (location: (70,22)-(70,26))
+        │   │   │           │   ├── value:
+        │   │   │           │   │   @ HashNode (location: (70,24)-(70,26))
+        │   │   │           │   │   ├── opening_loc: (70,24)-(70,25) = "{"
+        │   │   │           │   │   ├── elements: (length: 0)
+        │   │   │           │   │   └── closing_loc: (70,25)-(70,26) = "}"
+        │   │   │           │   └── operator_loc: (70,22)-(70,24) = "**"
+        │   │   │           └── @ AssocNode (location: (70,28)-(70,40))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (70,28)-(70,35))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (70,28)-(70,34) = "whatup"
+        │   │   │               │   ├── closing_loc: (70,34)-(70,35) = ":"
+        │   │   │               │   └── unescaped: "whatup"
+        │   │   │               ├── value:
+        │   │   │               │   @ SymbolNode (location: (70,36)-(70,40))
+        │   │   │               │   ├── opening_loc: (70,36)-(70,37) = ":"
+        │   │   │               │   ├── value_loc: (70,37)-(70,40) = "dog"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "dog"
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: keyword_splat
         │   ├── closing_loc: (70,40)-(70,41) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1068,31 +1089,32 @@
         │   ├── opening_loc: (72,3)-(72,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (72,4)-(72,26))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ HashNode (location: (72,4)-(72,26))
-        │   │           ├── opening_loc: (72,4)-(72,5) = "{"
-        │   │           ├── elements: (length: 2)
-        │   │           │   ├── @ AssocNode (location: (72,6)-(72,13))
-        │   │           │   │   ├── key:
-        │   │           │   │   │   @ SymbolNode (location: (72,6)-(72,8))
-        │   │           │   │   │   ├── opening_loc: ∅
-        │   │           │   │   │   ├── value_loc: (72,6)-(72,7) = "a"
-        │   │           │   │   │   ├── closing_loc: (72,7)-(72,8) = ":"
-        │   │           │   │   │   └── unescaped: "a"
-        │   │           │   │   ├── value:
-        │   │           │   │   │   @ TrueNode (location: (72,9)-(72,13))
-        │   │           │   │   └── operator_loc: ∅
-        │   │           │   └── @ AssocNode (location: (72,15)-(72,23))
-        │   │           │       ├── key:
-        │   │           │       │   @ SymbolNode (location: (72,15)-(72,17))
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── value_loc: (72,15)-(72,16) = "b"
-        │   │           │       │   ├── closing_loc: (72,16)-(72,17) = ":"
-        │   │           │       │   └── unescaped: "b"
-        │   │           │       ├── value:
-        │   │           │       │   @ FalseNode (location: (72,18)-(72,23))
-        │   │           │       └── operator_loc: ∅
-        │   │           └── closing_loc: (72,25)-(72,26) = "}"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ HashNode (location: (72,4)-(72,26))
+        │   │   │       ├── opening_loc: (72,4)-(72,5) = "{"
+        │   │   │       ├── elements: (length: 2)
+        │   │   │       │   ├── @ AssocNode (location: (72,6)-(72,13))
+        │   │   │       │   │   ├── key:
+        │   │   │       │   │   │   @ SymbolNode (location: (72,6)-(72,8))
+        │   │   │       │   │   │   ├── opening_loc: ∅
+        │   │   │       │   │   │   ├── value_loc: (72,6)-(72,7) = "a"
+        │   │   │       │   │   │   ├── closing_loc: (72,7)-(72,8) = ":"
+        │   │   │       │   │   │   └── unescaped: "a"
+        │   │   │       │   │   ├── value:
+        │   │   │       │   │   │   @ TrueNode (location: (72,9)-(72,13))
+        │   │   │       │   │   └── operator_loc: ∅
+        │   │   │       │   └── @ AssocNode (location: (72,15)-(72,23))
+        │   │   │       │       ├── key:
+        │   │   │       │       │   @ SymbolNode (location: (72,15)-(72,17))
+        │   │   │       │       │   ├── opening_loc: ∅
+        │   │   │       │       │   ├── value_loc: (72,15)-(72,16) = "b"
+        │   │   │       │       │   ├── closing_loc: (72,16)-(72,17) = ":"
+        │   │   │       │       │   └── unescaped: "b"
+        │   │   │       │       ├── value:
+        │   │   │       │       │   @ FalseNode (location: (72,18)-(72,23))
+        │   │   │       │       └── operator_loc: ∅
+        │   │   │       └── closing_loc: (72,25)-(72,26) = "}"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (72,35)-(72,36) = ")"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (72,28)-(72,35))
@@ -1112,23 +1134,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (74,3)-(74,20))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (74,3)-(74,20))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (74,3)-(74,20))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (74,3)-(74,9))
-        │   │                   │   ├── opening_loc: (74,3)-(74,4) = ":"
-        │   │                   │   ├── value_loc: (74,4)-(74,9) = "there"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "there"
-        │   │                   ├── value:
-        │   │                   │   @ SymbolNode (location: (74,13)-(74,20))
-        │   │                   │   ├── opening_loc: (74,13)-(74,14) = ":"
-        │   │                   │   ├── value_loc: (74,14)-(74,20) = "friend"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "friend"
-        │   │                   └── operator_loc: (74,10)-(74,12) = "=>"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (74,3)-(74,20))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (74,3)-(74,20))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (74,3)-(74,9))
+        │   │   │               │   ├── opening_loc: (74,3)-(74,4) = ":"
+        │   │   │               │   ├── value_loc: (74,4)-(74,9) = "there"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "there"
+        │   │   │               ├── value:
+        │   │   │               │   @ SymbolNode (location: (74,13)-(74,20))
+        │   │   │               │   ├── opening_loc: (74,13)-(74,14) = ":"
+        │   │   │               │   ├── value_loc: (74,14)-(74,20) = "friend"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "friend"
+        │   │   │               └── operator_loc: (74,10)-(74,12) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1140,17 +1163,18 @@
         │   ├── opening_loc: (76,3)-(76,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (76,4)-(77,2))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SymbolNode (location: (76,4)-(76,6))
-        │   │       │   ├── opening_loc: (76,4)-(76,5) = ":"
-        │   │       │   ├── value_loc: (76,5)-(76,6) = "a"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "a"
-        │   │       └── @ SymbolNode (location: (77,0)-(77,2))
-        │   │           ├── opening_loc: (77,0)-(77,1) = ":"
-        │   │           ├── value_loc: (77,1)-(77,2) = "b"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "b"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SymbolNode (location: (76,4)-(76,6))
+        │   │   │   │   ├── opening_loc: (76,4)-(76,5) = ":"
+        │   │   │   │   ├── value_loc: (76,5)-(76,6) = "a"
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── unescaped: "a"
+        │   │   │   └── @ SymbolNode (location: (77,0)-(77,2))
+        │   │   │       ├── opening_loc: (77,0)-(77,1) = ":"
+        │   │   │       ├── value_loc: (77,1)-(77,2) = "b"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "b"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (78,0)-(78,1) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1162,28 +1186,29 @@
         │   ├── opening_loc: (80,3)-(80,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (81,0)-(82,5))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SymbolNode (location: (81,0)-(81,2))
-        │   │       │   ├── opening_loc: (81,0)-(81,1) = ":"
-        │   │       │   ├── value_loc: (81,1)-(81,2) = "a"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "a"
-        │   │       └── @ KeywordHashNode (location: (82,0)-(82,5))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (82,0)-(82,5))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (82,0)-(82,2))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (82,0)-(82,1) = "b"
-        │   │                   │   ├── closing_loc: (82,1)-(82,2) = ":"
-        │   │                   │   └── unescaped: "b"
-        │   │                   ├── value:
-        │   │                   │   @ SymbolNode (location: (82,3)-(82,5))
-        │   │                   │   ├── opening_loc: (82,3)-(82,4) = ":"
-        │   │                   │   ├── value_loc: (82,4)-(82,5) = "c"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "c"
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SymbolNode (location: (81,0)-(81,2))
+        │   │   │   │   ├── opening_loc: (81,0)-(81,1) = ":"
+        │   │   │   │   ├── value_loc: (81,1)-(81,2) = "a"
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── unescaped: "a"
+        │   │   │   └── @ KeywordHashNode (location: (82,0)-(82,5))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (82,0)-(82,5))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (82,0)-(82,2))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (82,0)-(82,1) = "b"
+        │   │   │               │   ├── closing_loc: (82,1)-(82,2) = ":"
+        │   │   │               │   └── unescaped: "b"
+        │   │   │               ├── value:
+        │   │   │               │   @ SymbolNode (location: (82,3)-(82,5))
+        │   │   │               │   ├── opening_loc: (82,3)-(82,4) = ":"
+        │   │   │               │   ├── value_loc: (82,4)-(82,5) = "c"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "c"
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: (83,0)-(83,1) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1213,29 +1238,30 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (87,4)-(87,21))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (87,4)-(87,21))
-        │   │           └── elements: (length: 2)
-        │   │               ├── @ AssocNode (location: (87,4)-(87,11))
-        │   │               │   ├── key:
-        │   │               │   │   @ SymbolNode (location: (87,4)-(87,6))
-        │   │               │   │   ├── opening_loc: ∅
-        │   │               │   │   ├── value_loc: (87,4)-(87,5) = "a"
-        │   │               │   │   ├── closing_loc: (87,5)-(87,6) = ":"
-        │   │               │   │   └── unescaped: "a"
-        │   │               │   ├── value:
-        │   │               │   │   @ TrueNode (location: (87,7)-(87,11))
-        │   │               │   └── operator_loc: ∅
-        │   │               └── @ AssocNode (location: (87,13)-(87,21))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (87,13)-(87,15))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (87,13)-(87,14) = "b"
-        │   │                   │   ├── closing_loc: (87,14)-(87,15) = ":"
-        │   │                   │   └── unescaped: "b"
-        │   │                   ├── value:
-        │   │                   │   @ FalseNode (location: (87,16)-(87,21))
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (87,4)-(87,21))
+        │   │   │       └── elements: (length: 2)
+        │   │   │           ├── @ AssocNode (location: (87,4)-(87,11))
+        │   │   │           │   ├── key:
+        │   │   │           │   │   @ SymbolNode (location: (87,4)-(87,6))
+        │   │   │           │   │   ├── opening_loc: ∅
+        │   │   │           │   │   ├── value_loc: (87,4)-(87,5) = "a"
+        │   │   │           │   │   ├── closing_loc: (87,5)-(87,6) = ":"
+        │   │   │           │   │   └── unescaped: "a"
+        │   │   │           │   ├── value:
+        │   │   │           │   │   @ TrueNode (location: (87,7)-(87,11))
+        │   │   │           │   └── operator_loc: ∅
+        │   │   │           └── @ AssocNode (location: (87,13)-(87,21))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (87,13)-(87,15))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (87,13)-(87,14) = "b"
+        │   │   │               │   ├── closing_loc: (87,14)-(87,15) = ":"
+        │   │   │               │   └── unescaped: "b"
+        │   │   │               ├── value:
+        │   │   │               │   @ FalseNode (location: (87,16)-(87,21))
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (87,23)-(87,30))
@@ -1255,22 +1281,23 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (89,10)-(89,21))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ IntegerNode (location: (89,10)-(89,11))
-        │   │       │   └── flags: decimal
-        │   │       └── @ KeywordHashNode (location: (89,13)-(89,21))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (89,13)-(89,21))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (89,13)-(89,19))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (89,13)-(89,18) = "kwarg"
-        │   │                   │   ├── closing_loc: (89,18)-(89,19) = ":"
-        │   │                   │   └── unescaped: "kwarg"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (89,20)-(89,21))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ IntegerNode (location: (89,10)-(89,11))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ KeywordHashNode (location: (89,13)-(89,21))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (89,13)-(89,21))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (89,13)-(89,19))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (89,13)-(89,18) = "kwarg"
+        │   │   │               │   ├── closing_loc: (89,18)-(89,19) = ":"
+        │   │   │               │   └── unescaped: "kwarg"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (89,20)-(89,21))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1284,9 +1311,10 @@
         │   ├── opening_loc: (91,14)-(91,15) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (91,15)-(91,17))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (91,15)-(91,17))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (91,15)-(91,17))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (91,17)-(91,18) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1362,12 +1390,13 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (97,8)-(97,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SymbolNode (location: (97,8)-(97,12))
-        │   │           ├── opening_loc: (97,8)-(97,9) = ":"
-        │   │           ├── value_loc: (97,9)-(97,12) = "foo"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "foo"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SymbolNode (location: (97,8)-(97,12))
+        │   │   │       ├── opening_loc: (97,8)-(97,9) = ":"
+        │   │   │       ├── value_loc: (97,9)-(97,12) = "foo"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "foo"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1387,12 +1416,13 @@
         │   ├── opening_loc: (99,7)-(99,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (99,8)-(99,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SymbolNode (location: (99,8)-(99,12))
-        │   │           ├── opening_loc: (99,8)-(99,9) = ":"
-        │   │           ├── value_loc: (99,9)-(99,12) = "foo"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "foo"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SymbolNode (location: (99,8)-(99,12))
+        │   │   │       ├── opening_loc: (99,8)-(99,9) = ":"
+        │   │   │       ├── value_loc: (99,9)-(99,12) = "foo"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "foo"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (99,12)-(99,13) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1412,12 +1442,13 @@
         │   ├── opening_loc: (101,7)-(101,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (101,8)-(101,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SymbolNode (location: (101,8)-(101,12))
-        │   │           ├── opening_loc: (101,8)-(101,9) = ":"
-        │   │           ├── value_loc: (101,9)-(101,12) = "foo"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "foo"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SymbolNode (location: (101,8)-(101,12))
+        │   │   │       ├── opening_loc: (101,8)-(101,9) = ":"
+        │   │   │       ├── value_loc: (101,9)-(101,12) = "foo"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "foo"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (101,12)-(101,13) = ")"
         │   ├── block:
         │   │   @ BlockNode (location: (101,14)-(101,17))
@@ -1435,20 +1466,21 @@
         │   ├── opening_loc: (103,3)-(103,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (103,4)-(103,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (103,4)-(103,11))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (103,4)-(103,11))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (103,4)-(103,8))
-        │   │                   │   ├── opening_loc: (103,4)-(103,5) = "\""
-        │   │                   │   ├── value_loc: (103,5)-(103,6) = "a"
-        │   │                   │   ├── closing_loc: (103,6)-(103,8) = "\":"
-        │   │                   │   └── unescaped: "a"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (103,9)-(103,11))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (103,4)-(103,11))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (103,4)-(103,11))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (103,4)-(103,8))
+        │   │   │               │   ├── opening_loc: (103,4)-(103,5) = "\""
+        │   │   │               │   ├── value_loc: (103,5)-(103,6) = "a"
+        │   │   │               │   ├── closing_loc: (103,6)-(103,8) = "\":"
+        │   │   │               │   └── unescaped: "a"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (103,9)-(103,11))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: (103,11)-(103,12) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1460,47 +1492,48 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (105,4)-(105,28))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (105,4)-(105,28))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (105,4)-(105,28))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (105,4)-(105,8))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (105,4)-(105,7) = "bar"
-        │   │                   │   ├── closing_loc: (105,7)-(105,8) = ":"
-        │   │                   │   └── unescaped: "bar"
-        │   │                   ├── value:
-        │   │                   │   @ HashNode (location: (105,9)-(105,28))
-        │   │                   │   ├── opening_loc: (105,9)-(105,10) = "{"
-        │   │                   │   ├── elements: (length: 1)
-        │   │                   │   │   └── @ AssocNode (location: (105,11)-(105,26))
-        │   │                   │   │       ├── key:
-        │   │                   │   │       │   @ SymbolNode (location: (105,11)-(105,15))
-        │   │                   │   │       │   ├── opening_loc: ∅
-        │   │                   │   │       │   ├── value_loc: (105,11)-(105,14) = "baz"
-        │   │                   │   │       │   ├── closing_loc: (105,14)-(105,15) = ":"
-        │   │                   │   │       │   └── unescaped: "baz"
-        │   │                   │   │       ├── value:
-        │   │                   │   │       │   @ CallNode (location: (105,16)-(105,26))
-        │   │                   │   │       │   ├── receiver: ∅
-        │   │                   │   │       │   ├── call_operator_loc: ∅
-        │   │                   │   │       │   ├── message_loc: (105,16)-(105,19) = "qux"
-        │   │                   │   │       │   ├── opening_loc: ∅
-        │   │                   │   │       │   ├── arguments: ∅
-        │   │                   │   │       │   ├── closing_loc: ∅
-        │   │                   │   │       │   ├── block:
-        │   │                   │   │       │   │   @ BlockNode (location: (105,20)-(105,26))
-        │   │                   │   │       │   │   ├── locals: []
-        │   │                   │   │       │   │   ├── parameters: ∅
-        │   │                   │   │       │   │   ├── body: ∅
-        │   │                   │   │       │   │   ├── opening_loc: (105,20)-(105,22) = "do"
-        │   │                   │   │       │   │   └── closing_loc: (105,23)-(105,26) = "end"
-        │   │                   │   │       │   ├── flags: ∅
-        │   │                   │   │       │   └── name: :qux
-        │   │                   │   │       └── operator_loc: ∅
-        │   │                   │   └── closing_loc: (105,27)-(105,28) = "}"
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (105,4)-(105,28))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (105,4)-(105,28))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (105,4)-(105,8))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (105,4)-(105,7) = "bar"
+        │   │   │               │   ├── closing_loc: (105,7)-(105,8) = ":"
+        │   │   │               │   └── unescaped: "bar"
+        │   │   │               ├── value:
+        │   │   │               │   @ HashNode (location: (105,9)-(105,28))
+        │   │   │               │   ├── opening_loc: (105,9)-(105,10) = "{"
+        │   │   │               │   ├── elements: (length: 1)
+        │   │   │               │   │   └── @ AssocNode (location: (105,11)-(105,26))
+        │   │   │               │   │       ├── key:
+        │   │   │               │   │       │   @ SymbolNode (location: (105,11)-(105,15))
+        │   │   │               │   │       │   ├── opening_loc: ∅
+        │   │   │               │   │       │   ├── value_loc: (105,11)-(105,14) = "baz"
+        │   │   │               │   │       │   ├── closing_loc: (105,14)-(105,15) = ":"
+        │   │   │               │   │       │   └── unescaped: "baz"
+        │   │   │               │   │       ├── value:
+        │   │   │               │   │       │   @ CallNode (location: (105,16)-(105,26))
+        │   │   │               │   │       │   ├── receiver: ∅
+        │   │   │               │   │       │   ├── call_operator_loc: ∅
+        │   │   │               │   │       │   ├── message_loc: (105,16)-(105,19) = "qux"
+        │   │   │               │   │       │   ├── opening_loc: ∅
+        │   │   │               │   │       │   ├── arguments: ∅
+        │   │   │               │   │       │   ├── closing_loc: ∅
+        │   │   │               │   │       │   ├── block:
+        │   │   │               │   │       │   │   @ BlockNode (location: (105,20)-(105,26))
+        │   │   │               │   │       │   │   ├── locals: []
+        │   │   │               │   │       │   │   ├── parameters: ∅
+        │   │   │               │   │       │   │   ├── body: ∅
+        │   │   │               │   │       │   │   ├── opening_loc: (105,20)-(105,22) = "do"
+        │   │   │               │   │       │   │   └── closing_loc: (105,23)-(105,26) = "end"
+        │   │   │               │   │       │   ├── flags: ∅
+        │   │   │               │   │       │   └── name: :qux
+        │   │   │               │   │       └── operator_loc: ∅
+        │   │   │               │   └── closing_loc: (105,27)-(105,28) = "}"
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1512,41 +1545,42 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (107,4)-(107,24))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (107,4)-(107,24))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (107,4)-(107,24))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (107,4)-(107,8))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (107,4)-(107,7) = "bar"
-        │   │                   │   ├── closing_loc: (107,7)-(107,8) = ":"
-        │   │                   │   └── unescaped: "bar"
-        │   │                   ├── value:
-        │   │                   │   @ HashNode (location: (107,9)-(107,24))
-        │   │                   │   ├── opening_loc: (107,9)-(107,10) = "{"
-        │   │                   │   ├── elements: (length: 1)
-        │   │                   │   │   └── @ AssocSplatNode (location: (107,11)-(107,22))
-        │   │                   │   │       ├── value:
-        │   │                   │   │       │   @ CallNode (location: (107,13)-(107,22))
-        │   │                   │   │       │   ├── receiver: ∅
-        │   │                   │   │       │   ├── call_operator_loc: ∅
-        │   │                   │   │       │   ├── message_loc: (107,13)-(107,15) = "kw"
-        │   │                   │   │       │   ├── opening_loc: ∅
-        │   │                   │   │       │   ├── arguments: ∅
-        │   │                   │   │       │   ├── closing_loc: ∅
-        │   │                   │   │       │   ├── block:
-        │   │                   │   │       │   │   @ BlockNode (location: (107,16)-(107,22))
-        │   │                   │   │       │   │   ├── locals: []
-        │   │                   │   │       │   │   ├── parameters: ∅
-        │   │                   │   │       │   │   ├── body: ∅
-        │   │                   │   │       │   │   ├── opening_loc: (107,16)-(107,18) = "do"
-        │   │                   │   │       │   │   └── closing_loc: (107,19)-(107,22) = "end"
-        │   │                   │   │       │   ├── flags: ∅
-        │   │                   │   │       │   └── name: :kw
-        │   │                   │   │       └── operator_loc: (107,11)-(107,13) = "**"
-        │   │                   │   └── closing_loc: (107,23)-(107,24) = "}"
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (107,4)-(107,24))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (107,4)-(107,24))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (107,4)-(107,8))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (107,4)-(107,7) = "bar"
+        │   │   │               │   ├── closing_loc: (107,7)-(107,8) = ":"
+        │   │   │               │   └── unescaped: "bar"
+        │   │   │               ├── value:
+        │   │   │               │   @ HashNode (location: (107,9)-(107,24))
+        │   │   │               │   ├── opening_loc: (107,9)-(107,10) = "{"
+        │   │   │               │   ├── elements: (length: 1)
+        │   │   │               │   │   └── @ AssocSplatNode (location: (107,11)-(107,22))
+        │   │   │               │   │       ├── value:
+        │   │   │               │   │       │   @ CallNode (location: (107,13)-(107,22))
+        │   │   │               │   │       │   ├── receiver: ∅
+        │   │   │               │   │       │   ├── call_operator_loc: ∅
+        │   │   │               │   │       │   ├── message_loc: (107,13)-(107,15) = "kw"
+        │   │   │               │   │       │   ├── opening_loc: ∅
+        │   │   │               │   │       │   ├── arguments: ∅
+        │   │   │               │   │       │   ├── closing_loc: ∅
+        │   │   │               │   │       │   ├── block:
+        │   │   │               │   │       │   │   @ BlockNode (location: (107,16)-(107,22))
+        │   │   │               │   │       │   │   ├── locals: []
+        │   │   │               │   │       │   │   ├── parameters: ∅
+        │   │   │               │   │       │   │   ├── body: ∅
+        │   │   │               │   │       │   │   ├── opening_loc: (107,16)-(107,18) = "do"
+        │   │   │               │   │       │   │   └── closing_loc: (107,19)-(107,22) = "end"
+        │   │   │               │   │       │   ├── flags: ∅
+        │   │   │               │   │       │   └── name: :kw
+        │   │   │               │   │       └── operator_loc: (107,11)-(107,13) = "**"
+        │   │   │               │   └── closing_loc: (107,23)-(107,24) = "}"
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1558,51 +1592,52 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (109,4)-(109,29))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (109,4)-(109,29))
-        │   │           ├── opening_loc: (109,4)-(109,5) = "\""
-        │   │           ├── parts: (length: 1)
-        │   │           │   └── @ EmbeddedStatementsNode (location: (109,5)-(109,28))
-        │   │           │       ├── opening_loc: (109,5)-(109,7) = "\#{"
-        │   │           │       ├── statements:
-        │   │           │       │   @ StatementsNode (location: (109,7)-(109,27))
-        │   │           │       │   └── body: (length: 1)
-        │   │           │       │       └── @ CallNode (location: (109,7)-(109,27))
-        │   │           │       │           ├── receiver:
-        │   │           │       │           │   @ CallNode (location: (109,7)-(109,10))
-        │   │           │       │           │   ├── receiver: ∅
-        │   │           │       │           │   ├── call_operator_loc: ∅
-        │   │           │       │           │   ├── message_loc: (109,7)-(109,10) = "bar"
-        │   │           │       │           │   ├── opening_loc: ∅
-        │   │           │       │           │   ├── arguments: ∅
-        │   │           │       │           │   ├── closing_loc: ∅
-        │   │           │       │           │   ├── block: ∅
-        │   │           │       │           │   ├── flags: variable_call
-        │   │           │       │           │   └── name: :bar
-        │   │           │       │           ├── call_operator_loc: (109,10)-(109,11) = "."
-        │   │           │       │           ├── message_loc: (109,11)-(109,14) = "map"
-        │   │           │       │           ├── opening_loc: ∅
-        │   │           │       │           ├── arguments: ∅
-        │   │           │       │           ├── closing_loc: ∅
-        │   │           │       │           ├── block:
-        │   │           │       │           │   @ BlockNode (location: (109,15)-(109,27))
-        │   │           │       │           │   ├── locals: []
-        │   │           │       │           │   ├── parameters: ∅
-        │   │           │       │           │   ├── body:
-        │   │           │       │           │   │   @ StatementsNode (location: (109,18)-(109,23))
-        │   │           │       │           │   │   └── body: (length: 1)
-        │   │           │       │           │   │       └── @ StringNode (location: (109,18)-(109,23))
-        │   │           │       │           │   │           ├── flags: ∅
-        │   │           │       │           │   │           ├── opening_loc: (109,18)-(109,19) = "\""
-        │   │           │       │           │   │           ├── content_loc: (109,19)-(109,22) = "baz"
-        │   │           │       │           │   │           ├── closing_loc: (109,22)-(109,23) = "\""
-        │   │           │       │           │   │           └── unescaped: "baz"
-        │   │           │       │           │   ├── opening_loc: (109,15)-(109,17) = "do"
-        │   │           │       │           │   └── closing_loc: (109,24)-(109,27) = "end"
-        │   │           │       │           ├── flags: ∅
-        │   │           │       │           └── name: :map
-        │   │           │       └── closing_loc: (109,27)-(109,28) = "}"
-        │   │           └── closing_loc: (109,28)-(109,29) = "\""
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (109,4)-(109,29))
+        │   │   │       ├── opening_loc: (109,4)-(109,5) = "\""
+        │   │   │       ├── parts: (length: 1)
+        │   │   │       │   └── @ EmbeddedStatementsNode (location: (109,5)-(109,28))
+        │   │   │       │       ├── opening_loc: (109,5)-(109,7) = "\#{"
+        │   │   │       │       ├── statements:
+        │   │   │       │       │   @ StatementsNode (location: (109,7)-(109,27))
+        │   │   │       │       │   └── body: (length: 1)
+        │   │   │       │       │       └── @ CallNode (location: (109,7)-(109,27))
+        │   │   │       │       │           ├── receiver:
+        │   │   │       │       │           │   @ CallNode (location: (109,7)-(109,10))
+        │   │   │       │       │           │   ├── receiver: ∅
+        │   │   │       │       │           │   ├── call_operator_loc: ∅
+        │   │   │       │       │           │   ├── message_loc: (109,7)-(109,10) = "bar"
+        │   │   │       │       │           │   ├── opening_loc: ∅
+        │   │   │       │       │           │   ├── arguments: ∅
+        │   │   │       │       │           │   ├── closing_loc: ∅
+        │   │   │       │       │           │   ├── block: ∅
+        │   │   │       │       │           │   ├── flags: variable_call
+        │   │   │       │       │           │   └── name: :bar
+        │   │   │       │       │           ├── call_operator_loc: (109,10)-(109,11) = "."
+        │   │   │       │       │           ├── message_loc: (109,11)-(109,14) = "map"
+        │   │   │       │       │           ├── opening_loc: ∅
+        │   │   │       │       │           ├── arguments: ∅
+        │   │   │       │       │           ├── closing_loc: ∅
+        │   │   │       │       │           ├── block:
+        │   │   │       │       │           │   @ BlockNode (location: (109,15)-(109,27))
+        │   │   │       │       │           │   ├── locals: []
+        │   │   │       │       │           │   ├── parameters: ∅
+        │   │   │       │       │           │   ├── body:
+        │   │   │       │       │           │   │   @ StatementsNode (location: (109,18)-(109,23))
+        │   │   │       │       │           │   │   └── body: (length: 1)
+        │   │   │       │       │           │   │       └── @ StringNode (location: (109,18)-(109,23))
+        │   │   │       │       │           │   │           ├── flags: ∅
+        │   │   │       │       │           │   │           ├── opening_loc: (109,18)-(109,19) = "\""
+        │   │   │       │       │           │   │           ├── content_loc: (109,19)-(109,22) = "baz"
+        │   │   │       │       │           │   │           ├── closing_loc: (109,22)-(109,23) = "\""
+        │   │   │       │       │           │   │           └── unescaped: "baz"
+        │   │   │       │       │           │   ├── opening_loc: (109,15)-(109,17) = "do"
+        │   │   │       │       │           │   └── closing_loc: (109,24)-(109,27) = "end"
+        │   │   │       │       │           ├── flags: ∅
+        │   │   │       │       │           └── name: :map
+        │   │   │       │       └── closing_loc: (109,27)-(109,28) = "}"
+        │   │   │       └── closing_loc: (109,28)-(109,29) = "\""
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (109,30)-(109,36))
@@ -1620,36 +1655,37 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (111,4)-(111,28))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ClassNode (location: (111,4)-(111,28))
-        │   │           ├── locals: []
-        │   │           ├── class_keyword_loc: (111,4)-(111,9) = "class"
-        │   │           ├── constant_path:
-        │   │           │   @ ConstantReadNode (location: (111,10)-(111,13))
-        │   │           │   └── name: :Bar
-        │   │           ├── inheritance_operator_loc: ∅
-        │   │           ├── superclass: ∅
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (111,14)-(111,24))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (111,14)-(111,24))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (111,14)-(111,17) = "baz"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block:
-        │   │           │           │   @ BlockNode (location: (111,18)-(111,24))
-        │   │           │           │   ├── locals: []
-        │   │           │           │   ├── parameters: ∅
-        │   │           │           │   ├── body: ∅
-        │   │           │           │   ├── opening_loc: (111,18)-(111,20) = "do"
-        │   │           │           │   └── closing_loc: (111,21)-(111,24) = "end"
-        │   │           │           ├── flags: ∅
-        │   │           │           └── name: :baz
-        │   │           ├── end_keyword_loc: (111,25)-(111,28) = "end"
-        │   │           └── name: :Bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ClassNode (location: (111,4)-(111,28))
+        │   │   │       ├── locals: []
+        │   │   │       ├── class_keyword_loc: (111,4)-(111,9) = "class"
+        │   │   │       ├── constant_path:
+        │   │   │       │   @ ConstantReadNode (location: (111,10)-(111,13))
+        │   │   │       │   └── name: :Bar
+        │   │   │       ├── inheritance_operator_loc: ∅
+        │   │   │       ├── superclass: ∅
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (111,14)-(111,24))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (111,14)-(111,24))
+        │   │   │       │           ├── receiver: ∅
+        │   │   │       │           ├── call_operator_loc: ∅
+        │   │   │       │           ├── message_loc: (111,14)-(111,17) = "baz"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block:
+        │   │   │       │           │   @ BlockNode (location: (111,18)-(111,24))
+        │   │   │       │           │   ├── locals: []
+        │   │   │       │           │   ├── parameters: ∅
+        │   │   │       │           │   ├── body: ∅
+        │   │   │       │           │   ├── opening_loc: (111,18)-(111,20) = "do"
+        │   │   │       │           │   └── closing_loc: (111,21)-(111,24) = "end"
+        │   │   │       │           ├── flags: ∅
+        │   │   │       │           └── name: :baz
+        │   │   │       ├── end_keyword_loc: (111,25)-(111,28) = "end"
+        │   │   │       └── name: :Bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1661,34 +1697,35 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (113,4)-(113,29))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ModuleNode (location: (113,4)-(113,29))
-        │   │           ├── locals: []
-        │   │           ├── module_keyword_loc: (113,4)-(113,10) = "module"
-        │   │           ├── constant_path:
-        │   │           │   @ ConstantReadNode (location: (113,11)-(113,14))
-        │   │           │   └── name: :Bar
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (113,15)-(113,25))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (113,15)-(113,25))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (113,15)-(113,18) = "baz"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block:
-        │   │           │           │   @ BlockNode (location: (113,19)-(113,25))
-        │   │           │           │   ├── locals: []
-        │   │           │           │   ├── parameters: ∅
-        │   │           │           │   ├── body: ∅
-        │   │           │           │   ├── opening_loc: (113,19)-(113,21) = "do"
-        │   │           │           │   └── closing_loc: (113,22)-(113,25) = "end"
-        │   │           │           ├── flags: ∅
-        │   │           │           └── name: :baz
-        │   │           ├── end_keyword_loc: (113,26)-(113,29) = "end"
-        │   │           └── name: :Bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ModuleNode (location: (113,4)-(113,29))
+        │   │   │       ├── locals: []
+        │   │   │       ├── module_keyword_loc: (113,4)-(113,10) = "module"
+        │   │   │       ├── constant_path:
+        │   │   │       │   @ ConstantReadNode (location: (113,11)-(113,14))
+        │   │   │       │   └── name: :Bar
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (113,15)-(113,25))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (113,15)-(113,25))
+        │   │   │       │           ├── receiver: ∅
+        │   │   │       │           ├── call_operator_loc: ∅
+        │   │   │       │           ├── message_loc: (113,15)-(113,18) = "baz"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block:
+        │   │   │       │           │   @ BlockNode (location: (113,19)-(113,25))
+        │   │   │       │           │   ├── locals: []
+        │   │   │       │           │   ├── parameters: ∅
+        │   │   │       │           │   ├── body: ∅
+        │   │   │       │           │   ├── opening_loc: (113,19)-(113,21) = "do"
+        │   │   │       │           │   └── closing_loc: (113,22)-(113,25) = "end"
+        │   │   │       │           ├── flags: ∅
+        │   │   │       │           └── name: :baz
+        │   │   │       ├── end_keyword_loc: (113,26)-(113,29) = "end"
+        │   │   │       └── name: :Bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1700,27 +1737,28 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (115,4)-(115,16))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ArrayNode (location: (115,4)-(115,16))
-        │   │           ├── elements: (length: 1)
-        │   │           │   └── @ CallNode (location: (115,5)-(115,15))
-        │   │           │       ├── receiver: ∅
-        │   │           │       ├── call_operator_loc: ∅
-        │   │           │       ├── message_loc: (115,5)-(115,8) = "baz"
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── arguments: ∅
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       ├── block:
-        │   │           │       │   @ BlockNode (location: (115,9)-(115,15))
-        │   │           │       │   ├── locals: []
-        │   │           │       │   ├── parameters: ∅
-        │   │           │       │   ├── body: ∅
-        │   │           │       │   ├── opening_loc: (115,9)-(115,11) = "do"
-        │   │           │       │   └── closing_loc: (115,12)-(115,15) = "end"
-        │   │           │       ├── flags: ∅
-        │   │           │       └── name: :baz
-        │   │           ├── opening_loc: (115,4)-(115,5) = "["
-        │   │           └── closing_loc: (115,15)-(115,16) = "]"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ArrayNode (location: (115,4)-(115,16))
+        │   │   │       ├── elements: (length: 1)
+        │   │   │       │   └── @ CallNode (location: (115,5)-(115,15))
+        │   │   │       │       ├── receiver: ∅
+        │   │   │       │       ├── call_operator_loc: ∅
+        │   │   │       │       ├── message_loc: (115,5)-(115,8) = "baz"
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── arguments: ∅
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       ├── block:
+        │   │   │       │       │   @ BlockNode (location: (115,9)-(115,15))
+        │   │   │       │       │   ├── locals: []
+        │   │   │       │       │   ├── parameters: ∅
+        │   │   │       │       │   ├── body: ∅
+        │   │   │       │       │   ├── opening_loc: (115,9)-(115,11) = "do"
+        │   │   │       │       │   └── closing_loc: (115,12)-(115,15) = "end"
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       └── name: :baz
+        │   │   │       ├── opening_loc: (115,4)-(115,5) = "["
+        │   │   │       └── closing_loc: (115,15)-(115,16) = "]"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1732,38 +1770,39 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (117,2)-(117,28))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ BeginNode (location: (117,2)-(117,28))
-        │   │           ├── begin_keyword_loc: (117,2)-(117,7) = "begin"
-        │   │           ├── statements:
-        │   │           │   @ StatementsNode (location: (117,8)-(117,24))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (117,8)-(117,24))
-        │   │           │           ├── receiver:
-        │   │           │           │   @ IntegerNode (location: (117,8)-(117,9))
-        │   │           │           │   └── flags: decimal
-        │   │           │           ├── call_operator_loc: (117,9)-(117,10) = "."
-        │   │           │           ├── message_loc: (117,10)-(117,15) = "times"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block:
-        │   │           │           │   @ BlockNode (location: (117,16)-(117,24))
-        │   │           │           │   ├── locals: []
-        │   │           │           │   ├── parameters: ∅
-        │   │           │           │   ├── body:
-        │   │           │           │   │   @ StatementsNode (location: (117,19)-(117,20))
-        │   │           │           │   │   └── body: (length: 1)
-        │   │           │           │   │       └── @ IntegerNode (location: (117,19)-(117,20))
-        │   │           │           │   │           └── flags: decimal
-        │   │           │           │   ├── opening_loc: (117,16)-(117,18) = "do"
-        │   │           │           │   └── closing_loc: (117,21)-(117,24) = "end"
-        │   │           │           ├── flags: ∅
-        │   │           │           └── name: :times
-        │   │           ├── rescue_clause: ∅
-        │   │           ├── else_clause: ∅
-        │   │           ├── ensure_clause: ∅
-        │   │           └── end_keyword_loc: (117,25)-(117,28) = "end"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ BeginNode (location: (117,2)-(117,28))
+        │   │   │       ├── begin_keyword_loc: (117,2)-(117,7) = "begin"
+        │   │   │       ├── statements:
+        │   │   │       │   @ StatementsNode (location: (117,8)-(117,24))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (117,8)-(117,24))
+        │   │   │       │           ├── receiver:
+        │   │   │       │           │   @ IntegerNode (location: (117,8)-(117,9))
+        │   │   │       │           │   └── flags: decimal
+        │   │   │       │           ├── call_operator_loc: (117,9)-(117,10) = "."
+        │   │   │       │           ├── message_loc: (117,10)-(117,15) = "times"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block:
+        │   │   │       │           │   @ BlockNode (location: (117,16)-(117,24))
+        │   │   │       │           │   ├── locals: []
+        │   │   │       │           │   ├── parameters: ∅
+        │   │   │       │           │   ├── body:
+        │   │   │       │           │   │   @ StatementsNode (location: (117,19)-(117,20))
+        │   │   │       │           │   │   └── body: (length: 1)
+        │   │   │       │           │   │       └── @ IntegerNode (location: (117,19)-(117,20))
+        │   │   │       │           │   │           └── flags: decimal
+        │   │   │       │           │   ├── opening_loc: (117,16)-(117,18) = "do"
+        │   │   │       │           │   └── closing_loc: (117,21)-(117,24) = "end"
+        │   │   │       │           ├── flags: ∅
+        │   │   │       │           └── name: :times
+        │   │   │       ├── rescue_clause: ∅
+        │   │   │       ├── else_clause: ∅
+        │   │   │       ├── ensure_clause: ∅
+        │   │   │       └── end_keyword_loc: (117,25)-(117,28) = "end"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1775,66 +1814,67 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (119,4)-(124,5))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SymbolNode (location: (119,4)-(119,6))
-        │   │       │   ├── opening_loc: (119,4)-(119,5) = ":"
-        │   │       │   ├── value_loc: (119,5)-(119,6) = "a"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "a"
-        │   │       └── @ IfNode (location: (120,2)-(124,5))
-        │   │           ├── if_keyword_loc: (120,2)-(120,4) = "if"
-        │   │           ├── predicate:
-        │   │           │   @ CallNode (location: (120,5)-(120,6))
-        │   │           │   ├── receiver: ∅
-        │   │           │   ├── call_operator_loc: ∅
-        │   │           │   ├── message_loc: (120,5)-(120,6) = "x"
-        │   │           │   ├── opening_loc: ∅
-        │   │           │   ├── arguments: ∅
-        │   │           │   ├── closing_loc: ∅
-        │   │           │   ├── block: ∅
-        │   │           │   ├── flags: variable_call
-        │   │           │   └── name: :x
-        │   │           ├── statements:
-        │   │           │   @ StatementsNode (location: (121,4)-(123,7))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (121,4)-(123,7))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (121,4)-(121,7) = "bar"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block:
-        │   │           │           │   @ BlockNode (location: (121,8)-(123,7))
-        │   │           │           │   ├── locals: [:a]
-        │   │           │           │   ├── parameters:
-        │   │           │           │   │   @ BlockParametersNode (location: (121,11)-(121,14))
-        │   │           │           │   │   ├── parameters:
-        │   │           │           │   │   │   @ ParametersNode (location: (121,12)-(121,13))
-        │   │           │           │   │   │   ├── requireds: (length: 1)
-        │   │           │           │   │   │   │   └── @ RequiredParameterNode (location: (121,12)-(121,13))
-        │   │           │           │   │   │   │       └── name: :a
-        │   │           │           │   │   │   ├── optionals: (length: 0)
-        │   │           │           │   │   │   ├── rest: ∅
-        │   │           │           │   │   │   ├── posts: (length: 0)
-        │   │           │           │   │   │   ├── keywords: (length: 0)
-        │   │           │           │   │   │   ├── keyword_rest: ∅
-        │   │           │           │   │   │   └── block: ∅
-        │   │           │           │   │   ├── locals: (length: 0)
-        │   │           │           │   │   ├── opening_loc: (121,11)-(121,12) = "|"
-        │   │           │           │   │   └── closing_loc: (121,13)-(121,14) = "|"
-        │   │           │           │   ├── body:
-        │   │           │           │   │   @ StatementsNode (location: (122,6)-(122,7))
-        │   │           │           │   │   └── body: (length: 1)
-        │   │           │           │   │       └── @ LocalVariableReadNode (location: (122,6)-(122,7))
-        │   │           │           │   │           ├── name: :a
-        │   │           │           │   │           └── depth: 0
-        │   │           │           │   ├── opening_loc: (121,8)-(121,10) = "do"
-        │   │           │           │   └── closing_loc: (123,4)-(123,7) = "end"
-        │   │           │           ├── flags: ∅
-        │   │           │           └── name: :bar
-        │   │           ├── consequent: ∅
-        │   │           └── end_keyword_loc: (124,2)-(124,5) = "end"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SymbolNode (location: (119,4)-(119,6))
+        │   │   │   │   ├── opening_loc: (119,4)-(119,5) = ":"
+        │   │   │   │   ├── value_loc: (119,5)-(119,6) = "a"
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── unescaped: "a"
+        │   │   │   └── @ IfNode (location: (120,2)-(124,5))
+        │   │   │       ├── if_keyword_loc: (120,2)-(120,4) = "if"
+        │   │   │       ├── predicate:
+        │   │   │       │   @ CallNode (location: (120,5)-(120,6))
+        │   │   │       │   ├── receiver: ∅
+        │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │       │   ├── message_loc: (120,5)-(120,6) = "x"
+        │   │   │       │   ├── opening_loc: ∅
+        │   │   │       │   ├── arguments: ∅
+        │   │   │       │   ├── closing_loc: ∅
+        │   │   │       │   ├── block: ∅
+        │   │   │       │   ├── flags: variable_call
+        │   │   │       │   └── name: :x
+        │   │   │       ├── statements:
+        │   │   │       │   @ StatementsNode (location: (121,4)-(123,7))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (121,4)-(123,7))
+        │   │   │       │           ├── receiver: ∅
+        │   │   │       │           ├── call_operator_loc: ∅
+        │   │   │       │           ├── message_loc: (121,4)-(121,7) = "bar"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block:
+        │   │   │       │           │   @ BlockNode (location: (121,8)-(123,7))
+        │   │   │       │           │   ├── locals: [:a]
+        │   │   │       │           │   ├── parameters:
+        │   │   │       │           │   │   @ BlockParametersNode (location: (121,11)-(121,14))
+        │   │   │       │           │   │   ├── parameters:
+        │   │   │       │           │   │   │   @ ParametersNode (location: (121,12)-(121,13))
+        │   │   │       │           │   │   │   ├── requireds: (length: 1)
+        │   │   │       │           │   │   │   │   └── @ RequiredParameterNode (location: (121,12)-(121,13))
+        │   │   │       │           │   │   │   │       └── name: :a
+        │   │   │       │           │   │   │   ├── optionals: (length: 0)
+        │   │   │       │           │   │   │   ├── rest: ∅
+        │   │   │       │           │   │   │   ├── posts: (length: 0)
+        │   │   │       │           │   │   │   ├── keywords: (length: 0)
+        │   │   │       │           │   │   │   ├── keyword_rest: ∅
+        │   │   │       │           │   │   │   └── block: ∅
+        │   │   │       │           │   │   ├── locals: (length: 0)
+        │   │   │       │           │   │   ├── opening_loc: (121,11)-(121,12) = "|"
+        │   │   │       │           │   │   └── closing_loc: (121,13)-(121,14) = "|"
+        │   │   │       │           │   ├── body:
+        │   │   │       │           │   │   @ StatementsNode (location: (122,6)-(122,7))
+        │   │   │       │           │   │   └── body: (length: 1)
+        │   │   │       │           │   │       └── @ LocalVariableReadNode (location: (122,6)-(122,7))
+        │   │   │       │           │   │           ├── name: :a
+        │   │   │       │           │   │           └── depth: 0
+        │   │   │       │           │   ├── opening_loc: (121,8)-(121,10) = "do"
+        │   │   │       │           │   └── closing_loc: (123,4)-(123,7) = "end"
+        │   │   │       │           ├── flags: ∅
+        │   │   │       │           └── name: :bar
+        │   │   │       ├── consequent: ∅
+        │   │   │       └── end_keyword_loc: (124,2)-(124,5) = "end"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1846,100 +1886,101 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (126,4)-(135,5))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ SymbolNode (location: (126,4)-(126,6))
-        │   │       │   ├── opening_loc: (126,4)-(126,5) = ":"
-        │   │       │   ├── value_loc: (126,5)-(126,6) = "a"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "a"
-        │   │       ├── @ WhileNode (location: (127,2)-(131,5))
-        │   │       │   ├── keyword_loc: (127,2)-(127,7) = "while"
-        │   │       │   ├── closing_loc: (131,2)-(131,5) = "end"
-        │   │       │   ├── predicate:
-        │   │       │   │   @ CallNode (location: (127,8)-(127,9))
-        │   │       │   │   ├── receiver: ∅
-        │   │       │   │   ├── call_operator_loc: ∅
-        │   │       │   │   ├── message_loc: (127,8)-(127,9) = "x"
-        │   │       │   │   ├── opening_loc: ∅
-        │   │       │   │   ├── arguments: ∅
-        │   │       │   │   ├── closing_loc: ∅
-        │   │       │   │   ├── block: ∅
-        │   │       │   │   ├── flags: variable_call
-        │   │       │   │   └── name: :x
-        │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (128,4)-(130,7))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (128,4)-(130,7))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (128,4)-(128,7) = "bar"
-        │   │       │   │           ├── opening_loc: ∅
-        │   │       │   │           ├── arguments: ∅
-        │   │       │   │           ├── closing_loc: ∅
-        │   │       │   │           ├── block:
-        │   │       │   │           │   @ BlockNode (location: (128,8)-(130,7))
-        │   │       │   │           │   ├── locals: [:a]
-        │   │       │   │           │   ├── parameters:
-        │   │       │   │           │   │   @ BlockParametersNode (location: (128,11)-(128,14))
-        │   │       │   │           │   │   ├── parameters:
-        │   │       │   │           │   │   │   @ ParametersNode (location: (128,12)-(128,13))
-        │   │       │   │           │   │   │   ├── requireds: (length: 1)
-        │   │       │   │           │   │   │   │   └── @ RequiredParameterNode (location: (128,12)-(128,13))
-        │   │       │   │           │   │   │   │       └── name: :a
-        │   │       │   │           │   │   │   ├── optionals: (length: 0)
-        │   │       │   │           │   │   │   ├── rest: ∅
-        │   │       │   │           │   │   │   ├── posts: (length: 0)
-        │   │       │   │           │   │   │   ├── keywords: (length: 0)
-        │   │       │   │           │   │   │   ├── keyword_rest: ∅
-        │   │       │   │           │   │   │   └── block: ∅
-        │   │       │   │           │   │   ├── locals: (length: 0)
-        │   │       │   │           │   │   ├── opening_loc: (128,11)-(128,12) = "|"
-        │   │       │   │           │   │   └── closing_loc: (128,13)-(128,14) = "|"
-        │   │       │   │           │   ├── body:
-        │   │       │   │           │   │   @ StatementsNode (location: (129,6)-(129,7))
-        │   │       │   │           │   │   └── body: (length: 1)
-        │   │       │   │           │   │       └── @ LocalVariableReadNode (location: (129,6)-(129,7))
-        │   │       │   │           │   │           ├── name: :a
-        │   │       │   │           │   │           └── depth: 0
-        │   │       │   │           │   ├── opening_loc: (128,8)-(128,10) = "do"
-        │   │       │   │           │   └── closing_loc: (130,4)-(130,7) = "end"
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :bar
-        │   │       │   └── flags: ∅
-        │   │       └── @ UntilNode (location: (132,2)-(135,5))
-        │   │           ├── keyword_loc: (132,2)-(132,7) = "until"
-        │   │           ├── closing_loc: (135,2)-(135,5) = "end"
-        │   │           ├── predicate:
-        │   │           │   @ CallNode (location: (132,8)-(132,9))
-        │   │           │   ├── receiver: ∅
-        │   │           │   ├── call_operator_loc: ∅
-        │   │           │   ├── message_loc: (132,8)-(132,9) = "x"
-        │   │           │   ├── opening_loc: ∅
-        │   │           │   ├── arguments: ∅
-        │   │           │   ├── closing_loc: ∅
-        │   │           │   ├── block: ∅
-        │   │           │   ├── flags: variable_call
-        │   │           │   └── name: :x
-        │   │           ├── statements:
-        │   │           │   @ StatementsNode (location: (133,4)-(134,7))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (133,4)-(134,7))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (133,4)-(133,7) = "baz"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block:
-        │   │           │           │   @ BlockNode (location: (133,8)-(134,7))
-        │   │           │           │   ├── locals: []
-        │   │           │           │   ├── parameters: ∅
-        │   │           │           │   ├── body: ∅
-        │   │           │           │   ├── opening_loc: (133,8)-(133,10) = "do"
-        │   │           │           │   └── closing_loc: (134,4)-(134,7) = "end"
-        │   │           │           ├── flags: ∅
-        │   │           │           └── name: :baz
-        │   │           └── flags: ∅
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ SymbolNode (location: (126,4)-(126,6))
+        │   │   │   │   ├── opening_loc: (126,4)-(126,5) = ":"
+        │   │   │   │   ├── value_loc: (126,5)-(126,6) = "a"
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── unescaped: "a"
+        │   │   │   ├── @ WhileNode (location: (127,2)-(131,5))
+        │   │   │   │   ├── keyword_loc: (127,2)-(127,7) = "while"
+        │   │   │   │   ├── closing_loc: (131,2)-(131,5) = "end"
+        │   │   │   │   ├── predicate:
+        │   │   │   │   │   @ CallNode (location: (127,8)-(127,9))
+        │   │   │   │   │   ├── receiver: ∅
+        │   │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   │   ├── message_loc: (127,8)-(127,9) = "x"
+        │   │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   │   ├── arguments: ∅
+        │   │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   │   ├── block: ∅
+        │   │   │   │   │   ├── flags: variable_call
+        │   │   │   │   │   └── name: :x
+        │   │   │   │   ├── statements:
+        │   │   │   │   │   @ StatementsNode (location: (128,4)-(130,7))
+        │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │       └── @ CallNode (location: (128,4)-(130,7))
+        │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │           ├── message_loc: (128,4)-(128,7) = "bar"
+        │   │   │   │   │           ├── opening_loc: ∅
+        │   │   │   │   │           ├── arguments: ∅
+        │   │   │   │   │           ├── closing_loc: ∅
+        │   │   │   │   │           ├── block:
+        │   │   │   │   │           │   @ BlockNode (location: (128,8)-(130,7))
+        │   │   │   │   │           │   ├── locals: [:a]
+        │   │   │   │   │           │   ├── parameters:
+        │   │   │   │   │           │   │   @ BlockParametersNode (location: (128,11)-(128,14))
+        │   │   │   │   │           │   │   ├── parameters:
+        │   │   │   │   │           │   │   │   @ ParametersNode (location: (128,12)-(128,13))
+        │   │   │   │   │           │   │   │   ├── requireds: (length: 1)
+        │   │   │   │   │           │   │   │   │   └── @ RequiredParameterNode (location: (128,12)-(128,13))
+        │   │   │   │   │           │   │   │   │       └── name: :a
+        │   │   │   │   │           │   │   │   ├── optionals: (length: 0)
+        │   │   │   │   │           │   │   │   ├── rest: ∅
+        │   │   │   │   │           │   │   │   ├── posts: (length: 0)
+        │   │   │   │   │           │   │   │   ├── keywords: (length: 0)
+        │   │   │   │   │           │   │   │   ├── keyword_rest: ∅
+        │   │   │   │   │           │   │   │   └── block: ∅
+        │   │   │   │   │           │   │   ├── locals: (length: 0)
+        │   │   │   │   │           │   │   ├── opening_loc: (128,11)-(128,12) = "|"
+        │   │   │   │   │           │   │   └── closing_loc: (128,13)-(128,14) = "|"
+        │   │   │   │   │           │   ├── body:
+        │   │   │   │   │           │   │   @ StatementsNode (location: (129,6)-(129,7))
+        │   │   │   │   │           │   │   └── body: (length: 1)
+        │   │   │   │   │           │   │       └── @ LocalVariableReadNode (location: (129,6)-(129,7))
+        │   │   │   │   │           │   │           ├── name: :a
+        │   │   │   │   │           │   │           └── depth: 0
+        │   │   │   │   │           │   ├── opening_loc: (128,8)-(128,10) = "do"
+        │   │   │   │   │           │   └── closing_loc: (130,4)-(130,7) = "end"
+        │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │           └── name: :bar
+        │   │   │   │   └── flags: ∅
+        │   │   │   └── @ UntilNode (location: (132,2)-(135,5))
+        │   │   │       ├── keyword_loc: (132,2)-(132,7) = "until"
+        │   │   │       ├── closing_loc: (135,2)-(135,5) = "end"
+        │   │   │       ├── predicate:
+        │   │   │       │   @ CallNode (location: (132,8)-(132,9))
+        │   │   │       │   ├── receiver: ∅
+        │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │       │   ├── message_loc: (132,8)-(132,9) = "x"
+        │   │   │       │   ├── opening_loc: ∅
+        │   │   │       │   ├── arguments: ∅
+        │   │   │       │   ├── closing_loc: ∅
+        │   │   │       │   ├── block: ∅
+        │   │   │       │   ├── flags: variable_call
+        │   │   │       │   └── name: :x
+        │   │   │       ├── statements:
+        │   │   │       │   @ StatementsNode (location: (133,4)-(134,7))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (133,4)-(134,7))
+        │   │   │       │           ├── receiver: ∅
+        │   │   │       │           ├── call_operator_loc: ∅
+        │   │   │       │           ├── message_loc: (133,4)-(133,7) = "baz"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block:
+        │   │   │       │           │   @ BlockNode (location: (133,8)-(134,7))
+        │   │   │       │           │   ├── locals: []
+        │   │   │       │           │   ├── parameters: ∅
+        │   │   │       │           │   ├── body: ∅
+        │   │   │       │           │   ├── opening_loc: (133,8)-(133,10) = "do"
+        │   │   │       │           │   └── closing_loc: (134,4)-(134,7) = "end"
+        │   │   │       │           ├── flags: ∅
+        │   │   │       │           └── name: :baz
+        │   │   │       └── flags: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1955,23 +1996,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (137,5)-(137,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (137,5)-(137,9))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (137,5)-(137,6) = "A"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block:
-        │   │           │   @ BlockNode (location: (137,7)-(137,9))
-        │   │           │   ├── locals: []
-        │   │           │   ├── parameters: ∅
-        │   │           │   ├── body: ∅
-        │   │           │   ├── opening_loc: (137,7)-(137,8) = "{"
-        │   │           │   └── closing_loc: (137,8)-(137,9) = "}"
-        │   │           ├── flags: ∅
-        │   │           └── name: :A
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (137,5)-(137,9))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (137,5)-(137,6) = "A"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block:
+        │   │   │       │   @ BlockNode (location: (137,7)-(137,9))
+        │   │   │       │   ├── locals: []
+        │   │   │       │   ├── parameters: ∅
+        │   │   │       │   ├── body: ∅
+        │   │   │       │   ├── opening_loc: (137,7)-(137,8) = "{"
+        │   │   │       │   └── closing_loc: (137,8)-(137,9) = "}"
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :A
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1987,43 +2029,44 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (139,5)-(139,16))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (139,5)-(139,16))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (139,5)-(139,6) = "A"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block:
-        │   │           │   @ BlockNode (location: (139,7)-(139,16))
-        │   │           │   ├── locals: [:a]
-        │   │           │   ├── parameters:
-        │   │           │   │   @ BlockParametersNode (location: (139,9)-(139,12))
-        │   │           │   │   ├── parameters:
-        │   │           │   │   │   @ ParametersNode (location: (139,10)-(139,11))
-        │   │           │   │   │   ├── requireds: (length: 1)
-        │   │           │   │   │   │   └── @ RequiredParameterNode (location: (139,10)-(139,11))
-        │   │           │   │   │   │       └── name: :a
-        │   │           │   │   │   ├── optionals: (length: 0)
-        │   │           │   │   │   ├── rest: ∅
-        │   │           │   │   │   ├── posts: (length: 0)
-        │   │           │   │   │   ├── keywords: (length: 0)
-        │   │           │   │   │   ├── keyword_rest: ∅
-        │   │           │   │   │   └── block: ∅
-        │   │           │   │   ├── locals: (length: 0)
-        │   │           │   │   ├── opening_loc: (139,9)-(139,10) = "|"
-        │   │           │   │   └── closing_loc: (139,11)-(139,12) = "|"
-        │   │           │   ├── body:
-        │   │           │   │   @ StatementsNode (location: (139,13)-(139,14))
-        │   │           │   │   └── body: (length: 1)
-        │   │           │   │       └── @ LocalVariableReadNode (location: (139,13)-(139,14))
-        │   │           │   │           ├── name: :a
-        │   │           │   │           └── depth: 0
-        │   │           │   ├── opening_loc: (139,7)-(139,8) = "{"
-        │   │           │   └── closing_loc: (139,15)-(139,16) = "}"
-        │   │           ├── flags: ∅
-        │   │           └── name: :A
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (139,5)-(139,16))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (139,5)-(139,6) = "A"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block:
+        │   │   │       │   @ BlockNode (location: (139,7)-(139,16))
+        │   │   │       │   ├── locals: [:a]
+        │   │   │       │   ├── parameters:
+        │   │   │       │   │   @ BlockParametersNode (location: (139,9)-(139,12))
+        │   │   │       │   │   ├── parameters:
+        │   │   │       │   │   │   @ ParametersNode (location: (139,10)-(139,11))
+        │   │   │       │   │   │   ├── requireds: (length: 1)
+        │   │   │       │   │   │   │   └── @ RequiredParameterNode (location: (139,10)-(139,11))
+        │   │   │       │   │   │   │       └── name: :a
+        │   │   │       │   │   │   ├── optionals: (length: 0)
+        │   │   │       │   │   │   ├── rest: ∅
+        │   │   │       │   │   │   ├── posts: (length: 0)
+        │   │   │       │   │   │   ├── keywords: (length: 0)
+        │   │   │       │   │   │   ├── keyword_rest: ∅
+        │   │   │       │   │   │   └── block: ∅
+        │   │   │       │   │   ├── locals: (length: 0)
+        │   │   │       │   │   ├── opening_loc: (139,9)-(139,10) = "|"
+        │   │   │       │   │   └── closing_loc: (139,11)-(139,12) = "|"
+        │   │   │       │   ├── body:
+        │   │   │       │   │   @ StatementsNode (location: (139,13)-(139,14))
+        │   │   │       │   │   └── body: (length: 1)
+        │   │   │       │   │       └── @ LocalVariableReadNode (location: (139,13)-(139,14))
+        │   │   │       │   │           ├── name: :a
+        │   │   │       │   │           └── depth: 0
+        │   │   │       │   ├── opening_loc: (139,7)-(139,8) = "{"
+        │   │   │       │   └── closing_loc: (139,15)-(139,16) = "}"
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :A
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -2051,23 +2094,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (141,7)-(141,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (141,7)-(141,11))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (141,7)-(141,8) = "A"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block:
-        │   │           │   @ BlockNode (location: (141,9)-(141,11))
-        │   │           │   ├── locals: []
-        │   │           │   ├── parameters: ∅
-        │   │           │   ├── body: ∅
-        │   │           │   ├── opening_loc: (141,9)-(141,10) = "{"
-        │   │           │   └── closing_loc: (141,10)-(141,11) = "}"
-        │   │           ├── flags: ∅
-        │   │           └── name: :A
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (141,7)-(141,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (141,7)-(141,8) = "A"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block:
+        │   │   │       │   @ BlockNode (location: (141,9)-(141,11))
+        │   │   │       │   ├── locals: []
+        │   │   │       │   ├── parameters: ∅
+        │   │   │       │   ├── body: ∅
+        │   │   │       │   ├── opening_loc: (141,9)-(141,10) = "{"
+        │   │   │       │   └── closing_loc: (141,10)-(141,11) = "}"
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :A
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -2089,23 +2133,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (143,7)-(143,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (143,7)-(143,11))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (143,7)-(143,8) = "A"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block:
-        │   │           │   @ BlockNode (location: (143,9)-(143,11))
-        │   │           │   ├── locals: []
-        │   │           │   ├── parameters: ∅
-        │   │           │   ├── body: ∅
-        │   │           │   ├── opening_loc: (143,9)-(143,10) = "{"
-        │   │           │   └── closing_loc: (143,10)-(143,11) = "}"
-        │   │           ├── flags: ∅
-        │   │           └── name: :A
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (143,7)-(143,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (143,7)-(143,8) = "A"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block:
+        │   │   │       │   @ BlockNode (location: (143,9)-(143,11))
+        │   │   │       │   ├── locals: []
+        │   │   │       │   ├── parameters: ∅
+        │   │   │       │   ├── body: ∅
+        │   │   │       │   ├── opening_loc: (143,9)-(143,10) = "{"
+        │   │   │       │   └── closing_loc: (143,10)-(143,11) = "}"
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :A
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -2125,19 +2170,20 @@
         │   │       │           ├── opening_loc: ∅
         │   │       │           ├── arguments:
         │   │       │           │   @ ArgumentsNode (location: (145,9)-(145,14))
-        │   │       │           │   └── arguments: (length: 1)
-        │   │       │           │       └── @ ParenthesesNode (location: (145,9)-(145,14))
-        │   │       │           │           ├── body:
-        │   │       │           │           │   @ StatementsNode (location: (145,10)-(145,13))
-        │   │       │           │           │   └── body: (length: 1)
-        │   │       │           │           │       └── @ StringNode (location: (145,10)-(145,13))
-        │   │       │           │           │           ├── flags: ∅
-        │   │       │           │           │           ├── opening_loc: (145,10)-(145,11) = "\""
-        │   │       │           │           │           ├── content_loc: (145,11)-(145,12) = " "
-        │   │       │           │           │           ├── closing_loc: (145,12)-(145,13) = "\""
-        │   │       │           │           │           └── unescaped: " "
-        │   │       │           │           ├── opening_loc: (145,9)-(145,10) = "("
-        │   │       │           │           └── closing_loc: (145,13)-(145,14) = ")"
+        │   │       │           │   ├── arguments: (length: 1)
+        │   │       │           │   │   └── @ ParenthesesNode (location: (145,9)-(145,14))
+        │   │       │           │   │       ├── body:
+        │   │       │           │   │       │   @ StatementsNode (location: (145,10)-(145,13))
+        │   │       │           │   │       │   └── body: (length: 1)
+        │   │       │           │   │       │       └── @ StringNode (location: (145,10)-(145,13))
+        │   │       │           │   │       │           ├── flags: ∅
+        │   │       │           │   │       │           ├── opening_loc: (145,10)-(145,11) = "\""
+        │   │       │           │   │       │           ├── content_loc: (145,11)-(145,12) = " "
+        │   │       │           │   │       │           ├── closing_loc: (145,12)-(145,13) = "\""
+        │   │       │           │   │       │           └── unescaped: " "
+        │   │       │           │   │       ├── opening_loc: (145,9)-(145,10) = "("
+        │   │       │           │   │       └── closing_loc: (145,13)-(145,14) = ")"
+        │   │       │           │   └── flags: ∅
         │   │       │           ├── closing_loc: ∅
         │   │       │           ├── block: ∅
         │   │       │           ├── flags: ∅

--- a/test/prism/snapshots/methods.txt
+++ b/test/prism/snapshots/methods.txt
@@ -779,12 +779,13 @@
         │   │       │   │           ├── keyword_loc: (99,0)-(99,6) = "return"
         │   │       │   │           └── arguments:
         │   │       │   │               @ ArgumentsNode (location: (99,7)-(99,10))
-        │   │       │   │               └── arguments: (length: 1)
-        │   │       │   │                   └── @ SymbolNode (location: (99,7)-(99,10))
-        │   │       │   │                       ├── opening_loc: (99,7)-(99,8) = ":"
-        │   │       │   │                       ├── value_loc: (99,8)-(99,10) = "hi"
-        │   │       │   │                       ├── closing_loc: ∅
-        │   │       │   │                       └── unescaped: "hi"
+        │   │       │   │               ├── arguments: (length: 1)
+        │   │       │   │               │   └── @ SymbolNode (location: (99,7)-(99,10))
+        │   │       │   │               │       ├── opening_loc: (99,7)-(99,8) = ":"
+        │   │       │   │               │       ├── value_loc: (99,8)-(99,10) = "hi"
+        │   │       │   │               │       ├── closing_loc: ∅
+        │   │       │   │               │       └── unescaped: "hi"
+        │   │       │   │               └── flags: ∅
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       └── @ SymbolNode (location: (100,0)-(100,4))
@@ -904,10 +905,11 @@
         │   │           ├── opening_loc: (110,11)-(110,12) = "("
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (110,12)-(110,13))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ SplatNode (location: (110,12)-(110,13))
-        │   │           │           ├── operator_loc: (110,12)-(110,13) = "*"
-        │   │           │           └── expression: ∅
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ SplatNode (location: (110,12)-(110,13))
+        │   │           │   │       ├── operator_loc: (110,12)-(110,13) = "*"
+        │   │           │   │       └── expression: ∅
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: (110,13)-(110,14) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -943,8 +945,9 @@
         │   │           ├── opening_loc: (112,13)-(112,14) = "("
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (112,14)-(112,17))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ ForwardingArgumentsNode (location: (112,14)-(112,17))
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ ForwardingArgumentsNode (location: (112,14)-(112,17))
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: (112,17)-(112,18) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -980,12 +983,13 @@
         │   │           ├── opening_loc: (114,13)-(114,14) = "("
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (114,14)-(114,23))
-        │   │           │   └── arguments: (length: 3)
-        │   │           │       ├── @ IntegerNode (location: (114,14)-(114,15))
-        │   │           │       │   └── flags: decimal
-        │   │           │       ├── @ IntegerNode (location: (114,17)-(114,18))
-        │   │           │       │   └── flags: decimal
-        │   │           │       └── @ ForwardingArgumentsNode (location: (114,20)-(114,23))
+        │   │           │   ├── arguments: (length: 3)
+        │   │           │   │   ├── @ IntegerNode (location: (114,14)-(114,15))
+        │   │           │   │   │   └── flags: decimal
+        │   │           │   │   ├── @ IntegerNode (location: (114,17)-(114,18))
+        │   │           │   │   │   └── flags: decimal
+        │   │           │   │   └── @ ForwardingArgumentsNode (location: (114,20)-(114,23))
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: (114,23)-(114,24) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -1202,8 +1206,9 @@
         │   │           │       │           ├── opening_loc: (136,19)-(136,20) = "("
         │   │           │       │           ├── arguments:
         │   │           │       │           │   @ ArgumentsNode (location: (136,20)-(136,23))
-        │   │           │       │           │   └── arguments: (length: 1)
-        │   │           │       │           │       └── @ ForwardingArgumentsNode (location: (136,20)-(136,23))
+        │   │           │       │           │   ├── arguments: (length: 1)
+        │   │           │       │           │   │   └── @ ForwardingArgumentsNode (location: (136,20)-(136,23))
+        │   │           │       │           │   └── flags: ∅
         │   │           │       │           ├── closing_loc: (136,23)-(136,24) = ")"
         │   │           │       │           ├── block: ∅
         │   │           │       │           ├── flags: ∅
@@ -1236,48 +1241,49 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (139,11)-(139,30))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ KeywordHashNode (location: (139,11)-(139,30))
-        │   │           │           └── elements: (length: 3)
-        │   │           │               ├── @ AssocSplatNode (location: (139,11)-(139,16))
-        │   │           │               │   ├── value:
-        │   │           │               │   │   @ CallNode (location: (139,13)-(139,16))
-        │   │           │               │   │   ├── receiver: ∅
-        │   │           │               │   │   ├── call_operator_loc: ∅
-        │   │           │               │   │   ├── message_loc: (139,13)-(139,16) = "bar"
-        │   │           │               │   │   ├── opening_loc: ∅
-        │   │           │               │   │   ├── arguments: ∅
-        │   │           │               │   │   ├── closing_loc: ∅
-        │   │           │               │   │   ├── block: ∅
-        │   │           │               │   │   ├── flags: variable_call
-        │   │           │               │   │   └── name: :bar
-        │   │           │               │   └── operator_loc: (139,11)-(139,13) = "**"
-        │   │           │               ├── @ AssocSplatNode (location: (139,18)-(139,23))
-        │   │           │               │   ├── value:
-        │   │           │               │   │   @ CallNode (location: (139,20)-(139,23))
-        │   │           │               │   │   ├── receiver: ∅
-        │   │           │               │   │   ├── call_operator_loc: ∅
-        │   │           │               │   │   ├── message_loc: (139,20)-(139,23) = "baz"
-        │   │           │               │   │   ├── opening_loc: ∅
-        │   │           │               │   │   ├── arguments: ∅
-        │   │           │               │   │   ├── closing_loc: ∅
-        │   │           │               │   │   ├── block: ∅
-        │   │           │               │   │   ├── flags: variable_call
-        │   │           │               │   │   └── name: :baz
-        │   │           │               │   └── operator_loc: (139,18)-(139,20) = "**"
-        │   │           │               └── @ AssocSplatNode (location: (139,25)-(139,30))
-        │   │           │                   ├── value:
-        │   │           │                   │   @ CallNode (location: (139,27)-(139,30))
-        │   │           │                   │   ├── receiver: ∅
-        │   │           │                   │   ├── call_operator_loc: ∅
-        │   │           │                   │   ├── message_loc: (139,27)-(139,30) = "qux"
-        │   │           │                   │   ├── opening_loc: ∅
-        │   │           │                   │   ├── arguments: ∅
-        │   │           │                   │   ├── closing_loc: ∅
-        │   │           │                   │   ├── block: ∅
-        │   │           │                   │   ├── flags: variable_call
-        │   │           │                   │   └── name: :qux
-        │   │           │                   └── operator_loc: (139,25)-(139,27) = "**"
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ KeywordHashNode (location: (139,11)-(139,30))
+        │   │           │   │       └── elements: (length: 3)
+        │   │           │   │           ├── @ AssocSplatNode (location: (139,11)-(139,16))
+        │   │           │   │           │   ├── value:
+        │   │           │   │           │   │   @ CallNode (location: (139,13)-(139,16))
+        │   │           │   │           │   │   ├── receiver: ∅
+        │   │           │   │           │   │   ├── call_operator_loc: ∅
+        │   │           │   │           │   │   ├── message_loc: (139,13)-(139,16) = "bar"
+        │   │           │   │           │   │   ├── opening_loc: ∅
+        │   │           │   │           │   │   ├── arguments: ∅
+        │   │           │   │           │   │   ├── closing_loc: ∅
+        │   │           │   │           │   │   ├── block: ∅
+        │   │           │   │           │   │   ├── flags: variable_call
+        │   │           │   │           │   │   └── name: :bar
+        │   │           │   │           │   └── operator_loc: (139,11)-(139,13) = "**"
+        │   │           │   │           ├── @ AssocSplatNode (location: (139,18)-(139,23))
+        │   │           │   │           │   ├── value:
+        │   │           │   │           │   │   @ CallNode (location: (139,20)-(139,23))
+        │   │           │   │           │   │   ├── receiver: ∅
+        │   │           │   │           │   │   ├── call_operator_loc: ∅
+        │   │           │   │           │   │   ├── message_loc: (139,20)-(139,23) = "baz"
+        │   │           │   │           │   │   ├── opening_loc: ∅
+        │   │           │   │           │   │   ├── arguments: ∅
+        │   │           │   │           │   │   ├── closing_loc: ∅
+        │   │           │   │           │   │   ├── block: ∅
+        │   │           │   │           │   │   ├── flags: variable_call
+        │   │           │   │           │   │   └── name: :baz
+        │   │           │   │           │   └── operator_loc: (139,18)-(139,20) = "**"
+        │   │           │   │           └── @ AssocSplatNode (location: (139,25)-(139,30))
+        │   │           │   │               ├── value:
+        │   │           │   │               │   @ CallNode (location: (139,27)-(139,30))
+        │   │           │   │               │   ├── receiver: ∅
+        │   │           │   │               │   ├── call_operator_loc: ∅
+        │   │           │   │               │   ├── message_loc: (139,27)-(139,30) = "qux"
+        │   │           │   │               │   ├── opening_loc: ∅
+        │   │           │   │               │   ├── arguments: ∅
+        │   │           │   │               │   ├── closing_loc: ∅
+        │   │           │   │               │   ├── block: ∅
+        │   │           │   │               │   ├── flags: variable_call
+        │   │           │   │               │   └── name: :qux
+        │   │           │   │               └── operator_loc: (139,25)-(139,27) = "**"
+        │   │           │   └── flags: keyword_splat
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -1559,23 +1565,24 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (161,10)-(161,14))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ CallNode (location: (161,10)-(161,14))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (161,10)-(161,11) = "a"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block:
-        │   │           │           │   @ BlockNode (location: (161,12)-(161,14))
-        │   │           │           │   ├── locals: []
-        │   │           │           │   ├── parameters: ∅
-        │   │           │           │   ├── body: ∅
-        │   │           │           │   ├── opening_loc: (161,12)-(161,13) = "{"
-        │   │           │           │   └── closing_loc: (161,13)-(161,14) = "}"
-        │   │           │           ├── flags: ∅
-        │   │           │           └── name: :a
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ CallNode (location: (161,10)-(161,14))
+        │   │           │   │       ├── receiver: ∅
+        │   │           │   │       ├── call_operator_loc: ∅
+        │   │           │   │       ├── message_loc: (161,10)-(161,11) = "a"
+        │   │           │   │       ├── opening_loc: ∅
+        │   │           │   │       ├── arguments: ∅
+        │   │           │   │       ├── closing_loc: ∅
+        │   │           │   │       ├── block:
+        │   │           │   │       │   @ BlockNode (location: (161,12)-(161,14))
+        │   │           │   │       │   ├── locals: []
+        │   │           │   │       │   ├── parameters: ∅
+        │   │           │   │       │   ├── body: ∅
+        │   │           │   │       │   ├── opening_loc: (161,12)-(161,13) = "{"
+        │   │           │   │       │   └── closing_loc: (161,13)-(161,14) = "}"
+        │   │           │   │       ├── flags: ∅
+        │   │           │   │       └── name: :a
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅

--- a/test/prism/snapshots/modules.txt
+++ b/test/prism/snapshots/modules.txt
@@ -163,9 +163,10 @@
             │   │   ├── opening_loc: (17,8)-(17,9) = "["
             │   │   ├── arguments:
             │   │   │   @ ArgumentsNode (location: (17,9)-(17,10))
-            │   │   │   └── arguments: (length: 1)
-            │   │   │       └── @ IntegerNode (location: (17,9)-(17,10))
-            │   │   │           └── flags: decimal
+            │   │   │   ├── arguments: (length: 1)
+            │   │   │   │   └── @ IntegerNode (location: (17,9)-(17,10))
+            │   │   │   │       └── flags: decimal
+            │   │   │   └── flags: ∅
             │   │   ├── closing_loc: (17,10)-(17,11) = "]"
             │   │   ├── block: ∅
             │   │   ├── flags: ∅

--- a/test/prism/snapshots/next.txt
+++ b/test/prism/snapshots/next.txt
@@ -9,90 +9,96 @@
         ├── @ NextNode (location: (3,0)-(3,18))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,5)-(3,18))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ ParenthesesNode (location: (3,5)-(3,8))
-        │   │       │   ├── body:
-        │   │       │   │   @ StatementsNode (location: (3,6)-(3,7))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ IntegerNode (location: (3,6)-(3,7))
-        │   │       │   │           └── flags: decimal
-        │   │       │   ├── opening_loc: (3,5)-(3,6) = "("
-        │   │       │   └── closing_loc: (3,7)-(3,8) = ")"
-        │   │       ├── @ ParenthesesNode (location: (3,10)-(3,13))
-        │   │       │   ├── body:
-        │   │       │   │   @ StatementsNode (location: (3,11)-(3,12))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ IntegerNode (location: (3,11)-(3,12))
-        │   │       │   │           └── flags: decimal
-        │   │       │   ├── opening_loc: (3,10)-(3,11) = "("
-        │   │       │   └── closing_loc: (3,12)-(3,13) = ")"
-        │   │       └── @ ParenthesesNode (location: (3,15)-(3,18))
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (3,16)-(3,17))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (3,16)-(3,17))
-        │   │           │           └── flags: decimal
-        │   │           ├── opening_loc: (3,15)-(3,16) = "("
-        │   │           └── closing_loc: (3,17)-(3,18) = ")"
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ ParenthesesNode (location: (3,5)-(3,8))
+        │   │   │   │   ├── body:
+        │   │   │   │   │   @ StatementsNode (location: (3,6)-(3,7))
+        │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │       └── @ IntegerNode (location: (3,6)-(3,7))
+        │   │   │   │   │           └── flags: decimal
+        │   │   │   │   ├── opening_loc: (3,5)-(3,6) = "("
+        │   │   │   │   └── closing_loc: (3,7)-(3,8) = ")"
+        │   │   │   ├── @ ParenthesesNode (location: (3,10)-(3,13))
+        │   │   │   │   ├── body:
+        │   │   │   │   │   @ StatementsNode (location: (3,11)-(3,12))
+        │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │       └── @ IntegerNode (location: (3,11)-(3,12))
+        │   │   │   │   │           └── flags: decimal
+        │   │   │   │   ├── opening_loc: (3,10)-(3,11) = "("
+        │   │   │   │   └── closing_loc: (3,12)-(3,13) = ")"
+        │   │   │   └── @ ParenthesesNode (location: (3,15)-(3,18))
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (3,16)-(3,17))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ IntegerNode (location: (3,16)-(3,17))
+        │   │   │       │           └── flags: decimal
+        │   │   │       ├── opening_loc: (3,15)-(3,16) = "("
+        │   │   │       └── closing_loc: (3,17)-(3,18) = ")"
+        │   │   └── flags: ∅
         │   └── keyword_loc: (3,0)-(3,4) = "next"
         ├── @ NextNode (location: (5,0)-(5,6))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,5)-(5,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (5,5)-(5,6))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (5,5)-(5,6))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   └── keyword_loc: (5,0)-(5,4) = "next"
         ├── @ NextNode (location: (7,0)-(8,1))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,5)-(8,1))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ IntegerNode (location: (7,5)-(7,6))
-        │   │       │   └── flags: decimal
-        │   │       ├── @ IntegerNode (location: (7,8)-(7,9))
-        │   │       │   └── flags: decimal
-        │   │       └── @ IntegerNode (location: (8,0)-(8,1))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ IntegerNode (location: (7,5)-(7,6))
+        │   │   │   │   └── flags: decimal
+        │   │   │   ├── @ IntegerNode (location: (7,8)-(7,9))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ IntegerNode (location: (8,0)-(8,1))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   └── keyword_loc: (7,0)-(7,4) = "next"
         ├── @ NextNode (location: (10,0)-(10,12))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (10,5)-(10,12))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ IntegerNode (location: (10,5)-(10,6))
-        │   │       │   └── flags: decimal
-        │   │       ├── @ IntegerNode (location: (10,8)-(10,9))
-        │   │       │   └── flags: decimal
-        │   │       └── @ IntegerNode (location: (10,11)-(10,12))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ IntegerNode (location: (10,5)-(10,6))
+        │   │   │   │   └── flags: decimal
+        │   │   │   ├── @ IntegerNode (location: (10,8)-(10,9))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ IntegerNode (location: (10,11)-(10,12))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   └── keyword_loc: (10,0)-(10,4) = "next"
         ├── @ NextNode (location: (12,0)-(12,14))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (12,5)-(12,14))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ArrayNode (location: (12,5)-(12,14))
-        │   │           ├── elements: (length: 3)
-        │   │           │   ├── @ IntegerNode (location: (12,6)-(12,7))
-        │   │           │   │   └── flags: decimal
-        │   │           │   ├── @ IntegerNode (location: (12,9)-(12,10))
-        │   │           │   │   └── flags: decimal
-        │   │           │   └── @ IntegerNode (location: (12,12)-(12,13))
-        │   │           │       └── flags: decimal
-        │   │           ├── opening_loc: (12,5)-(12,6) = "["
-        │   │           └── closing_loc: (12,13)-(12,14) = "]"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ArrayNode (location: (12,5)-(12,14))
+        │   │   │       ├── elements: (length: 3)
+        │   │   │       │   ├── @ IntegerNode (location: (12,6)-(12,7))
+        │   │   │       │   │   └── flags: decimal
+        │   │   │       │   ├── @ IntegerNode (location: (12,9)-(12,10))
+        │   │   │       │   │   └── flags: decimal
+        │   │   │       │   └── @ IntegerNode (location: (12,12)-(12,13))
+        │   │   │       │       └── flags: decimal
+        │   │   │       ├── opening_loc: (12,5)-(12,6) = "["
+        │   │   │       └── closing_loc: (12,13)-(12,14) = "]"
+        │   │   └── flags: ∅
         │   └── keyword_loc: (12,0)-(12,4) = "next"
         ├── @ NextNode (location: (14,0)-(17,1))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (14,4)-(17,1))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (14,4)-(17,1))
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (15,2)-(16,3))
-        │   │           │   └── body: (length: 2)
-        │   │           │       ├── @ IntegerNode (location: (15,2)-(15,3))
-        │   │           │       │   └── flags: decimal
-        │   │           │       └── @ IntegerNode (location: (16,2)-(16,3))
-        │   │           │           └── flags: decimal
-        │   │           ├── opening_loc: (14,4)-(14,5) = "("
-        │   │           └── closing_loc: (17,0)-(17,1) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (14,4)-(17,1))
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (15,2)-(16,3))
+        │   │   │       │   └── body: (length: 2)
+        │   │   │       │       ├── @ IntegerNode (location: (15,2)-(15,3))
+        │   │   │       │       │   └── flags: decimal
+        │   │   │       │       └── @ IntegerNode (location: (16,2)-(16,3))
+        │   │   │       │           └── flags: decimal
+        │   │   │       ├── opening_loc: (14,4)-(14,5) = "("
+        │   │   │       └── closing_loc: (17,0)-(17,1) = ")"
+        │   │   └── flags: ∅
         │   └── keyword_loc: (14,0)-(14,4) = "next"
         ├── @ NextNode (location: (19,0)-(19,4))
         │   ├── arguments: ∅
@@ -102,22 +108,24 @@
         ├── @ NextNode (location: (22,0)-(22,6))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (22,4)-(22,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (22,4)-(22,6))
-        │   │           ├── body: ∅
-        │   │           ├── opening_loc: (22,4)-(22,5) = "("
-        │   │           └── closing_loc: (22,5)-(22,6) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (22,4)-(22,6))
+        │   │   │       ├── body: ∅
+        │   │   │       ├── opening_loc: (22,4)-(22,5) = "("
+        │   │   │       └── closing_loc: (22,5)-(22,6) = ")"
+        │   │   └── flags: ∅
         │   └── keyword_loc: (22,0)-(22,4) = "next"
         └── @ NextNode (location: (24,0)-(24,7))
             ├── arguments:
             │   @ ArgumentsNode (location: (24,4)-(24,7))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (24,4)-(24,7))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (24,5)-(24,6))
-            │           │   └── body: (length: 1)
-            │           │       └── @ IntegerNode (location: (24,5)-(24,6))
-            │           │           └── flags: decimal
-            │           ├── opening_loc: (24,4)-(24,5) = "("
-            │           └── closing_loc: (24,6)-(24,7) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (24,4)-(24,7))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (24,5)-(24,6))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ IntegerNode (location: (24,5)-(24,6))
+            │   │       │           └── flags: decimal
+            │   │       ├── opening_loc: (24,4)-(24,5) = "("
+            │   │       └── closing_loc: (24,6)-(24,7) = ")"
+            │   └── flags: ∅
             └── keyword_loc: (24,0)-(24,4) = "next"

--- a/test/prism/snapshots/patterns.txt
+++ b/test/prism/snapshots/patterns.txt
@@ -1345,13 +1345,14 @@
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (61,17)-(61,22))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ StringNode (location: (61,17)-(61,22))
-        │   │   │   │           ├── flags: ∅
-        │   │   │   │           ├── opening_loc: (61,17)-(61,18) = "\""
-        │   │   │   │           ├── content_loc: (61,18)-(61,21) = "baz"
-        │   │   │   │           ├── closing_loc: (61,21)-(61,22) = "\""
-        │   │   │   │           └── unescaped: "baz"
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ StringNode (location: (61,17)-(61,22))
+        │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │       ├── opening_loc: (61,17)-(61,18) = "\""
+        │   │   │   │   │       ├── content_loc: (61,18)-(61,21) = "baz"
+        │   │   │   │   │       ├── closing_loc: (61,21)-(61,22) = "\""
+        │   │   │   │   │       └── unescaped: "baz"
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: ∅
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅

--- a/test/prism/snapshots/procs.txt
+++ b/test/prism/snapshots/procs.txt
@@ -333,10 +333,11 @@
         │                           ├── opening_loc: ∅
         │                           ├── arguments:
         │                           │   @ ArgumentsNode (location: (25,20)-(25,21))
-        │                           │   └── arguments: (length: 1)
-        │                           │       └── @ LocalVariableReadNode (location: (25,20)-(25,21))
-        │                           │           ├── name: :b
-        │                           │           └── depth: 0
+        │                           │   ├── arguments: (length: 1)
+        │                           │   │   └── @ LocalVariableReadNode (location: (25,20)-(25,21))
+        │                           │   │       ├── name: :b
+        │                           │   │       └── depth: 0
+        │                           │   └── flags: ∅
         │                           ├── closing_loc: ∅
         │                           ├── block: ∅
         │                           ├── flags: ∅

--- a/test/prism/snapshots/ranges.txt
+++ b/test/prism/snapshots/ranges.txt
@@ -55,14 +55,15 @@
         │   ├── opening_loc: (7,3)-(7,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,4)-(7,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ RangeNode (location: (7,4)-(7,8))
-        │   │           ├── left: ∅
-        │   │           ├── right:
-        │   │           │   @ IntegerNode (location: (7,7)-(7,8))
-        │   │           │   └── flags: decimal
-        │   │           ├── operator_loc: (7,4)-(7,7) = "..."
-        │   │           └── flags: exclude_end
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ RangeNode (location: (7,4)-(7,8))
+        │   │   │       ├── left: ∅
+        │   │   │       ├── right:
+        │   │   │       │   @ IntegerNode (location: (7,7)-(7,8))
+        │   │   │       │   └── flags: decimal
+        │   │   │       ├── operator_loc: (7,4)-(7,7) = "..."
+        │   │   │       └── flags: exclude_end
+        │   │   └── flags: ∅
         │   ├── closing_loc: (7,8)-(7,9) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/regex.txt
+++ b/test/prism/snapshots/regex.txt
@@ -10,13 +10,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,4)-(1,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ RegularExpressionNode (location: (1,4)-(1,9))
-        │   │           ├── opening_loc: (1,4)-(1,5) = "/"
-        │   │           ├── content_loc: (1,5)-(1,8) = "bar"
-        │   │           ├── closing_loc: (1,8)-(1,9) = "/"
-        │   │           ├── unescaped: "bar"
-        │   │           └── flags: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ RegularExpressionNode (location: (1,4)-(1,9))
+        │   │   │       ├── opening_loc: (1,4)-(1,5) = "/"
+        │   │   │       ├── content_loc: (1,5)-(1,8) = "bar"
+        │   │   │       ├── closing_loc: (1,8)-(1,9) = "/"
+        │   │   │       ├── unescaped: "bar"
+        │   │   │       └── flags: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -99,17 +100,18 @@
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── arguments:
         │   │   │   │   │   @ ArgumentsNode (location: (11,18)-(11,21))
-        │   │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │   │       └── @ CallNode (location: (11,18)-(11,21))
-        │   │   │   │   │           ├── receiver: ∅
-        │   │   │   │   │           ├── call_operator_loc: ∅
-        │   │   │   │   │           ├── message_loc: (11,18)-(11,21) = "baz"
-        │   │   │   │   │           ├── opening_loc: ∅
-        │   │   │   │   │           ├── arguments: ∅
-        │   │   │   │   │           ├── closing_loc: ∅
-        │   │   │   │   │           ├── block: ∅
-        │   │   │   │   │           ├── flags: variable_call
-        │   │   │   │   │           └── name: :baz
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (11,18)-(11,21))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (11,18)-(11,21) = "baz"
+        │   │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       ├── arguments: ∅
+        │   │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: variable_call
+        │   │   │   │   │   │       └── name: :baz
+        │   │   │   │   │   └── flags: ∅
         │   │   │   │   ├── closing_loc: ∅
         │   │   │   │   ├── block: ∅
         │   │   │   │   ├── flags: ∅
@@ -163,13 +165,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (26,12)-(26,16))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (26,12)-(26,16))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (26,12)-(26,13) = "\""
-        │   │           ├── content_loc: (26,13)-(26,15) = "hi"
-        │   │           ├── closing_loc: (26,15)-(26,16) = "\""
-        │   │           └── unescaped: "hi"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (26,12)-(26,16))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (26,12)-(26,13) = "\""
+        │   │   │       ├── content_loc: (26,13)-(26,15) = "hi"
+        │   │   │       ├── closing_loc: (26,15)-(26,16) = "\""
+        │   │   │       └── unescaped: "hi"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -222,13 +225,14 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (33,8)-(33,10))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ StringNode (location: (33,8)-(33,10))
-        │   │   │           ├── flags: ∅
-        │   │   │           ├── opening_loc: (33,8)-(33,9) = "\""
-        │   │   │           ├── content_loc: (33,9)-(33,9) = ""
-        │   │   │           ├── closing_loc: (33,9)-(33,10) = "\""
-        │   │   │           └── unescaped: ""
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ StringNode (location: (33,8)-(33,10))
+        │   │   │   │       ├── flags: ∅
+        │   │   │   │       ├── opening_loc: (33,8)-(33,9) = "\""
+        │   │   │   │       ├── content_loc: (33,9)-(33,9) = ""
+        │   │   │   │       ├── closing_loc: (33,9)-(33,10) = "\""
+        │   │   │   │       └── unescaped: ""
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block: ∅
         │   │   ├── flags: ∅

--- a/test/prism/snapshots/rescue.txt
+++ b/test/prism/snapshots/rescue.txt
@@ -188,17 +188,18 @@
         │   │   │           │   ├── opening_loc: (19,5)-(19,6) = "("
         │   │   │           │   ├── arguments:
         │   │   │           │   │   @ ArgumentsNode (location: (19,6)-(19,7))
-        │   │   │           │   │   └── arguments: (length: 1)
-        │   │   │           │   │       └── @ CallNode (location: (19,6)-(19,7))
-        │   │   │           │   │           ├── receiver: ∅
-        │   │   │           │   │           ├── call_operator_loc: ∅
-        │   │   │           │   │           ├── message_loc: (19,6)-(19,7) = "y"
-        │   │   │           │   │           ├── opening_loc: ∅
-        │   │   │           │   │           ├── arguments: ∅
-        │   │   │           │   │           ├── closing_loc: ∅
-        │   │   │           │   │           ├── block: ∅
-        │   │   │           │   │           ├── flags: variable_call
-        │   │   │           │   │           └── name: :y
+        │   │   │           │   │   ├── arguments: (length: 1)
+        │   │   │           │   │   │   └── @ CallNode (location: (19,6)-(19,7))
+        │   │   │           │   │   │       ├── receiver: ∅
+        │   │   │           │   │   │       ├── call_operator_loc: ∅
+        │   │   │           │   │   │       ├── message_loc: (19,6)-(19,7) = "y"
+        │   │   │           │   │   │       ├── opening_loc: ∅
+        │   │   │           │   │   │       ├── arguments: ∅
+        │   │   │           │   │   │       ├── closing_loc: ∅
+        │   │   │           │   │   │       ├── block: ∅
+        │   │   │           │   │   │       ├── flags: variable_call
+        │   │   │           │   │   │       └── name: :y
+        │   │   │           │   │   └── flags: ∅
         │   │   │           │   ├── closing_loc: (19,7)-(19,8) = ")"
         │   │   │           │   ├── block: ∅
         │   │   │           │   ├── flags: ∅
@@ -212,25 +213,27 @@
         │   │   │               ├── opening_loc: ∅
         │   │   │               ├── arguments:
         │   │   │               │   @ ArgumentsNode (location: (19,30)-(19,40))
-        │   │   │               │   └── arguments: (length: 1)
-        │   │   │               │       └── @ CallNode (location: (19,30)-(19,40))
-        │   │   │               │           ├── receiver: ∅
-        │   │   │               │           ├── call_operator_loc: ∅
-        │   │   │               │           ├── message_loc: (19,30)-(19,34) = "fail"
-        │   │   │               │           ├── opening_loc: ∅
-        │   │   │               │           ├── arguments:
-        │   │   │               │           │   @ ArgumentsNode (location: (19,35)-(19,40))
-        │   │   │               │           │   └── arguments: (length: 1)
-        │   │   │               │           │       └── @ StringNode (location: (19,35)-(19,40))
-        │   │   │               │           │           ├── flags: ∅
-        │   │   │               │           │           ├── opening_loc: (19,35)-(19,36) = "\""
-        │   │   │               │           │           ├── content_loc: (19,36)-(19,39) = "baz"
-        │   │   │               │           │           ├── closing_loc: (19,39)-(19,40) = "\""
-        │   │   │               │           │           └── unescaped: "baz"
-        │   │   │               │           ├── closing_loc: ∅
-        │   │   │               │           ├── block: ∅
-        │   │   │               │           ├── flags: ∅
-        │   │   │               │           └── name: :fail
+        │   │   │               │   ├── arguments: (length: 1)
+        │   │   │               │   │   └── @ CallNode (location: (19,30)-(19,40))
+        │   │   │               │   │       ├── receiver: ∅
+        │   │   │               │   │       ├── call_operator_loc: ∅
+        │   │   │               │   │       ├── message_loc: (19,30)-(19,34) = "fail"
+        │   │   │               │   │       ├── opening_loc: ∅
+        │   │   │               │   │       ├── arguments:
+        │   │   │               │   │       │   @ ArgumentsNode (location: (19,35)-(19,40))
+        │   │   │               │   │       │   ├── arguments: (length: 1)
+        │   │   │               │   │       │   │   └── @ StringNode (location: (19,35)-(19,40))
+        │   │   │               │   │       │   │       ├── flags: ∅
+        │   │   │               │   │       │   │       ├── opening_loc: (19,35)-(19,36) = "\""
+        │   │   │               │   │       │   │       ├── content_loc: (19,36)-(19,39) = "baz"
+        │   │   │               │   │       │   │       ├── closing_loc: (19,39)-(19,40) = "\""
+        │   │   │               │   │       │   │       └── unescaped: "baz"
+        │   │   │               │   │       │   └── flags: ∅
+        │   │   │               │   │       ├── closing_loc: ∅
+        │   │   │               │   │       ├── block: ∅
+        │   │   │               │   │       ├── flags: ∅
+        │   │   │               │   │       └── name: :fail
+        │   │   │               │   └── flags: ∅
         │   │   │               ├── closing_loc: ∅
         │   │   │               ├── block: ∅
         │   │   │               ├── flags: ∅
@@ -293,14 +296,15 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (26,31)-(26,44))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ RescueModifierNode (location: (26,31)-(26,44))
-        │   │           │           ├── expression:
-        │   │           │           │   @ IntegerNode (location: (26,31)-(26,33))
-        │   │           │           │   └── flags: decimal
-        │   │           │           ├── keyword_loc: (26,34)-(26,40) = "rescue"
-        │   │           │           └── rescue_expression:
-        │   │           │               @ NilNode (location: (26,41)-(26,44))
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ RescueModifierNode (location: (26,31)-(26,44))
+        │   │           │   │       ├── expression:
+        │   │           │   │       │   @ IntegerNode (location: (26,31)-(26,33))
+        │   │           │   │       │   └── flags: decimal
+        │   │           │   │       ├── keyword_loc: (26,34)-(26,40) = "rescue"
+        │   │           │   │       └── rescue_expression:
+        │   │           │   │           @ NilNode (location: (26,41)-(26,44))
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -330,30 +334,31 @@
             │   │           ├── opening_loc: ∅
             │   │           ├── arguments:
             │   │           │   @ ArgumentsNode (location: (29,4)-(29,6))
-            │   │           │   └── arguments: (length: 1)
-            │   │           │       └── @ KeywordHashNode (location: (29,4)-(29,6))
-            │   │           │           └── elements: (length: 1)
-            │   │           │               └── @ AssocNode (location: (29,4)-(29,6))
-            │   │           │                   ├── key:
-            │   │           │                   │   @ SymbolNode (location: (29,4)-(29,6))
-            │   │           │                   │   ├── opening_loc: ∅
-            │   │           │                   │   ├── value_loc: (29,4)-(29,5) = "b"
-            │   │           │                   │   ├── closing_loc: (29,5)-(29,6) = ":"
-            │   │           │                   │   └── unescaped: "b"
-            │   │           │                   ├── value:
-            │   │           │                   │   @ ImplicitNode (location: (29,4)-(29,6))
-            │   │           │                   │   └── value:
-            │   │           │                   │       @ CallNode (location: (29,4)-(29,6))
-            │   │           │                   │       ├── receiver: ∅
-            │   │           │                   │       ├── call_operator_loc: ∅
-            │   │           │                   │       ├── message_loc: (29,4)-(29,5) = "b"
-            │   │           │                   │       ├── opening_loc: ∅
-            │   │           │                   │       ├── arguments: ∅
-            │   │           │                   │       ├── closing_loc: ∅
-            │   │           │                   │       ├── block: ∅
-            │   │           │                   │       ├── flags: ∅
-            │   │           │                   │       └── name: :b
-            │   │           │                   └── operator_loc: ∅
+            │   │           │   ├── arguments: (length: 1)
+            │   │           │   │   └── @ KeywordHashNode (location: (29,4)-(29,6))
+            │   │           │   │       └── elements: (length: 1)
+            │   │           │   │           └── @ AssocNode (location: (29,4)-(29,6))
+            │   │           │   │               ├── key:
+            │   │           │   │               │   @ SymbolNode (location: (29,4)-(29,6))
+            │   │           │   │               │   ├── opening_loc: ∅
+            │   │           │   │               │   ├── value_loc: (29,4)-(29,5) = "b"
+            │   │           │   │               │   ├── closing_loc: (29,5)-(29,6) = ":"
+            │   │           │   │               │   └── unescaped: "b"
+            │   │           │   │               ├── value:
+            │   │           │   │               │   @ ImplicitNode (location: (29,4)-(29,6))
+            │   │           │   │               │   └── value:
+            │   │           │   │               │       @ CallNode (location: (29,4)-(29,6))
+            │   │           │   │               │       ├── receiver: ∅
+            │   │           │   │               │       ├── call_operator_loc: ∅
+            │   │           │   │               │       ├── message_loc: (29,4)-(29,5) = "b"
+            │   │           │   │               │       ├── opening_loc: ∅
+            │   │           │   │               │       ├── arguments: ∅
+            │   │           │   │               │       ├── closing_loc: ∅
+            │   │           │   │               │       ├── block: ∅
+            │   │           │   │               │       ├── flags: ∅
+            │   │           │   │               │       └── name: :b
+            │   │           │   │               └── operator_loc: ∅
+            │   │           │   └── flags: ∅
             │   │           ├── closing_loc: ∅
             │   │           ├── block: ∅
             │   │           ├── flags: ∅

--- a/test/prism/snapshots/return.txt
+++ b/test/prism/snapshots/return.txt
@@ -10,119 +10,128 @@
         │   ├── keyword_loc: (3,0)-(3,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (3,7)-(3,20))
-        │       └── arguments: (length: 3)
-        │           ├── @ ParenthesesNode (location: (3,7)-(3,10))
-        │           │   ├── body:
-        │           │   │   @ StatementsNode (location: (3,8)-(3,9))
-        │           │   │   └── body: (length: 1)
-        │           │   │       └── @ IntegerNode (location: (3,8)-(3,9))
-        │           │   │           └── flags: decimal
-        │           │   ├── opening_loc: (3,7)-(3,8) = "("
-        │           │   └── closing_loc: (3,9)-(3,10) = ")"
-        │           ├── @ ParenthesesNode (location: (3,12)-(3,15))
-        │           │   ├── body:
-        │           │   │   @ StatementsNode (location: (3,13)-(3,14))
-        │           │   │   └── body: (length: 1)
-        │           │   │       └── @ IntegerNode (location: (3,13)-(3,14))
-        │           │   │           └── flags: decimal
-        │           │   ├── opening_loc: (3,12)-(3,13) = "("
-        │           │   └── closing_loc: (3,14)-(3,15) = ")"
-        │           └── @ ParenthesesNode (location: (3,17)-(3,20))
-        │               ├── body:
-        │               │   @ StatementsNode (location: (3,18)-(3,19))
-        │               │   └── body: (length: 1)
-        │               │       └── @ IntegerNode (location: (3,18)-(3,19))
-        │               │           └── flags: decimal
-        │               ├── opening_loc: (3,17)-(3,18) = "("
-        │               └── closing_loc: (3,19)-(3,20) = ")"
+        │       ├── arguments: (length: 3)
+        │       │   ├── @ ParenthesesNode (location: (3,7)-(3,10))
+        │       │   │   ├── body:
+        │       │   │   │   @ StatementsNode (location: (3,8)-(3,9))
+        │       │   │   │   └── body: (length: 1)
+        │       │   │   │       └── @ IntegerNode (location: (3,8)-(3,9))
+        │       │   │   │           └── flags: decimal
+        │       │   │   ├── opening_loc: (3,7)-(3,8) = "("
+        │       │   │   └── closing_loc: (3,9)-(3,10) = ")"
+        │       │   ├── @ ParenthesesNode (location: (3,12)-(3,15))
+        │       │   │   ├── body:
+        │       │   │   │   @ StatementsNode (location: (3,13)-(3,14))
+        │       │   │   │   └── body: (length: 1)
+        │       │   │   │       └── @ IntegerNode (location: (3,13)-(3,14))
+        │       │   │   │           └── flags: decimal
+        │       │   │   ├── opening_loc: (3,12)-(3,13) = "("
+        │       │   │   └── closing_loc: (3,14)-(3,15) = ")"
+        │       │   └── @ ParenthesesNode (location: (3,17)-(3,20))
+        │       │       ├── body:
+        │       │       │   @ StatementsNode (location: (3,18)-(3,19))
+        │       │       │   └── body: (length: 1)
+        │       │       │       └── @ IntegerNode (location: (3,18)-(3,19))
+        │       │       │           └── flags: decimal
+        │       │       ├── opening_loc: (3,17)-(3,18) = "("
+        │       │       └── closing_loc: (3,19)-(3,20) = ")"
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (5,0)-(5,9))
         │   ├── keyword_loc: (5,0)-(5,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (5,7)-(5,9))
-        │       └── arguments: (length: 1)
-        │           └── @ SplatNode (location: (5,7)-(5,9))
-        │               ├── operator_loc: (5,7)-(5,8) = "*"
-        │               └── expression:
-        │                   @ IntegerNode (location: (5,8)-(5,9))
-        │                   └── flags: decimal
+        │       ├── arguments: (length: 1)
+        │       │   └── @ SplatNode (location: (5,7)-(5,9))
+        │       │       ├── operator_loc: (5,7)-(5,8) = "*"
+        │       │       └── expression:
+        │       │           @ IntegerNode (location: (5,8)-(5,9))
+        │       │           └── flags: decimal
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (7,0)-(7,8))
         │   ├── keyword_loc: (7,0)-(7,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (7,7)-(7,8))
-        │       └── arguments: (length: 1)
-        │           └── @ IntegerNode (location: (7,7)-(7,8))
-        │               └── flags: decimal
+        │       ├── arguments: (length: 1)
+        │       │   └── @ IntegerNode (location: (7,7)-(7,8))
+        │       │       └── flags: decimal
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (9,0)-(10,1))
         │   ├── keyword_loc: (9,0)-(9,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (9,7)-(10,1))
-        │       └── arguments: (length: 3)
-        │           ├── @ IntegerNode (location: (9,7)-(9,8))
-        │           │   └── flags: decimal
-        │           ├── @ IntegerNode (location: (9,10)-(9,11))
-        │           │   └── flags: decimal
-        │           └── @ IntegerNode (location: (10,0)-(10,1))
-        │               └── flags: decimal
+        │       ├── arguments: (length: 3)
+        │       │   ├── @ IntegerNode (location: (9,7)-(9,8))
+        │       │   │   └── flags: decimal
+        │       │   ├── @ IntegerNode (location: (9,10)-(9,11))
+        │       │   │   └── flags: decimal
+        │       │   └── @ IntegerNode (location: (10,0)-(10,1))
+        │       │       └── flags: decimal
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (12,0)-(12,14))
         │   ├── keyword_loc: (12,0)-(12,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (12,7)-(12,14))
-        │       └── arguments: (length: 3)
-        │           ├── @ IntegerNode (location: (12,7)-(12,8))
-        │           │   └── flags: decimal
-        │           ├── @ IntegerNode (location: (12,10)-(12,11))
-        │           │   └── flags: decimal
-        │           └── @ IntegerNode (location: (12,13)-(12,14))
-        │               └── flags: decimal
+        │       ├── arguments: (length: 3)
+        │       │   ├── @ IntegerNode (location: (12,7)-(12,8))
+        │       │   │   └── flags: decimal
+        │       │   ├── @ IntegerNode (location: (12,10)-(12,11))
+        │       │   │   └── flags: decimal
+        │       │   └── @ IntegerNode (location: (12,13)-(12,14))
+        │       │       └── flags: decimal
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (14,0)-(14,16))
         │   ├── keyword_loc: (14,0)-(14,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (14,7)-(14,16))
-        │       └── arguments: (length: 1)
-        │           └── @ ArrayNode (location: (14,7)-(14,16))
-        │               ├── elements: (length: 3)
-        │               │   ├── @ IntegerNode (location: (14,8)-(14,9))
-        │               │   │   └── flags: decimal
-        │               │   ├── @ IntegerNode (location: (14,11)-(14,12))
-        │               │   │   └── flags: decimal
-        │               │   └── @ IntegerNode (location: (14,14)-(14,15))
-        │               │       └── flags: decimal
-        │               ├── opening_loc: (14,7)-(14,8) = "["
-        │               └── closing_loc: (14,15)-(14,16) = "]"
+        │       ├── arguments: (length: 1)
+        │       │   └── @ ArrayNode (location: (14,7)-(14,16))
+        │       │       ├── elements: (length: 3)
+        │       │       │   ├── @ IntegerNode (location: (14,8)-(14,9))
+        │       │       │   │   └── flags: decimal
+        │       │       │   ├── @ IntegerNode (location: (14,11)-(14,12))
+        │       │       │   │   └── flags: decimal
+        │       │       │   └── @ IntegerNode (location: (14,14)-(14,15))
+        │       │       │       └── flags: decimal
+        │       │       ├── opening_loc: (14,7)-(14,8) = "["
+        │       │       └── closing_loc: (14,15)-(14,16) = "]"
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (16,0)-(19,1))
         │   ├── keyword_loc: (16,0)-(16,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (16,6)-(19,1))
-        │       └── arguments: (length: 1)
-        │           └── @ ParenthesesNode (location: (16,6)-(19,1))
-        │               ├── body:
-        │               │   @ StatementsNode (location: (17,2)-(18,3))
-        │               │   └── body: (length: 2)
-        │               │       ├── @ IntegerNode (location: (17,2)-(17,3))
-        │               │       │   └── flags: decimal
-        │               │       └── @ IntegerNode (location: (18,2)-(18,3))
-        │               │           └── flags: decimal
-        │               ├── opening_loc: (16,6)-(16,7) = "("
-        │               └── closing_loc: (19,0)-(19,1) = ")"
+        │       ├── arguments: (length: 1)
+        │       │   └── @ ParenthesesNode (location: (16,6)-(19,1))
+        │       │       ├── body:
+        │       │       │   @ StatementsNode (location: (17,2)-(18,3))
+        │       │       │   └── body: (length: 2)
+        │       │       │       ├── @ IntegerNode (location: (17,2)-(17,3))
+        │       │       │       │   └── flags: decimal
+        │       │       │       └── @ IntegerNode (location: (18,2)-(18,3))
+        │       │       │           └── flags: decimal
+        │       │       ├── opening_loc: (16,6)-(16,7) = "("
+        │       │       └── closing_loc: (19,0)-(19,1) = ")"
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (21,0)-(21,8))
         │   ├── keyword_loc: (21,0)-(21,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (21,6)-(21,8))
-        │       └── arguments: (length: 1)
-        │           └── @ ParenthesesNode (location: (21,6)-(21,8))
-        │               ├── body: ∅
-        │               ├── opening_loc: (21,6)-(21,7) = "("
-        │               └── closing_loc: (21,7)-(21,8) = ")"
+        │       ├── arguments: (length: 1)
+        │       │   └── @ ParenthesesNode (location: (21,6)-(21,8))
+        │       │       ├── body: ∅
+        │       │       ├── opening_loc: (21,6)-(21,7) = "("
+        │       │       └── closing_loc: (21,7)-(21,8) = ")"
+        │       └── flags: ∅
         └── @ ReturnNode (location: (23,0)-(23,9))
             ├── keyword_loc: (23,0)-(23,6) = "return"
             └── arguments:
                 @ ArgumentsNode (location: (23,6)-(23,9))
-                └── arguments: (length: 1)
-                    └── @ ParenthesesNode (location: (23,6)-(23,9))
-                        ├── body:
-                        │   @ StatementsNode (location: (23,7)-(23,8))
-                        │   └── body: (length: 1)
-                        │       └── @ IntegerNode (location: (23,7)-(23,8))
-                        │           └── flags: decimal
-                        ├── opening_loc: (23,6)-(23,7) = "("
-                        └── closing_loc: (23,8)-(23,9) = ")"
+                ├── arguments: (length: 1)
+                │   └── @ ParenthesesNode (location: (23,6)-(23,9))
+                │       ├── body:
+                │       │   @ StatementsNode (location: (23,7)-(23,8))
+                │       │   └── body: (length: 1)
+                │       │       └── @ IntegerNode (location: (23,7)-(23,8))
+                │       │           └── flags: decimal
+                │       ├── opening_loc: (23,6)-(23,7) = "("
+                │       └── closing_loc: (23,8)-(23,9) = ")"
+                └── flags: ∅

--- a/test/prism/snapshots/seattlerb/TestRubyParserShared.txt
+++ b/test/prism/snapshots/seattlerb/TestRubyParserShared.txt
@@ -141,10 +141,11 @@
         │   │           │           ├── opening_loc: ∅
         │   │           │           ├── arguments:
         │   │           │           │   @ ArgumentsNode (location: (54,8)-(54,9))
-        │   │           │           │   └── arguments: (length: 1)
-        │   │           │           │       └── @ LocalVariableReadNode (location: (54,8)-(54,9))
-        │   │           │           │           ├── name: :b
-        │   │           │           │           └── depth: 0
+        │   │           │           │   ├── arguments: (length: 1)
+        │   │           │           │   │   └── @ LocalVariableReadNode (location: (54,8)-(54,9))
+        │   │           │           │   │       ├── name: :b
+        │   │           │           │   │       └── depth: 0
+        │   │           │           │   └── flags: ∅
         │   │           │           ├── closing_loc: ∅
         │   │           │           ├── block: ∅
         │   │           │           ├── flags: ∅
@@ -232,10 +233,11 @@
         │   │           │           ├── opening_loc: ∅
         │   │           │           ├── arguments:
         │   │           │           │   @ ArgumentsNode (location: (69,8)-(69,9))
-        │   │           │           │   └── arguments: (length: 1)
-        │   │           │           │       └── @ LocalVariableReadNode (location: (69,8)-(69,9))
-        │   │           │           │           ├── name: :b
-        │   │           │           │           └── depth: 0
+        │   │           │           │   ├── arguments: (length: 1)
+        │   │           │           │   │   └── @ LocalVariableReadNode (location: (69,8)-(69,9))
+        │   │           │           │   │       ├── name: :b
+        │   │           │           │   │       └── depth: 0
+        │   │           │           │   └── flags: ∅
         │   │           │           ├── closing_loc: ∅
         │   │           │           ├── block: ∅
         │   │           │           ├── flags: ∅
@@ -315,17 +317,18 @@
             ├── opening_loc: (89,1)-(89,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (90,0)-(91,6))
-            │   └── arguments: (length: 2)
-            │       ├── @ SymbolNode (location: (90,0)-(90,6))
-            │       │   ├── opening_loc: (90,0)-(90,1) = ":"
-            │       │   ├── value_loc: (90,1)-(90,6) = "line2"
-            │       │   ├── closing_loc: ∅
-            │       │   └── unescaped: "line2"
-            │       └── @ SymbolNode (location: (91,0)-(91,6))
-            │           ├── opening_loc: (91,0)-(91,1) = ":"
-            │           ├── value_loc: (91,1)-(91,6) = "line3"
-            │           ├── closing_loc: ∅
-            │           └── unescaped: "line3"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ SymbolNode (location: (90,0)-(90,6))
+            │   │   │   ├── opening_loc: (90,0)-(90,1) = ":"
+            │   │   │   ├── value_loc: (90,1)-(90,6) = "line2"
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   └── unescaped: "line2"
+            │   │   └── @ SymbolNode (location: (91,0)-(91,6))
+            │   │       ├── opening_loc: (91,0)-(91,1) = ":"
+            │   │       ├── value_loc: (91,1)-(91,6) = "line3"
+            │   │       ├── closing_loc: ∅
+            │   │       └── unescaped: "line3"
+            │   └── flags: ∅
             ├── closing_loc: (92,0)-(92,1) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/assoc_label.txt
+++ b/test/prism/snapshots/seattlerb/assoc_label.txt
@@ -10,20 +10,21 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,5))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,2)-(1,5))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,2)-(1,5))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (1,2)-(1,4))
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── value_loc: (1,2)-(1,3) = "b"
-            │                   │   ├── closing_loc: (1,3)-(1,4) = ":"
-            │                   │   └── unescaped: "b"
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,4)-(1,5))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,2)-(1,5))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,2)-(1,5))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (1,2)-(1,4))
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── value_loc: (1,2)-(1,3) = "b"
+            │   │               │   ├── closing_loc: (1,3)-(1,4) = ":"
+            │   │               │   └── unescaped: "b"
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,4)-(1,5))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: (1,5)-(1,6) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/attr_asgn_colon_id.txt
+++ b/test/prism/snapshots/seattlerb/attr_asgn_colon_id.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,7)-(1,8))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,7)-(1,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,7)-(1,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/attrasgn_array_arg.txt
+++ b/test/prism/snapshots/seattlerb/attrasgn_array_arg.txt
@@ -20,17 +20,18 @@
             ├── opening_loc: (1,1)-(1,2) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,13))
-            │   └── arguments: (length: 2)
-            │       ├── @ ArrayNode (location: (1,2)-(1,8))
-            │       │   ├── elements: (length: 2)
-            │       │   │   ├── @ IntegerNode (location: (1,3)-(1,4))
-            │       │   │   │   └── flags: decimal
-            │       │   │   └── @ IntegerNode (location: (1,6)-(1,7))
-            │       │   │       └── flags: decimal
-            │       │   ├── opening_loc: (1,2)-(1,3) = "["
-            │       │   └── closing_loc: (1,7)-(1,8) = "]"
-            │       └── @ IntegerNode (location: (1,12)-(1,13))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ ArrayNode (location: (1,2)-(1,8))
+            │   │   │   ├── elements: (length: 2)
+            │   │   │   │   ├── @ IntegerNode (location: (1,3)-(1,4))
+            │   │   │   │   │   └── flags: decimal
+            │   │   │   │   └── @ IntegerNode (location: (1,6)-(1,7))
+            │   │   │   │       └── flags: decimal
+            │   │   │   ├── opening_loc: (1,2)-(1,3) = "["
+            │   │   │   └── closing_loc: (1,7)-(1,8) = "]"
+            │   │   └── @ IntegerNode (location: (1,12)-(1,13))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,8)-(1,9) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/attrasgn_array_lhs.txt
+++ b/test/prism/snapshots/seattlerb/attrasgn_array_lhs.txt
@@ -22,54 +22,55 @@
             ├── opening_loc: (1,12)-(1,13) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,13)-(1,42))
-            │   └── arguments: (length: 2)
-            │       ├── @ RangeNode (location: (1,13)-(1,23))
-            │       │   ├── left:
-            │       │   │   @ CallNode (location: (1,13)-(1,17))
-            │       │   │   ├── receiver: ∅
-            │       │   │   ├── call_operator_loc: ∅
-            │       │   │   ├── message_loc: (1,13)-(1,17) = "from"
-            │       │   │   ├── opening_loc: ∅
-            │       │   │   ├── arguments: ∅
-            │       │   │   ├── closing_loc: ∅
-            │       │   │   ├── block: ∅
-            │       │   │   ├── flags: variable_call
-            │       │   │   └── name: :from
-            │       │   ├── right:
-            │       │   │   @ CallNode (location: (1,21)-(1,23))
-            │       │   │   ├── receiver: ∅
-            │       │   │   ├── call_operator_loc: ∅
-            │       │   │   ├── message_loc: (1,21)-(1,23) = "to"
-            │       │   │   ├── opening_loc: ∅
-            │       │   │   ├── arguments: ∅
-            │       │   │   ├── closing_loc: ∅
-            │       │   │   ├── block: ∅
-            │       │   │   ├── flags: variable_call
-            │       │   │   └── name: :to
-            │       │   ├── operator_loc: (1,18)-(1,20) = ".."
-            │       │   └── flags: ∅
-            │       └── @ ArrayNode (location: (1,27)-(1,42))
-            │           ├── elements: (length: 3)
-            │           │   ├── @ StringNode (location: (1,28)-(1,31))
-            │           │   │   ├── flags: ∅
-            │           │   │   ├── opening_loc: (1,28)-(1,29) = "\""
-            │           │   │   ├── content_loc: (1,29)-(1,30) = "a"
-            │           │   │   ├── closing_loc: (1,30)-(1,31) = "\""
-            │           │   │   └── unescaped: "a"
-            │           │   ├── @ StringNode (location: (1,33)-(1,36))
-            │           │   │   ├── flags: ∅
-            │           │   │   ├── opening_loc: (1,33)-(1,34) = "\""
-            │           │   │   ├── content_loc: (1,34)-(1,35) = "b"
-            │           │   │   ├── closing_loc: (1,35)-(1,36) = "\""
-            │           │   │   └── unescaped: "b"
-            │           │   └── @ StringNode (location: (1,38)-(1,41))
-            │           │       ├── flags: ∅
-            │           │       ├── opening_loc: (1,38)-(1,39) = "\""
-            │           │       ├── content_loc: (1,39)-(1,40) = "c"
-            │           │       ├── closing_loc: (1,40)-(1,41) = "\""
-            │           │       └── unescaped: "c"
-            │           ├── opening_loc: (1,27)-(1,28) = "["
-            │           └── closing_loc: (1,41)-(1,42) = "]"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ RangeNode (location: (1,13)-(1,23))
+            │   │   │   ├── left:
+            │   │   │   │   @ CallNode (location: (1,13)-(1,17))
+            │   │   │   │   ├── receiver: ∅
+            │   │   │   │   ├── call_operator_loc: ∅
+            │   │   │   │   ├── message_loc: (1,13)-(1,17) = "from"
+            │   │   │   │   ├── opening_loc: ∅
+            │   │   │   │   ├── arguments: ∅
+            │   │   │   │   ├── closing_loc: ∅
+            │   │   │   │   ├── block: ∅
+            │   │   │   │   ├── flags: variable_call
+            │   │   │   │   └── name: :from
+            │   │   │   ├── right:
+            │   │   │   │   @ CallNode (location: (1,21)-(1,23))
+            │   │   │   │   ├── receiver: ∅
+            │   │   │   │   ├── call_operator_loc: ∅
+            │   │   │   │   ├── message_loc: (1,21)-(1,23) = "to"
+            │   │   │   │   ├── opening_loc: ∅
+            │   │   │   │   ├── arguments: ∅
+            │   │   │   │   ├── closing_loc: ∅
+            │   │   │   │   ├── block: ∅
+            │   │   │   │   ├── flags: variable_call
+            │   │   │   │   └── name: :to
+            │   │   │   ├── operator_loc: (1,18)-(1,20) = ".."
+            │   │   │   └── flags: ∅
+            │   │   └── @ ArrayNode (location: (1,27)-(1,42))
+            │   │       ├── elements: (length: 3)
+            │   │       │   ├── @ StringNode (location: (1,28)-(1,31))
+            │   │       │   │   ├── flags: ∅
+            │   │       │   │   ├── opening_loc: (1,28)-(1,29) = "\""
+            │   │       │   │   ├── content_loc: (1,29)-(1,30) = "a"
+            │   │       │   │   ├── closing_loc: (1,30)-(1,31) = "\""
+            │   │       │   │   └── unescaped: "a"
+            │   │       │   ├── @ StringNode (location: (1,33)-(1,36))
+            │   │       │   │   ├── flags: ∅
+            │   │       │   │   ├── opening_loc: (1,33)-(1,34) = "\""
+            │   │       │   │   ├── content_loc: (1,34)-(1,35) = "b"
+            │   │       │   │   ├── closing_loc: (1,35)-(1,36) = "\""
+            │   │       │   │   └── unescaped: "b"
+            │   │       │   └── @ StringNode (location: (1,38)-(1,41))
+            │   │       │       ├── flags: ∅
+            │   │       │       ├── opening_loc: (1,38)-(1,39) = "\""
+            │   │       │       ├── content_loc: (1,39)-(1,40) = "c"
+            │   │       │       ├── closing_loc: (1,40)-(1,41) = "\""
+            │   │       │       └── unescaped: "c"
+            │   │       ├── opening_loc: (1,27)-(1,28) = "["
+            │   │       └── closing_loc: (1,41)-(1,42) = "]"
+            │   └── flags: ∅
             ├── closing_loc: (1,23)-(1,24) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/attrasgn_primary_dot_constant.txt
+++ b/test/prism/snapshots/seattlerb/attrasgn_primary_dot_constant.txt
@@ -20,9 +20,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,6)-(1,7))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,6)-(1,7))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,6)-(1,7))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/backticks_interpolation_line.txt
+++ b/test/prism/snapshots/seattlerb/backticks_interpolation_line.txt
@@ -10,27 +10,28 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,8))
-            │   └── arguments: (length: 1)
-            │       └── @ InterpolatedXStringNode (location: (1,2)-(1,8))
-            │           ├── opening_loc: (1,2)-(1,3) = "`"
-            │           ├── parts: (length: 1)
-            │           │   └── @ EmbeddedStatementsNode (location: (1,3)-(1,7))
-            │           │       ├── opening_loc: (1,3)-(1,5) = "\#{"
-            │           │       ├── statements:
-            │           │       │   @ StatementsNode (location: (1,5)-(1,6))
-            │           │       │   └── body: (length: 1)
-            │           │       │       └── @ CallNode (location: (1,5)-(1,6))
-            │           │       │           ├── receiver: ∅
-            │           │       │           ├── call_operator_loc: ∅
-            │           │       │           ├── message_loc: (1,5)-(1,6) = "y"
-            │           │       │           ├── opening_loc: ∅
-            │           │       │           ├── arguments: ∅
-            │           │       │           ├── closing_loc: ∅
-            │           │       │           ├── block: ∅
-            │           │       │           ├── flags: variable_call
-            │           │       │           └── name: :y
-            │           │       └── closing_loc: (1,6)-(1,7) = "}"
-            │           └── closing_loc: (1,7)-(1,8) = "`"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ InterpolatedXStringNode (location: (1,2)-(1,8))
+            │   │       ├── opening_loc: (1,2)-(1,3) = "`"
+            │   │       ├── parts: (length: 1)
+            │   │       │   └── @ EmbeddedStatementsNode (location: (1,3)-(1,7))
+            │   │       │       ├── opening_loc: (1,3)-(1,5) = "\#{"
+            │   │       │       ├── statements:
+            │   │       │       │   @ StatementsNode (location: (1,5)-(1,6))
+            │   │       │       │   └── body: (length: 1)
+            │   │       │       │       └── @ CallNode (location: (1,5)-(1,6))
+            │   │       │       │           ├── receiver: ∅
+            │   │       │       │           ├── call_operator_loc: ∅
+            │   │       │       │           ├── message_loc: (1,5)-(1,6) = "y"
+            │   │       │       │           ├── opening_loc: ∅
+            │   │       │       │           ├── arguments: ∅
+            │   │       │       │           ├── closing_loc: ∅
+            │   │       │       │           ├── block: ∅
+            │   │       │       │           ├── flags: variable_call
+            │   │       │       │           └── name: :y
+            │   │       │       └── closing_loc: (1,6)-(1,7) = "}"
+            │   │       └── closing_loc: (1,7)-(1,8) = "`"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/bang_eq.txt
+++ b/test/prism/snapshots/seattlerb/bang_eq.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,5)-(1,6))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,5)-(1,6))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/block_break.txt
+++ b/test/prism/snapshots/seattlerb/block_break.txt
@@ -6,48 +6,50 @@
         └── @ BreakNode (location: (1,0)-(1,26))
             ├── arguments:
             │   @ ArgumentsNode (location: (1,6)-(1,26))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,6)-(1,26))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,6)-(1,9) = "foo"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (1,10)-(1,13))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ CallNode (location: (1,10)-(1,13))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (1,10)-(1,13) = "arg"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: variable_call
-            │           │           └── name: :arg
-            │           ├── closing_loc: ∅
-            │           ├── block:
-            │           │   @ BlockNode (location: (1,14)-(1,26))
-            │           │   ├── locals: [:bar]
-            │           │   ├── parameters:
-            │           │   │   @ BlockParametersNode (location: (1,17)-(1,22))
-            │           │   │   ├── parameters:
-            │           │   │   │   @ ParametersNode (location: (1,18)-(1,21))
-            │           │   │   │   ├── requireds: (length: 1)
-            │           │   │   │   │   └── @ RequiredParameterNode (location: (1,18)-(1,21))
-            │           │   │   │   │       └── name: :bar
-            │           │   │   │   ├── optionals: (length: 0)
-            │           │   │   │   ├── rest: ∅
-            │           │   │   │   ├── posts: (length: 0)
-            │           │   │   │   ├── keywords: (length: 0)
-            │           │   │   │   ├── keyword_rest: ∅
-            │           │   │   │   └── block: ∅
-            │           │   │   ├── locals: (length: 0)
-            │           │   │   ├── opening_loc: (1,17)-(1,18) = "|"
-            │           │   │   └── closing_loc: (1,21)-(1,22) = "|"
-            │           │   ├── body: ∅
-            │           │   ├── opening_loc: (1,14)-(1,16) = "do"
-            │           │   └── closing_loc: (1,23)-(1,26) = "end"
-            │           ├── flags: ∅
-            │           └── name: :foo
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,6)-(1,26))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,6)-(1,9) = "foo"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (1,10)-(1,13))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ CallNode (location: (1,10)-(1,13))
+            │   │       │   │       ├── receiver: ∅
+            │   │       │   │       ├── call_operator_loc: ∅
+            │   │       │   │       ├── message_loc: (1,10)-(1,13) = "arg"
+            │   │       │   │       ├── opening_loc: ∅
+            │   │       │   │       ├── arguments: ∅
+            │   │       │   │       ├── closing_loc: ∅
+            │   │       │   │       ├── block: ∅
+            │   │       │   │       ├── flags: variable_call
+            │   │       │   │       └── name: :arg
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block:
+            │   │       │   @ BlockNode (location: (1,14)-(1,26))
+            │   │       │   ├── locals: [:bar]
+            │   │       │   ├── parameters:
+            │   │       │   │   @ BlockParametersNode (location: (1,17)-(1,22))
+            │   │       │   │   ├── parameters:
+            │   │       │   │   │   @ ParametersNode (location: (1,18)-(1,21))
+            │   │       │   │   │   ├── requireds: (length: 1)
+            │   │       │   │   │   │   └── @ RequiredParameterNode (location: (1,18)-(1,21))
+            │   │       │   │   │   │       └── name: :bar
+            │   │       │   │   │   ├── optionals: (length: 0)
+            │   │       │   │   │   ├── rest: ∅
+            │   │       │   │   │   ├── posts: (length: 0)
+            │   │       │   │   │   ├── keywords: (length: 0)
+            │   │       │   │   │   ├── keyword_rest: ∅
+            │   │       │   │   │   └── block: ∅
+            │   │       │   │   ├── locals: (length: 0)
+            │   │       │   │   ├── opening_loc: (1,17)-(1,18) = "|"
+            │   │       │   │   └── closing_loc: (1,21)-(1,22) = "|"
+            │   │       │   ├── body: ∅
+            │   │       │   ├── opening_loc: (1,14)-(1,16) = "do"
+            │   │       │   └── closing_loc: (1,23)-(1,26) = "end"
+            │   │       ├── flags: ∅
+            │   │       └── name: :foo
+            │   └── flags: ∅
             └── keyword_loc: (1,0)-(1,5) = "break"

--- a/test/prism/snapshots/seattlerb/block_call_defn_call_block_call.txt
+++ b/test/prism/snapshots/seattlerb/block_call_defn_call_block_call.txt
@@ -10,42 +10,43 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(3,4))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ DefNode (location: (1,2)-(3,4))
-        │   │           ├── name: :b
-        │   │           ├── name_loc: (1,6)-(1,7) = "b"
-        │   │           ├── receiver: ∅
-        │   │           ├── parameters:
-        │   │           │   @ ParametersNode (location: (1,8)-(1,9))
-        │   │           │   ├── requireds: (length: 1)
-        │   │           │   │   └── @ RequiredParameterNode (location: (1,8)-(1,9))
-        │   │           │   │       └── name: :c
-        │   │           │   ├── optionals: (length: 0)
-        │   │           │   ├── rest: ∅
-        │   │           │   ├── posts: (length: 0)
-        │   │           │   ├── keywords: (length: 0)
-        │   │           │   ├── keyword_rest: ∅
-        │   │           │   └── block: ∅
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (2,1)-(2,2))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (2,1)-(2,2))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (2,1)-(2,2) = "d"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block: ∅
-        │   │           │           ├── flags: variable_call
-        │   │           │           └── name: :d
-        │   │           ├── locals: [:c]
-        │   │           ├── def_keyword_loc: (1,2)-(1,5) = "def"
-        │   │           ├── operator_loc: ∅
-        │   │           ├── lparen_loc: (1,7)-(1,8) = "("
-        │   │           ├── rparen_loc: (1,9)-(1,10) = ")"
-        │   │           ├── equal_loc: ∅
-        │   │           └── end_keyword_loc: (3,1)-(3,4) = "end"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ DefNode (location: (1,2)-(3,4))
+        │   │   │       ├── name: :b
+        │   │   │       ├── name_loc: (1,6)-(1,7) = "b"
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── parameters:
+        │   │   │       │   @ ParametersNode (location: (1,8)-(1,9))
+        │   │   │       │   ├── requireds: (length: 1)
+        │   │   │       │   │   └── @ RequiredParameterNode (location: (1,8)-(1,9))
+        │   │   │       │   │       └── name: :c
+        │   │   │       │   ├── optionals: (length: 0)
+        │   │   │       │   ├── rest: ∅
+        │   │   │       │   ├── posts: (length: 0)
+        │   │   │       │   ├── keywords: (length: 0)
+        │   │   │       │   ├── keyword_rest: ∅
+        │   │   │       │   └── block: ∅
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (2,1)-(2,2))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (2,1)-(2,2))
+        │   │   │       │           ├── receiver: ∅
+        │   │   │       │           ├── call_operator_loc: ∅
+        │   │   │       │           ├── message_loc: (2,1)-(2,2) = "d"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block: ∅
+        │   │   │       │           ├── flags: variable_call
+        │   │   │       │           └── name: :d
+        │   │   │       ├── locals: [:c]
+        │   │   │       ├── def_keyword_loc: (1,2)-(1,5) = "def"
+        │   │   │       ├── operator_loc: ∅
+        │   │   │       ├── lparen_loc: (1,7)-(1,8) = "("
+        │   │   │       ├── rparen_loc: (1,9)-(1,10) = ")"
+        │   │   │       ├── equal_loc: ∅
+        │   │   │       └── end_keyword_loc: (3,1)-(3,4) = "end"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/block_call_dot_op2_brace_block.txt
+++ b/test/prism/snapshots/seattlerb/block_call_dot_op2_brace_block.txt
@@ -22,17 +22,18 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,4)-(1,7))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ CallNode (location: (1,4)-(1,7))
-            │   │           ├── receiver: ∅
-            │   │           ├── call_operator_loc: ∅
-            │   │           ├── message_loc: (1,4)-(1,5) = "c"
-            │   │           ├── opening_loc: (1,5)-(1,6) = "("
-            │   │           ├── arguments: ∅
-            │   │           ├── closing_loc: (1,6)-(1,7) = ")"
-            │   │           ├── block: ∅
-            │   │           ├── flags: ∅
-            │   │           └── name: :c
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ CallNode (location: (1,4)-(1,7))
+            │   │   │       ├── receiver: ∅
+            │   │   │       ├── call_operator_loc: ∅
+            │   │   │       ├── message_loc: (1,4)-(1,5) = "c"
+            │   │   │       ├── opening_loc: (1,5)-(1,6) = "("
+            │   │   │       ├── arguments: ∅
+            │   │   │       ├── closing_loc: (1,6)-(1,7) = ")"
+            │   │   │       ├── block: ∅
+            │   │   │       ├── flags: ∅
+            │   │   │       └── name: :c
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block:
             │   │   @ BlockNode (location: (1,8)-(1,16))

--- a/test/prism/snapshots/seattlerb/block_call_dot_op2_cmd_args_do_block.txt
+++ b/test/prism/snapshots/seattlerb/block_call_dot_op2_cmd_args_do_block.txt
@@ -22,17 +22,18 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,4)-(1,7))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ CallNode (location: (1,4)-(1,7))
-            │   │           ├── receiver: ∅
-            │   │           ├── call_operator_loc: ∅
-            │   │           ├── message_loc: (1,4)-(1,5) = "c"
-            │   │           ├── opening_loc: (1,5)-(1,6) = "("
-            │   │           ├── arguments: ∅
-            │   │           ├── closing_loc: (1,6)-(1,7) = ")"
-            │   │           ├── block: ∅
-            │   │           ├── flags: ∅
-            │   │           └── name: :c
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ CallNode (location: (1,4)-(1,7))
+            │   │   │       ├── receiver: ∅
+            │   │   │       ├── call_operator_loc: ∅
+            │   │   │       ├── message_loc: (1,4)-(1,5) = "c"
+            │   │   │       ├── opening_loc: (1,5)-(1,6) = "("
+            │   │   │       ├── arguments: ∅
+            │   │   │       ├── closing_loc: (1,6)-(1,7) = ")"
+            │   │   │       ├── block: ∅
+            │   │   │       ├── flags: ∅
+            │   │   │       └── name: :c
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block:
             │   │   @ BlockNode (location: (1,8)-(1,16))
@@ -60,17 +61,18 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,19)-(1,20))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,19)-(1,20))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,19)-(1,20) = "f"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :f
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,19)-(1,20))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,19)-(1,20) = "f"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :f
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,21)-(1,33))

--- a/test/prism/snapshots/seattlerb/block_call_operation_colon.txt
+++ b/test/prism/snapshots/seattlerb/block_call_operation_colon.txt
@@ -22,17 +22,18 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,4)-(1,5))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ CallNode (location: (1,4)-(1,5))
-            │   │           ├── receiver: ∅
-            │   │           ├── call_operator_loc: ∅
-            │   │           ├── message_loc: (1,4)-(1,5) = "c"
-            │   │           ├── opening_loc: ∅
-            │   │           ├── arguments: ∅
-            │   │           ├── closing_loc: ∅
-            │   │           ├── block: ∅
-            │   │           ├── flags: variable_call
-            │   │           └── name: :c
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ CallNode (location: (1,4)-(1,5))
+            │   │   │       ├── receiver: ∅
+            │   │   │       ├── call_operator_loc: ∅
+            │   │   │       ├── message_loc: (1,4)-(1,5) = "c"
+            │   │   │       ├── opening_loc: ∅
+            │   │   │       ├── arguments: ∅
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       ├── block: ∅
+            │   │   │       ├── flags: variable_call
+            │   │   │       └── name: :c
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block:
             │   │   @ BlockNode (location: (1,6)-(1,12))

--- a/test/prism/snapshots/seattlerb/block_call_operation_dot.txt
+++ b/test/prism/snapshots/seattlerb/block_call_operation_dot.txt
@@ -22,17 +22,18 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,4)-(1,5))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ CallNode (location: (1,4)-(1,5))
-            │   │           ├── receiver: ∅
-            │   │           ├── call_operator_loc: ∅
-            │   │           ├── message_loc: (1,4)-(1,5) = "c"
-            │   │           ├── opening_loc: ∅
-            │   │           ├── arguments: ∅
-            │   │           ├── closing_loc: ∅
-            │   │           ├── block: ∅
-            │   │           ├── flags: variable_call
-            │   │           └── name: :c
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ CallNode (location: (1,4)-(1,5))
+            │   │   │       ├── receiver: ∅
+            │   │   │       ├── call_operator_loc: ∅
+            │   │   │       ├── message_loc: (1,4)-(1,5) = "c"
+            │   │   │       ├── opening_loc: ∅
+            │   │   │       ├── arguments: ∅
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       ├── block: ∅
+            │   │   │       ├── flags: variable_call
+            │   │   │       └── name: :c
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block:
             │   │   @ BlockNode (location: (1,6)-(1,12))

--- a/test/prism/snapshots/seattlerb/block_call_paren_call_block_call.txt
+++ b/test/prism/snapshots/seattlerb/block_call_paren_call_block_call.txt
@@ -10,23 +10,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (1,2)-(1,5))
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (1,3)-(1,4))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (1,3)-(1,4))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (1,3)-(1,4) = "b"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block: ∅
-        │   │           │           ├── flags: variable_call
-        │   │           │           └── name: :b
-        │   │           ├── opening_loc: (1,2)-(1,3) = "("
-        │   │           └── closing_loc: (1,4)-(1,5) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (1,2)-(1,5))
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (1,3)-(1,4))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (1,3)-(1,4))
+        │   │   │       │           ├── receiver: ∅
+        │   │   │       │           ├── call_operator_loc: ∅
+        │   │   │       │           ├── message_loc: (1,3)-(1,4) = "b"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block: ∅
+        │   │   │       │           ├── flags: variable_call
+        │   │   │       │           └── name: :b
+        │   │   │       ├── opening_loc: (1,2)-(1,3) = "("
+        │   │   │       └── closing_loc: (1,4)-(1,5) = ")"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/block_command_operation_colon.txt
+++ b/test/prism/snapshots/seattlerb/block_command_operation_colon.txt
@@ -12,12 +12,13 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,2)-(1,4))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ SymbolNode (location: (1,2)-(1,4))
-            │   │           ├── opening_loc: (1,2)-(1,3) = ":"
-            │   │           ├── value_loc: (1,3)-(1,4) = "b"
-            │   │           ├── closing_loc: ∅
-            │   │           └── unescaped: "b"
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ SymbolNode (location: (1,2)-(1,4))
+            │   │   │       ├── opening_loc: (1,2)-(1,3) = ":"
+            │   │   │       ├── value_loc: (1,3)-(1,4) = "b"
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       └── unescaped: "b"
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block:
             │   │   @ BlockNode (location: (1,5)-(1,11))
@@ -33,12 +34,13 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,15)-(1,17))
-            │   └── arguments: (length: 1)
-            │       └── @ SymbolNode (location: (1,15)-(1,17))
-            │           ├── opening_loc: (1,15)-(1,16) = ":"
-            │           ├── value_loc: (1,16)-(1,17) = "d"
-            │           ├── closing_loc: ∅
-            │           └── unescaped: "d"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ SymbolNode (location: (1,15)-(1,17))
+            │   │       ├── opening_loc: (1,15)-(1,16) = ":"
+            │   │       ├── value_loc: (1,16)-(1,17) = "d"
+            │   │       ├── closing_loc: ∅
+            │   │       └── unescaped: "d"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/block_command_operation_dot.txt
+++ b/test/prism/snapshots/seattlerb/block_command_operation_dot.txt
@@ -12,12 +12,13 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,2)-(1,4))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ SymbolNode (location: (1,2)-(1,4))
-            │   │           ├── opening_loc: (1,2)-(1,3) = ":"
-            │   │           ├── value_loc: (1,3)-(1,4) = "b"
-            │   │           ├── closing_loc: ∅
-            │   │           └── unescaped: "b"
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ SymbolNode (location: (1,2)-(1,4))
+            │   │   │       ├── opening_loc: (1,2)-(1,3) = ":"
+            │   │   │       ├── value_loc: (1,3)-(1,4) = "b"
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       └── unescaped: "b"
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block:
             │   │   @ BlockNode (location: (1,5)-(1,11))
@@ -33,12 +34,13 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,14)-(1,16))
-            │   └── arguments: (length: 1)
-            │       └── @ SymbolNode (location: (1,14)-(1,16))
-            │           ├── opening_loc: (1,14)-(1,15) = ":"
-            │           ├── value_loc: (1,15)-(1,16) = "d"
-            │           ├── closing_loc: ∅
-            │           └── unescaped: "d"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ SymbolNode (location: (1,14)-(1,16))
+            │   │       ├── opening_loc: (1,14)-(1,15) = ":"
+            │   │       ├── value_loc: (1,15)-(1,16) = "d"
+            │   │       ├── closing_loc: ∅
+            │   │       └── unescaped: "d"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/block_next.txt
+++ b/test/prism/snapshots/seattlerb/block_next.txt
@@ -6,48 +6,50 @@
         └── @ NextNode (location: (1,0)-(1,25))
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,25))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,5)-(1,25))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,5)-(1,8) = "foo"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (1,9)-(1,12))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ CallNode (location: (1,9)-(1,12))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (1,9)-(1,12) = "arg"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: variable_call
-            │           │           └── name: :arg
-            │           ├── closing_loc: ∅
-            │           ├── block:
-            │           │   @ BlockNode (location: (1,13)-(1,25))
-            │           │   ├── locals: [:bar]
-            │           │   ├── parameters:
-            │           │   │   @ BlockParametersNode (location: (1,16)-(1,21))
-            │           │   │   ├── parameters:
-            │           │   │   │   @ ParametersNode (location: (1,17)-(1,20))
-            │           │   │   │   ├── requireds: (length: 1)
-            │           │   │   │   │   └── @ RequiredParameterNode (location: (1,17)-(1,20))
-            │           │   │   │   │       └── name: :bar
-            │           │   │   │   ├── optionals: (length: 0)
-            │           │   │   │   ├── rest: ∅
-            │           │   │   │   ├── posts: (length: 0)
-            │           │   │   │   ├── keywords: (length: 0)
-            │           │   │   │   ├── keyword_rest: ∅
-            │           │   │   │   └── block: ∅
-            │           │   │   ├── locals: (length: 0)
-            │           │   │   ├── opening_loc: (1,16)-(1,17) = "|"
-            │           │   │   └── closing_loc: (1,20)-(1,21) = "|"
-            │           │   ├── body: ∅
-            │           │   ├── opening_loc: (1,13)-(1,15) = "do"
-            │           │   └── closing_loc: (1,22)-(1,25) = "end"
-            │           ├── flags: ∅
-            │           └── name: :foo
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,5)-(1,25))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,5)-(1,8) = "foo"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (1,9)-(1,12))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ CallNode (location: (1,9)-(1,12))
+            │   │       │   │       ├── receiver: ∅
+            │   │       │   │       ├── call_operator_loc: ∅
+            │   │       │   │       ├── message_loc: (1,9)-(1,12) = "arg"
+            │   │       │   │       ├── opening_loc: ∅
+            │   │       │   │       ├── arguments: ∅
+            │   │       │   │       ├── closing_loc: ∅
+            │   │       │   │       ├── block: ∅
+            │   │       │   │       ├── flags: variable_call
+            │   │       │   │       └── name: :arg
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block:
+            │   │       │   @ BlockNode (location: (1,13)-(1,25))
+            │   │       │   ├── locals: [:bar]
+            │   │       │   ├── parameters:
+            │   │       │   │   @ BlockParametersNode (location: (1,16)-(1,21))
+            │   │       │   │   ├── parameters:
+            │   │       │   │   │   @ ParametersNode (location: (1,17)-(1,20))
+            │   │       │   │   │   ├── requireds: (length: 1)
+            │   │       │   │   │   │   └── @ RequiredParameterNode (location: (1,17)-(1,20))
+            │   │       │   │   │   │       └── name: :bar
+            │   │       │   │   │   ├── optionals: (length: 0)
+            │   │       │   │   │   ├── rest: ∅
+            │   │       │   │   │   ├── posts: (length: 0)
+            │   │       │   │   │   ├── keywords: (length: 0)
+            │   │       │   │   │   ├── keyword_rest: ∅
+            │   │       │   │   │   └── block: ∅
+            │   │       │   │   ├── locals: (length: 0)
+            │   │       │   │   ├── opening_loc: (1,16)-(1,17) = "|"
+            │   │       │   │   └── closing_loc: (1,20)-(1,21) = "|"
+            │   │       │   ├── body: ∅
+            │   │       │   ├── opening_loc: (1,13)-(1,15) = "do"
+            │   │       │   └── closing_loc: (1,22)-(1,25) = "end"
+            │   │       ├── flags: ∅
+            │   │       └── name: :foo
+            │   └── flags: ∅
             └── keyword_loc: (1,0)-(1,4) = "next"

--- a/test/prism/snapshots/seattlerb/block_return.txt
+++ b/test/prism/snapshots/seattlerb/block_return.txt
@@ -7,47 +7,49 @@
             ├── keyword_loc: (1,0)-(1,6) = "return"
             └── arguments:
                 @ ArgumentsNode (location: (1,7)-(1,27))
-                └── arguments: (length: 1)
-                    └── @ CallNode (location: (1,7)-(1,27))
-                        ├── receiver: ∅
-                        ├── call_operator_loc: ∅
-                        ├── message_loc: (1,7)-(1,10) = "foo"
-                        ├── opening_loc: ∅
-                        ├── arguments:
-                        │   @ ArgumentsNode (location: (1,11)-(1,14))
-                        │   └── arguments: (length: 1)
-                        │       └── @ CallNode (location: (1,11)-(1,14))
-                        │           ├── receiver: ∅
-                        │           ├── call_operator_loc: ∅
-                        │           ├── message_loc: (1,11)-(1,14) = "arg"
-                        │           ├── opening_loc: ∅
-                        │           ├── arguments: ∅
-                        │           ├── closing_loc: ∅
-                        │           ├── block: ∅
-                        │           ├── flags: variable_call
-                        │           └── name: :arg
-                        ├── closing_loc: ∅
-                        ├── block:
-                        │   @ BlockNode (location: (1,15)-(1,27))
-                        │   ├── locals: [:bar]
-                        │   ├── parameters:
-                        │   │   @ BlockParametersNode (location: (1,18)-(1,23))
-                        │   │   ├── parameters:
-                        │   │   │   @ ParametersNode (location: (1,19)-(1,22))
-                        │   │   │   ├── requireds: (length: 1)
-                        │   │   │   │   └── @ RequiredParameterNode (location: (1,19)-(1,22))
-                        │   │   │   │       └── name: :bar
-                        │   │   │   ├── optionals: (length: 0)
-                        │   │   │   ├── rest: ∅
-                        │   │   │   ├── posts: (length: 0)
-                        │   │   │   ├── keywords: (length: 0)
-                        │   │   │   ├── keyword_rest: ∅
-                        │   │   │   └── block: ∅
-                        │   │   ├── locals: (length: 0)
-                        │   │   ├── opening_loc: (1,18)-(1,19) = "|"
-                        │   │   └── closing_loc: (1,22)-(1,23) = "|"
-                        │   ├── body: ∅
-                        │   ├── opening_loc: (1,15)-(1,17) = "do"
-                        │   └── closing_loc: (1,24)-(1,27) = "end"
-                        ├── flags: ∅
-                        └── name: :foo
+                ├── arguments: (length: 1)
+                │   └── @ CallNode (location: (1,7)-(1,27))
+                │       ├── receiver: ∅
+                │       ├── call_operator_loc: ∅
+                │       ├── message_loc: (1,7)-(1,10) = "foo"
+                │       ├── opening_loc: ∅
+                │       ├── arguments:
+                │       │   @ ArgumentsNode (location: (1,11)-(1,14))
+                │       │   ├── arguments: (length: 1)
+                │       │   │   └── @ CallNode (location: (1,11)-(1,14))
+                │       │   │       ├── receiver: ∅
+                │       │   │       ├── call_operator_loc: ∅
+                │       │   │       ├── message_loc: (1,11)-(1,14) = "arg"
+                │       │   │       ├── opening_loc: ∅
+                │       │   │       ├── arguments: ∅
+                │       │   │       ├── closing_loc: ∅
+                │       │   │       ├── block: ∅
+                │       │   │       ├── flags: variable_call
+                │       │   │       └── name: :arg
+                │       │   └── flags: ∅
+                │       ├── closing_loc: ∅
+                │       ├── block:
+                │       │   @ BlockNode (location: (1,15)-(1,27))
+                │       │   ├── locals: [:bar]
+                │       │   ├── parameters:
+                │       │   │   @ BlockParametersNode (location: (1,18)-(1,23))
+                │       │   │   ├── parameters:
+                │       │   │   │   @ ParametersNode (location: (1,19)-(1,22))
+                │       │   │   │   ├── requireds: (length: 1)
+                │       │   │   │   │   └── @ RequiredParameterNode (location: (1,19)-(1,22))
+                │       │   │   │   │       └── name: :bar
+                │       │   │   │   ├── optionals: (length: 0)
+                │       │   │   │   ├── rest: ∅
+                │       │   │   │   ├── posts: (length: 0)
+                │       │   │   │   ├── keywords: (length: 0)
+                │       │   │   │   ├── keyword_rest: ∅
+                │       │   │   │   └── block: ∅
+                │       │   │   ├── locals: (length: 0)
+                │       │   │   ├── opening_loc: (1,18)-(1,19) = "|"
+                │       │   │   └── closing_loc: (1,22)-(1,23) = "|"
+                │       │   ├── body: ∅
+                │       │   ├── opening_loc: (1,15)-(1,17) = "do"
+                │       │   └── closing_loc: (1,24)-(1,27) = "end"
+                │       ├── flags: ∅
+                │       └── name: :foo
+                └── flags: ∅

--- a/test/prism/snapshots/seattlerb/bug169.txt
+++ b/test/prism/snapshots/seattlerb/bug169.txt
@@ -10,11 +10,12 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,4))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,2)-(1,4))
-            │           ├── body: ∅
-            │           ├── opening_loc: (1,2)-(1,3) = "("
-            │           └── closing_loc: (1,3)-(1,4) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,2)-(1,4))
+            │   │       ├── body: ∅
+            │   │       ├── opening_loc: (1,2)-(1,3) = "("
+            │   │       └── closing_loc: (1,3)-(1,4) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,5)-(1,7))

--- a/test/prism/snapshots/seattlerb/bug179.txt
+++ b/test/prism/snapshots/seattlerb/bug179.txt
@@ -10,17 +10,18 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,9))
-            │   └── arguments: (length: 1)
-            │       └── @ RangeNode (location: (1,2)-(1,9))
-            │           ├── left:
-            │           │   @ ParenthesesNode (location: (1,2)-(1,4))
-            │           │   ├── body: ∅
-            │           │   ├── opening_loc: (1,2)-(1,3) = "("
-            │           │   └── closing_loc: (1,3)-(1,4) = ")"
-            │           ├── right:
-            │           │   @ NilNode (location: (1,6)-(1,9))
-            │           ├── operator_loc: (1,4)-(1,6) = ".."
-            │           └── flags: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ RangeNode (location: (1,2)-(1,9))
+            │   │       ├── left:
+            │   │       │   @ ParenthesesNode (location: (1,2)-(1,4))
+            │   │       │   ├── body: ∅
+            │   │       │   ├── opening_loc: (1,2)-(1,3) = "("
+            │   │       │   └── closing_loc: (1,3)-(1,4) = ")"
+            │   │       ├── right:
+            │   │       │   @ NilNode (location: (1,6)-(1,9))
+            │   │       ├── operator_loc: (1,4)-(1,6) = ".."
+            │   │       └── flags: ∅
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/bug_187.txt
+++ b/test/prism/snapshots/seattlerb/bug_187.txt
@@ -10,48 +10,49 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,8)-(3,3))
-            │   └── arguments: (length: 1)
-            │       └── @ DefNode (location: (1,8)-(3,3))
-            │           ├── name: :f
-            │           ├── name_loc: (1,12)-(1,13) = "f"
-            │           ├── receiver: ∅
-            │           ├── parameters: ∅
-            │           ├── body:
-            │           │   @ StatementsNode (location: (2,0)-(2,10))
-            │           │   └── body: (length: 1)
-            │           │       └── @ CallNode (location: (2,0)-(2,10))
-            │           │           ├── receiver:
-            │           │           │   @ CallNode (location: (2,0)-(2,1))
-            │           │           │   ├── receiver: ∅
-            │           │           │   ├── call_operator_loc: ∅
-            │           │           │   ├── message_loc: (2,0)-(2,1) = "a"
-            │           │           │   ├── opening_loc: ∅
-            │           │           │   ├── arguments: ∅
-            │           │           │   ├── closing_loc: ∅
-            │           │           │   ├── block: ∅
-            │           │           │   ├── flags: variable_call
-            │           │           │   └── name: :a
-            │           │           ├── call_operator_loc: (2,1)-(2,2) = "."
-            │           │           ├── message_loc: (2,2)-(2,3) = "b"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block:
-            │           │           │   @ BlockNode (location: (2,4)-(2,10))
-            │           │           │   ├── locals: []
-            │           │           │   ├── parameters: ∅
-            │           │           │   ├── body: ∅
-            │           │           │   ├── opening_loc: (2,4)-(2,6) = "do"
-            │           │           │   └── closing_loc: (2,7)-(2,10) = "end"
-            │           │           ├── flags: ∅
-            │           │           └── name: :b
-            │           ├── locals: []
-            │           ├── def_keyword_loc: (1,8)-(1,11) = "def"
-            │           ├── operator_loc: ∅
-            │           ├── lparen_loc: ∅
-            │           ├── rparen_loc: ∅
-            │           ├── equal_loc: ∅
-            │           └── end_keyword_loc: (3,0)-(3,3) = "end"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ DefNode (location: (1,8)-(3,3))
+            │   │       ├── name: :f
+            │   │       ├── name_loc: (1,12)-(1,13) = "f"
+            │   │       ├── receiver: ∅
+            │   │       ├── parameters: ∅
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (2,0)-(2,10))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ CallNode (location: (2,0)-(2,10))
+            │   │       │           ├── receiver:
+            │   │       │           │   @ CallNode (location: (2,0)-(2,1))
+            │   │       │           │   ├── receiver: ∅
+            │   │       │           │   ├── call_operator_loc: ∅
+            │   │       │           │   ├── message_loc: (2,0)-(2,1) = "a"
+            │   │       │           │   ├── opening_loc: ∅
+            │   │       │           │   ├── arguments: ∅
+            │   │       │           │   ├── closing_loc: ∅
+            │   │       │           │   ├── block: ∅
+            │   │       │           │   ├── flags: variable_call
+            │   │       │           │   └── name: :a
+            │   │       │           ├── call_operator_loc: (2,1)-(2,2) = "."
+            │   │       │           ├── message_loc: (2,2)-(2,3) = "b"
+            │   │       │           ├── opening_loc: ∅
+            │   │       │           ├── arguments: ∅
+            │   │       │           ├── closing_loc: ∅
+            │   │       │           ├── block:
+            │   │       │           │   @ BlockNode (location: (2,4)-(2,10))
+            │   │       │           │   ├── locals: []
+            │   │       │           │   ├── parameters: ∅
+            │   │       │           │   ├── body: ∅
+            │   │       │           │   ├── opening_loc: (2,4)-(2,6) = "do"
+            │   │       │           │   └── closing_loc: (2,7)-(2,10) = "end"
+            │   │       │           ├── flags: ∅
+            │   │       │           └── name: :b
+            │   │       ├── locals: []
+            │   │       ├── def_keyword_loc: (1,8)-(1,11) = "def"
+            │   │       ├── operator_loc: ∅
+            │   │       ├── lparen_loc: ∅
+            │   │       ├── rparen_loc: ∅
+            │   │       ├── equal_loc: ∅
+            │   │       └── end_keyword_loc: (3,0)-(3,3) = "end"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/bug_249.txt
+++ b/test/prism/snapshots/seattlerb/bug_249.txt
@@ -10,73 +10,74 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,6)-(4,28))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (1,6)-(4,9))
-            │       │   ├── receiver:
-            │       │   │   @ ParenthesesNode (location: (1,6)-(4,5))
-            │       │   │   ├── body:
-            │       │   │   │   @ StatementsNode (location: (1,7)-(4,4))
-            │       │   │   │   └── body: (length: 1)
-            │       │   │   │       └── @ CallNode (location: (1,7)-(4,4))
-            │       │   │   │           ├── receiver:
-            │       │   │   │           │   @ ConstantReadNode (location: (1,7)-(1,12))
-            │       │   │   │           │   └── name: :Class
-            │       │   │   │           ├── call_operator_loc: (1,12)-(1,13) = "."
-            │       │   │   │           ├── message_loc: (1,13)-(1,16) = "new"
-            │       │   │   │           ├── opening_loc: ∅
-            │       │   │   │           ├── arguments: ∅
-            │       │   │   │           ├── closing_loc: ∅
-            │       │   │   │           ├── block:
-            │       │   │   │           │   @ BlockNode (location: (1,17)-(4,4))
-            │       │   │   │           │   ├── locals: []
-            │       │   │   │           │   ├── parameters: ∅
-            │       │   │   │           │   ├── body:
-            │       │   │   │           │   │   @ StatementsNode (location: (2,0)-(3,3))
-            │       │   │   │           │   │   └── body: (length: 1)
-            │       │   │   │           │   │       └── @ DefNode (location: (2,0)-(3,3))
-            │       │   │   │           │   │           ├── name: :initialize
-            │       │   │   │           │   │           ├── name_loc: (2,4)-(2,14) = "initialize"
-            │       │   │   │           │   │           ├── receiver: ∅
-            │       │   │   │           │   │           ├── parameters: ∅
-            │       │   │   │           │   │           ├── body: ∅
-            │       │   │   │           │   │           ├── locals: []
-            │       │   │   │           │   │           ├── def_keyword_loc: (2,0)-(2,3) = "def"
-            │       │   │   │           │   │           ├── operator_loc: ∅
-            │       │   │   │           │   │           ├── lparen_loc: ∅
-            │       │   │   │           │   │           ├── rparen_loc: ∅
-            │       │   │   │           │   │           ├── equal_loc: ∅
-            │       │   │   │           │   │           └── end_keyword_loc: (3,0)-(3,3) = "end"
-            │       │   │   │           │   ├── opening_loc: (1,17)-(1,19) = "do"
-            │       │   │   │           │   └── closing_loc: (4,1)-(4,4) = "end"
-            │       │   │   │           ├── flags: ∅
-            │       │   │   │           └── name: :new
-            │       │   │   ├── opening_loc: (1,6)-(1,7) = "("
-            │       │   │   └── closing_loc: (4,4)-(4,5) = ")"
-            │       │   ├── call_operator_loc: (4,5)-(4,6) = "."
-            │       │   ├── message_loc: (4,6)-(4,9) = "new"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block: ∅
-            │       │   ├── flags: ∅
-            │       │   └── name: :new
-            │       └── @ KeywordHashNode (location: (4,11)-(4,28))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (4,11)-(4,28))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (4,11)-(4,14))
-            │                   │   ├── opening_loc: (4,11)-(4,12) = ":"
-            │                   │   ├── value_loc: (4,12)-(4,14) = "at"
-            │                   │   ├── closing_loc: ∅
-            │                   │   └── unescaped: "at"
-            │                   ├── value:
-            │                   │   @ StringNode (location: (4,18)-(4,28))
-            │                   │   ├── flags: ∅
-            │                   │   ├── opening_loc: (4,18)-(4,19) = "'"
-            │                   │   ├── content_loc: (4,19)-(4,27) = "endpoint"
-            │                   │   ├── closing_loc: (4,27)-(4,28) = "'"
-            │                   │   └── unescaped: "endpoint"
-            │                   └── operator_loc: (4,15)-(4,17) = "=>"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (1,6)-(4,9))
+            │   │   │   ├── receiver:
+            │   │   │   │   @ ParenthesesNode (location: (1,6)-(4,5))
+            │   │   │   │   ├── body:
+            │   │   │   │   │   @ StatementsNode (location: (1,7)-(4,4))
+            │   │   │   │   │   └── body: (length: 1)
+            │   │   │   │   │       └── @ CallNode (location: (1,7)-(4,4))
+            │   │   │   │   │           ├── receiver:
+            │   │   │   │   │           │   @ ConstantReadNode (location: (1,7)-(1,12))
+            │   │   │   │   │           │   └── name: :Class
+            │   │   │   │   │           ├── call_operator_loc: (1,12)-(1,13) = "."
+            │   │   │   │   │           ├── message_loc: (1,13)-(1,16) = "new"
+            │   │   │   │   │           ├── opening_loc: ∅
+            │   │   │   │   │           ├── arguments: ∅
+            │   │   │   │   │           ├── closing_loc: ∅
+            │   │   │   │   │           ├── block:
+            │   │   │   │   │           │   @ BlockNode (location: (1,17)-(4,4))
+            │   │   │   │   │           │   ├── locals: []
+            │   │   │   │   │           │   ├── parameters: ∅
+            │   │   │   │   │           │   ├── body:
+            │   │   │   │   │           │   │   @ StatementsNode (location: (2,0)-(3,3))
+            │   │   │   │   │           │   │   └── body: (length: 1)
+            │   │   │   │   │           │   │       └── @ DefNode (location: (2,0)-(3,3))
+            │   │   │   │   │           │   │           ├── name: :initialize
+            │   │   │   │   │           │   │           ├── name_loc: (2,4)-(2,14) = "initialize"
+            │   │   │   │   │           │   │           ├── receiver: ∅
+            │   │   │   │   │           │   │           ├── parameters: ∅
+            │   │   │   │   │           │   │           ├── body: ∅
+            │   │   │   │   │           │   │           ├── locals: []
+            │   │   │   │   │           │   │           ├── def_keyword_loc: (2,0)-(2,3) = "def"
+            │   │   │   │   │           │   │           ├── operator_loc: ∅
+            │   │   │   │   │           │   │           ├── lparen_loc: ∅
+            │   │   │   │   │           │   │           ├── rparen_loc: ∅
+            │   │   │   │   │           │   │           ├── equal_loc: ∅
+            │   │   │   │   │           │   │           └── end_keyword_loc: (3,0)-(3,3) = "end"
+            │   │   │   │   │           │   ├── opening_loc: (1,17)-(1,19) = "do"
+            │   │   │   │   │           │   └── closing_loc: (4,1)-(4,4) = "end"
+            │   │   │   │   │           ├── flags: ∅
+            │   │   │   │   │           └── name: :new
+            │   │   │   │   ├── opening_loc: (1,6)-(1,7) = "("
+            │   │   │   │   └── closing_loc: (4,4)-(4,5) = ")"
+            │   │   │   ├── call_operator_loc: (4,5)-(4,6) = "."
+            │   │   │   ├── message_loc: (4,6)-(4,9) = "new"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block: ∅
+            │   │   │   ├── flags: ∅
+            │   │   │   └── name: :new
+            │   │   └── @ KeywordHashNode (location: (4,11)-(4,28))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (4,11)-(4,28))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (4,11)-(4,14))
+            │   │               │   ├── opening_loc: (4,11)-(4,12) = ":"
+            │   │               │   ├── value_loc: (4,12)-(4,14) = "at"
+            │   │               │   ├── closing_loc: ∅
+            │   │               │   └── unescaped: "at"
+            │   │               ├── value:
+            │   │               │   @ StringNode (location: (4,18)-(4,28))
+            │   │               │   ├── flags: ∅
+            │   │               │   ├── opening_loc: (4,18)-(4,19) = "'"
+            │   │               │   ├── content_loc: (4,19)-(4,27) = "endpoint"
+            │   │               │   ├── closing_loc: (4,27)-(4,28) = "'"
+            │   │               │   └── unescaped: "endpoint"
+            │   │               └── operator_loc: (4,15)-(4,17) = "=>"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/bug_call_arglist_parens.txt
+++ b/test/prism/snapshots/seattlerb/bug_call_arglist_parens.txt
@@ -18,17 +18,18 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (2,10)-(2,17))
-        │   │           │   └── arguments: (length: 2)
-        │   │           │       ├── @ ParenthesesNode (location: (2,10)-(2,14))
-        │   │           │       │   ├── body:
-        │   │           │       │   │   @ StatementsNode (location: (2,12)-(2,13))
-        │   │           │       │   │   └── body: (length: 1)
-        │   │           │       │   │       └── @ IntegerNode (location: (2,12)-(2,13))
-        │   │           │       │   │           └── flags: decimal
-        │   │           │       │   ├── opening_loc: (2,10)-(2,11) = "("
-        │   │           │       │   └── closing_loc: (2,13)-(2,14) = ")"
-        │   │           │       └── @ IntegerNode (location: (2,16)-(2,17))
-        │   │           │           └── flags: decimal
+        │   │           │   ├── arguments: (length: 2)
+        │   │           │   │   ├── @ ParenthesesNode (location: (2,10)-(2,14))
+        │   │           │   │   │   ├── body:
+        │   │           │   │   │   │   @ StatementsNode (location: (2,12)-(2,13))
+        │   │           │   │   │   │   └── body: (length: 1)
+        │   │           │   │   │   │       └── @ IntegerNode (location: (2,12)-(2,13))
+        │   │           │   │   │   │           └── flags: decimal
+        │   │           │   │   │   ├── opening_loc: (2,10)-(2,11) = "("
+        │   │           │   │   │   └── closing_loc: (2,13)-(2,14) = ")"
+        │   │           │   │   └── @ IntegerNode (location: (2,16)-(2,17))
+        │   │           │   │       └── flags: decimal
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -55,17 +56,18 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (7,10)-(7,16))
-        │   │           │   └── arguments: (length: 2)
-        │   │           │       ├── @ ParenthesesNode (location: (7,10)-(7,13))
-        │   │           │       │   ├── body:
-        │   │           │       │   │   @ StatementsNode (location: (7,11)-(7,12))
-        │   │           │       │   │   └── body: (length: 1)
-        │   │           │       │   │       └── @ IntegerNode (location: (7,11)-(7,12))
-        │   │           │       │   │           └── flags: decimal
-        │   │           │       │   ├── opening_loc: (7,10)-(7,11) = "("
-        │   │           │       │   └── closing_loc: (7,12)-(7,13) = ")"
-        │   │           │       └── @ IntegerNode (location: (7,15)-(7,16))
-        │   │           │           └── flags: decimal
+        │   │           │   ├── arguments: (length: 2)
+        │   │           │   │   ├── @ ParenthesesNode (location: (7,10)-(7,13))
+        │   │           │   │   │   ├── body:
+        │   │           │   │   │   │   @ StatementsNode (location: (7,11)-(7,12))
+        │   │           │   │   │   │   └── body: (length: 1)
+        │   │           │   │   │   │       └── @ IntegerNode (location: (7,11)-(7,12))
+        │   │           │   │   │   │           └── flags: decimal
+        │   │           │   │   │   ├── opening_loc: (7,10)-(7,11) = "("
+        │   │           │   │   │   └── closing_loc: (7,12)-(7,13) = ")"
+        │   │           │   │   └── @ IntegerNode (location: (7,15)-(7,16))
+        │   │           │   │       └── flags: decimal
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -84,17 +86,18 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (11,2)-(11,9))
-            │   └── arguments: (length: 2)
-            │       ├── @ ParenthesesNode (location: (11,2)-(11,6))
-            │       │   ├── body:
-            │       │   │   @ StatementsNode (location: (11,4)-(11,5))
-            │       │   │   └── body: (length: 1)
-            │       │   │       └── @ IntegerNode (location: (11,4)-(11,5))
-            │       │   │           └── flags: decimal
-            │       │   ├── opening_loc: (11,2)-(11,3) = "("
-            │       │   └── closing_loc: (11,5)-(11,6) = ")"
-            │       └── @ IntegerNode (location: (11,8)-(11,9))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ ParenthesesNode (location: (11,2)-(11,6))
+            │   │   │   ├── body:
+            │   │   │   │   @ StatementsNode (location: (11,4)-(11,5))
+            │   │   │   │   └── body: (length: 1)
+            │   │   │   │       └── @ IntegerNode (location: (11,4)-(11,5))
+            │   │   │   │           └── flags: decimal
+            │   │   │   ├── opening_loc: (11,2)-(11,3) = "("
+            │   │   │   └── closing_loc: (11,5)-(11,6) = ")"
+            │   │   └── @ IntegerNode (location: (11,8)-(11,9))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/bug_comma.txt
+++ b/test/prism/snapshots/seattlerb/bug_comma.txt
@@ -13,23 +13,24 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,8)-(1,15))
-            │   │   └── arguments: (length: 2)
-            │   │       ├── @ StringNode (location: (1,8)-(1,10))
-            │   │       │   ├── flags: ∅
-            │   │       │   ├── opening_loc: (1,8)-(1,9) = "?"
-            │   │       │   ├── content_loc: (1,9)-(1,10) = "d"
-            │   │       │   ├── closing_loc: ∅
-            │   │       │   └── unescaped: "d"
-            │   │       └── @ CallNode (location: (1,12)-(1,15))
-            │   │           ├── receiver: ∅
-            │   │           ├── call_operator_loc: ∅
-            │   │           ├── message_loc: (1,12)-(1,15) = "dir"
-            │   │           ├── opening_loc: ∅
-            │   │           ├── arguments: ∅
-            │   │           ├── closing_loc: ∅
-            │   │           ├── block: ∅
-            │   │           ├── flags: variable_call
-            │   │           └── name: :dir
+            │   │   ├── arguments: (length: 2)
+            │   │   │   ├── @ StringNode (location: (1,8)-(1,10))
+            │   │   │   │   ├── flags: ∅
+            │   │   │   │   ├── opening_loc: (1,8)-(1,9) = "?"
+            │   │   │   │   ├── content_loc: (1,9)-(1,10) = "d"
+            │   │   │   │   ├── closing_loc: ∅
+            │   │   │   │   └── unescaped: "d"
+            │   │   │   └── @ CallNode (location: (1,12)-(1,15))
+            │   │   │       ├── receiver: ∅
+            │   │   │       ├── call_operator_loc: ∅
+            │   │   │       ├── message_loc: (1,12)-(1,15) = "dir"
+            │   │   │       ├── opening_loc: ∅
+            │   │   │       ├── arguments: ∅
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       ├── block: ∅
+            │   │   │       ├── flags: variable_call
+            │   │   │       └── name: :dir
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/bug_hash_args.txt
+++ b/test/prism/snapshots/seattlerb/bug_hash_args.txt
@@ -10,24 +10,25 @@
             ├── opening_loc: (1,3)-(1,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,18))
-            │   └── arguments: (length: 2)
-            │       ├── @ SymbolNode (location: (1,4)-(1,8))
-            │       │   ├── opening_loc: (1,4)-(1,5) = ":"
-            │       │   ├── value_loc: (1,5)-(1,8) = "bar"
-            │       │   ├── closing_loc: ∅
-            │       │   └── unescaped: "bar"
-            │       └── @ KeywordHashNode (location: (1,10)-(1,18))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,10)-(1,18))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (1,10)-(1,14))
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── value_loc: (1,10)-(1,13) = "baz"
-            │                   │   ├── closing_loc: (1,13)-(1,14) = ":"
-            │                   │   └── unescaped: "baz"
-            │                   ├── value:
-            │                   │   @ NilNode (location: (1,15)-(1,18))
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ SymbolNode (location: (1,4)-(1,8))
+            │   │   │   ├── opening_loc: (1,4)-(1,5) = ":"
+            │   │   │   ├── value_loc: (1,5)-(1,8) = "bar"
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   └── unescaped: "bar"
+            │   │   └── @ KeywordHashNode (location: (1,10)-(1,18))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,10)-(1,18))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (1,10)-(1,14))
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── value_loc: (1,10)-(1,13) = "baz"
+            │   │               │   ├── closing_loc: (1,13)-(1,14) = ":"
+            │   │               │   └── unescaped: "baz"
+            │   │               ├── value:
+            │   │               │   @ NilNode (location: (1,15)-(1,18))
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: (1,18)-(1,19) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/bug_hash_args_trailing_comma.txt
+++ b/test/prism/snapshots/seattlerb/bug_hash_args_trailing_comma.txt
@@ -10,24 +10,25 @@
             ├── opening_loc: (1,3)-(1,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,18))
-            │   └── arguments: (length: 2)
-            │       ├── @ SymbolNode (location: (1,4)-(1,8))
-            │       │   ├── opening_loc: (1,4)-(1,5) = ":"
-            │       │   ├── value_loc: (1,5)-(1,8) = "bar"
-            │       │   ├── closing_loc: ∅
-            │       │   └── unescaped: "bar"
-            │       └── @ KeywordHashNode (location: (1,10)-(1,18))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,10)-(1,18))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (1,10)-(1,14))
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── value_loc: (1,10)-(1,13) = "baz"
-            │                   │   ├── closing_loc: (1,13)-(1,14) = ":"
-            │                   │   └── unescaped: "baz"
-            │                   ├── value:
-            │                   │   @ NilNode (location: (1,15)-(1,18))
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ SymbolNode (location: (1,4)-(1,8))
+            │   │   │   ├── opening_loc: (1,4)-(1,5) = ":"
+            │   │   │   ├── value_loc: (1,5)-(1,8) = "bar"
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   └── unescaped: "bar"
+            │   │   └── @ KeywordHashNode (location: (1,10)-(1,18))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,10)-(1,18))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (1,10)-(1,14))
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── value_loc: (1,10)-(1,13) = "baz"
+            │   │               │   ├── closing_loc: (1,13)-(1,14) = ":"
+            │   │               │   └── unescaped: "baz"
+            │   │               ├── value:
+            │   │               │   @ NilNode (location: (1,15)-(1,18))
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: (1,19)-(1,20) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_and.txt
+++ b/test/prism/snapshots/seattlerb/call_and.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,5))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,4)-(1,5))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,4)-(1,5))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_arg_assoc.txt
+++ b/test/prism/snapshots/seattlerb/call_arg_assoc.txt
@@ -10,19 +10,20 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,9))
-            │   └── arguments: (length: 2)
-            │       ├── @ IntegerNode (location: (1,2)-(1,3))
-            │       │   └── flags: decimal
-            │       └── @ KeywordHashNode (location: (1,5)-(1,9))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,5)-(1,9))
-            │                   ├── key:
-            │                   │   @ IntegerNode (location: (1,5)-(1,6))
-            │                   │   └── flags: decimal
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,8)-(1,9))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (1,6)-(1,8) = "=>"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ IntegerNode (location: (1,2)-(1,3))
+            │   │   │   └── flags: decimal
+            │   │   └── @ KeywordHashNode (location: (1,5)-(1,9))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,5)-(1,9))
+            │   │               ├── key:
+            │   │               │   @ IntegerNode (location: (1,5)-(1,6))
+            │   │               │   └── flags: decimal
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,8)-(1,9))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (1,6)-(1,8) = "=>"
+            │   └── flags: ∅
             ├── closing_loc: (1,9)-(1,10) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_arg_assoc_kwsplat.txt
+++ b/test/prism/snapshots/seattlerb/call_arg_assoc_kwsplat.txt
@@ -10,27 +10,28 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,15))
-            │   └── arguments: (length: 2)
-            │       ├── @ IntegerNode (location: (1,2)-(1,3))
-            │       │   └── flags: decimal
-            │       └── @ KeywordHashNode (location: (1,5)-(1,15))
-            │           └── elements: (length: 2)
-            │               ├── @ AssocNode (location: (1,5)-(1,10))
-            │               │   ├── key:
-            │               │   │   @ SymbolNode (location: (1,5)-(1,8))
-            │               │   │   ├── opening_loc: ∅
-            │               │   │   ├── value_loc: (1,5)-(1,7) = "kw"
-            │               │   │   ├── closing_loc: (1,7)-(1,8) = ":"
-            │               │   │   └── unescaped: "kw"
-            │               │   ├── value:
-            │               │   │   @ IntegerNode (location: (1,9)-(1,10))
-            │               │   │   └── flags: decimal
-            │               │   └── operator_loc: ∅
-            │               └── @ AssocSplatNode (location: (1,12)-(1,15))
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,14)-(1,15))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (1,12)-(1,14) = "**"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ IntegerNode (location: (1,2)-(1,3))
+            │   │   │   └── flags: decimal
+            │   │   └── @ KeywordHashNode (location: (1,5)-(1,15))
+            │   │       └── elements: (length: 2)
+            │   │           ├── @ AssocNode (location: (1,5)-(1,10))
+            │   │           │   ├── key:
+            │   │           │   │   @ SymbolNode (location: (1,5)-(1,8))
+            │   │           │   │   ├── opening_loc: ∅
+            │   │           │   │   ├── value_loc: (1,5)-(1,7) = "kw"
+            │   │           │   │   ├── closing_loc: (1,7)-(1,8) = ":"
+            │   │           │   │   └── unescaped: "kw"
+            │   │           │   ├── value:
+            │   │           │   │   @ IntegerNode (location: (1,9)-(1,10))
+            │   │           │   │   └── flags: decimal
+            │   │           │   └── operator_loc: ∅
+            │   │           └── @ AssocSplatNode (location: (1,12)-(1,15))
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,14)-(1,15))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (1,12)-(1,14) = "**"
+            │   └── flags: keyword_splat
             ├── closing_loc: (1,15)-(1,16) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_arg_kwsplat.txt
+++ b/test/prism/snapshots/seattlerb/call_arg_kwsplat.txt
@@ -10,24 +10,25 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,8))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (1,2)-(1,3))
-            │       │   ├── receiver: ∅
-            │       │   ├── call_operator_loc: ∅
-            │       │   ├── message_loc: (1,2)-(1,3) = "b"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block: ∅
-            │       │   ├── flags: variable_call
-            │       │   └── name: :b
-            │       └── @ KeywordHashNode (location: (1,5)-(1,8))
-            │           └── elements: (length: 1)
-            │               └── @ AssocSplatNode (location: (1,5)-(1,8))
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,7)-(1,8))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (1,5)-(1,7) = "**"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (1,2)-(1,3))
+            │   │   │   ├── receiver: ∅
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── message_loc: (1,2)-(1,3) = "b"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block: ∅
+            │   │   │   ├── flags: variable_call
+            │   │   │   └── name: :b
+            │   │   └── @ KeywordHashNode (location: (1,5)-(1,8))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocSplatNode (location: (1,5)-(1,8))
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,7)-(1,8))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (1,5)-(1,7) = "**"
+            │   └── flags: keyword_splat
             ├── closing_loc: (1,8)-(1,9) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_args_assoc_quoted.txt
+++ b/test/prism/snapshots/seattlerb/call_args_assoc_quoted.txt
@@ -10,35 +10,36 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (1,2)-(1,11))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (1,2)-(1,11))
-        │   │                   ├── key:
-        │   │                   │   @ InterpolatedSymbolNode (location: (1,2)-(1,9))
-        │   │                   │   ├── opening_loc: (1,2)-(1,3) = "\""
-        │   │                   │   ├── parts: (length: 1)
-        │   │                   │   │   └── @ EmbeddedStatementsNode (location: (1,3)-(1,7))
-        │   │                   │   │       ├── opening_loc: (1,3)-(1,5) = "\#{"
-        │   │                   │   │       ├── statements:
-        │   │                   │   │       │   @ StatementsNode (location: (1,5)-(1,6))
-        │   │                   │   │       │   └── body: (length: 1)
-        │   │                   │   │       │       └── @ CallNode (location: (1,5)-(1,6))
-        │   │                   │   │       │           ├── receiver: ∅
-        │   │                   │   │       │           ├── call_operator_loc: ∅
-        │   │                   │   │       │           ├── message_loc: (1,5)-(1,6) = "k"
-        │   │                   │   │       │           ├── opening_loc: ∅
-        │   │                   │   │       │           ├── arguments: ∅
-        │   │                   │   │       │           ├── closing_loc: ∅
-        │   │                   │   │       │           ├── block: ∅
-        │   │                   │   │       │           ├── flags: variable_call
-        │   │                   │   │       │           └── name: :k
-        │   │                   │   │       └── closing_loc: (1,6)-(1,7) = "}"
-        │   │                   │   └── closing_loc: (1,7)-(1,9) = "\":"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (1,9)-(1,11))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (1,2)-(1,11))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (1,2)-(1,11))
+        │   │   │               ├── key:
+        │   │   │               │   @ InterpolatedSymbolNode (location: (1,2)-(1,9))
+        │   │   │               │   ├── opening_loc: (1,2)-(1,3) = "\""
+        │   │   │               │   ├── parts: (length: 1)
+        │   │   │               │   │   └── @ EmbeddedStatementsNode (location: (1,3)-(1,7))
+        │   │   │               │   │       ├── opening_loc: (1,3)-(1,5) = "\#{"
+        │   │   │               │   │       ├── statements:
+        │   │   │               │   │       │   @ StatementsNode (location: (1,5)-(1,6))
+        │   │   │               │   │       │   └── body: (length: 1)
+        │   │   │               │   │       │       └── @ CallNode (location: (1,5)-(1,6))
+        │   │   │               │   │       │           ├── receiver: ∅
+        │   │   │               │   │       │           ├── call_operator_loc: ∅
+        │   │   │               │   │       │           ├── message_loc: (1,5)-(1,6) = "k"
+        │   │   │               │   │       │           ├── opening_loc: ∅
+        │   │   │               │   │       │           ├── arguments: ∅
+        │   │   │               │   │       │           ├── closing_loc: ∅
+        │   │   │               │   │       │           ├── block: ∅
+        │   │   │               │   │       │           ├── flags: variable_call
+        │   │   │               │   │       │           └── name: :k
+        │   │   │               │   │       └── closing_loc: (1,6)-(1,7) = "}"
+        │   │   │               │   └── closing_loc: (1,7)-(1,9) = "\":"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (1,9)-(1,11))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -50,20 +51,21 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,2)-(3,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (3,2)-(3,8))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (3,2)-(3,8))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (3,2)-(3,6))
-        │   │                   │   ├── opening_loc: (3,2)-(3,3) = "\""
-        │   │                   │   ├── value_loc: (3,3)-(3,4) = "k"
-        │   │                   │   ├── closing_loc: (3,4)-(3,6) = "\":"
-        │   │                   │   └── unescaped: "k"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (3,6)-(3,8))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (3,2)-(3,8))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (3,2)-(3,8))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (3,2)-(3,6))
+        │   │   │               │   ├── opening_loc: (3,2)-(3,3) = "\""
+        │   │   │               │   ├── value_loc: (3,3)-(3,4) = "k"
+        │   │   │               │   ├── closing_loc: (3,4)-(3,6) = "\":"
+        │   │   │               │   └── unescaped: "k"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (3,6)-(3,8))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -75,20 +77,21 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (5,2)-(5,8))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (5,2)-(5,8))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (5,2)-(5,8))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (5,2)-(5,6))
-            │                   │   ├── opening_loc: (5,2)-(5,3) = "'"
-            │                   │   ├── value_loc: (5,3)-(5,4) = "k"
-            │                   │   ├── closing_loc: (5,4)-(5,6) = "':"
-            │                   │   └── unescaped: "k"
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (5,6)-(5,8))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (5,2)-(5,8))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (5,2)-(5,8))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (5,2)-(5,6))
+            │   │               │   ├── opening_loc: (5,2)-(5,3) = "'"
+            │   │               │   ├── value_loc: (5,3)-(5,4) = "k"
+            │   │               │   ├── closing_loc: (5,4)-(5,6) = "':"
+            │   │               │   └── unescaped: "k"
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (5,6)-(5,8))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_args_assoc_trailing_comma.txt
+++ b/test/prism/snapshots/seattlerb/call_args_assoc_trailing_comma.txt
@@ -10,19 +10,20 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,9))
-            │   └── arguments: (length: 2)
-            │       ├── @ IntegerNode (location: (1,2)-(1,3))
-            │       │   └── flags: decimal
-            │       └── @ KeywordHashNode (location: (1,5)-(1,9))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,5)-(1,9))
-            │                   ├── key:
-            │                   │   @ IntegerNode (location: (1,5)-(1,6))
-            │                   │   └── flags: decimal
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,8)-(1,9))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (1,6)-(1,8) = "=>"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ IntegerNode (location: (1,2)-(1,3))
+            │   │   │   └── flags: decimal
+            │   │   └── @ KeywordHashNode (location: (1,5)-(1,9))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,5)-(1,9))
+            │   │               ├── key:
+            │   │               │   @ IntegerNode (location: (1,5)-(1,6))
+            │   │               │   └── flags: decimal
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,8)-(1,9))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (1,6)-(1,8) = "=>"
+            │   └── flags: ∅
             ├── closing_loc: (1,10)-(1,11) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_args_command.txt
+++ b/test/prism/snapshots/seattlerb/call_args_command.txt
@@ -20,31 +20,33 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,9))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,4)-(1,9))
-            │           ├── receiver:
-            │           │   @ CallNode (location: (1,4)-(1,5))
-            │           │   ├── receiver: ∅
-            │           │   ├── call_operator_loc: ∅
-            │           │   ├── message_loc: (1,4)-(1,5) = "c"
-            │           │   ├── opening_loc: ∅
-            │           │   ├── arguments: ∅
-            │           │   ├── closing_loc: ∅
-            │           │   ├── block: ∅
-            │           │   ├── flags: variable_call
-            │           │   └── name: :c
-            │           ├── call_operator_loc: (1,5)-(1,6) = "."
-            │           ├── message_loc: (1,6)-(1,7) = "d"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (1,8)-(1,9))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ IntegerNode (location: (1,8)-(1,9))
-            │           │           └── flags: decimal
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :d
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,4)-(1,9))
+            │   │       ├── receiver:
+            │   │       │   @ CallNode (location: (1,4)-(1,5))
+            │   │       │   ├── receiver: ∅
+            │   │       │   ├── call_operator_loc: ∅
+            │   │       │   ├── message_loc: (1,4)-(1,5) = "c"
+            │   │       │   ├── opening_loc: ∅
+            │   │       │   ├── arguments: ∅
+            │   │       │   ├── closing_loc: ∅
+            │   │       │   ├── block: ∅
+            │   │       │   ├── flags: variable_call
+            │   │       │   └── name: :c
+            │   │       ├── call_operator_loc: (1,5)-(1,6) = "."
+            │   │       ├── message_loc: (1,6)-(1,7) = "d"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (1,8)-(1,9))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ IntegerNode (location: (1,8)-(1,9))
+            │   │       │   │       └── flags: decimal
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: ∅
+            │   │       └── name: :d
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_array_arg.txt
+++ b/test/prism/snapshots/seattlerb/call_array_arg.txt
@@ -12,21 +12,22 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,13))
-            │   └── arguments: (length: 1)
-            │       └── @ ArrayNode (location: (1,5)-(1,13))
-            │           ├── elements: (length: 2)
-            │           │   ├── @ SymbolNode (location: (1,6)-(1,8))
-            │           │   │   ├── opening_loc: (1,6)-(1,7) = ":"
-            │           │   │   ├── value_loc: (1,7)-(1,8) = "b"
-            │           │   │   ├── closing_loc: ∅
-            │           │   │   └── unescaped: "b"
-            │           │   └── @ SymbolNode (location: (1,10)-(1,12))
-            │           │       ├── opening_loc: (1,10)-(1,11) = ":"
-            │           │       ├── value_loc: (1,11)-(1,12) = "c"
-            │           │       ├── closing_loc: ∅
-            │           │       └── unescaped: "c"
-            │           ├── opening_loc: (1,5)-(1,6) = "["
-            │           └── closing_loc: (1,12)-(1,13) = "]"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ArrayNode (location: (1,5)-(1,13))
+            │   │       ├── elements: (length: 2)
+            │   │       │   ├── @ SymbolNode (location: (1,6)-(1,8))
+            │   │       │   │   ├── opening_loc: (1,6)-(1,7) = ":"
+            │   │       │   │   ├── value_loc: (1,7)-(1,8) = "b"
+            │   │       │   │   ├── closing_loc: ∅
+            │   │       │   │   └── unescaped: "b"
+            │   │       │   └── @ SymbolNode (location: (1,10)-(1,12))
+            │   │       │       ├── opening_loc: (1,10)-(1,11) = ":"
+            │   │       │       ├── value_loc: (1,11)-(1,12) = "c"
+            │   │       │       ├── closing_loc: ∅
+            │   │       │       └── unescaped: "c"
+            │   │       ├── opening_loc: (1,5)-(1,6) = "["
+            │   │       └── closing_loc: (1,12)-(1,13) = "]"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_array_block_call.txt
+++ b/test/prism/snapshots/seattlerb/call_array_block_call.txt
@@ -10,28 +10,29 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,19))
-            │   └── arguments: (length: 1)
-            │       └── @ ArrayNode (location: (1,2)-(1,19))
-            │           ├── elements: (length: 2)
-            │           │   ├── @ NilNode (location: (1,4)-(1,7))
-            │           │   └── @ CallNode (location: (1,9)-(1,17))
-            │           │       ├── receiver: ∅
-            │           │       ├── call_operator_loc: ∅
-            │           │       ├── message_loc: (1,9)-(1,10) = "b"
-            │           │       ├── opening_loc: ∅
-            │           │       ├── arguments: ∅
-            │           │       ├── closing_loc: ∅
-            │           │       ├── block:
-            │           │       │   @ BlockNode (location: (1,11)-(1,17))
-            │           │       │   ├── locals: []
-            │           │       │   ├── parameters: ∅
-            │           │       │   ├── body: ∅
-            │           │       │   ├── opening_loc: (1,11)-(1,13) = "do"
-            │           │       │   └── closing_loc: (1,14)-(1,17) = "end"
-            │           │       ├── flags: ∅
-            │           │       └── name: :b
-            │           ├── opening_loc: (1,2)-(1,3) = "["
-            │           └── closing_loc: (1,18)-(1,19) = "]"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ArrayNode (location: (1,2)-(1,19))
+            │   │       ├── elements: (length: 2)
+            │   │       │   ├── @ NilNode (location: (1,4)-(1,7))
+            │   │       │   └── @ CallNode (location: (1,9)-(1,17))
+            │   │       │       ├── receiver: ∅
+            │   │       │       ├── call_operator_loc: ∅
+            │   │       │       ├── message_loc: (1,9)-(1,10) = "b"
+            │   │       │       ├── opening_loc: ∅
+            │   │       │       ├── arguments: ∅
+            │   │       │       ├── closing_loc: ∅
+            │   │       │       ├── block:
+            │   │       │       │   @ BlockNode (location: (1,11)-(1,17))
+            │   │       │       │   ├── locals: []
+            │   │       │       │   ├── parameters: ∅
+            │   │       │       │   ├── body: ∅
+            │   │       │       │   ├── opening_loc: (1,11)-(1,13) = "do"
+            │   │       │       │   └── closing_loc: (1,14)-(1,17) = "end"
+            │   │       │       ├── flags: ∅
+            │   │       │       └── name: :b
+            │   │       ├── opening_loc: (1,2)-(1,3) = "["
+            │   │       └── closing_loc: (1,18)-(1,19) = "]"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_array_lambda_block_call.txt
+++ b/test/prism/snapshots/seattlerb/call_array_lambda_block_call.txt
@@ -10,23 +10,24 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,11))
-            │   └── arguments: (length: 1)
-            │       └── @ ArrayNode (location: (1,2)-(1,11))
-            │           ├── elements: (length: 1)
-            │           │   └── @ LambdaNode (location: (1,3)-(1,10))
-            │           │       ├── locals: []
-            │           │       ├── operator_loc: (1,3)-(1,5) = "->"
-            │           │       ├── opening_loc: (1,8)-(1,9) = "{"
-            │           │       ├── closing_loc: (1,9)-(1,10) = "}"
-            │           │       ├── parameters:
-            │           │       │   @ BlockParametersNode (location: (1,5)-(1,7))
-            │           │       │   ├── parameters: ∅
-            │           │       │   ├── locals: (length: 0)
-            │           │       │   ├── opening_loc: (1,5)-(1,6) = "("
-            │           │       │   └── closing_loc: (1,6)-(1,7) = ")"
-            │           │       └── body: ∅
-            │           ├── opening_loc: (1,2)-(1,3) = "["
-            │           └── closing_loc: (1,10)-(1,11) = "]"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ArrayNode (location: (1,2)-(1,11))
+            │   │       ├── elements: (length: 1)
+            │   │       │   └── @ LambdaNode (location: (1,3)-(1,10))
+            │   │       │       ├── locals: []
+            │   │       │       ├── operator_loc: (1,3)-(1,5) = "->"
+            │   │       │       ├── opening_loc: (1,8)-(1,9) = "{"
+            │   │       │       ├── closing_loc: (1,9)-(1,10) = "}"
+            │   │       │       ├── parameters:
+            │   │       │       │   @ BlockParametersNode (location: (1,5)-(1,7))
+            │   │       │       │   ├── parameters: ∅
+            │   │       │       │   ├── locals: (length: 0)
+            │   │       │       │   ├── opening_loc: (1,5)-(1,6) = "("
+            │   │       │       │   └── closing_loc: (1,6)-(1,7) = ")"
+            │   │       │       └── body: ∅
+            │   │       ├── opening_loc: (1,2)-(1,3) = "["
+            │   │       └── closing_loc: (1,10)-(1,11) = "]"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,12)-(2,3))

--- a/test/prism/snapshots/seattlerb/call_array_lit_inline_hash.txt
+++ b/test/prism/snapshots/seattlerb/call_array_lit_inline_hash.txt
@@ -10,29 +10,30 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,15))
-            │   └── arguments: (length: 1)
-            │       └── @ ArrayNode (location: (1,2)-(1,15))
-            │           ├── elements: (length: 2)
-            │           │   ├── @ SymbolNode (location: (1,3)-(1,5))
-            │           │   │   ├── opening_loc: (1,3)-(1,4) = ":"
-            │           │   │   ├── value_loc: (1,4)-(1,5) = "b"
-            │           │   │   ├── closing_loc: ∅
-            │           │   │   └── unescaped: "b"
-            │           │   └── @ KeywordHashNode (location: (1,7)-(1,14))
-            │           │       └── elements: (length: 1)
-            │           │           └── @ AssocNode (location: (1,7)-(1,14))
-            │           │               ├── key:
-            │           │               │   @ SymbolNode (location: (1,7)-(1,9))
-            │           │               │   ├── opening_loc: (1,7)-(1,8) = ":"
-            │           │               │   ├── value_loc: (1,8)-(1,9) = "c"
-            │           │               │   ├── closing_loc: ∅
-            │           │               │   └── unescaped: "c"
-            │           │               ├── value:
-            │           │               │   @ IntegerNode (location: (1,13)-(1,14))
-            │           │               │   └── flags: decimal
-            │           │               └── operator_loc: (1,10)-(1,12) = "=>"
-            │           ├── opening_loc: (1,2)-(1,3) = "["
-            │           └── closing_loc: (1,14)-(1,15) = "]"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ArrayNode (location: (1,2)-(1,15))
+            │   │       ├── elements: (length: 2)
+            │   │       │   ├── @ SymbolNode (location: (1,3)-(1,5))
+            │   │       │   │   ├── opening_loc: (1,3)-(1,4) = ":"
+            │   │       │   │   ├── value_loc: (1,4)-(1,5) = "b"
+            │   │       │   │   ├── closing_loc: ∅
+            │   │       │   │   └── unescaped: "b"
+            │   │       │   └── @ KeywordHashNode (location: (1,7)-(1,14))
+            │   │       │       └── elements: (length: 1)
+            │   │       │           └── @ AssocNode (location: (1,7)-(1,14))
+            │   │       │               ├── key:
+            │   │       │               │   @ SymbolNode (location: (1,7)-(1,9))
+            │   │       │               │   ├── opening_loc: (1,7)-(1,8) = ":"
+            │   │       │               │   ├── value_loc: (1,8)-(1,9) = "c"
+            │   │       │               │   ├── closing_loc: ∅
+            │   │       │               │   └── unescaped: "c"
+            │   │       │               ├── value:
+            │   │       │               │   @ IntegerNode (location: (1,13)-(1,14))
+            │   │       │               │   └── flags: decimal
+            │   │       │               └── operator_loc: (1,10)-(1,12) = "=>"
+            │   │       ├── opening_loc: (1,2)-(1,3) = "["
+            │   │       └── closing_loc: (1,14)-(1,15) = "]"
+            │   └── flags: ∅
             ├── closing_loc: (1,15)-(1,16) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_assoc.txt
+++ b/test/prism/snapshots/seattlerb/call_assoc.txt
@@ -10,17 +10,18 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,2)-(1,6))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,2)-(1,6))
-            │                   ├── key:
-            │                   │   @ IntegerNode (location: (1,2)-(1,3))
-            │                   │   └── flags: decimal
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,5)-(1,6))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (1,3)-(1,5) = "=>"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,2)-(1,6))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,2)-(1,6))
+            │   │               ├── key:
+            │   │               │   @ IntegerNode (location: (1,2)-(1,3))
+            │   │               │   └── flags: decimal
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,5)-(1,6))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (1,3)-(1,5) = "=>"
+            │   └── flags: ∅
             ├── closing_loc: (1,6)-(1,7) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_assoc_new.txt
+++ b/test/prism/snapshots/seattlerb/call_assoc_new.txt
@@ -10,20 +10,21 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,5))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,2)-(1,5))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,2)-(1,5))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (1,2)-(1,4))
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── value_loc: (1,2)-(1,3) = "a"
-            │                   │   ├── closing_loc: (1,3)-(1,4) = ":"
-            │                   │   └── unescaped: "a"
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,4)-(1,5))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,2)-(1,5))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,2)-(1,5))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (1,2)-(1,4))
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── value_loc: (1,2)-(1,3) = "a"
+            │   │               │   ├── closing_loc: (1,3)-(1,4) = ":"
+            │   │               │   └── unescaped: "a"
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,4)-(1,5))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: (1,5)-(1,6) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_assoc_new_if_multiline.txt
+++ b/test/prism/snapshots/seattlerb/call_assoc_new_if_multiline.txt
@@ -10,41 +10,42 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(5,3))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,2)-(5,3))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,2)-(5,3))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (1,2)-(1,4))
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── value_loc: (1,2)-(1,3) = "b"
-            │                   │   ├── closing_loc: (1,3)-(1,4) = ":"
-            │                   │   └── unescaped: "b"
-            │                   ├── value:
-            │                   │   @ IfNode (location: (1,5)-(5,3))
-            │                   │   ├── if_keyword_loc: (1,5)-(1,7) = "if"
-            │                   │   ├── predicate:
-            │                   │   │   @ SymbolNode (location: (1,8)-(1,10))
-            │                   │   │   ├── opening_loc: (1,8)-(1,9) = ":"
-            │                   │   │   ├── value_loc: (1,9)-(1,10) = "c"
-            │                   │   │   ├── closing_loc: ∅
-            │                   │   │   └── unescaped: "c"
-            │                   │   ├── statements:
-            │                   │   │   @ StatementsNode (location: (2,0)-(2,1))
-            │                   │   │   └── body: (length: 1)
-            │                   │   │       └── @ IntegerNode (location: (2,0)-(2,1))
-            │                   │   │           └── flags: decimal
-            │                   │   ├── consequent:
-            │                   │   │   @ ElseNode (location: (3,0)-(5,3))
-            │                   │   │   ├── else_keyword_loc: (3,0)-(3,4) = "else"
-            │                   │   │   ├── statements:
-            │                   │   │   │   @ StatementsNode (location: (4,0)-(4,1))
-            │                   │   │   │   └── body: (length: 1)
-            │                   │   │   │       └── @ IntegerNode (location: (4,0)-(4,1))
-            │                   │   │   │           └── flags: decimal
-            │                   │   │   └── end_keyword_loc: (5,0)-(5,3) = "end"
-            │                   │   └── end_keyword_loc: (5,0)-(5,3) = "end"
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,2)-(5,3))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,2)-(5,3))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (1,2)-(1,4))
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── value_loc: (1,2)-(1,3) = "b"
+            │   │               │   ├── closing_loc: (1,3)-(1,4) = ":"
+            │   │               │   └── unescaped: "b"
+            │   │               ├── value:
+            │   │               │   @ IfNode (location: (1,5)-(5,3))
+            │   │               │   ├── if_keyword_loc: (1,5)-(1,7) = "if"
+            │   │               │   ├── predicate:
+            │   │               │   │   @ SymbolNode (location: (1,8)-(1,10))
+            │   │               │   │   ├── opening_loc: (1,8)-(1,9) = ":"
+            │   │               │   │   ├── value_loc: (1,9)-(1,10) = "c"
+            │   │               │   │   ├── closing_loc: ∅
+            │   │               │   │   └── unescaped: "c"
+            │   │               │   ├── statements:
+            │   │               │   │   @ StatementsNode (location: (2,0)-(2,1))
+            │   │               │   │   └── body: (length: 1)
+            │   │               │   │       └── @ IntegerNode (location: (2,0)-(2,1))
+            │   │               │   │           └── flags: decimal
+            │   │               │   ├── consequent:
+            │   │               │   │   @ ElseNode (location: (3,0)-(5,3))
+            │   │               │   │   ├── else_keyword_loc: (3,0)-(3,4) = "else"
+            │   │               │   │   ├── statements:
+            │   │               │   │   │   @ StatementsNode (location: (4,0)-(4,1))
+            │   │               │   │   │   └── body: (length: 1)
+            │   │               │   │   │       └── @ IntegerNode (location: (4,0)-(4,1))
+            │   │               │   │   │           └── flags: decimal
+            │   │               │   │   └── end_keyword_loc: (5,0)-(5,3) = "end"
+            │   │               │   └── end_keyword_loc: (5,0)-(5,3) = "end"
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: (5,3)-(5,4) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_assoc_trailing_comma.txt
+++ b/test/prism/snapshots/seattlerb/call_assoc_trailing_comma.txt
@@ -10,17 +10,18 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,2)-(1,6))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,2)-(1,6))
-            │                   ├── key:
-            │                   │   @ IntegerNode (location: (1,2)-(1,3))
-            │                   │   └── flags: decimal
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,5)-(1,6))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (1,3)-(1,5) = "=>"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,2)-(1,6))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,2)-(1,6))
+            │   │               ├── key:
+            │   │               │   @ IntegerNode (location: (1,2)-(1,3))
+            │   │               │   └── flags: decimal
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,5)-(1,6))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (1,3)-(1,5) = "=>"
+            │   └── flags: ∅
             ├── closing_loc: (1,7)-(1,8) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_bang_command_call.txt
+++ b/test/prism/snapshots/seattlerb/call_bang_command_call.txt
@@ -22,9 +22,10 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,6)-(1,7))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ IntegerNode (location: (1,6)-(1,7))
-            │   │           └── flags: decimal
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ IntegerNode (location: (1,6)-(1,7))
+            │   │   │       └── flags: decimal
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_bang_squiggle.txt
+++ b/test/prism/snapshots/seattlerb/call_bang_squiggle.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,5)-(1,6))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,5)-(1,6))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_begin_call_block_call.txt
+++ b/test/prism/snapshots/seattlerb/call_begin_call_block_call.txt
@@ -10,42 +10,43 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(3,3))
-            │   └── arguments: (length: 1)
-            │       └── @ BeginNode (location: (1,2)-(3,3))
-            │           ├── begin_keyword_loc: (1,2)-(1,7) = "begin"
-            │           ├── statements:
-            │           │   @ StatementsNode (location: (2,0)-(2,10))
-            │           │   └── body: (length: 1)
-            │           │       └── @ CallNode (location: (2,0)-(2,10))
-            │           │           ├── receiver:
-            │           │           │   @ CallNode (location: (2,0)-(2,1))
-            │           │           │   ├── receiver: ∅
-            │           │           │   ├── call_operator_loc: ∅
-            │           │           │   ├── message_loc: (2,0)-(2,1) = "b"
-            │           │           │   ├── opening_loc: ∅
-            │           │           │   ├── arguments: ∅
-            │           │           │   ├── closing_loc: ∅
-            │           │           │   ├── block: ∅
-            │           │           │   ├── flags: variable_call
-            │           │           │   └── name: :b
-            │           │           ├── call_operator_loc: (2,1)-(2,2) = "."
-            │           │           ├── message_loc: (2,2)-(2,3) = "c"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block:
-            │           │           │   @ BlockNode (location: (2,4)-(2,10))
-            │           │           │   ├── locals: []
-            │           │           │   ├── parameters: ∅
-            │           │           │   ├── body: ∅
-            │           │           │   ├── opening_loc: (2,4)-(2,6) = "do"
-            │           │           │   └── closing_loc: (2,7)-(2,10) = "end"
-            │           │           ├── flags: ∅
-            │           │           └── name: :c
-            │           ├── rescue_clause: ∅
-            │           ├── else_clause: ∅
-            │           ├── ensure_clause: ∅
-            │           └── end_keyword_loc: (3,0)-(3,3) = "end"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ BeginNode (location: (1,2)-(3,3))
+            │   │       ├── begin_keyword_loc: (1,2)-(1,7) = "begin"
+            │   │       ├── statements:
+            │   │       │   @ StatementsNode (location: (2,0)-(2,10))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ CallNode (location: (2,0)-(2,10))
+            │   │       │           ├── receiver:
+            │   │       │           │   @ CallNode (location: (2,0)-(2,1))
+            │   │       │           │   ├── receiver: ∅
+            │   │       │           │   ├── call_operator_loc: ∅
+            │   │       │           │   ├── message_loc: (2,0)-(2,1) = "b"
+            │   │       │           │   ├── opening_loc: ∅
+            │   │       │           │   ├── arguments: ∅
+            │   │       │           │   ├── closing_loc: ∅
+            │   │       │           │   ├── block: ∅
+            │   │       │           │   ├── flags: variable_call
+            │   │       │           │   └── name: :b
+            │   │       │           ├── call_operator_loc: (2,1)-(2,2) = "."
+            │   │       │           ├── message_loc: (2,2)-(2,3) = "c"
+            │   │       │           ├── opening_loc: ∅
+            │   │       │           ├── arguments: ∅
+            │   │       │           ├── closing_loc: ∅
+            │   │       │           ├── block:
+            │   │       │           │   @ BlockNode (location: (2,4)-(2,10))
+            │   │       │           │   ├── locals: []
+            │   │       │           │   ├── parameters: ∅
+            │   │       │           │   ├── body: ∅
+            │   │       │           │   ├── opening_loc: (2,4)-(2,6) = "do"
+            │   │       │           │   └── closing_loc: (2,7)-(2,10) = "end"
+            │   │       │           ├── flags: ∅
+            │   │       │           └── name: :c
+            │   │       ├── rescue_clause: ∅
+            │   │       ├── else_clause: ∅
+            │   │       ├── ensure_clause: ∅
+            │   │       └── end_keyword_loc: (3,0)-(3,3) = "end"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_carat.txt
+++ b/test/prism/snapshots/seattlerb/call_carat.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,5))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,4)-(1,5))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,4)-(1,5))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_div.txt
+++ b/test/prism/snapshots/seattlerb/call_div.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,5))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,4)-(1,5))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,4)-(1,5))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_eq3.txt
+++ b/test/prism/snapshots/seattlerb/call_eq3.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,6)-(1,7))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,6)-(1,7))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,6)-(1,7))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_gt.txt
+++ b/test/prism/snapshots/seattlerb/call_gt.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,5))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,4)-(1,5))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,4)-(1,5))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_kwsplat.txt
+++ b/test/prism/snapshots/seattlerb/call_kwsplat.txt
@@ -10,14 +10,15 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,5))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,2)-(1,5))
-            │           └── elements: (length: 1)
-            │               └── @ AssocSplatNode (location: (1,2)-(1,5))
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,4)-(1,5))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (1,2)-(1,4) = "**"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,2)-(1,5))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocSplatNode (location: (1,2)-(1,5))
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,4)-(1,5))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (1,2)-(1,4) = "**"
+            │   └── flags: keyword_splat
             ├── closing_loc: (1,5)-(1,6) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_lt.txt
+++ b/test/prism/snapshots/seattlerb/call_lt.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,5))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,4)-(1,5))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,4)-(1,5))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_lte.txt
+++ b/test/prism/snapshots/seattlerb/call_lte.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,5)-(1,6))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,5)-(1,6))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_pipe.txt
+++ b/test/prism/snapshots/seattlerb/call_pipe.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,5))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,4)-(1,5))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,4)-(1,5))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_rshift.txt
+++ b/test/prism/snapshots/seattlerb/call_rshift.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,5)-(1,6))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,5)-(1,6))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_self_brackets.txt
+++ b/test/prism/snapshots/seattlerb/call_self_brackets.txt
@@ -11,9 +11,10 @@
             ├── opening_loc: (1,4)-(1,5) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,5)-(1,6))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,5)-(1,6))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,6)-(1,7) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_spaceship.txt
+++ b/test/prism/snapshots/seattlerb/call_spaceship.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,6)-(1,7))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,6)-(1,7))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,6)-(1,7))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_stabby_do_end_with_block.txt
+++ b/test/prism/snapshots/seattlerb/call_stabby_do_end_with_block.txt
@@ -10,18 +10,19 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,13))
-            │   └── arguments: (length: 1)
-            │       └── @ LambdaNode (location: (1,2)-(1,13))
-            │           ├── locals: []
-            │           ├── operator_loc: (1,2)-(1,4) = "->"
-            │           ├── opening_loc: (1,5)-(1,7) = "do"
-            │           ├── closing_loc: (1,10)-(1,13) = "end"
-            │           ├── parameters: ∅
-            │           └── body:
-            │               @ StatementsNode (location: (1,8)-(1,9))
-            │               └── body: (length: 1)
-            │                   └── @ IntegerNode (location: (1,8)-(1,9))
-            │                       └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ LambdaNode (location: (1,2)-(1,13))
+            │   │       ├── locals: []
+            │   │       ├── operator_loc: (1,2)-(1,4) = "->"
+            │   │       ├── opening_loc: (1,5)-(1,7) = "do"
+            │   │       ├── closing_loc: (1,10)-(1,13) = "end"
+            │   │       ├── parameters: ∅
+            │   │       └── body:
+            │   │           @ StatementsNode (location: (1,8)-(1,9))
+            │   │           └── body: (length: 1)
+            │   │               └── @ IntegerNode (location: (1,8)-(1,9))
+            │   │                   └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,14)-(1,22))

--- a/test/prism/snapshots/seattlerb/call_stabby_with_braces_block.txt
+++ b/test/prism/snapshots/seattlerb/call_stabby_with_braces_block.txt
@@ -10,18 +10,19 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,10))
-            │   └── arguments: (length: 1)
-            │       └── @ LambdaNode (location: (1,2)-(1,10))
-            │           ├── locals: []
-            │           ├── operator_loc: (1,2)-(1,4) = "->"
-            │           ├── opening_loc: (1,5)-(1,6) = "{"
-            │           ├── closing_loc: (1,9)-(1,10) = "}"
-            │           ├── parameters: ∅
-            │           └── body:
-            │               @ StatementsNode (location: (1,7)-(1,8))
-            │               └── body: (length: 1)
-            │                   └── @ IntegerNode (location: (1,7)-(1,8))
-            │                       └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ LambdaNode (location: (1,2)-(1,10))
+            │   │       ├── locals: []
+            │   │       ├── operator_loc: (1,2)-(1,4) = "->"
+            │   │       ├── opening_loc: (1,5)-(1,6) = "{"
+            │   │       ├── closing_loc: (1,9)-(1,10) = "}"
+            │   │       ├── parameters: ∅
+            │   │       └── body:
+            │   │           @ StatementsNode (location: (1,7)-(1,8))
+            │   │           └── body: (length: 1)
+            │   │               └── @ IntegerNode (location: (1,7)-(1,8))
+            │   │                   └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,11)-(1,19))

--- a/test/prism/snapshots/seattlerb/call_star.txt
+++ b/test/prism/snapshots/seattlerb/call_star.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,5))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,4)-(1,5))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,4)-(1,5))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_star2.txt
+++ b/test/prism/snapshots/seattlerb/call_star2.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,5)-(1,6))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,5)-(1,6))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_trailing_comma.txt
+++ b/test/prism/snapshots/seattlerb/call_trailing_comma.txt
@@ -10,9 +10,10 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,3))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,2)-(1,3))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,2)-(1,3))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,4)-(1,5) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defn_arg_forward_args.txt
+++ b/test/prism/snapshots/seattlerb/defn_arg_forward_args.txt
@@ -29,11 +29,12 @@
             │           ├── opening_loc: (1,16)-(1,17) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,17)-(1,23))
-            │           │   └── arguments: (length: 2)
-            │           │       ├── @ LocalVariableReadNode (location: (1,17)-(1,18))
-            │           │       │   ├── name: :x
-            │           │       │   └── depth: 0
-            │           │       └── @ ForwardingArgumentsNode (location: (1,20)-(1,23))
+            │           │   ├── arguments: (length: 2)
+            │           │   │   ├── @ LocalVariableReadNode (location: (1,17)-(1,18))
+            │           │   │   │   ├── name: :x
+            │           │   │   │   └── depth: 0
+            │           │   │   └── @ ForwardingArgumentsNode (location: (1,20)-(1,23))
+            │           │   └── flags: ∅
             │           ├── closing_loc: (1,23)-(1,24) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defn_args_forward_args.txt
+++ b/test/prism/snapshots/seattlerb/defn_args_forward_args.txt
@@ -33,16 +33,17 @@
             │           ├── opening_loc: (1,22)-(1,23) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,23)-(1,35))
-            │           │   └── arguments: (length: 3)
-            │           │       ├── @ SymbolNode (location: (1,23)-(1,27))
-            │           │       │   ├── opening_loc: (1,23)-(1,24) = ":"
-            │           │       │   ├── value_loc: (1,24)-(1,27) = "get"
-            │           │       │   ├── closing_loc: ∅
-            │           │       │   └── unescaped: "get"
-            │           │       ├── @ LocalVariableReadNode (location: (1,29)-(1,30))
-            │           │       │   ├── name: :z
-            │           │       │   └── depth: 0
-            │           │       └── @ ForwardingArgumentsNode (location: (1,32)-(1,35))
+            │           │   ├── arguments: (length: 3)
+            │           │   │   ├── @ SymbolNode (location: (1,23)-(1,27))
+            │           │   │   │   ├── opening_loc: (1,23)-(1,24) = ":"
+            │           │   │   │   ├── value_loc: (1,24)-(1,27) = "get"
+            │           │   │   │   ├── closing_loc: ∅
+            │           │   │   │   └── unescaped: "get"
+            │           │   │   ├── @ LocalVariableReadNode (location: (1,29)-(1,30))
+            │           │   │   │   ├── name: :z
+            │           │   │   │   └── depth: 0
+            │           │   │   └── @ ForwardingArgumentsNode (location: (1,32)-(1,35))
+            │           │   └── flags: ∅
             │           ├── closing_loc: (1,35)-(1,36) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defn_endless_command.txt
+++ b/test/prism/snapshots/seattlerb/defn_endless_command.txt
@@ -18,9 +18,10 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,31)-(1,33))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ IntegerNode (location: (1,31)-(1,33))
-            │           │           └── flags: decimal
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ IntegerNode (location: (1,31)-(1,33))
+            │           │   │       └── flags: decimal
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defn_endless_command_rescue.txt
+++ b/test/prism/snapshots/seattlerb/defn_endless_command_rescue.txt
@@ -18,15 +18,16 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,31)-(1,43))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ RescueModifierNode (location: (1,31)-(1,43))
-            │           │           ├── expression:
-            │           │           │   @ IntegerNode (location: (1,31)-(1,33))
-            │           │           │   └── flags: decimal
-            │           │           ├── keyword_loc: (1,34)-(1,40) = "rescue"
-            │           │           └── rescue_expression:
-            │           │               @ IntegerNode (location: (1,41)-(1,43))
-            │           │               └── flags: decimal
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ RescueModifierNode (location: (1,31)-(1,43))
+            │           │   │       ├── expression:
+            │           │   │       │   @ IntegerNode (location: (1,31)-(1,33))
+            │           │   │       │   └── flags: decimal
+            │           │   │       ├── keyword_loc: (1,34)-(1,40) = "rescue"
+            │           │   │       └── rescue_expression:
+            │           │   │           @ IntegerNode (location: (1,41)-(1,43))
+            │           │   │           └── flags: decimal
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defn_forward_args.txt
+++ b/test/prism/snapshots/seattlerb/defn_forward_args.txt
@@ -27,8 +27,9 @@
             │           ├── opening_loc: (1,13)-(1,14) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,14)-(1,17))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ ForwardingArgumentsNode (location: (1,14)-(1,17))
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ ForwardingArgumentsNode (location: (1,14)-(1,17))
+            │           │   └── flags: ∅
             │           ├── closing_loc: (1,17)-(1,18) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defn_forward_args__no_parens.txt
+++ b/test/prism/snapshots/seattlerb/defn_forward_args__no_parens.txt
@@ -27,8 +27,9 @@
             │           ├── opening_loc: (2,3)-(2,4) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (2,4)-(2,7))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ ForwardingArgumentsNode (location: (2,4)-(2,7))
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ ForwardingArgumentsNode (location: (2,4)-(2,7))
+            │           │   └── flags: ∅
             │           ├── closing_loc: (2,7)-(2,8) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defn_kwarg_env.txt
+++ b/test/prism/snapshots/seattlerb/defn_kwarg_env.txt
@@ -30,15 +30,16 @@
             │           ├── opening_loc: (1,30)-(1,31) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,31)-(1,40))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ KeywordHashNode (location: (1,31)-(1,40))
-            │           │           └── elements: (length: 1)
-            │           │               └── @ AssocSplatNode (location: (1,31)-(1,40))
-            │           │                   ├── value:
-            │           │                   │   @ LocalVariableReadNode (location: (1,33)-(1,40))
-            │           │                   │   ├── name: :testing
-            │           │                   │   └── depth: 0
-            │           │                   └── operator_loc: (1,31)-(1,33) = "**"
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ KeywordHashNode (location: (1,31)-(1,40))
+            │           │   │       └── elements: (length: 1)
+            │           │   │           └── @ AssocSplatNode (location: (1,31)-(1,40))
+            │           │   │               ├── value:
+            │           │   │               │   @ LocalVariableReadNode (location: (1,33)-(1,40))
+            │           │   │               │   ├── name: :testing
+            │           │   │               │   └── depth: 0
+            │           │   │               └── operator_loc: (1,31)-(1,33) = "**"
+            │           │   └── flags: keyword_splat
             │           ├── closing_loc: (1,40)-(1,41) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defn_oneliner.txt
+++ b/test/prism/snapshots/seattlerb/defn_oneliner.txt
@@ -28,10 +28,11 @@
             │           ├── opening_loc: (1,22)-(1,23) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,23)-(1,26))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ LocalVariableReadNode (location: (1,23)-(1,26))
-            │           │           ├── name: :cmd
-            │           │           └── depth: 0
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ LocalVariableReadNode (location: (1,23)-(1,26))
+            │           │   │       ├── name: :cmd
+            │           │   │       └── depth: 0
+            │           │   └── flags: ∅
             │           ├── closing_loc: (1,26)-(1,27) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defn_oneliner_rescue.txt
+++ b/test/prism/snapshots/seattlerb/defn_oneliner_rescue.txt
@@ -31,10 +31,11 @@
         │   │   │           ├── opening_loc: (2,8)-(2,9) = "("
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (2,9)-(2,12))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ LocalVariableReadNode (location: (2,9)-(2,12))
-        │   │   │           │           ├── name: :cmd
-        │   │   │           │           └── depth: 0
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ LocalVariableReadNode (location: (2,9)-(2,12))
+        │   │   │           │   │       ├── name: :cmd
+        │   │   │           │   │       └── depth: 0
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: (2,12)-(2,13) = ")"
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅
@@ -87,10 +88,11 @@
         │   │           │   ├── opening_loc: (9,8)-(9,9) = "("
         │   │           │   ├── arguments:
         │   │           │   │   @ ArgumentsNode (location: (9,9)-(9,12))
-        │   │           │   │   └── arguments: (length: 1)
-        │   │           │   │       └── @ LocalVariableReadNode (location: (9,9)-(9,12))
-        │   │           │   │           ├── name: :cmd
-        │   │           │   │           └── depth: 0
+        │   │           │   │   ├── arguments: (length: 1)
+        │   │           │   │   │   └── @ LocalVariableReadNode (location: (9,9)-(9,12))
+        │   │           │   │   │       ├── name: :cmd
+        │   │           │   │   │       └── depth: 0
+        │   │           │   │   └── flags: ∅
         │   │           │   ├── closing_loc: (9,12)-(9,13) = ")"
         │   │           │   ├── block: ∅
         │   │           │   ├── flags: ∅
@@ -132,10 +134,11 @@
             │           │   ├── opening_loc: (13,22)-(13,23) = "("
             │           │   ├── arguments:
             │           │   │   @ ArgumentsNode (location: (13,23)-(13,26))
-            │           │   │   └── arguments: (length: 1)
-            │           │   │       └── @ LocalVariableReadNode (location: (13,23)-(13,26))
-            │           │   │           ├── name: :cmd
-            │           │   │           └── depth: 0
+            │           │   │   ├── arguments: (length: 1)
+            │           │   │   │   └── @ LocalVariableReadNode (location: (13,23)-(13,26))
+            │           │   │   │       ├── name: :cmd
+            │           │   │   │       └── depth: 0
+            │           │   │   └── flags: ∅
             │           │   ├── closing_loc: (13,26)-(13,27) = ")"
             │           │   ├── block: ∅
             │           │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defs_as_arg_with_do_block_inside.txt
+++ b/test/prism/snapshots/seattlerb/defs_as_arg_with_do_block_inside.txt
@@ -10,49 +10,50 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,30))
-            │   └── arguments: (length: 1)
-            │       └── @ DefNode (location: (1,2)-(1,30))
-            │           ├── name: :b
-            │           ├── name_loc: (1,11)-(1,12) = "b"
-            │           ├── receiver:
-            │           │   @ SelfNode (location: (1,6)-(1,10))
-            │           ├── parameters: ∅
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,14)-(1,25))
-            │           │   └── body: (length: 1)
-            │           │       └── @ CallNode (location: (1,14)-(1,25))
-            │           │           ├── receiver:
-            │           │           │   @ CallNode (location: (1,14)-(1,15))
-            │           │           │   ├── receiver: ∅
-            │           │           │   ├── call_operator_loc: ∅
-            │           │           │   ├── message_loc: (1,14)-(1,15) = "x"
-            │           │           │   ├── opening_loc: ∅
-            │           │           │   ├── arguments: ∅
-            │           │           │   ├── closing_loc: ∅
-            │           │           │   ├── block: ∅
-            │           │           │   ├── flags: variable_call
-            │           │           │   └── name: :x
-            │           │           ├── call_operator_loc: (1,15)-(1,16) = "."
-            │           │           ├── message_loc: (1,16)-(1,17) = "y"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block:
-            │           │           │   @ BlockNode (location: (1,18)-(1,25))
-            │           │           │   ├── locals: []
-            │           │           │   ├── parameters: ∅
-            │           │           │   ├── body: ∅
-            │           │           │   ├── opening_loc: (1,18)-(1,20) = "do"
-            │           │           │   └── closing_loc: (1,22)-(1,25) = "end"
-            │           │           ├── flags: ∅
-            │           │           └── name: :y
-            │           ├── locals: []
-            │           ├── def_keyword_loc: (1,2)-(1,5) = "def"
-            │           ├── operator_loc: (1,10)-(1,11) = "."
-            │           ├── lparen_loc: ∅
-            │           ├── rparen_loc: ∅
-            │           ├── equal_loc: ∅
-            │           └── end_keyword_loc: (1,27)-(1,30) = "end"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ DefNode (location: (1,2)-(1,30))
+            │   │       ├── name: :b
+            │   │       ├── name_loc: (1,11)-(1,12) = "b"
+            │   │       ├── receiver:
+            │   │       │   @ SelfNode (location: (1,6)-(1,10))
+            │   │       ├── parameters: ∅
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,14)-(1,25))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ CallNode (location: (1,14)-(1,25))
+            │   │       │           ├── receiver:
+            │   │       │           │   @ CallNode (location: (1,14)-(1,15))
+            │   │       │           │   ├── receiver: ∅
+            │   │       │           │   ├── call_operator_loc: ∅
+            │   │       │           │   ├── message_loc: (1,14)-(1,15) = "x"
+            │   │       │           │   ├── opening_loc: ∅
+            │   │       │           │   ├── arguments: ∅
+            │   │       │           │   ├── closing_loc: ∅
+            │   │       │           │   ├── block: ∅
+            │   │       │           │   ├── flags: variable_call
+            │   │       │           │   └── name: :x
+            │   │       │           ├── call_operator_loc: (1,15)-(1,16) = "."
+            │   │       │           ├── message_loc: (1,16)-(1,17) = "y"
+            │   │       │           ├── opening_loc: ∅
+            │   │       │           ├── arguments: ∅
+            │   │       │           ├── closing_loc: ∅
+            │   │       │           ├── block:
+            │   │       │           │   @ BlockNode (location: (1,18)-(1,25))
+            │   │       │           │   ├── locals: []
+            │   │       │           │   ├── parameters: ∅
+            │   │       │           │   ├── body: ∅
+            │   │       │           │   ├── opening_loc: (1,18)-(1,20) = "do"
+            │   │       │           │   └── closing_loc: (1,22)-(1,25) = "end"
+            │   │       │           ├── flags: ∅
+            │   │       │           └── name: :y
+            │   │       ├── locals: []
+            │   │       ├── def_keyword_loc: (1,2)-(1,5) = "def"
+            │   │       ├── operator_loc: (1,10)-(1,11) = "."
+            │   │       ├── lparen_loc: ∅
+            │   │       ├── rparen_loc: ∅
+            │   │       ├── equal_loc: ∅
+            │   │       └── end_keyword_loc: (1,27)-(1,30) = "end"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defs_endless_command.txt
+++ b/test/prism/snapshots/seattlerb/defs_endless_command.txt
@@ -28,9 +28,10 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,33)-(1,35))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ IntegerNode (location: (1,33)-(1,35))
-            │           │           └── flags: decimal
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ IntegerNode (location: (1,33)-(1,35))
+            │           │   │       └── flags: decimal
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defs_endless_command_rescue.txt
+++ b/test/prism/snapshots/seattlerb/defs_endless_command_rescue.txt
@@ -28,15 +28,16 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,33)-(1,45))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ RescueModifierNode (location: (1,33)-(1,45))
-            │           │           ├── expression:
-            │           │           │   @ IntegerNode (location: (1,33)-(1,35))
-            │           │           │   └── flags: decimal
-            │           │           ├── keyword_loc: (1,36)-(1,42) = "rescue"
-            │           │           └── rescue_expression:
-            │           │               @ IntegerNode (location: (1,43)-(1,45))
-            │           │               └── flags: decimal
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ RescueModifierNode (location: (1,33)-(1,45))
+            │           │   │       ├── expression:
+            │           │   │       │   @ IntegerNode (location: (1,33)-(1,35))
+            │           │   │       │   └── flags: decimal
+            │           │   │       ├── keyword_loc: (1,36)-(1,42) = "rescue"
+            │           │   │       └── rescue_expression:
+            │           │   │           @ IntegerNode (location: (1,43)-(1,45))
+            │           │   │           └── flags: decimal
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defs_oneliner.txt
+++ b/test/prism/snapshots/seattlerb/defs_oneliner.txt
@@ -29,10 +29,11 @@
             │           ├── opening_loc: (1,27)-(1,28) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,28)-(1,31))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ LocalVariableReadNode (location: (1,28)-(1,31))
-            │           │           ├── name: :cmd
-            │           │           └── depth: 0
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ LocalVariableReadNode (location: (1,28)-(1,31))
+            │           │   │       ├── name: :cmd
+            │           │   │       └── depth: 0
+            │           │   └── flags: ∅
             │           ├── closing_loc: (1,31)-(1,32) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defs_oneliner_rescue.txt
+++ b/test/prism/snapshots/seattlerb/defs_oneliner_rescue.txt
@@ -32,10 +32,11 @@
         │   │   │           ├── opening_loc: (2,8)-(2,9) = "("
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (2,9)-(2,12))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ LocalVariableReadNode (location: (2,9)-(2,12))
-        │   │   │           │           ├── name: :cmd
-        │   │   │           │           └── depth: 0
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ LocalVariableReadNode (location: (2,9)-(2,12))
+        │   │   │           │   │       ├── name: :cmd
+        │   │   │           │   │       └── depth: 0
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: (2,12)-(2,13) = ")"
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅
@@ -89,10 +90,11 @@
         │   │           │   ├── opening_loc: (9,8)-(9,9) = "("
         │   │           │   ├── arguments:
         │   │           │   │   @ ArgumentsNode (location: (9,9)-(9,12))
-        │   │           │   │   └── arguments: (length: 1)
-        │   │           │   │       └── @ LocalVariableReadNode (location: (9,9)-(9,12))
-        │   │           │   │           ├── name: :cmd
-        │   │           │   │           └── depth: 0
+        │   │           │   │   ├── arguments: (length: 1)
+        │   │           │   │   │   └── @ LocalVariableReadNode (location: (9,9)-(9,12))
+        │   │           │   │   │       ├── name: :cmd
+        │   │           │   │   │       └── depth: 0
+        │   │           │   │   └── flags: ∅
         │   │           │   ├── closing_loc: (9,12)-(9,13) = ")"
         │   │           │   ├── block: ∅
         │   │           │   ├── flags: ∅
@@ -135,10 +137,11 @@
             │           │   ├── opening_loc: (13,27)-(13,28) = "("
             │           │   ├── arguments:
             │           │   │   @ ArgumentsNode (location: (13,28)-(13,31))
-            │           │   │   └── arguments: (length: 1)
-            │           │   │       └── @ LocalVariableReadNode (location: (13,28)-(13,31))
-            │           │   │           ├── name: :cmd
-            │           │   │           └── depth: 0
+            │           │   │   ├── arguments: (length: 1)
+            │           │   │   │   └── @ LocalVariableReadNode (location: (13,28)-(13,31))
+            │           │   │   │       ├── name: :cmd
+            │           │   │   │       └── depth: 0
+            │           │   │   └── flags: ∅
             │           │   ├── closing_loc: (13,31)-(13,32) = ")"
             │           │   ├── block: ∅
             │           │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/difficult0_.txt
+++ b/test/prism/snapshots/seattlerb/difficult0_.txt
@@ -10,59 +10,62 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(4,8))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,2)-(4,8))
-            │           ├── receiver:
-            │           │   @ CallNode (location: (1,2)-(4,4))
-            │           │   ├── receiver:
-            │           │   │   @ StringNode (location: (1,2)-(1,8))
-            │           │   │   ├── flags: ∅
-            │           │   │   ├── opening_loc: (1,2)-(1,8) = "<<-END"
-            │           │   │   ├── content_loc: (2,0)-(2,0) = "  a\n"
-            │           │   │   ├── closing_loc: (3,0)-(3,0) = "  END\n"
-            │           │   │   └── unescaped: "  a\n"
-            │           │   ├── call_operator_loc: ∅
-            │           │   ├── message_loc: (1,8)-(1,9) = "+"
-            │           │   ├── opening_loc: ∅
-            │           │   ├── arguments:
-            │           │   │   @ ArgumentsNode (location: (1,9)-(4,4))
-            │           │   │   └── arguments: (length: 1)
-            │           │   │       └── @ InterpolatedStringNode (location: (1,9)-(4,4))
-            │           │   │           ├── opening_loc: (1,9)-(1,10) = "'"
-            │           │   │           ├── parts: (length: 2)
-            │           │   │           │   ├── @ StringNode (location: (1,10)-(1,0))
-            │           │   │           │   │   ├── flags: ∅
-            │           │   │           │   │   ├── opening_loc: ∅
-            │           │   │           │   │   ├── content_loc: (1,10)-(1,0) = "b\n"
-            │           │   │           │   │   ├── closing_loc: ∅
-            │           │   │           │   │   └── unescaped: "b\n"
-            │           │   │           │   └── @ StringNode (location: (4,0)-(4,3))
-            │           │   │           │       ├── flags: ∅
-            │           │   │           │       ├── opening_loc: ∅
-            │           │   │           │       ├── content_loc: (4,0)-(4,3) = "  c"
-            │           │   │           │       ├── closing_loc: ∅
-            │           │   │           │       └── unescaped: "  c"
-            │           │   │           └── closing_loc: (4,3)-(4,4) = "'"
-            │           │   ├── closing_loc: ∅
-            │           │   ├── block: ∅
-            │           │   ├── flags: ∅
-            │           │   └── name: :+
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (4,4)-(4,5) = "+"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (4,5)-(4,8))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ StringNode (location: (4,5)-(4,8))
-            │           │           ├── flags: ∅
-            │           │           ├── opening_loc: (4,5)-(4,6) = "'"
-            │           │           ├── content_loc: (4,6)-(4,7) = "d"
-            │           │           ├── closing_loc: (4,7)-(4,8) = "'"
-            │           │           └── unescaped: "d"
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :+
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,2)-(4,8))
+            │   │       ├── receiver:
+            │   │       │   @ CallNode (location: (1,2)-(4,4))
+            │   │       │   ├── receiver:
+            │   │       │   │   @ StringNode (location: (1,2)-(1,8))
+            │   │       │   │   ├── flags: ∅
+            │   │       │   │   ├── opening_loc: (1,2)-(1,8) = "<<-END"
+            │   │       │   │   ├── content_loc: (2,0)-(2,0) = "  a\n"
+            │   │       │   │   ├── closing_loc: (3,0)-(3,0) = "  END\n"
+            │   │       │   │   └── unescaped: "  a\n"
+            │   │       │   ├── call_operator_loc: ∅
+            │   │       │   ├── message_loc: (1,8)-(1,9) = "+"
+            │   │       │   ├── opening_loc: ∅
+            │   │       │   ├── arguments:
+            │   │       │   │   @ ArgumentsNode (location: (1,9)-(4,4))
+            │   │       │   │   ├── arguments: (length: 1)
+            │   │       │   │   │   └── @ InterpolatedStringNode (location: (1,9)-(4,4))
+            │   │       │   │   │       ├── opening_loc: (1,9)-(1,10) = "'"
+            │   │       │   │   │       ├── parts: (length: 2)
+            │   │       │   │   │       │   ├── @ StringNode (location: (1,10)-(1,0))
+            │   │       │   │   │       │   │   ├── flags: ∅
+            │   │       │   │   │       │   │   ├── opening_loc: ∅
+            │   │       │   │   │       │   │   ├── content_loc: (1,10)-(1,0) = "b\n"
+            │   │       │   │   │       │   │   ├── closing_loc: ∅
+            │   │       │   │   │       │   │   └── unescaped: "b\n"
+            │   │       │   │   │       │   └── @ StringNode (location: (4,0)-(4,3))
+            │   │       │   │   │       │       ├── flags: ∅
+            │   │       │   │   │       │       ├── opening_loc: ∅
+            │   │       │   │   │       │       ├── content_loc: (4,0)-(4,3) = "  c"
+            │   │       │   │   │       │       ├── closing_loc: ∅
+            │   │       │   │   │       │       └── unescaped: "  c"
+            │   │       │   │   │       └── closing_loc: (4,3)-(4,4) = "'"
+            │   │       │   │   └── flags: ∅
+            │   │       │   ├── closing_loc: ∅
+            │   │       │   ├── block: ∅
+            │   │       │   ├── flags: ∅
+            │   │       │   └── name: :+
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (4,4)-(4,5) = "+"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (4,5)-(4,8))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ StringNode (location: (4,5)-(4,8))
+            │   │       │   │       ├── flags: ∅
+            │   │       │   │       ├── opening_loc: (4,5)-(4,6) = "'"
+            │   │       │   │       ├── content_loc: (4,6)-(4,7) = "d"
+            │   │       │   │       ├── closing_loc: (4,7)-(4,8) = "'"
+            │   │       │   │       └── unescaped: "d"
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: ∅
+            │   │       └── name: :+
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/difficult1_line_numbers.txt
+++ b/test/prism/snapshots/seattlerb/difficult1_line_numbers.txt
@@ -17,9 +17,10 @@
             │       │   ├── opening_loc: ∅
             │       │   ├── arguments:
             │       │   │   @ ArgumentsNode (location: (2,4)-(2,5))
-            │       │   │   └── arguments: (length: 1)
-            │       │   │       └── @ IntegerNode (location: (2,4)-(2,5))
-            │       │   │           └── flags: decimal
+            │       │   │   ├── arguments: (length: 1)
+            │       │   │   │   └── @ IntegerNode (location: (2,4)-(2,5))
+            │       │   │   │       └── flags: decimal
+            │       │   │   └── flags: ∅
             │       │   ├── closing_loc: ∅
             │       │   ├── block: ∅
             │       │   ├── flags: ∅
@@ -41,9 +42,10 @@
             │       │   ├── opening_loc: ∅
             │       │   ├── arguments:
             │       │   │   @ ArgumentsNode (location: (3,6)-(3,7))
-            │       │   │   └── arguments: (length: 1)
-            │       │   │       └── @ IntegerNode (location: (3,6)-(3,7))
-            │       │   │           └── flags: decimal
+            │       │   │   ├── arguments: (length: 1)
+            │       │   │   │   └── @ IntegerNode (location: (3,6)-(3,7))
+            │       │   │   │       └── flags: decimal
+            │       │   │   └── flags: ∅
             │       │   ├── closing_loc: ∅
             │       │   ├── block: ∅
             │       │   ├── flags: ∅
@@ -65,11 +67,12 @@
             │       │   ├── opening_loc: ∅
             │       │   ├── arguments:
             │       │   │   @ ArgumentsNode (location: (4,6)-(4,10))
-            │       │   │   └── arguments: (length: 2)
-            │       │   │       ├── @ IntegerNode (location: (4,6)-(4,7))
-            │       │   │       │   └── flags: decimal
-            │       │   │       └── @ IntegerNode (location: (4,9)-(4,10))
-            │       │   │           └── flags: decimal
+            │       │   │   ├── arguments: (length: 2)
+            │       │   │   │   ├── @ IntegerNode (location: (4,6)-(4,7))
+            │       │   │   │   │   └── flags: decimal
+            │       │   │   │   └── @ IntegerNode (location: (4,9)-(4,10))
+            │       │   │   │       └── flags: decimal
+            │       │   │   └── flags: ∅
             │       │   ├── closing_loc: ∅
             │       │   ├── block: ∅
             │       │   ├── flags: ∅
@@ -91,9 +94,10 @@
             │       │   ├── opening_loc: ∅
             │       │   ├── arguments:
             │       │   │   @ ArgumentsNode (location: (5,6)-(5,7))
-            │       │   │   └── arguments: (length: 1)
-            │       │   │       └── @ IntegerNode (location: (5,6)-(5,7))
-            │       │   │           └── flags: decimal
+            │       │   │   ├── arguments: (length: 1)
+            │       │   │   │   └── @ IntegerNode (location: (5,6)-(5,7))
+            │       │   │   │       └── flags: decimal
+            │       │   │   └── flags: ∅
             │       │   ├── closing_loc: ∅
             │       │   ├── block: ∅
             │       │   ├── flags: ∅
@@ -115,11 +119,12 @@
             │       │   ├── opening_loc: ∅
             │       │   ├── arguments:
             │       │   │   @ ArgumentsNode (location: (6,6)-(6,10))
-            │       │   │   └── arguments: (length: 2)
-            │       │   │       ├── @ IntegerNode (location: (6,6)-(6,7))
-            │       │   │       │   └── flags: decimal
-            │       │   │       └── @ IntegerNode (location: (6,9)-(6,10))
-            │       │   │           └── flags: decimal
+            │       │   │   ├── arguments: (length: 2)
+            │       │   │   │   ├── @ IntegerNode (location: (6,6)-(6,7))
+            │       │   │   │   │   └── flags: decimal
+            │       │   │   │   └── @ IntegerNode (location: (6,9)-(6,10))
+            │       │   │   │       └── flags: decimal
+            │       │   │   └── flags: ∅
             │       │   ├── closing_loc: ∅
             │       │   ├── block: ∅
             │       │   ├── flags: ∅
@@ -131,9 +136,10 @@
             │       │   ├── opening_loc: (7,3)-(7,4) = "("
             │       │   ├── arguments:
             │       │   │   @ ArgumentsNode (location: (7,4)-(7,5))
-            │       │   │   └── arguments: (length: 1)
-            │       │   │       └── @ IntegerNode (location: (7,4)-(7,5))
-            │       │   │           └── flags: decimal
+            │       │   │   ├── arguments: (length: 1)
+            │       │   │   │   └── @ IntegerNode (location: (7,4)-(7,5))
+            │       │   │   │       └── flags: decimal
+            │       │   │   └── flags: ∅
             │       │   ├── closing_loc: (7,5)-(7,6) = ")"
             │       │   ├── block: ∅
             │       │   ├── flags: ∅
@@ -155,9 +161,10 @@
             │       │   ├── opening_loc: (8,5)-(8,6) = "("
             │       │   ├── arguments:
             │       │   │   @ ArgumentsNode (location: (8,6)-(8,7))
-            │       │   │   └── arguments: (length: 1)
-            │       │   │       └── @ IntegerNode (location: (8,6)-(8,7))
-            │       │   │           └── flags: decimal
+            │       │   │   ├── arguments: (length: 1)
+            │       │   │   │   └── @ IntegerNode (location: (8,6)-(8,7))
+            │       │   │   │       └── flags: decimal
+            │       │   │   └── flags: ∅
             │       │   ├── closing_loc: (8,7)-(8,8) = ")"
             │       │   ├── block: ∅
             │       │   ├── flags: ∅
@@ -179,11 +186,12 @@
             │       │   ├── opening_loc: (9,5)-(9,6) = "("
             │       │   ├── arguments:
             │       │   │   @ ArgumentsNode (location: (9,6)-(9,10))
-            │       │   │   └── arguments: (length: 2)
-            │       │   │       ├── @ IntegerNode (location: (9,6)-(9,7))
-            │       │   │       │   └── flags: decimal
-            │       │   │       └── @ IntegerNode (location: (9,9)-(9,10))
-            │       │   │           └── flags: decimal
+            │       │   │   ├── arguments: (length: 2)
+            │       │   │   │   ├── @ IntegerNode (location: (9,6)-(9,7))
+            │       │   │   │   │   └── flags: decimal
+            │       │   │   │   └── @ IntegerNode (location: (9,9)-(9,10))
+            │       │   │   │       └── flags: decimal
+            │       │   │   └── flags: ∅
             │       │   ├── closing_loc: (9,10)-(9,11) = ")"
             │       │   ├── block: ∅
             │       │   ├── flags: ∅
@@ -205,9 +213,10 @@
             │       │   ├── opening_loc: (10,5)-(10,6) = "("
             │       │   ├── arguments:
             │       │   │   @ ArgumentsNode (location: (10,6)-(10,7))
-            │       │   │   └── arguments: (length: 1)
-            │       │   │       └── @ IntegerNode (location: (10,6)-(10,7))
-            │       │   │           └── flags: decimal
+            │       │   │   ├── arguments: (length: 1)
+            │       │   │   │   └── @ IntegerNode (location: (10,6)-(10,7))
+            │       │   │   │       └── flags: decimal
+            │       │   │   └── flags: ∅
             │       │   ├── closing_loc: (10,7)-(10,8) = ")"
             │       │   ├── block: ∅
             │       │   ├── flags: ∅
@@ -229,11 +238,12 @@
             │           ├── opening_loc: (11,5)-(11,6) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (11,6)-(11,10))
-            │           │   └── arguments: (length: 2)
-            │           │       ├── @ IntegerNode (location: (11,6)-(11,7))
-            │           │       │   └── flags: decimal
-            │           │       └── @ IntegerNode (location: (11,9)-(11,10))
-            │           │           └── flags: decimal
+            │           │   ├── arguments: (length: 2)
+            │           │   │   ├── @ IntegerNode (location: (11,6)-(11,7))
+            │           │   │   │   └── flags: decimal
+            │           │   │   └── @ IntegerNode (location: (11,9)-(11,10))
+            │           │   │       └── flags: decimal
+            │           │   └── flags: ∅
             │           ├── closing_loc: (11,10)-(11,11) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/difficult1_line_numbers2.txt
+++ b/test/prism/snapshots/seattlerb/difficult1_line_numbers2.txt
@@ -17,13 +17,14 @@
         │   │       │   ├── opening_loc: (2,3)-(2,4) = "("
         │   │       │   ├── arguments:
         │   │       │   │   @ ArgumentsNode (location: (2,4)-(2,7))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ StringNode (location: (2,4)-(2,7))
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           ├── opening_loc: (2,4)-(2,5) = "\""
-        │   │       │   │           ├── content_loc: (2,5)-(2,6) = "a"
-        │   │       │   │           ├── closing_loc: (2,6)-(2,7) = "\""
-        │   │       │   │           └── unescaped: "a"
+        │   │       │   │   ├── arguments: (length: 1)
+        │   │       │   │   │   └── @ StringNode (location: (2,4)-(2,7))
+        │   │       │   │   │       ├── flags: ∅
+        │   │       │   │   │       ├── opening_loc: (2,4)-(2,5) = "\""
+        │   │       │   │   │       ├── content_loc: (2,5)-(2,6) = "a"
+        │   │       │   │   │       ├── closing_loc: (2,6)-(2,7) = "\""
+        │   │       │   │   │       └── unescaped: "a"
+        │   │       │   │   └── flags: ∅
         │   │       │   ├── closing_loc: (2,7)-(2,8) = ")"
         │   │       │   ├── block: ∅
         │   │       │   ├── flags: ∅
@@ -43,10 +44,11 @@
         │   │       │   ├── opening_loc: ∅
         │   │       │   ├── arguments:
         │   │       │   │   @ ArgumentsNode (location: (4,4)-(4,5))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ LocalVariableReadNode (location: (4,4)-(4,5))
-        │   │       │   │           ├── name: :b
-        │   │       │   │           └── depth: 0
+        │   │       │   │   ├── arguments: (length: 1)
+        │   │       │   │   │   └── @ LocalVariableReadNode (location: (4,4)-(4,5))
+        │   │       │   │   │       ├── name: :b
+        │   │       │   │   │       └── depth: 0
+        │   │       │   │   └── flags: ∅
         │   │       │   ├── closing_loc: ∅
         │   │       │   ├── block: ∅
         │   │       │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/difficult2_.txt
+++ b/test/prism/snapshots/seattlerb/difficult2_.txt
@@ -18,13 +18,14 @@
         │   │           ├── opening_loc: (1,5)-(1,6) = "("
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (1,6)-(1,8))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ StringNode (location: (1,6)-(1,8))
-        │   │           │           ├── flags: ∅
-        │   │           │           ├── opening_loc: (1,6)-(1,7) = "'"
-        │   │           │           ├── content_loc: (1,7)-(1,7) = ""
-        │   │           │           ├── closing_loc: (1,7)-(1,8) = "'"
-        │   │           │           └── unescaped: ""
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ StringNode (location: (1,6)-(1,8))
+        │   │           │   │       ├── flags: ∅
+        │   │           │   │       ├── opening_loc: (1,6)-(1,7) = "'"
+        │   │           │   │       ├── content_loc: (1,7)-(1,7) = ""
+        │   │           │   │       ├── closing_loc: (1,7)-(1,8) = "'"
+        │   │           │   │       └── unescaped: ""
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: (1,8)-(1,9) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -46,20 +47,21 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (2,2)-(2,6))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (2,2)-(2,6))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (2,2)-(2,6))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (2,2)-(2,4))
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── value_loc: (2,2)-(2,3) = "d"
-            │                   │   ├── closing_loc: (2,3)-(2,4) = ":"
-            │                   │   └── unescaped: "d"
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (2,5)-(2,6))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (2,2)-(2,6))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (2,2)-(2,6))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (2,2)-(2,4))
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── value_loc: (2,2)-(2,3) = "d"
+            │   │               │   ├── closing_loc: (2,3)-(2,4) = ":"
+            │   │               │   └── unescaped: "d"
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (2,5)-(2,6))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/difficult3_5.txt
+++ b/test/prism/snapshots/seattlerb/difficult3_5.txt
@@ -10,37 +10,38 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,19))
-            │   └── arguments: (length: 1)
-            │       └── @ LambdaNode (location: (1,2)-(1,19))
-            │           ├── locals: []
-            │           ├── operator_loc: (1,2)-(1,4) = "->"
-            │           ├── opening_loc: (1,7)-(1,8) = "{"
-            │           ├── closing_loc: (1,18)-(1,19) = "}"
-            │           ├── parameters:
-            │           │   @ BlockParametersNode (location: (1,4)-(1,6))
-            │           │   ├── parameters: ∅
-            │           │   ├── locals: (length: 0)
-            │           │   ├── opening_loc: (1,4)-(1,5) = "("
-            │           │   └── closing_loc: (1,5)-(1,6) = ")"
-            │           └── body:
-            │               @ StatementsNode (location: (1,9)-(1,17))
-            │               └── body: (length: 1)
-            │                   └── @ CallNode (location: (1,9)-(1,17))
-            │                       ├── receiver: ∅
-            │                       ├── call_operator_loc: ∅
-            │                       ├── message_loc: (1,9)-(1,10) = "g"
-            │                       ├── opening_loc: ∅
-            │                       ├── arguments: ∅
-            │                       ├── closing_loc: ∅
-            │                       ├── block:
-            │                       │   @ BlockNode (location: (1,11)-(1,17))
-            │                       │   ├── locals: []
-            │                       │   ├── parameters: ∅
-            │                       │   ├── body: ∅
-            │                       │   ├── opening_loc: (1,11)-(1,13) = "do"
-            │                       │   └── closing_loc: (1,14)-(1,17) = "end"
-            │                       ├── flags: ∅
-            │                       └── name: :g
+            │   ├── arguments: (length: 1)
+            │   │   └── @ LambdaNode (location: (1,2)-(1,19))
+            │   │       ├── locals: []
+            │   │       ├── operator_loc: (1,2)-(1,4) = "->"
+            │   │       ├── opening_loc: (1,7)-(1,8) = "{"
+            │   │       ├── closing_loc: (1,18)-(1,19) = "}"
+            │   │       ├── parameters:
+            │   │       │   @ BlockParametersNode (location: (1,4)-(1,6))
+            │   │       │   ├── parameters: ∅
+            │   │       │   ├── locals: (length: 0)
+            │   │       │   ├── opening_loc: (1,4)-(1,5) = "("
+            │   │       │   └── closing_loc: (1,5)-(1,6) = ")"
+            │   │       └── body:
+            │   │           @ StatementsNode (location: (1,9)-(1,17))
+            │   │           └── body: (length: 1)
+            │   │               └── @ CallNode (location: (1,9)-(1,17))
+            │   │                   ├── receiver: ∅
+            │   │                   ├── call_operator_loc: ∅
+            │   │                   ├── message_loc: (1,9)-(1,10) = "g"
+            │   │                   ├── opening_loc: ∅
+            │   │                   ├── arguments: ∅
+            │   │                   ├── closing_loc: ∅
+            │   │                   ├── block:
+            │   │                   │   @ BlockNode (location: (1,11)-(1,17))
+            │   │                   │   ├── locals: []
+            │   │                   │   ├── parameters: ∅
+            │   │                   │   ├── body: ∅
+            │   │                   │   ├── opening_loc: (1,11)-(1,13) = "do"
+            │   │                   │   └── closing_loc: (1,14)-(1,17) = "end"
+            │   │                   ├── flags: ∅
+            │   │                   └── name: :g
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/difficult6_.txt
+++ b/test/prism/snapshots/seattlerb/difficult6_.txt
@@ -40,17 +40,18 @@
                         ├── opening_loc: ∅
                         ├── arguments:
                         │   @ ArgumentsNode (location: (1,17)-(1,23))
-                        │   └── arguments: (length: 1)
-                        │       └── @ ArrayNode (location: (1,17)-(1,23))
-                        │           ├── elements: (length: 2)
-                        │           │   ├── @ LocalVariableReadNode (location: (1,18)-(1,19))
-                        │           │   │   ├── name: :a
-                        │           │   │   └── depth: 0
-                        │           │   └── @ LocalVariableReadNode (location: (1,21)-(1,22))
-                        │           │       ├── name: :b
-                        │           │       └── depth: 0
-                        │           ├── opening_loc: (1,17)-(1,18) = "["
-                        │           └── closing_loc: (1,22)-(1,23) = "]"
+                        │   ├── arguments: (length: 1)
+                        │   │   └── @ ArrayNode (location: (1,17)-(1,23))
+                        │   │       ├── elements: (length: 2)
+                        │   │       │   ├── @ LocalVariableReadNode (location: (1,18)-(1,19))
+                        │   │       │   │   ├── name: :a
+                        │   │       │   │   └── depth: 0
+                        │   │       │   └── @ LocalVariableReadNode (location: (1,21)-(1,22))
+                        │   │       │       ├── name: :b
+                        │   │       │       └── depth: 0
+                        │   │       ├── opening_loc: (1,17)-(1,18) = "["
+                        │   │       └── closing_loc: (1,22)-(1,23) = "]"
+                        │   └── flags: ∅
                         ├── closing_loc: ∅
                         ├── block: ∅
                         ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/difficult6__7.txt
+++ b/test/prism/snapshots/seattlerb/difficult6__7.txt
@@ -20,15 +20,16 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,7))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,4)-(1,7))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,5)-(1,6))
-            │           │   └── body: (length: 1)
-            │           │       └── @ IntegerNode (location: (1,5)-(1,6))
-            │           │           └── flags: decimal
-            │           ├── opening_loc: (1,4)-(1,5) = "("
-            │           └── closing_loc: (1,6)-(1,7) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,4)-(1,7))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,5)-(1,6))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ IntegerNode (location: (1,5)-(1,6))
+            │   │       │           └── flags: decimal
+            │   │       ├── opening_loc: (1,4)-(1,5) = "("
+            │   │       └── closing_loc: (1,6)-(1,7) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,8)-(1,11))

--- a/test/prism/snapshots/seattlerb/difficult6__8.txt
+++ b/test/prism/snapshots/seattlerb/difficult6__8.txt
@@ -20,15 +20,16 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,8))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,5)-(1,8))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,6)-(1,7))
-            │           │   └── body: (length: 1)
-            │           │       └── @ IntegerNode (location: (1,6)-(1,7))
-            │           │           └── flags: decimal
-            │           ├── opening_loc: (1,5)-(1,6) = "("
-            │           └── closing_loc: (1,7)-(1,8) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,5)-(1,8))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,6)-(1,7))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ IntegerNode (location: (1,6)-(1,7))
+            │   │       │           └── flags: decimal
+            │   │       ├── opening_loc: (1,5)-(1,6) = "("
+            │   │       └── closing_loc: (1,7)-(1,8) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,9)-(1,12))

--- a/test/prism/snapshots/seattlerb/do_bug.txt
+++ b/test/prism/snapshots/seattlerb/do_bug.txt
@@ -10,9 +10,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,3))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (1,2)-(1,3))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (1,2)-(1,3))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/dstr_lex_state.txt
+++ b/test/prism/snapshots/seattlerb/dstr_lex_state.txt
@@ -18,12 +18,13 @@
             │       │           ├── opening_loc: ∅
             │       │           ├── arguments:
             │       │           │   @ ArgumentsNode (location: (1,4)-(1,6))
-            │       │           │   └── arguments: (length: 1)
-            │       │           │       └── @ SymbolNode (location: (1,4)-(1,6))
-            │       │           │           ├── opening_loc: (1,4)-(1,5) = ":"
-            │       │           │           ├── value_loc: (1,5)-(1,6) = "a"
-            │       │           │           ├── closing_loc: ∅
-            │       │           │           └── unescaped: "a"
+            │       │           │   ├── arguments: (length: 1)
+            │       │           │   │   └── @ SymbolNode (location: (1,4)-(1,6))
+            │       │           │   │       ├── opening_loc: (1,4)-(1,5) = ":"
+            │       │           │   │       ├── value_loc: (1,5)-(1,6) = "a"
+            │       │           │   │       ├── closing_loc: ∅
+            │       │           │   │       └── unescaped: "a"
+            │       │           │   └── flags: ∅
             │       │           ├── closing_loc: ∅
             │       │           ├── block: ∅
             │       │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/eq_begin_why_wont_people_use_their_spacebar.txt
+++ b/test/prism/snapshots/seattlerb/eq_begin_why_wont_people_use_their_spacebar.txt
@@ -20,28 +20,29 @@
             ├── opening_loc: (1,1)-(1,2) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(3,8))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (1,2)-(1,3))
-            │       │   ├── receiver: ∅
-            │       │   ├── call_operator_loc: ∅
-            │       │   ├── message_loc: (1,2)-(1,3) = "k"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block: ∅
-            │       │   ├── flags: variable_call
-            │       │   └── name: :k
-            │       └── @ BeginNode (location: (1,5)-(3,8))
-            │           ├── begin_keyword_loc: (1,5)-(1,10) = "begin"
-            │           ├── statements:
-            │           │   @ StatementsNode (location: (2,7)-(2,9))
-            │           │   └── body: (length: 1)
-            │           │       └── @ IntegerNode (location: (2,7)-(2,9))
-            │           │           └── flags: decimal
-            │           ├── rescue_clause: ∅
-            │           ├── else_clause: ∅
-            │           ├── ensure_clause: ∅
-            │           └── end_keyword_loc: (3,5)-(3,8) = "end"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (1,2)-(1,3))
+            │   │   │   ├── receiver: ∅
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── message_loc: (1,2)-(1,3) = "k"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block: ∅
+            │   │   │   ├── flags: variable_call
+            │   │   │   └── name: :k
+            │   │   └── @ BeginNode (location: (1,5)-(3,8))
+            │   │       ├── begin_keyword_loc: (1,5)-(1,10) = "begin"
+            │   │       ├── statements:
+            │   │       │   @ StatementsNode (location: (2,7)-(2,9))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ IntegerNode (location: (2,7)-(2,9))
+            │   │       │           └── flags: decimal
+            │   │       ├── rescue_clause: ∅
+            │   │       ├── else_clause: ∅
+            │   │       ├── ensure_clause: ∅
+            │   │       └── end_keyword_loc: (3,5)-(3,8) = "end"
+            │   └── flags: ∅
             ├── closing_loc: (1,3)-(1,4) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/expr_not_bang.txt
+++ b/test/prism/snapshots/seattlerb/expr_not_bang.txt
@@ -12,17 +12,18 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,4)-(1,5))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ CallNode (location: (1,4)-(1,5))
-            │   │           ├── receiver: ∅
-            │   │           ├── call_operator_loc: ∅
-            │   │           ├── message_loc: (1,4)-(1,5) = "b"
-            │   │           ├── opening_loc: ∅
-            │   │           ├── arguments: ∅
-            │   │           ├── closing_loc: ∅
-            │   │           ├── block: ∅
-            │   │           ├── flags: variable_call
-            │   │           └── name: :b
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ CallNode (location: (1,4)-(1,5))
+            │   │   │       ├── receiver: ∅
+            │   │   │       ├── call_operator_loc: ∅
+            │   │   │       ├── message_loc: (1,4)-(1,5) = "b"
+            │   │   │       ├── opening_loc: ∅
+            │   │   │       ├── arguments: ∅
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       ├── block: ∅
+            │   │   │       ├── flags: variable_call
+            │   │   │       └── name: :b
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.txt
+++ b/test/prism/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.txt
@@ -15,49 +15,50 @@
             │   ├── opening_loc: (1,7)-(1,8) = "("
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,8)-(1,19))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ CallNode (location: (1,8)-(1,19))
-            │   │           ├── receiver:
-            │   │           │   @ InterpolatedStringNode (location: (1,8)-(1,14))
-            │   │           │   ├── opening_loc: (1,8)-(1,14) = "<<~EOF"
-            │   │           │   ├── parts: (length: 3)
-            │   │           │   │   ├── @ StringNode (location: (2,0)-(2,0))
-            │   │           │   │   │   ├── flags: ∅
-            │   │           │   │   │   ├── opening_loc: ∅
-            │   │           │   │   │   ├── content_loc: (2,0)-(2,0) = "\n"
-            │   │           │   │   │   ├── closing_loc: ∅
-            │   │           │   │   │   └── unescaped: "\n"
-            │   │           │   │   ├── @ EmbeddedStatementsNode (location: (3,4)-(3,10))
-            │   │           │   │   │   ├── opening_loc: (3,4)-(3,6) = "\#{"
-            │   │           │   │   │   ├── statements:
-            │   │           │   │   │   │   @ StatementsNode (location: (3,6)-(3,9))
-            │   │           │   │   │   │   └── body: (length: 1)
-            │   │           │   │   │   │       └── @ CallNode (location: (3,6)-(3,9))
-            │   │           │   │   │   │           ├── receiver: ∅
-            │   │           │   │   │   │           ├── call_operator_loc: ∅
-            │   │           │   │   │   │           ├── message_loc: (3,6)-(3,9) = "bar"
-            │   │           │   │   │   │           ├── opening_loc: ∅
-            │   │           │   │   │   │           ├── arguments: ∅
-            │   │           │   │   │   │           ├── closing_loc: ∅
-            │   │           │   │   │   │           ├── block: ∅
-            │   │           │   │   │   │           ├── flags: variable_call
-            │   │           │   │   │   │           └── name: :bar
-            │   │           │   │   │   └── closing_loc: (3,9)-(3,10) = "}"
-            │   │           │   │   └── @ StringNode (location: (3,10)-(3,0))
-            │   │           │   │       ├── flags: ∅
-            │   │           │   │       ├── opening_loc: ∅
-            │   │           │   │       ├── content_loc: (3,10)-(3,0) = "baz\n"
-            │   │           │   │       ├── closing_loc: ∅
-            │   │           │   │       └── unescaped: "baz\n"
-            │   │           │   └── closing_loc: (4,0)-(4,0) = "  EOF\n"
-            │   │           ├── call_operator_loc: (1,14)-(1,15) = "."
-            │   │           ├── message_loc: (1,15)-(1,19) = "chop"
-            │   │           ├── opening_loc: ∅
-            │   │           ├── arguments: ∅
-            │   │           ├── closing_loc: ∅
-            │   │           ├── block: ∅
-            │   │           ├── flags: ∅
-            │   │           └── name: :chop
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ CallNode (location: (1,8)-(1,19))
+            │   │   │       ├── receiver:
+            │   │   │       │   @ InterpolatedStringNode (location: (1,8)-(1,14))
+            │   │   │       │   ├── opening_loc: (1,8)-(1,14) = "<<~EOF"
+            │   │   │       │   ├── parts: (length: 3)
+            │   │   │       │   │   ├── @ StringNode (location: (2,0)-(2,0))
+            │   │   │       │   │   │   ├── flags: ∅
+            │   │   │       │   │   │   ├── opening_loc: ∅
+            │   │   │       │   │   │   ├── content_loc: (2,0)-(2,0) = "\n"
+            │   │   │       │   │   │   ├── closing_loc: ∅
+            │   │   │       │   │   │   └── unescaped: "\n"
+            │   │   │       │   │   ├── @ EmbeddedStatementsNode (location: (3,4)-(3,10))
+            │   │   │       │   │   │   ├── opening_loc: (3,4)-(3,6) = "\#{"
+            │   │   │       │   │   │   ├── statements:
+            │   │   │       │   │   │   │   @ StatementsNode (location: (3,6)-(3,9))
+            │   │   │       │   │   │   │   └── body: (length: 1)
+            │   │   │       │   │   │   │       └── @ CallNode (location: (3,6)-(3,9))
+            │   │   │       │   │   │   │           ├── receiver: ∅
+            │   │   │       │   │   │   │           ├── call_operator_loc: ∅
+            │   │   │       │   │   │   │           ├── message_loc: (3,6)-(3,9) = "bar"
+            │   │   │       │   │   │   │           ├── opening_loc: ∅
+            │   │   │       │   │   │   │           ├── arguments: ∅
+            │   │   │       │   │   │   │           ├── closing_loc: ∅
+            │   │   │       │   │   │   │           ├── block: ∅
+            │   │   │       │   │   │   │           ├── flags: variable_call
+            │   │   │       │   │   │   │           └── name: :bar
+            │   │   │       │   │   │   └── closing_loc: (3,9)-(3,10) = "}"
+            │   │   │       │   │   └── @ StringNode (location: (3,10)-(3,0))
+            │   │   │       │   │       ├── flags: ∅
+            │   │   │       │   │       ├── opening_loc: ∅
+            │   │   │       │   │       ├── content_loc: (3,10)-(3,0) = "baz\n"
+            │   │   │       │   │       ├── closing_loc: ∅
+            │   │   │       │   │       └── unescaped: "baz\n"
+            │   │   │       │   └── closing_loc: (4,0)-(4,0) = "  EOF\n"
+            │   │   │       ├── call_operator_loc: (1,14)-(1,15) = "."
+            │   │   │       ├── message_loc: (1,15)-(1,19) = "chop"
+            │   │   │       ├── opening_loc: ∅
+            │   │   │       ├── arguments: ∅
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       ├── block: ∅
+            │   │   │       ├── flags: ∅
+            │   │   │       └── name: :chop
+            │   │   └── flags: ∅
             │   ├── closing_loc: (1,19)-(1,20) = ")"
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/if_symbol.txt
+++ b/test/prism/snapshots/seattlerb/if_symbol.txt
@@ -13,12 +13,13 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,5)-(1,7))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ SymbolNode (location: (1,5)-(1,7))
-            │   │           ├── opening_loc: (1,5)-(1,6) = ":"
-            │   │           ├── value_loc: (1,6)-(1,7) = "x"
-            │   │           ├── closing_loc: ∅
-            │   │           └── unescaped: "x"
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ SymbolNode (location: (1,5)-(1,7))
+            │   │   │       ├── opening_loc: (1,5)-(1,6) = ":"
+            │   │   │       ├── value_loc: (1,6)-(1,7) = "x"
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       └── unescaped: "x"
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/index_0.txt
+++ b/test/prism/snapshots/seattlerb/index_0.txt
@@ -20,17 +20,18 @@
             ├── opening_loc: (1,1)-(1,2) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,6)-(1,7))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,6)-(1,7))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,6)-(1,7) = "b"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :b
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,6)-(1,7))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,6)-(1,7) = "b"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :b
+            │   └── flags: ∅
             ├── closing_loc: (1,2)-(1,3) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/label_vs_string.txt
+++ b/test/prism/snapshots/seattlerb/label_vs_string.txt
@@ -20,13 +20,14 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,8)-(2,1))
-            │   └── arguments: (length: 1)
-            │       └── @ StringNode (location: (1,8)-(2,1))
-            │           ├── flags: ∅
-            │           ├── opening_loc: (1,8)-(1,9) = "'"
-            │           ├── content_loc: (1,9)-(1,0) = ":\n"
-            │           ├── closing_loc: (2,0)-(2,1) = "'"
-            │           └── unescaped: ":\n"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ StringNode (location: (1,8)-(2,1))
+            │   │       ├── flags: ∅
+            │   │       ├── opening_loc: (1,8)-(1,9) = "'"
+            │   │       ├── content_loc: (1,9)-(1,0) = ":\n"
+            │   │       ├── closing_loc: (2,0)-(2,1) = "'"
+            │   │       └── unescaped: ":\n"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/lambda_do_vs_brace.txt
+++ b/test/prism/snapshots/seattlerb/lambda_do_vs_brace.txt
@@ -10,14 +10,15 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ LambdaNode (location: (1,2)-(1,11))
-        │   │           ├── locals: []
-        │   │           ├── operator_loc: (1,2)-(1,4) = "->"
-        │   │           ├── opening_loc: (1,5)-(1,7) = "do"
-        │   │           ├── closing_loc: (1,8)-(1,11) = "end"
-        │   │           ├── parameters: ∅
-        │   │           └── body: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ LambdaNode (location: (1,2)-(1,11))
+        │   │   │       ├── locals: []
+        │   │   │       ├── operator_loc: (1,2)-(1,4) = "->"
+        │   │   │       ├── opening_loc: (1,5)-(1,7) = "do"
+        │   │   │       ├── closing_loc: (1,8)-(1,11) = "end"
+        │   │   │       ├── parameters: ∅
+        │   │   │       └── body: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -29,14 +30,15 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,2)-(3,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ LambdaNode (location: (3,2)-(3,7))
-        │   │           ├── locals: []
-        │   │           ├── operator_loc: (3,2)-(3,4) = "->"
-        │   │           ├── opening_loc: (3,5)-(3,6) = "{"
-        │   │           ├── closing_loc: (3,6)-(3,7) = "}"
-        │   │           ├── parameters: ∅
-        │   │           └── body: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ LambdaNode (location: (3,2)-(3,7))
+        │   │   │       ├── locals: []
+        │   │   │       ├── operator_loc: (3,2)-(3,4) = "->"
+        │   │   │       ├── opening_loc: (3,5)-(3,6) = "{"
+        │   │   │       ├── closing_loc: (3,6)-(3,7) = "}"
+        │   │   │       ├── parameters: ∅
+        │   │   │       └── body: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -48,19 +50,20 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,2)-(5,13))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ LambdaNode (location: (5,2)-(5,13))
-        │   │           ├── locals: []
-        │   │           ├── operator_loc: (5,2)-(5,4) = "->"
-        │   │           ├── opening_loc: (5,7)-(5,9) = "do"
-        │   │           ├── closing_loc: (5,10)-(5,13) = "end"
-        │   │           ├── parameters:
-        │   │           │   @ BlockParametersNode (location: (5,4)-(5,6))
-        │   │           │   ├── parameters: ∅
-        │   │           │   ├── locals: (length: 0)
-        │   │           │   ├── opening_loc: (5,4)-(5,5) = "("
-        │   │           │   └── closing_loc: (5,5)-(5,6) = ")"
-        │   │           └── body: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ LambdaNode (location: (5,2)-(5,13))
+        │   │   │       ├── locals: []
+        │   │   │       ├── operator_loc: (5,2)-(5,4) = "->"
+        │   │   │       ├── opening_loc: (5,7)-(5,9) = "do"
+        │   │   │       ├── closing_loc: (5,10)-(5,13) = "end"
+        │   │   │       ├── parameters:
+        │   │   │       │   @ BlockParametersNode (location: (5,4)-(5,6))
+        │   │   │       │   ├── parameters: ∅
+        │   │   │       │   ├── locals: (length: 0)
+        │   │   │       │   ├── opening_loc: (5,4)-(5,5) = "("
+        │   │   │       │   └── closing_loc: (5,5)-(5,6) = ")"
+        │   │   │       └── body: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -72,19 +75,20 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (7,2)-(7,9))
-            │   └── arguments: (length: 1)
-            │       └── @ LambdaNode (location: (7,2)-(7,9))
-            │           ├── locals: []
-            │           ├── operator_loc: (7,2)-(7,4) = "->"
-            │           ├── opening_loc: (7,7)-(7,8) = "{"
-            │           ├── closing_loc: (7,8)-(7,9) = "}"
-            │           ├── parameters:
-            │           │   @ BlockParametersNode (location: (7,4)-(7,6))
-            │           │   ├── parameters: ∅
-            │           │   ├── locals: (length: 0)
-            │           │   ├── opening_loc: (7,4)-(7,5) = "("
-            │           │   └── closing_loc: (7,5)-(7,6) = ")"
-            │           └── body: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ LambdaNode (location: (7,2)-(7,9))
+            │   │       ├── locals: []
+            │   │       ├── operator_loc: (7,2)-(7,4) = "->"
+            │   │       ├── opening_loc: (7,7)-(7,8) = "{"
+            │   │       ├── closing_loc: (7,8)-(7,9) = "}"
+            │   │       ├── parameters:
+            │   │       │   @ BlockParametersNode (location: (7,4)-(7,6))
+            │   │       │   ├── parameters: ∅
+            │   │       │   ├── locals: (length: 0)
+            │   │       │   ├── opening_loc: (7,4)-(7,5) = "("
+            │   │       │   └── closing_loc: (7,5)-(7,6) = ")"
+            │   │       └── body: ∅
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/lasgn_call_bracket_rescue_arg.txt
+++ b/test/prism/snapshots/seattlerb/lasgn_call_bracket_rescue_arg.txt
@@ -17,9 +17,10 @@
             │   │   ├── opening_loc: (1,5)-(1,6) = "("
             │   │   ├── arguments:
             │   │   │   @ ArgumentsNode (location: (1,6)-(1,7))
-            │   │   │   └── arguments: (length: 1)
-            │   │   │       └── @ IntegerNode (location: (1,6)-(1,7))
-            │   │   │           └── flags: decimal
+            │   │   │   ├── arguments: (length: 1)
+            │   │   │   │   └── @ IntegerNode (location: (1,6)-(1,7))
+            │   │   │   │       └── flags: decimal
+            │   │   │   └── flags: ∅
             │   │   ├── closing_loc: (1,7)-(1,8) = ")"
             │   │   ├── block: ∅
             │   │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/lasgn_call_nobracket_rescue_arg.txt
+++ b/test/prism/snapshots/seattlerb/lasgn_call_nobracket_rescue_arg.txt
@@ -15,15 +15,16 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,6)-(1,16))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ RescueModifierNode (location: (1,6)-(1,16))
-            │   │           ├── expression:
-            │   │           │   @ IntegerNode (location: (1,6)-(1,7))
-            │   │           │   └── flags: decimal
-            │   │           ├── keyword_loc: (1,8)-(1,14) = "rescue"
-            │   │           └── rescue_expression:
-            │   │               @ IntegerNode (location: (1,15)-(1,16))
-            │   │               └── flags: decimal
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ RescueModifierNode (location: (1,6)-(1,16))
+            │   │   │       ├── expression:
+            │   │   │       │   @ IntegerNode (location: (1,6)-(1,7))
+            │   │   │       │   └── flags: decimal
+            │   │   │       ├── keyword_loc: (1,8)-(1,14) = "rescue"
+            │   │   │       └── rescue_expression:
+            │   │   │           @ IntegerNode (location: (1,15)-(1,16))
+            │   │   │           └── flags: decimal
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/lasgn_command.txt
+++ b/test/prism/snapshots/seattlerb/lasgn_command.txt
@@ -25,9 +25,10 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,8)-(1,9))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ IntegerNode (location: (1,8)-(1,9))
-            │   │           └── flags: decimal
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ IntegerNode (location: (1,8)-(1,9))
+            │   │   │       └── flags: decimal
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/lasgn_lasgn_command_call.txt
+++ b/test/prism/snapshots/seattlerb/lasgn_lasgn_command_call.txt
@@ -20,9 +20,10 @@
             │   │   ├── opening_loc: ∅
             │   │   ├── arguments:
             │   │   │   @ ArgumentsNode (location: (1,10)-(1,11))
-            │   │   │   └── arguments: (length: 1)
-            │   │   │       └── @ IntegerNode (location: (1,10)-(1,11))
-            │   │   │           └── flags: decimal
+            │   │   │   ├── arguments: (length: 1)
+            │   │   │   │   └── @ IntegerNode (location: (1,10)-(1,11))
+            │   │   │   │       └── flags: decimal
+            │   │   │   └── flags: ∅
             │   │   ├── closing_loc: ∅
             │   │   ├── block: ∅
             │   │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/masgn_command_call.txt
+++ b/test/prism/snapshots/seattlerb/masgn_command_call.txt
@@ -32,9 +32,10 @@
                 ├── opening_loc: ∅
                 ├── arguments:
                 │   @ ArgumentsNode (location: (1,9)-(1,10))
-                │   └── arguments: (length: 1)
-                │       └── @ IntegerNode (location: (1,9)-(1,10))
-                │           └── flags: decimal
+                │   ├── arguments: (length: 1)
+                │   │   └── @ IntegerNode (location: (1,9)-(1,10))
+                │   │       └── flags: decimal
+                │   └── flags: ∅
                 ├── closing_loc: ∅
                 ├── block: ∅
                 ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/messy_op_asgn_lineno.txt
+++ b/test/prism/snapshots/seattlerb/messy_op_asgn_lineno.txt
@@ -10,48 +10,50 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,15))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,2)-(1,15))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,3)-(1,14))
-            │           │   └── body: (length: 1)
-            │           │       └── @ ConstantPathOperatorWriteNode (location: (1,3)-(1,14))
-            │           │           ├── target:
-            │           │           │   @ ConstantPathNode (location: (1,3)-(1,7))
-            │           │           │   ├── parent:
-            │           │           │   │   @ ConstantReadNode (location: (1,3)-(1,4))
-            │           │           │   │   └── name: :B
-            │           │           │   ├── child:
-            │           │           │   │   @ ConstantReadNode (location: (1,6)-(1,7))
-            │           │           │   │   └── name: :C
-            │           │           │   └── delimiter_loc: (1,4)-(1,6) = "::"
-            │           │           ├── operator_loc: (1,8)-(1,10) = "*="
-            │           │           ├── value:
-            │           │           │   @ CallNode (location: (1,11)-(1,14))
-            │           │           │   ├── receiver: ∅
-            │           │           │   ├── call_operator_loc: ∅
-            │           │           │   ├── message_loc: (1,11)-(1,12) = "d"
-            │           │           │   ├── opening_loc: ∅
-            │           │           │   ├── arguments:
-            │           │           │   │   @ ArgumentsNode (location: (1,13)-(1,14))
-            │           │           │   │   └── arguments: (length: 1)
-            │           │           │   │       └── @ CallNode (location: (1,13)-(1,14))
-            │           │           │   │           ├── receiver: ∅
-            │           │           │   │           ├── call_operator_loc: ∅
-            │           │           │   │           ├── message_loc: (1,13)-(1,14) = "e"
-            │           │           │   │           ├── opening_loc: ∅
-            │           │           │   │           ├── arguments: ∅
-            │           │           │   │           ├── closing_loc: ∅
-            │           │           │   │           ├── block: ∅
-            │           │           │   │           ├── flags: variable_call
-            │           │           │   │           └── name: :e
-            │           │           │   ├── closing_loc: ∅
-            │           │           │   ├── block: ∅
-            │           │           │   ├── flags: ∅
-            │           │           │   └── name: :d
-            │           │           └── operator: :*
-            │           ├── opening_loc: (1,2)-(1,3) = "("
-            │           └── closing_loc: (1,14)-(1,15) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,2)-(1,15))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,3)-(1,14))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ ConstantPathOperatorWriteNode (location: (1,3)-(1,14))
+            │   │       │           ├── target:
+            │   │       │           │   @ ConstantPathNode (location: (1,3)-(1,7))
+            │   │       │           │   ├── parent:
+            │   │       │           │   │   @ ConstantReadNode (location: (1,3)-(1,4))
+            │   │       │           │   │   └── name: :B
+            │   │       │           │   ├── child:
+            │   │       │           │   │   @ ConstantReadNode (location: (1,6)-(1,7))
+            │   │       │           │   │   └── name: :C
+            │   │       │           │   └── delimiter_loc: (1,4)-(1,6) = "::"
+            │   │       │           ├── operator_loc: (1,8)-(1,10) = "*="
+            │   │       │           ├── value:
+            │   │       │           │   @ CallNode (location: (1,11)-(1,14))
+            │   │       │           │   ├── receiver: ∅
+            │   │       │           │   ├── call_operator_loc: ∅
+            │   │       │           │   ├── message_loc: (1,11)-(1,12) = "d"
+            │   │       │           │   ├── opening_loc: ∅
+            │   │       │           │   ├── arguments:
+            │   │       │           │   │   @ ArgumentsNode (location: (1,13)-(1,14))
+            │   │       │           │   │   ├── arguments: (length: 1)
+            │   │       │           │   │   │   └── @ CallNode (location: (1,13)-(1,14))
+            │   │       │           │   │   │       ├── receiver: ∅
+            │   │       │           │   │   │       ├── call_operator_loc: ∅
+            │   │       │           │   │   │       ├── message_loc: (1,13)-(1,14) = "e"
+            │   │       │           │   │   │       ├── opening_loc: ∅
+            │   │       │           │   │   │       ├── arguments: ∅
+            │   │       │           │   │   │       ├── closing_loc: ∅
+            │   │       │           │   │   │       ├── block: ∅
+            │   │       │           │   │   │       ├── flags: variable_call
+            │   │       │           │   │   │       └── name: :e
+            │   │       │           │   │   └── flags: ∅
+            │   │       │           │   ├── closing_loc: ∅
+            │   │       │           │   ├── block: ∅
+            │   │       │           │   ├── flags: ∅
+            │   │       │           │   └── name: :d
+            │   │       │           └── operator: :*
+            │   │       ├── opening_loc: (1,2)-(1,3) = "("
+            │   │       └── closing_loc: (1,14)-(1,15) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/method_call_assoc_trailing_comma.txt
+++ b/test/prism/snapshots/seattlerb/method_call_assoc_trailing_comma.txt
@@ -20,17 +20,18 @@
             ├── opening_loc: (1,3)-(1,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,8))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,4)-(1,8))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,4)-(1,8))
-            │                   ├── key:
-            │                   │   @ IntegerNode (location: (1,4)-(1,5))
-            │                   │   └── flags: decimal
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,7)-(1,8))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (1,5)-(1,7) = "=>"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,4)-(1,8))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,4)-(1,8))
+            │   │               ├── key:
+            │   │               │   @ IntegerNode (location: (1,4)-(1,5))
+            │   │               │   └── flags: decimal
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,7)-(1,8))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (1,5)-(1,7) = "=>"
+            │   └── flags: ∅
             ├── closing_loc: (1,9)-(1,10) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/method_call_trailing_comma.txt
+++ b/test/prism/snapshots/seattlerb/method_call_trailing_comma.txt
@@ -20,9 +20,10 @@
             ├── opening_loc: (1,3)-(1,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,5))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,4)-(1,5))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,4)-(1,5))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,6)-(1,7) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/mlhs_keyword.txt
+++ b/test/prism/snapshots/seattlerb/mlhs_keyword.txt
@@ -20,9 +20,10 @@
             ├── opening_loc: (1,4)-(1,5) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,15))
-            │   └── arguments: (length: 2)
-            │       ├── @ TrueNode (location: (1,5)-(1,9))
-            │       └── @ TrueNode (location: (1,11)-(1,15))
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ TrueNode (location: (1,5)-(1,9))
+            │   │   └── @ TrueNode (location: (1,11)-(1,15))
+            │   └── flags: ∅
             ├── closing_loc: (1,15)-(1,16) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/multiline_hash_declaration.txt
+++ b/test/prism/snapshots/seattlerb/multiline_hash_declaration.txt
@@ -10,22 +10,23 @@
         │   ├── opening_loc: (1,1)-(1,2) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(3,1))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (1,2)-(3,1))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (1,2)-(3,1))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (1,2)-(1,8))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (1,2)-(1,7) = "state"
-        │   │                   │   ├── closing_loc: (1,7)-(1,8) = ":"
-        │   │                   │   └── unescaped: "state"
-        │   │                   ├── value:
-        │   │                   │   @ HashNode (location: (2,1)-(3,1))
-        │   │                   │   ├── opening_loc: (2,1)-(2,2) = "{"
-        │   │                   │   ├── elements: (length: 0)
-        │   │                   │   └── closing_loc: (3,0)-(3,1) = "}"
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (1,2)-(3,1))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (1,2)-(3,1))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (1,2)-(1,8))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (1,2)-(1,7) = "state"
+        │   │   │               │   ├── closing_loc: (1,7)-(1,8) = ":"
+        │   │   │               │   └── unescaped: "state"
+        │   │   │               ├── value:
+        │   │   │               │   @ HashNode (location: (2,1)-(3,1))
+        │   │   │               │   ├── opening_loc: (2,1)-(2,2) = "{"
+        │   │   │               │   ├── elements: (length: 0)
+        │   │   │               │   └── closing_loc: (3,0)-(3,1) = "}"
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: (3,1)-(3,2) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -37,22 +38,23 @@
         │   ├── opening_loc: (5,1)-(5,2) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,2)-(6,1))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (5,2)-(6,1))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (5,2)-(6,1))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (5,2)-(5,8))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (5,2)-(5,7) = "state"
-        │   │                   │   ├── closing_loc: (5,7)-(5,8) = ":"
-        │   │                   │   └── unescaped: "state"
-        │   │                   ├── value:
-        │   │                   │   @ HashNode (location: (5,9)-(6,1))
-        │   │                   │   ├── opening_loc: (5,9)-(5,10) = "{"
-        │   │                   │   ├── elements: (length: 0)
-        │   │                   │   └── closing_loc: (6,0)-(6,1) = "}"
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (5,2)-(6,1))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (5,2)-(6,1))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (5,2)-(5,8))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (5,2)-(5,7) = "state"
+        │   │   │               │   ├── closing_loc: (5,7)-(5,8) = ":"
+        │   │   │               │   └── unescaped: "state"
+        │   │   │               ├── value:
+        │   │   │               │   @ HashNode (location: (5,9)-(6,1))
+        │   │   │               │   ├── opening_loc: (5,9)-(5,10) = "{"
+        │   │   │               │   ├── elements: (length: 0)
+        │   │   │               │   └── closing_loc: (6,0)-(6,1) = "}"
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: (6,1)-(6,2) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -64,22 +66,23 @@
             ├── opening_loc: (8,1)-(8,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (8,2)-(8,11))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (8,2)-(8,11))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (8,2)-(8,11))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (8,2)-(8,8))
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── value_loc: (8,2)-(8,7) = "state"
-            │                   │   ├── closing_loc: (8,7)-(8,8) = ":"
-            │                   │   └── unescaped: "state"
-            │                   ├── value:
-            │                   │   @ HashNode (location: (8,9)-(8,11))
-            │                   │   ├── opening_loc: (8,9)-(8,10) = "{"
-            │                   │   ├── elements: (length: 0)
-            │                   │   └── closing_loc: (8,10)-(8,11) = "}"
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (8,2)-(8,11))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (8,2)-(8,11))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (8,2)-(8,8))
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── value_loc: (8,2)-(8,7) = "state"
+            │   │               │   ├── closing_loc: (8,7)-(8,8) = ":"
+            │   │               │   └── unescaped: "state"
+            │   │               ├── value:
+            │   │               │   @ HashNode (location: (8,9)-(8,11))
+            │   │               │   ├── opening_loc: (8,9)-(8,10) = "{"
+            │   │               │   ├── elements: (length: 0)
+            │   │               │   └── closing_loc: (8,10)-(8,11) = "}"
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: (8,11)-(8,12) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/op_asgn_command_call.txt
+++ b/test/prism/snapshots/seattlerb/op_asgn_command_call.txt
@@ -24,9 +24,10 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,10)-(1,11))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ IntegerNode (location: (1,10)-(1,11))
-            │   │           └── flags: decimal
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ IntegerNode (location: (1,10)-(1,11))
+            │   │   │       └── flags: decimal
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/op_asgn_dot_ident_command_call.txt
+++ b/test/prism/snapshots/seattlerb/op_asgn_dot_ident_command_call.txt
@@ -21,9 +21,10 @@
                 ├── opening_loc: ∅
                 ├── arguments:
                 │   @ ArgumentsNode (location: (1,10)-(1,11))
-                │   └── arguments: (length: 1)
-                │       └── @ IntegerNode (location: (1,10)-(1,11))
-                │           └── flags: decimal
+                │   ├── arguments: (length: 1)
+                │   │   └── @ IntegerNode (location: (1,10)-(1,11))
+                │   │       └── flags: decimal
+                │   └── flags: ∅
                 ├── closing_loc: ∅
                 ├── block: ∅
                 ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/op_asgn_index_command_call.txt
+++ b/test/prism/snapshots/seattlerb/op_asgn_index_command_call.txt
@@ -19,12 +19,13 @@
             ├── opening_loc: (1,1)-(1,2) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,4))
-            │   └── arguments: (length: 1)
-            │       └── @ SymbolNode (location: (1,2)-(1,4))
-            │           ├── opening_loc: (1,2)-(1,3) = ":"
-            │           ├── value_loc: (1,3)-(1,4) = "b"
-            │           ├── closing_loc: ∅
-            │           └── unescaped: "b"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ SymbolNode (location: (1,2)-(1,4))
+            │   │       ├── opening_loc: (1,2)-(1,3) = ":"
+            │   │       ├── value_loc: (1,3)-(1,4) = "b"
+            │   │       ├── closing_loc: ∅
+            │   │       └── unescaped: "b"
+            │   └── flags: ∅
             ├── closing_loc: (1,4)-(1,5) = "]"
             ├── block: ∅
             ├── flags: ∅
@@ -37,11 +38,12 @@
                 ├── opening_loc: ∅
                 ├── arguments:
                 │   @ ArgumentsNode (location: (1,12)-(1,16))
-                │   └── arguments: (length: 2)
-                │       ├── @ IntegerNode (location: (1,12)-(1,13))
-                │       │   └── flags: decimal
-                │       └── @ IntegerNode (location: (1,15)-(1,16))
-                │           └── flags: decimal
+                │   ├── arguments: (length: 2)
+                │   │   ├── @ IntegerNode (location: (1,12)-(1,13))
+                │   │   │   └── flags: decimal
+                │   │   └── @ IntegerNode (location: (1,15)-(1,16))
+                │   │       └── flags: decimal
+                │   └── flags: ∅
                 ├── closing_loc: ∅
                 ├── block: ∅
                 ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/op_asgn_primary_colon_const_command_call.txt
+++ b/test/prism/snapshots/seattlerb/op_asgn_primary_colon_const_command_call.txt
@@ -22,17 +22,18 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,10)-(1,11))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ CallNode (location: (1,10)-(1,11))
-            │   │           ├── receiver: ∅
-            │   │           ├── call_operator_loc: ∅
-            │   │           ├── message_loc: (1,10)-(1,11) = "d"
-            │   │           ├── opening_loc: ∅
-            │   │           ├── arguments: ∅
-            │   │           ├── closing_loc: ∅
-            │   │           ├── block: ∅
-            │   │           ├── flags: variable_call
-            │   │           └── name: :d
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ CallNode (location: (1,10)-(1,11))
+            │   │   │       ├── receiver: ∅
+            │   │   │       ├── call_operator_loc: ∅
+            │   │   │       ├── message_loc: (1,10)-(1,11) = "d"
+            │   │   │       ├── opening_loc: ∅
+            │   │   │       ├── arguments: ∅
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       ├── block: ∅
+            │   │   │       ├── flags: variable_call
+            │   │   │       └── name: :d
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/op_asgn_primary_colon_identifier_command_call.txt
+++ b/test/prism/snapshots/seattlerb/op_asgn_primary_colon_identifier_command_call.txt
@@ -22,17 +22,18 @@
                 ├── opening_loc: ∅
                 ├── arguments:
                 │   @ ArgumentsNode (location: (1,10)-(1,11))
-                │   └── arguments: (length: 1)
-                │       └── @ CallNode (location: (1,10)-(1,11))
-                │           ├── receiver: ∅
-                │           ├── call_operator_loc: ∅
-                │           ├── message_loc: (1,10)-(1,11) = "d"
-                │           ├── opening_loc: ∅
-                │           ├── arguments: ∅
-                │           ├── closing_loc: ∅
-                │           ├── block: ∅
-                │           ├── flags: variable_call
-                │           └── name: :d
+                │   ├── arguments: (length: 1)
+                │   │   └── @ CallNode (location: (1,10)-(1,11))
+                │   │       ├── receiver: ∅
+                │   │       ├── call_operator_loc: ∅
+                │   │       ├── message_loc: (1,10)-(1,11) = "d"
+                │   │       ├── opening_loc: ∅
+                │   │       ├── arguments: ∅
+                │   │       ├── closing_loc: ∅
+                │   │       ├── block: ∅
+                │   │       ├── flags: variable_call
+                │   │       └── name: :d
+                │   └── flags: ∅
                 ├── closing_loc: ∅
                 ├── block: ∅
                 ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/op_asgn_val_dot_ident_command_call.txt
+++ b/test/prism/snapshots/seattlerb/op_asgn_val_dot_ident_command_call.txt
@@ -29,9 +29,10 @@
                 ├── opening_loc: ∅
                 ├── arguments:
                 │   @ ArgumentsNode (location: (1,10)-(1,11))
-                │   └── arguments: (length: 1)
-                │       └── @ IntegerNode (location: (1,10)-(1,11))
-                │           └── flags: decimal
+                │   ├── arguments: (length: 1)
+                │   │   └── @ IntegerNode (location: (1,10)-(1,11))
+                │   │       └── flags: decimal
+                │   └── flags: ∅
                 ├── closing_loc: ∅
                 ├── block: ∅
                 ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/parse_line_block.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_block.txt
@@ -18,10 +18,11 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (2,2)-(2,3))
-            │   └── arguments: (length: 1)
-            │       └── @ LocalVariableReadNode (location: (2,2)-(2,3))
-            │           ├── name: :a
-            │           └── depth: 0
+            │   ├── arguments: (length: 1)
+            │   │   └── @ LocalVariableReadNode (location: (2,2)-(2,3))
+            │   │       ├── name: :a
+            │   │       └── depth: 0
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/parse_line_call_ivar_arg_no_parens_line_break.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_call_ivar_arg_no_parens_line_break.txt
@@ -10,9 +10,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,4))
-            │   └── arguments: (length: 1)
-            │       └── @ InstanceVariableReadNode (location: (1,2)-(1,4))
-            │           └── name: :@b
+            │   ├── arguments: (length: 1)
+            │   │   └── @ InstanceVariableReadNode (location: (1,2)-(1,4))
+            │   │       └── name: :@b
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/parse_line_call_ivar_line_break_paren.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_call_ivar_line_break_paren.txt
@@ -10,9 +10,10 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,4))
-            │   └── arguments: (length: 1)
-            │       └── @ InstanceVariableReadNode (location: (1,2)-(1,4))
-            │           └── name: :@b
+            │   ├── arguments: (length: 1)
+            │   │   └── @ InstanceVariableReadNode (location: (1,2)-(1,4))
+            │   │       └── name: :@b
+            │   └── flags: ∅
             ├── closing_loc: (2,0)-(2,1) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/parse_line_call_no_args.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_call_no_args.txt
@@ -44,10 +44,11 @@
             │   │           ├── opening_loc: ∅
             │   │           ├── arguments:
             │   │           │   @ ArgumentsNode (location: (2,6)-(2,7))
-            │   │           │   └── arguments: (length: 1)
-            │   │           │       └── @ LocalVariableReadNode (location: (2,6)-(2,7))
-            │   │           │           ├── name: :y
-            │   │           │           └── depth: 0
+            │   │           │   ├── arguments: (length: 1)
+            │   │           │   │   └── @ LocalVariableReadNode (location: (2,6)-(2,7))
+            │   │           │   │       ├── name: :y
+            │   │           │   │       └── depth: 0
+            │   │           │   └── flags: ∅
             │   │           ├── closing_loc: ∅
             │   │           ├── block: ∅
             │   │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/parse_line_defn_complex.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_defn_complex.txt
@@ -28,10 +28,11 @@
             │       │   ├── opening_loc: (2,3)-(2,4) = "("
             │       │   ├── arguments:
             │       │   │   @ ArgumentsNode (location: (2,4)-(2,5))
-            │       │   │   └── arguments: (length: 1)
-            │       │   │       └── @ LocalVariableReadNode (location: (2,4)-(2,5))
-            │       │   │           ├── name: :y
-            │       │   │           └── depth: 0
+            │       │   │   ├── arguments: (length: 1)
+            │       │   │   │   └── @ LocalVariableReadNode (location: (2,4)-(2,5))
+            │       │   │   │       ├── name: :y
+            │       │   │   │       └── depth: 0
+            │       │   │   └── flags: ∅
             │       │   ├── closing_loc: (2,5)-(2,6) = ")"
             │       │   ├── block: ∅
             │       │   ├── flags: ∅
@@ -49,10 +50,11 @@
             │           ├── keyword_loc: (4,2)-(4,8) = "return"
             │           └── arguments:
             │               @ ArgumentsNode (location: (4,9)-(4,10))
-            │               └── arguments: (length: 1)
-            │                   └── @ LocalVariableReadNode (location: (4,9)-(4,10))
-            │                       ├── name: :y
-            │                       └── depth: 0
+            │               ├── arguments: (length: 1)
+            │               │   └── @ LocalVariableReadNode (location: (4,9)-(4,10))
+            │               │       ├── name: :y
+            │               │       └── depth: 0
+            │               └── flags: ∅
             ├── locals: [:y]
             ├── def_keyword_loc: (1,0)-(1,3) = "def"
             ├── operator_loc: ∅

--- a/test/prism/snapshots/seattlerb/parse_line_heredoc.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_heredoc.txt
@@ -32,10 +32,11 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (4,11)-(4,17))
-            │   └── arguments: (length: 1)
-            │       └── @ LocalVariableReadNode (location: (4,11)-(4,17))
-            │           ├── name: :string
-            │           └── depth: 0
+            │   ├── arguments: (length: 1)
+            │   │   └── @ LocalVariableReadNode (location: (4,11)-(4,17))
+            │   │       ├── name: :string
+            │   │       └── depth: 0
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/parse_line_heredoc_regexp_chars.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_heredoc_regexp_chars.txt
@@ -22,10 +22,11 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (4,11)-(4,17))
-            │   └── arguments: (length: 1)
-            │       └── @ LocalVariableReadNode (location: (4,11)-(4,17))
-            │           ├── name: :string
-            │           └── depth: 0
+            │   ├── arguments: (length: 1)
+            │   │   └── @ LocalVariableReadNode (location: (4,11)-(4,17))
+            │   │       ├── name: :string
+            │   │       └── depth: 0
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/parse_line_iter_call_no_parens.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_iter_call_no_parens.txt
@@ -10,17 +10,18 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,3))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,2)-(1,3))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,2)-(1,3) = "a"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :a
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,2)-(1,3))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,2)-(1,3) = "a"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :a
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,4)-(3,3))
@@ -56,10 +57,11 @@
             │   │           ├── opening_loc: ∅
             │   │           ├── arguments:
             │   │           │   @ ArgumentsNode (location: (2,6)-(2,7))
-            │   │           │   └── arguments: (length: 1)
-            │   │           │       └── @ LocalVariableReadNode (location: (2,6)-(2,7))
-            │   │           │           ├── name: :y
-            │   │           │           └── depth: 0
+            │   │           │   ├── arguments: (length: 1)
+            │   │           │   │   └── @ LocalVariableReadNode (location: (2,6)-(2,7))
+            │   │           │   │       ├── name: :y
+            │   │           │   │       └── depth: 0
+            │   │           │   └── flags: ∅
             │   │           ├── closing_loc: ∅
             │   │           ├── block: ∅
             │   │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/parse_line_iter_call_parens.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_iter_call_parens.txt
@@ -10,17 +10,18 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,3))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,2)-(1,3))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,2)-(1,3) = "a"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :a
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,2)-(1,3))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,2)-(1,3) = "a"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :a
+            │   └── flags: ∅
             ├── closing_loc: (1,3)-(1,4) = ")"
             ├── block:
             │   @ BlockNode (location: (1,5)-(3,3))
@@ -56,10 +57,11 @@
             │   │           ├── opening_loc: ∅
             │   │           ├── arguments:
             │   │           │   @ ArgumentsNode (location: (2,6)-(2,7))
-            │   │           │   └── arguments: (length: 1)
-            │   │           │       └── @ LocalVariableReadNode (location: (2,6)-(2,7))
-            │   │           │           ├── name: :y
-            │   │           │           └── depth: 0
+            │   │           │   ├── arguments: (length: 1)
+            │   │           │   │   └── @ LocalVariableReadNode (location: (2,6)-(2,7))
+            │   │           │   │       ├── name: :y
+            │   │           │   │       └── depth: 0
+            │   │           │   └── flags: ∅
             │   │           ├── closing_loc: ∅
             │   │           ├── block: ∅
             │   │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/parse_line_return.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_return.txt
@@ -22,9 +22,10 @@
             │           │           ├── keyword_loc: (3,10)-(3,16) = "return"
             │           │           └── arguments:
             │           │               @ ArgumentsNode (location: (3,17)-(3,19))
-            │           │               └── arguments: (length: 1)
-            │           │                   └── @ IntegerNode (location: (3,17)-(3,19))
-            │           │                       └── flags: decimal
+            │           │               ├── arguments: (length: 1)
+            │           │               │   └── @ IntegerNode (location: (3,17)-(3,19))
+            │           │               │       └── flags: decimal
+            │           │               └── flags: ∅
             │           ├── consequent: ∅
             │           └── end_keyword_loc: (4,8)-(4,11) = "end"
             ├── locals: []

--- a/test/prism/snapshots/seattlerb/parse_line_str_with_newline_escape.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_str_with_newline_escape.txt
@@ -10,14 +10,15 @@
             ├── opening_loc: (1,1)-(1,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,12))
-            │   └── arguments: (length: 2)
-            │       ├── @ StringNode (location: (1,2)-(1,6))
-            │       │   ├── flags: ∅
-            │       │   ├── opening_loc: (1,2)-(1,3) = "\""
-            │       │   ├── content_loc: (1,3)-(1,5) = "\\n"
-            │       │   ├── closing_loc: (1,5)-(1,6) = "\""
-            │       │   └── unescaped: "\n"
-            │       └── @ TrueNode (location: (1,8)-(1,12))
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ StringNode (location: (1,2)-(1,6))
+            │   │   │   ├── flags: ∅
+            │   │   │   ├── opening_loc: (1,2)-(1,3) = "\""
+            │   │   │   ├── content_loc: (1,3)-(1,5) = "\\n"
+            │   │   │   ├── closing_loc: (1,5)-(1,6) = "\""
+            │   │   │   └── unescaped: "\n"
+            │   │   └── @ TrueNode (location: (1,8)-(1,12))
+            │   └── flags: ∅
             ├── closing_loc: (1,12)-(1,13) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/parse_opt_call_args_assocs_comma.txt
+++ b/test/prism/snapshots/seattlerb/parse_opt_call_args_assocs_comma.txt
@@ -12,17 +12,18 @@
             ├── opening_loc: (1,1)-(1,2) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,2)-(1,6))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,2)-(1,6))
-            │                   ├── key:
-            │                   │   @ IntegerNode (location: (1,2)-(1,3))
-            │                   │   └── flags: decimal
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,5)-(1,6))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (1,3)-(1,5) = "=>"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,2)-(1,6))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,2)-(1,6))
+            │   │               ├── key:
+            │   │               │   @ IntegerNode (location: (1,2)-(1,3))
+            │   │               │   └── flags: decimal
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,5)-(1,6))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (1,3)-(1,5) = "=>"
+            │   └── flags: ∅
             ├── closing_loc: (1,7)-(1,8) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/parse_opt_call_args_lit_comma.txt
+++ b/test/prism/snapshots/seattlerb/parse_opt_call_args_lit_comma.txt
@@ -12,9 +12,10 @@
             ├── opening_loc: (1,1)-(1,2) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,3))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,2)-(1,3))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,2)-(1,3))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,4)-(1,5) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/qsymbols_interp.txt
+++ b/test/prism/snapshots/seattlerb/qsymbols_interp.txt
@@ -33,9 +33,10 @@
             │   │   │       │           ├── opening_loc: ∅
             │   │   │       │           ├── arguments:
             │   │   │       │           │   @ ArgumentsNode (location: (1,10)-(1,11))
-            │   │   │       │           │   └── arguments: (length: 1)
-            │   │   │       │           │       └── @ IntegerNode (location: (1,10)-(1,11))
-            │   │   │       │           │           └── flags: decimal
+            │   │   │       │           │   ├── arguments: (length: 1)
+            │   │   │       │           │   │   └── @ IntegerNode (location: (1,10)-(1,11))
+            │   │   │       │           │   │       └── flags: decimal
+            │   │   │       │           │   └── flags: ∅
             │   │   │       │           ├── closing_loc: ∅
             │   │   │       │           ├── block: ∅
             │   │   │       │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/quoted_symbol_hash_arg.txt
+++ b/test/prism/snapshots/seattlerb/quoted_symbol_hash_arg.txt
@@ -10,22 +10,23 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,12))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,5)-(1,12))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,5)-(1,12))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (1,5)-(1,9))
-            │                   │   ├── opening_loc: (1,5)-(1,6) = "'"
-            │                   │   ├── value_loc: (1,6)-(1,7) = "a"
-            │                   │   ├── closing_loc: (1,7)-(1,9) = "':"
-            │                   │   └── unescaped: "a"
-            │                   ├── value:
-            │                   │   @ HashNode (location: (1,10)-(1,12))
-            │                   │   ├── opening_loc: (1,10)-(1,11) = "{"
-            │                   │   ├── elements: (length: 0)
-            │                   │   └── closing_loc: (1,11)-(1,12) = "}"
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,5)-(1,12))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,5)-(1,12))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (1,5)-(1,9))
+            │   │               │   ├── opening_loc: (1,5)-(1,6) = "'"
+            │   │               │   ├── value_loc: (1,6)-(1,7) = "a"
+            │   │               │   ├── closing_loc: (1,7)-(1,9) = "':"
+            │   │               │   └── unescaped: "a"
+            │   │               ├── value:
+            │   │               │   @ HashNode (location: (1,10)-(1,12))
+            │   │               │   ├── opening_loc: (1,10)-(1,11) = "{"
+            │   │               │   ├── elements: (length: 0)
+            │   │               │   └── closing_loc: (1,11)-(1,12) = "}"
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/rescue_parens.txt
+++ b/test/prism/snapshots/seattlerb/rescue_parens.txt
@@ -10,37 +10,38 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,14))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,2)-(1,14))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,3)-(1,13))
-            │           │   └── body: (length: 1)
-            │           │       └── @ RescueModifierNode (location: (1,3)-(1,13))
-            │           │           ├── expression:
-            │           │           │   @ CallNode (location: (1,3)-(1,4))
-            │           │           │   ├── receiver: ∅
-            │           │           │   ├── call_operator_loc: ∅
-            │           │           │   ├── message_loc: (1,3)-(1,4) = "b"
-            │           │           │   ├── opening_loc: ∅
-            │           │           │   ├── arguments: ∅
-            │           │           │   ├── closing_loc: ∅
-            │           │           │   ├── block: ∅
-            │           │           │   ├── flags: variable_call
-            │           │           │   └── name: :b
-            │           │           ├── keyword_loc: (1,5)-(1,11) = "rescue"
-            │           │           └── rescue_expression:
-            │           │               @ CallNode (location: (1,12)-(1,13))
-            │           │               ├── receiver: ∅
-            │           │               ├── call_operator_loc: ∅
-            │           │               ├── message_loc: (1,12)-(1,13) = "c"
-            │           │               ├── opening_loc: ∅
-            │           │               ├── arguments: ∅
-            │           │               ├── closing_loc: ∅
-            │           │               ├── block: ∅
-            │           │               ├── flags: variable_call
-            │           │               └── name: :c
-            │           ├── opening_loc: (1,2)-(1,3) = "("
-            │           └── closing_loc: (1,13)-(1,14) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,2)-(1,14))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,3)-(1,13))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ RescueModifierNode (location: (1,3)-(1,13))
+            │   │       │           ├── expression:
+            │   │       │           │   @ CallNode (location: (1,3)-(1,4))
+            │   │       │           │   ├── receiver: ∅
+            │   │       │           │   ├── call_operator_loc: ∅
+            │   │       │           │   ├── message_loc: (1,3)-(1,4) = "b"
+            │   │       │           │   ├── opening_loc: ∅
+            │   │       │           │   ├── arguments: ∅
+            │   │       │           │   ├── closing_loc: ∅
+            │   │       │           │   ├── block: ∅
+            │   │       │           │   ├── flags: variable_call
+            │   │       │           │   └── name: :b
+            │   │       │           ├── keyword_loc: (1,5)-(1,11) = "rescue"
+            │   │       │           └── rescue_expression:
+            │   │       │               @ CallNode (location: (1,12)-(1,13))
+            │   │       │               ├── receiver: ∅
+            │   │       │               ├── call_operator_loc: ∅
+            │   │       │               ├── message_loc: (1,12)-(1,13) = "c"
+            │   │       │               ├── opening_loc: ∅
+            │   │       │               ├── arguments: ∅
+            │   │       │               ├── closing_loc: ∅
+            │   │       │               ├── block: ∅
+            │   │       │               ├── flags: variable_call
+            │   │       │               └── name: :c
+            │   │       ├── opening_loc: (1,2)-(1,3) = "("
+            │   │       └── closing_loc: (1,13)-(1,14) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/return_call_assocs.txt
+++ b/test/prism/snapshots/seattlerb/return_call_assocs.txt
@@ -7,175 +7,185 @@
         │   ├── keyword_loc: (1,0)-(1,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (1,7)-(1,17))
-        │       └── arguments: (length: 2)
-        │           ├── @ IntegerNode (location: (1,7)-(1,8))
-        │           │   └── flags: decimal
-        │           └── @ KeywordHashNode (location: (1,10)-(1,17))
-        │               └── elements: (length: 1)
-        │                   └── @ AssocNode (location: (1,10)-(1,17))
-        │                       ├── key:
-        │                       │   @ SymbolNode (location: (1,10)-(1,12))
-        │                       │   ├── opening_loc: (1,10)-(1,11) = ":"
-        │                       │   ├── value_loc: (1,11)-(1,12) = "z"
-        │                       │   ├── closing_loc: ∅
-        │                       │   └── unescaped: "z"
-        │                       ├── value:
-        │                       │   @ IntegerNode (location: (1,16)-(1,17))
-        │                       │   └── flags: decimal
-        │                       └── operator_loc: (1,13)-(1,15) = "=>"
+        │       ├── arguments: (length: 2)
+        │       │   ├── @ IntegerNode (location: (1,7)-(1,8))
+        │       │   │   └── flags: decimal
+        │       │   └── @ KeywordHashNode (location: (1,10)-(1,17))
+        │       │       └── elements: (length: 1)
+        │       │           └── @ AssocNode (location: (1,10)-(1,17))
+        │       │               ├── key:
+        │       │               │   @ SymbolNode (location: (1,10)-(1,12))
+        │       │               │   ├── opening_loc: (1,10)-(1,11) = ":"
+        │       │               │   ├── value_loc: (1,11)-(1,12) = "z"
+        │       │               │   ├── closing_loc: ∅
+        │       │               │   └── unescaped: "z"
+        │       │               ├── value:
+        │       │               │   @ IntegerNode (location: (1,16)-(1,17))
+        │       │               │   └── flags: decimal
+        │       │               └── operator_loc: (1,13)-(1,15) = "=>"
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (3,0)-(3,26))
         │   ├── keyword_loc: (3,0)-(3,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (3,7)-(3,26))
-        │       └── arguments: (length: 2)
-        │           ├── @ IntegerNode (location: (3,7)-(3,8))
-        │           │   └── flags: decimal
-        │           └── @ KeywordHashNode (location: (3,10)-(3,26))
-        │               └── elements: (length: 2)
-        │                   ├── @ AssocNode (location: (3,10)-(3,17))
-        │                   │   ├── key:
-        │                   │   │   @ SymbolNode (location: (3,10)-(3,12))
-        │                   │   │   ├── opening_loc: (3,10)-(3,11) = ":"
-        │                   │   │   ├── value_loc: (3,11)-(3,12) = "z"
-        │                   │   │   ├── closing_loc: ∅
-        │                   │   │   └── unescaped: "z"
-        │                   │   ├── value:
-        │                   │   │   @ IntegerNode (location: (3,16)-(3,17))
-        │                   │   │   └── flags: decimal
-        │                   │   └── operator_loc: (3,13)-(3,15) = "=>"
-        │                   └── @ AssocNode (location: (3,19)-(3,26))
-        │                       ├── key:
-        │                       │   @ SymbolNode (location: (3,19)-(3,21))
-        │                       │   ├── opening_loc: (3,19)-(3,20) = ":"
-        │                       │   ├── value_loc: (3,20)-(3,21) = "w"
-        │                       │   ├── closing_loc: ∅
-        │                       │   └── unescaped: "w"
-        │                       ├── value:
-        │                       │   @ IntegerNode (location: (3,25)-(3,26))
-        │                       │   └── flags: decimal
-        │                       └── operator_loc: (3,22)-(3,24) = "=>"
+        │       ├── arguments: (length: 2)
+        │       │   ├── @ IntegerNode (location: (3,7)-(3,8))
+        │       │   │   └── flags: decimal
+        │       │   └── @ KeywordHashNode (location: (3,10)-(3,26))
+        │       │       └── elements: (length: 2)
+        │       │           ├── @ AssocNode (location: (3,10)-(3,17))
+        │       │           │   ├── key:
+        │       │           │   │   @ SymbolNode (location: (3,10)-(3,12))
+        │       │           │   │   ├── opening_loc: (3,10)-(3,11) = ":"
+        │       │           │   │   ├── value_loc: (3,11)-(3,12) = "z"
+        │       │           │   │   ├── closing_loc: ∅
+        │       │           │   │   └── unescaped: "z"
+        │       │           │   ├── value:
+        │       │           │   │   @ IntegerNode (location: (3,16)-(3,17))
+        │       │           │   │   └── flags: decimal
+        │       │           │   └── operator_loc: (3,13)-(3,15) = "=>"
+        │       │           └── @ AssocNode (location: (3,19)-(3,26))
+        │       │               ├── key:
+        │       │               │   @ SymbolNode (location: (3,19)-(3,21))
+        │       │               │   ├── opening_loc: (3,19)-(3,20) = ":"
+        │       │               │   ├── value_loc: (3,20)-(3,21) = "w"
+        │       │               │   ├── closing_loc: ∅
+        │       │               │   └── unescaped: "w"
+        │       │               ├── value:
+        │       │               │   @ IntegerNode (location: (3,25)-(3,26))
+        │       │               │   └── flags: decimal
+        │       │               └── operator_loc: (3,22)-(3,24) = "=>"
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (5,0)-(5,14))
         │   ├── keyword_loc: (5,0)-(5,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (5,7)-(5,14))
-        │       └── arguments: (length: 1)
-        │           └── @ CallNode (location: (5,7)-(5,14))
-        │               ├── receiver: ∅
-        │               ├── call_operator_loc: ∅
-        │               ├── message_loc: (5,7)-(5,8) = "y"
-        │               ├── opening_loc: ∅
-        │               ├── arguments:
-        │               │   @ ArgumentsNode (location: (5,9)-(5,14))
-        │               │   └── arguments: (length: 1)
-        │               │       └── @ KeywordHashNode (location: (5,9)-(5,14))
-        │               │           └── elements: (length: 1)
-        │               │               └── @ AssocNode (location: (5,9)-(5,14))
-        │               │                   ├── key:
-        │               │                   │   @ SymbolNode (location: (5,9)-(5,11))
-        │               │                   │   ├── opening_loc: (5,9)-(5,10) = ":"
-        │               │                   │   ├── value_loc: (5,10)-(5,11) = "z"
-        │               │                   │   ├── closing_loc: ∅
-        │               │                   │   └── unescaped: "z"
-        │               │                   ├── value:
-        │               │                   │   @ IntegerNode (location: (5,13)-(5,14))
-        │               │                   │   └── flags: decimal
-        │               │                   └── operator_loc: (5,11)-(5,13) = "=>"
-        │               ├── closing_loc: ∅
-        │               ├── block: ∅
-        │               ├── flags: ∅
-        │               └── name: :y
+        │       ├── arguments: (length: 1)
+        │       │   └── @ CallNode (location: (5,7)-(5,14))
+        │       │       ├── receiver: ∅
+        │       │       ├── call_operator_loc: ∅
+        │       │       ├── message_loc: (5,7)-(5,8) = "y"
+        │       │       ├── opening_loc: ∅
+        │       │       ├── arguments:
+        │       │       │   @ ArgumentsNode (location: (5,9)-(5,14))
+        │       │       │   ├── arguments: (length: 1)
+        │       │       │   │   └── @ KeywordHashNode (location: (5,9)-(5,14))
+        │       │       │   │       └── elements: (length: 1)
+        │       │       │   │           └── @ AssocNode (location: (5,9)-(5,14))
+        │       │       │   │               ├── key:
+        │       │       │   │               │   @ SymbolNode (location: (5,9)-(5,11))
+        │       │       │   │               │   ├── opening_loc: (5,9)-(5,10) = ":"
+        │       │       │   │               │   ├── value_loc: (5,10)-(5,11) = "z"
+        │       │       │   │               │   ├── closing_loc: ∅
+        │       │       │   │               │   └── unescaped: "z"
+        │       │       │   │               ├── value:
+        │       │       │   │               │   @ IntegerNode (location: (5,13)-(5,14))
+        │       │       │   │               │   └── flags: decimal
+        │       │       │   │               └── operator_loc: (5,11)-(5,13) = "=>"
+        │       │       │   └── flags: ∅
+        │       │       ├── closing_loc: ∅
+        │       │       ├── block: ∅
+        │       │       ├── flags: ∅
+        │       │       └── name: :y
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (7,0)-(7,12))
         │   ├── keyword_loc: (7,0)-(7,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (7,7)-(7,12))
-        │       └── arguments: (length: 1)
-        │           └── @ CallNode (location: (7,7)-(7,12))
-        │               ├── receiver: ∅
-        │               ├── call_operator_loc: ∅
-        │               ├── message_loc: (7,7)-(7,8) = "y"
-        │               ├── opening_loc: ∅
-        │               ├── arguments:
-        │               │   @ ArgumentsNode (location: (7,9)-(7,12))
-        │               │   └── arguments: (length: 1)
-        │               │       └── @ KeywordHashNode (location: (7,9)-(7,12))
-        │               │           └── elements: (length: 1)
-        │               │               └── @ AssocNode (location: (7,9)-(7,12))
-        │               │                   ├── key:
-        │               │                   │   @ SymbolNode (location: (7,9)-(7,11))
-        │               │                   │   ├── opening_loc: ∅
-        │               │                   │   ├── value_loc: (7,9)-(7,10) = "z"
-        │               │                   │   ├── closing_loc: (7,10)-(7,11) = ":"
-        │               │                   │   └── unescaped: "z"
-        │               │                   ├── value:
-        │               │                   │   @ IntegerNode (location: (7,11)-(7,12))
-        │               │                   │   └── flags: decimal
-        │               │                   └── operator_loc: ∅
-        │               ├── closing_loc: ∅
-        │               ├── block: ∅
-        │               ├── flags: ∅
-        │               └── name: :y
+        │       ├── arguments: (length: 1)
+        │       │   └── @ CallNode (location: (7,7)-(7,12))
+        │       │       ├── receiver: ∅
+        │       │       ├── call_operator_loc: ∅
+        │       │       ├── message_loc: (7,7)-(7,8) = "y"
+        │       │       ├── opening_loc: ∅
+        │       │       ├── arguments:
+        │       │       │   @ ArgumentsNode (location: (7,9)-(7,12))
+        │       │       │   ├── arguments: (length: 1)
+        │       │       │   │   └── @ KeywordHashNode (location: (7,9)-(7,12))
+        │       │       │   │       └── elements: (length: 1)
+        │       │       │   │           └── @ AssocNode (location: (7,9)-(7,12))
+        │       │       │   │               ├── key:
+        │       │       │   │               │   @ SymbolNode (location: (7,9)-(7,11))
+        │       │       │   │               │   ├── opening_loc: ∅
+        │       │       │   │               │   ├── value_loc: (7,9)-(7,10) = "z"
+        │       │       │   │               │   ├── closing_loc: (7,10)-(7,11) = ":"
+        │       │       │   │               │   └── unescaped: "z"
+        │       │       │   │               ├── value:
+        │       │       │   │               │   @ IntegerNode (location: (7,11)-(7,12))
+        │       │       │   │               │   └── flags: decimal
+        │       │       │   │               └── operator_loc: ∅
+        │       │       │   └── flags: ∅
+        │       │       ├── closing_loc: ∅
+        │       │       ├── block: ∅
+        │       │       ├── flags: ∅
+        │       │       └── name: :y
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (9,0)-(9,13))
         │   ├── keyword_loc: (9,0)-(9,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (9,7)-(9,13))
-        │       └── arguments: (length: 1)
-        │           └── @ CallNode (location: (9,7)-(9,13))
-        │               ├── receiver: ∅
-        │               ├── call_operator_loc: ∅
-        │               ├── message_loc: (9,7)-(9,8) = "y"
-        │               ├── opening_loc: (9,8)-(9,9) = "("
-        │               ├── arguments:
-        │               │   @ ArgumentsNode (location: (9,9)-(9,12))
-        │               │   └── arguments: (length: 1)
-        │               │       └── @ KeywordHashNode (location: (9,9)-(9,12))
-        │               │           └── elements: (length: 1)
-        │               │               └── @ AssocNode (location: (9,9)-(9,12))
-        │               │                   ├── key:
-        │               │                   │   @ SymbolNode (location: (9,9)-(9,11))
-        │               │                   │   ├── opening_loc: ∅
-        │               │                   │   ├── value_loc: (9,9)-(9,10) = "z"
-        │               │                   │   ├── closing_loc: (9,10)-(9,11) = ":"
-        │               │                   │   └── unescaped: "z"
-        │               │                   ├── value:
-        │               │                   │   @ IntegerNode (location: (9,11)-(9,12))
-        │               │                   │   └── flags: decimal
-        │               │                   └── operator_loc: ∅
-        │               ├── closing_loc: (9,12)-(9,13) = ")"
-        │               ├── block: ∅
-        │               ├── flags: ∅
-        │               └── name: :y
+        │       ├── arguments: (length: 1)
+        │       │   └── @ CallNode (location: (9,7)-(9,13))
+        │       │       ├── receiver: ∅
+        │       │       ├── call_operator_loc: ∅
+        │       │       ├── message_loc: (9,7)-(9,8) = "y"
+        │       │       ├── opening_loc: (9,8)-(9,9) = "("
+        │       │       ├── arguments:
+        │       │       │   @ ArgumentsNode (location: (9,9)-(9,12))
+        │       │       │   ├── arguments: (length: 1)
+        │       │       │   │   └── @ KeywordHashNode (location: (9,9)-(9,12))
+        │       │       │   │       └── elements: (length: 1)
+        │       │       │   │           └── @ AssocNode (location: (9,9)-(9,12))
+        │       │       │   │               ├── key:
+        │       │       │   │               │   @ SymbolNode (location: (9,9)-(9,11))
+        │       │       │   │               │   ├── opening_loc: ∅
+        │       │       │   │               │   ├── value_loc: (9,9)-(9,10) = "z"
+        │       │       │   │               │   ├── closing_loc: (9,10)-(9,11) = ":"
+        │       │       │   │               │   └── unescaped: "z"
+        │       │       │   │               ├── value:
+        │       │       │   │               │   @ IntegerNode (location: (9,11)-(9,12))
+        │       │       │   │               │   └── flags: decimal
+        │       │       │   │               └── operator_loc: ∅
+        │       │       │   └── flags: ∅
+        │       │       ├── closing_loc: (9,12)-(9,13) = ")"
+        │       │       ├── block: ∅
+        │       │       ├── flags: ∅
+        │       │       └── name: :y
+        │       └── flags: ∅
         └── @ ReturnNode (location: (11,0)-(11,14))
             ├── keyword_loc: (11,0)-(11,6) = "return"
             └── arguments:
                 @ ArgumentsNode (location: (11,7)-(11,14))
-                └── arguments: (length: 1)
-                    └── @ CallNode (location: (11,7)-(11,14))
-                        ├── receiver: ∅
-                        ├── call_operator_loc: ∅
-                        ├── message_loc: (11,7)-(11,8) = "y"
-                        ├── opening_loc: (11,8)-(11,9) = "("
-                        ├── arguments:
-                        │   @ ArgumentsNode (location: (11,9)-(11,13))
-                        │   └── arguments: (length: 1)
-                        │       └── @ KeywordHashNode (location: (11,9)-(11,13))
-                        │           └── elements: (length: 1)
-                        │               └── @ AssocNode (location: (11,9)-(11,13))
-                        │                   ├── key:
-                        │                   │   @ CallNode (location: (11,9)-(11,10))
-                        │                   │   ├── receiver: ∅
-                        │                   │   ├── call_operator_loc: ∅
-                        │                   │   ├── message_loc: (11,9)-(11,10) = "z"
-                        │                   │   ├── opening_loc: ∅
-                        │                   │   ├── arguments: ∅
-                        │                   │   ├── closing_loc: ∅
-                        │                   │   ├── block: ∅
-                        │                   │   ├── flags: variable_call
-                        │                   │   └── name: :z
-                        │                   ├── value:
-                        │                   │   @ IntegerNode (location: (11,12)-(11,13))
-                        │                   │   └── flags: decimal
-                        │                   └── operator_loc: (11,10)-(11,12) = "=>"
-                        ├── closing_loc: (11,13)-(11,14) = ")"
-                        ├── block: ∅
-                        ├── flags: ∅
-                        └── name: :y
+                ├── arguments: (length: 1)
+                │   └── @ CallNode (location: (11,7)-(11,14))
+                │       ├── receiver: ∅
+                │       ├── call_operator_loc: ∅
+                │       ├── message_loc: (11,7)-(11,8) = "y"
+                │       ├── opening_loc: (11,8)-(11,9) = "("
+                │       ├── arguments:
+                │       │   @ ArgumentsNode (location: (11,9)-(11,13))
+                │       │   ├── arguments: (length: 1)
+                │       │   │   └── @ KeywordHashNode (location: (11,9)-(11,13))
+                │       │   │       └── elements: (length: 1)
+                │       │   │           └── @ AssocNode (location: (11,9)-(11,13))
+                │       │   │               ├── key:
+                │       │   │               │   @ CallNode (location: (11,9)-(11,10))
+                │       │   │               │   ├── receiver: ∅
+                │       │   │               │   ├── call_operator_loc: ∅
+                │       │   │               │   ├── message_loc: (11,9)-(11,10) = "z"
+                │       │   │               │   ├── opening_loc: ∅
+                │       │   │               │   ├── arguments: ∅
+                │       │   │               │   ├── closing_loc: ∅
+                │       │   │               │   ├── block: ∅
+                │       │   │               │   ├── flags: variable_call
+                │       │   │               │   └── name: :z
+                │       │   │               ├── value:
+                │       │   │               │   @ IntegerNode (location: (11,12)-(11,13))
+                │       │   │               │   └── flags: decimal
+                │       │   │               └── operator_loc: (11,10)-(11,12) = "=>"
+                │       │   └── flags: ∅
+                │       ├── closing_loc: (11,13)-(11,14) = ")"
+                │       ├── block: ∅
+                │       ├── flags: ∅
+                │       └── name: :y
+                └── flags: ∅

--- a/test/prism/snapshots/seattlerb/safe_attrasgn.txt
+++ b/test/prism/snapshots/seattlerb/safe_attrasgn.txt
@@ -20,9 +20,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,7)-(1,8))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,7)-(1,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,7)-(1,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: safe_navigation

--- a/test/prism/snapshots/seattlerb/safe_attrasgn_constant.txt
+++ b/test/prism/snapshots/seattlerb/safe_attrasgn_constant.txt
@@ -20,9 +20,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,7)-(1,8))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,7)-(1,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,7)-(1,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: safe_navigation

--- a/test/prism/snapshots/seattlerb/safe_call_operator.txt
+++ b/test/prism/snapshots/seattlerb/safe_call_operator.txt
@@ -20,9 +20,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,5)-(1,6))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,5)-(1,6))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: safe_navigation

--- a/test/prism/snapshots/seattlerb/safe_calls.txt
+++ b/test/prism/snapshots/seattlerb/safe_calls.txt
@@ -30,9 +30,10 @@
             ├── opening_loc: (1,7)-(1,8) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,8)-(1,9))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,8)-(1,9))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,8)-(1,9))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,9)-(1,10) = ")"
             ├── block: ∅
             ├── flags: safe_navigation

--- a/test/prism/snapshots/seattlerb/safe_op_asgn.txt
+++ b/test/prism/snapshots/seattlerb/safe_op_asgn.txt
@@ -30,9 +30,10 @@
                 ├── opening_loc: ∅
                 ├── arguments:
                 │   @ ArgumentsNode (location: (1,10)-(1,11))
-                │   └── arguments: (length: 1)
-                │       └── @ IntegerNode (location: (1,10)-(1,11))
-                │           └── flags: decimal
+                │   ├── arguments: (length: 1)
+                │   │   └── @ IntegerNode (location: (1,10)-(1,11))
+                │   │       └── flags: decimal
+                │   └── flags: ∅
                 ├── closing_loc: ∅
                 ├── block: ∅
                 ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/slashy_newlines_within_string.txt
+++ b/test/prism/snapshots/seattlerb/slashy_newlines_within_string.txt
@@ -10,13 +10,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,5)-(4,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (1,5)-(4,8))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (1,5)-(1,6) = "\""
-        │   │           ├── content_loc: (1,6)-(4,7) = "hello\\\n my\\\n dear\\\n friend"
-        │   │           ├── closing_loc: (4,7)-(4,8) = "\""
-        │   │           └── unescaped: "hello my dear friend"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (1,5)-(4,8))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (1,5)-(1,6) = "\""
+        │   │   │       ├── content_loc: (1,6)-(4,7) = "hello\\\n my\\\n dear\\\n friend"
+        │   │   │       ├── closing_loc: (4,7)-(4,8) = "\""
+        │   │   │       └── unescaped: "hello my dear friend"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -38,17 +39,18 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (6,4)-(6,5))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (6,4)-(6,5))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (6,4)-(6,5) = "b"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :b
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (6,4)-(6,5))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (6,4)-(6,5) = "b"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :b
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/stabby_block_iter_call.txt
+++ b/test/prism/snapshots/seattlerb/stabby_block_iter_call.txt
@@ -10,47 +10,48 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(4,3))
-            │   └── arguments: (length: 1)
-            │       └── @ LambdaNode (location: (1,2)-(4,3))
-            │           ├── locals: []
-            │           ├── operator_loc: (1,2)-(1,4) = "->"
-            │           ├── opening_loc: (1,8)-(1,10) = "do"
-            │           ├── closing_loc: (4,0)-(4,3) = "end"
-            │           ├── parameters:
-            │           │   @ BlockParametersNode (location: (1,5)-(1,7))
-            │           │   ├── parameters: ∅
-            │           │   ├── locals: (length: 0)
-            │           │   ├── opening_loc: (1,5)-(1,6) = "("
-            │           │   └── closing_loc: (1,6)-(1,7) = ")"
-            │           └── body:
-            │               @ StatementsNode (location: (2,0)-(3,3))
-            │               └── body: (length: 1)
-            │                   └── @ CallNode (location: (2,0)-(3,3))
-            │                       ├── receiver:
-            │                       │   @ CallNode (location: (2,0)-(2,1))
-            │                       │   ├── receiver: ∅
-            │                       │   ├── call_operator_loc: ∅
-            │                       │   ├── message_loc: (2,0)-(2,1) = "a"
-            │                       │   ├── opening_loc: ∅
-            │                       │   ├── arguments: ∅
-            │                       │   ├── closing_loc: ∅
-            │                       │   ├── block: ∅
-            │                       │   ├── flags: variable_call
-            │                       │   └── name: :a
-            │                       ├── call_operator_loc: (2,1)-(2,2) = "."
-            │                       ├── message_loc: (2,2)-(2,3) = "b"
-            │                       ├── opening_loc: ∅
-            │                       ├── arguments: ∅
-            │                       ├── closing_loc: ∅
-            │                       ├── block:
-            │                       │   @ BlockNode (location: (2,4)-(3,3))
-            │                       │   ├── locals: []
-            │                       │   ├── parameters: ∅
-            │                       │   ├── body: ∅
-            │                       │   ├── opening_loc: (2,4)-(2,6) = "do"
-            │                       │   └── closing_loc: (3,0)-(3,3) = "end"
-            │                       ├── flags: ∅
-            │                       └── name: :b
+            │   ├── arguments: (length: 1)
+            │   │   └── @ LambdaNode (location: (1,2)-(4,3))
+            │   │       ├── locals: []
+            │   │       ├── operator_loc: (1,2)-(1,4) = "->"
+            │   │       ├── opening_loc: (1,8)-(1,10) = "do"
+            │   │       ├── closing_loc: (4,0)-(4,3) = "end"
+            │   │       ├── parameters:
+            │   │       │   @ BlockParametersNode (location: (1,5)-(1,7))
+            │   │       │   ├── parameters: ∅
+            │   │       │   ├── locals: (length: 0)
+            │   │       │   ├── opening_loc: (1,5)-(1,6) = "("
+            │   │       │   └── closing_loc: (1,6)-(1,7) = ")"
+            │   │       └── body:
+            │   │           @ StatementsNode (location: (2,0)-(3,3))
+            │   │           └── body: (length: 1)
+            │   │               └── @ CallNode (location: (2,0)-(3,3))
+            │   │                   ├── receiver:
+            │   │                   │   @ CallNode (location: (2,0)-(2,1))
+            │   │                   │   ├── receiver: ∅
+            │   │                   │   ├── call_operator_loc: ∅
+            │   │                   │   ├── message_loc: (2,0)-(2,1) = "a"
+            │   │                   │   ├── opening_loc: ∅
+            │   │                   │   ├── arguments: ∅
+            │   │                   │   ├── closing_loc: ∅
+            │   │                   │   ├── block: ∅
+            │   │                   │   ├── flags: variable_call
+            │   │                   │   └── name: :a
+            │   │                   ├── call_operator_loc: (2,1)-(2,2) = "."
+            │   │                   ├── message_loc: (2,2)-(2,3) = "b"
+            │   │                   ├── opening_loc: ∅
+            │   │                   ├── arguments: ∅
+            │   │                   ├── closing_loc: ∅
+            │   │                   ├── block:
+            │   │                   │   @ BlockNode (location: (2,4)-(3,3))
+            │   │                   │   ├── locals: []
+            │   │                   │   ├── parameters: ∅
+            │   │                   │   ├── body: ∅
+            │   │                   │   ├── opening_loc: (2,4)-(2,6) = "do"
+            │   │                   │   └── closing_loc: (3,0)-(3,3) = "end"
+            │   │                   ├── flags: ∅
+            │   │                   └── name: :b
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/stabby_block_iter_call_no_target_with_arg.txt
+++ b/test/prism/snapshots/seattlerb/stabby_block_iter_call_no_target_with_arg.txt
@@ -10,41 +10,43 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(4,3))
-            │   └── arguments: (length: 1)
-            │       └── @ LambdaNode (location: (1,2)-(4,3))
-            │           ├── locals: []
-            │           ├── operator_loc: (1,2)-(1,4) = "->"
-            │           ├── opening_loc: (1,8)-(1,10) = "do"
-            │           ├── closing_loc: (4,0)-(4,3) = "end"
-            │           ├── parameters:
-            │           │   @ BlockParametersNode (location: (1,5)-(1,7))
-            │           │   ├── parameters: ∅
-            │           │   ├── locals: (length: 0)
-            │           │   ├── opening_loc: (1,5)-(1,6) = "("
-            │           │   └── closing_loc: (1,6)-(1,7) = ")"
-            │           └── body:
-            │               @ StatementsNode (location: (2,0)-(3,3))
-            │               └── body: (length: 1)
-            │                   └── @ CallNode (location: (2,0)-(3,3))
-            │                       ├── receiver: ∅
-            │                       ├── call_operator_loc: ∅
-            │                       ├── message_loc: (2,0)-(2,1) = "a"
-            │                       ├── opening_loc: (2,1)-(2,2) = "("
-            │                       ├── arguments:
-            │                       │   @ ArgumentsNode (location: (2,2)-(2,3))
-            │                       │   └── arguments: (length: 1)
-            │                       │       └── @ IntegerNode (location: (2,2)-(2,3))
-            │                       │           └── flags: decimal
-            │                       ├── closing_loc: (2,3)-(2,4) = ")"
-            │                       ├── block:
-            │                       │   @ BlockNode (location: (2,5)-(3,3))
-            │                       │   ├── locals: []
-            │                       │   ├── parameters: ∅
-            │                       │   ├── body: ∅
-            │                       │   ├── opening_loc: (2,5)-(2,7) = "do"
-            │                       │   └── closing_loc: (3,0)-(3,3) = "end"
-            │                       ├── flags: ∅
-            │                       └── name: :a
+            │   ├── arguments: (length: 1)
+            │   │   └── @ LambdaNode (location: (1,2)-(4,3))
+            │   │       ├── locals: []
+            │   │       ├── operator_loc: (1,2)-(1,4) = "->"
+            │   │       ├── opening_loc: (1,8)-(1,10) = "do"
+            │   │       ├── closing_loc: (4,0)-(4,3) = "end"
+            │   │       ├── parameters:
+            │   │       │   @ BlockParametersNode (location: (1,5)-(1,7))
+            │   │       │   ├── parameters: ∅
+            │   │       │   ├── locals: (length: 0)
+            │   │       │   ├── opening_loc: (1,5)-(1,6) = "("
+            │   │       │   └── closing_loc: (1,6)-(1,7) = ")"
+            │   │       └── body:
+            │   │           @ StatementsNode (location: (2,0)-(3,3))
+            │   │           └── body: (length: 1)
+            │   │               └── @ CallNode (location: (2,0)-(3,3))
+            │   │                   ├── receiver: ∅
+            │   │                   ├── call_operator_loc: ∅
+            │   │                   ├── message_loc: (2,0)-(2,1) = "a"
+            │   │                   ├── opening_loc: (2,1)-(2,2) = "("
+            │   │                   ├── arguments:
+            │   │                   │   @ ArgumentsNode (location: (2,2)-(2,3))
+            │   │                   │   ├── arguments: (length: 1)
+            │   │                   │   │   └── @ IntegerNode (location: (2,2)-(2,3))
+            │   │                   │   │       └── flags: decimal
+            │   │                   │   └── flags: ∅
+            │   │                   ├── closing_loc: (2,3)-(2,4) = ")"
+            │   │                   ├── block:
+            │   │                   │   @ BlockNode (location: (2,5)-(3,3))
+            │   │                   │   ├── locals: []
+            │   │                   │   ├── parameters: ∅
+            │   │                   │   ├── body: ∅
+            │   │                   │   ├── opening_loc: (2,5)-(2,7) = "do"
+            │   │                   │   └── closing_loc: (3,0)-(3,3) = "end"
+            │   │                   ├── flags: ∅
+            │   │                   └── name: :a
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/str_backslashes.txt
+++ b/test/prism/snapshots/seattlerb/str_backslashes.txt
@@ -10,13 +10,14 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,204))
-            │   └── arguments: (length: 1)
-            │       └── @ StringNode (location: (1,2)-(1,204))
-            │           ├── flags: ∅
-            │           ├── opening_loc: (1,2)-(1,3) = "'"
-            │           ├── content_loc: (1,3)-(1,203) = "\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n"
-            │           ├── closing_loc: (1,203)-(1,204) = "'"
-            │           └── unescaped: "\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ StringNode (location: (1,2)-(1,204))
+            │   │       ├── flags: ∅
+            │   │       ├── opening_loc: (1,2)-(1,3) = "'"
+            │   │       ├── content_loc: (1,3)-(1,203) = "\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n"
+            │   │       ├── closing_loc: (1,203)-(1,204) = "'"
+            │   │       └── unescaped: "\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/str_double_double_escaped_newline.txt
+++ b/test/prism/snapshots/seattlerb/str_double_double_escaped_newline.txt
@@ -10,13 +10,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (1,2)-(1,7))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (1,2)-(1,3) = "\""
-        │   │           ├── content_loc: (1,3)-(1,6) = "\\\\n"
-        │   │           ├── closing_loc: (1,6)-(1,7) = "\""
-        │   │           └── unescaped: "\\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (1,2)-(1,7))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (1,2)-(1,3) = "\""
+        │   │   │       ├── content_loc: (1,3)-(1,6) = "\\\\n"
+        │   │   │       ├── closing_loc: (1,6)-(1,7) = "\""
+        │   │   │       └── unescaped: "\\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/str_double_escaped_newline.txt
+++ b/test/prism/snapshots/seattlerb/str_double_escaped_newline.txt
@@ -10,13 +10,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (1,2)-(1,6))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (1,2)-(1,3) = "\""
-        │   │           ├── content_loc: (1,3)-(1,5) = "\\n"
-        │   │           ├── closing_loc: (1,5)-(1,6) = "\""
-        │   │           └── unescaped: "\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (1,2)-(1,6))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (1,2)-(1,3) = "\""
+        │   │   │       ├── content_loc: (1,3)-(1,5) = "\\n"
+        │   │   │       ├── closing_loc: (1,5)-(1,6) = "\""
+        │   │   │       └── unescaped: "\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/str_double_newline.txt
+++ b/test/prism/snapshots/seattlerb/str_double_newline.txt
@@ -10,13 +10,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(2,1))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (1,2)-(2,1))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (1,2)-(1,3) = "\""
-        │   │           ├── content_loc: (1,3)-(1,0) = "\n"
-        │   │           ├── closing_loc: (2,0)-(2,1) = "\""
-        │   │           └── unescaped: "\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (1,2)-(2,1))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (1,2)-(1,3) = "\""
+        │   │   │       ├── content_loc: (1,3)-(1,0) = "\n"
+        │   │   │       ├── closing_loc: (2,0)-(2,1) = "\""
+        │   │   │       └── unescaped: "\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/str_interp_ternary_or_label.txt
+++ b/test/prism/snapshots/seattlerb/str_interp_ternary_or_label.txt
@@ -52,17 +52,18 @@
             │       │           │           │   ├── opening_loc: ∅
             │       │           │           │   ├── arguments:
             │       │           │           │   │   @ ArgumentsNode (location: (1,13)-(1,14))
-            │       │           │           │   │   └── arguments: (length: 1)
-            │       │           │           │   │       └── @ CallNode (location: (1,13)-(1,14))
-            │       │           │           │   │           ├── receiver: ∅
-            │       │           │           │   │           ├── call_operator_loc: ∅
-            │       │           │           │   │           ├── message_loc: (1,13)-(1,14) = "a"
-            │       │           │           │   │           ├── opening_loc: ∅
-            │       │           │           │   │           ├── arguments: ∅
-            │       │           │           │   │           ├── closing_loc: ∅
-            │       │           │           │   │           ├── block: ∅
-            │       │           │           │   │           ├── flags: variable_call
-            │       │           │           │   │           └── name: :a
+            │       │           │           │   │   ├── arguments: (length: 1)
+            │       │           │           │   │   │   └── @ CallNode (location: (1,13)-(1,14))
+            │       │           │           │   │   │       ├── receiver: ∅
+            │       │           │           │   │   │       ├── call_operator_loc: ∅
+            │       │           │           │   │   │       ├── message_loc: (1,13)-(1,14) = "a"
+            │       │           │           │   │   │       ├── opening_loc: ∅
+            │       │           │           │   │   │       ├── arguments: ∅
+            │       │           │           │   │   │       ├── closing_loc: ∅
+            │       │           │           │   │   │       ├── block: ∅
+            │       │           │           │   │   │       ├── flags: variable_call
+            │       │           │           │   │   │       └── name: :a
+            │       │           │           │   │   └── flags: ∅
             │       │           │           │   ├── closing_loc: ∅
             │       │           │           │   ├── block: ∅
             │       │           │           │   ├── flags: ∅
@@ -72,13 +73,14 @@
             │       │           │           ├── opening_loc: ∅
             │       │           │           ├── arguments:
             │       │           │           │   @ ArgumentsNode (location: (1,15)-(1,17))
-            │       │           │           │   └── arguments: (length: 1)
-            │       │           │           │       └── @ StringNode (location: (1,15)-(1,17))
-            │       │           │           │           ├── flags: ∅
-            │       │           │           │           ├── opening_loc: (1,15)-(1,16) = "\""
-            │       │           │           │           ├── content_loc: (1,16)-(1,16) = ""
-            │       │           │           │           ├── closing_loc: (1,16)-(1,17) = "\""
-            │       │           │           │           └── unescaped: ""
+            │       │           │           │   ├── arguments: (length: 1)
+            │       │           │           │   │   └── @ StringNode (location: (1,15)-(1,17))
+            │       │           │           │   │       ├── flags: ∅
+            │       │           │           │   │       ├── opening_loc: (1,15)-(1,16) = "\""
+            │       │           │           │   │       ├── content_loc: (1,16)-(1,16) = ""
+            │       │           │           │   │       ├── closing_loc: (1,16)-(1,17) = "\""
+            │       │           │           │   │       └── unescaped: ""
+            │       │           │           │   └── flags: ∅
             │       │           │           ├── closing_loc: ∅
             │       │           │           ├── block: ∅
             │       │           │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/str_single_double_escaped_newline.txt
+++ b/test/prism/snapshots/seattlerb/str_single_double_escaped_newline.txt
@@ -10,13 +10,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (1,2)-(1,7))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (1,2)-(1,3) = "'"
-        │   │           ├── content_loc: (1,3)-(1,6) = "\\\\n"
-        │   │           ├── closing_loc: (1,6)-(1,7) = "'"
-        │   │           └── unescaped: "\\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (1,2)-(1,7))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (1,2)-(1,3) = "'"
+        │   │   │       ├── content_loc: (1,3)-(1,6) = "\\\\n"
+        │   │   │       ├── closing_loc: (1,6)-(1,7) = "'"
+        │   │   │       └── unescaped: "\\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/str_single_escaped_newline.txt
+++ b/test/prism/snapshots/seattlerb/str_single_escaped_newline.txt
@@ -10,13 +10,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (1,2)-(1,6))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (1,2)-(1,3) = "'"
-        │   │           ├── content_loc: (1,3)-(1,5) = "\\n"
-        │   │           ├── closing_loc: (1,5)-(1,6) = "'"
-        │   │           └── unescaped: "\\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (1,2)-(1,6))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (1,2)-(1,3) = "'"
+        │   │   │       ├── content_loc: (1,3)-(1,5) = "\\n"
+        │   │   │       ├── closing_loc: (1,5)-(1,6) = "'"
+        │   │   │       └── unescaped: "\\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/str_single_newline.txt
+++ b/test/prism/snapshots/seattlerb/str_single_newline.txt
@@ -10,13 +10,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(2,1))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (1,2)-(2,1))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (1,2)-(1,3) = "'"
-        │   │           ├── content_loc: (1,3)-(1,0) = "\n"
-        │   │           ├── closing_loc: (2,0)-(2,1) = "'"
-        │   │           └── unescaped: "\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (1,2)-(2,1))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (1,2)-(1,3) = "'"
+        │   │   │       ├── content_loc: (1,3)-(1,0) = "\n"
+        │   │   │       ├── closing_loc: (2,0)-(2,1) = "'"
+        │   │   │       └── unescaped: "\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/super_arg.txt
+++ b/test/prism/snapshots/seattlerb/super_arg.txt
@@ -8,8 +8,9 @@
             ├── lparen_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,6)-(1,8))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,6)-(1,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,6)-(1,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── rparen_loc: ∅
             └── block: ∅

--- a/test/prism/snapshots/seattlerb/thingy.txt
+++ b/test/prism/snapshots/seattlerb/thingy.txt
@@ -20,9 +20,10 @@
         │   ├── opening_loc: (1,2)-(1,3) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,3)-(1,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (1,3)-(1,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (1,3)-(1,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (1,5)-(1,6) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -44,9 +45,10 @@
             ├── opening_loc: (3,3)-(3,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (3,4)-(3,6))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (3,4)-(3,6))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (3,4)-(3,6))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (3,6)-(3,7) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/utf8_bom.txt
+++ b/test/prism/snapshots/seattlerb/utf8_bom.txt
@@ -10,9 +10,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (2,2)-(2,3))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (2,2)-(2,3))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (2,2)-(2,3))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/yield_arg.txt
+++ b/test/prism/snapshots/seattlerb/yield_arg.txt
@@ -8,7 +8,8 @@
             ├── lparen_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,6)-(1,8))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,6)-(1,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,6)-(1,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             └── rparen_loc: ∅

--- a/test/prism/snapshots/seattlerb/yield_call_assocs.txt
+++ b/test/prism/snapshots/seattlerb/yield_call_assocs.txt
@@ -8,186 +8,196 @@
         │   ├── lparen_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,6)-(1,16))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ IntegerNode (location: (1,6)-(1,7))
-        │   │       │   └── flags: decimal
-        │   │       └── @ KeywordHashNode (location: (1,9)-(1,16))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (1,9)-(1,16))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (1,9)-(1,11))
-        │   │                   │   ├── opening_loc: (1,9)-(1,10) = ":"
-        │   │                   │   ├── value_loc: (1,10)-(1,11) = "z"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "z"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (1,15)-(1,16))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (1,12)-(1,14) = "=>"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ IntegerNode (location: (1,6)-(1,7))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ KeywordHashNode (location: (1,9)-(1,16))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (1,9)-(1,16))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (1,9)-(1,11))
+        │   │   │               │   ├── opening_loc: (1,9)-(1,10) = ":"
+        │   │   │               │   ├── value_loc: (1,10)-(1,11) = "z"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "z"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (1,15)-(1,16))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (1,12)-(1,14) = "=>"
+        │   │   └── flags: ∅
         │   └── rparen_loc: ∅
         ├── @ YieldNode (location: (3,0)-(3,25))
         │   ├── keyword_loc: (3,0)-(3,5) = "yield"
         │   ├── lparen_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,6)-(3,25))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ IntegerNode (location: (3,6)-(3,7))
-        │   │       │   └── flags: decimal
-        │   │       └── @ KeywordHashNode (location: (3,9)-(3,25))
-        │   │           └── elements: (length: 2)
-        │   │               ├── @ AssocNode (location: (3,9)-(3,16))
-        │   │               │   ├── key:
-        │   │               │   │   @ SymbolNode (location: (3,9)-(3,11))
-        │   │               │   │   ├── opening_loc: (3,9)-(3,10) = ":"
-        │   │               │   │   ├── value_loc: (3,10)-(3,11) = "z"
-        │   │               │   │   ├── closing_loc: ∅
-        │   │               │   │   └── unescaped: "z"
-        │   │               │   ├── value:
-        │   │               │   │   @ IntegerNode (location: (3,15)-(3,16))
-        │   │               │   │   └── flags: decimal
-        │   │               │   └── operator_loc: (3,12)-(3,14) = "=>"
-        │   │               └── @ AssocNode (location: (3,18)-(3,25))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (3,18)-(3,20))
-        │   │                   │   ├── opening_loc: (3,18)-(3,19) = ":"
-        │   │                   │   ├── value_loc: (3,19)-(3,20) = "w"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "w"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (3,24)-(3,25))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (3,21)-(3,23) = "=>"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ IntegerNode (location: (3,6)-(3,7))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ KeywordHashNode (location: (3,9)-(3,25))
+        │   │   │       └── elements: (length: 2)
+        │   │   │           ├── @ AssocNode (location: (3,9)-(3,16))
+        │   │   │           │   ├── key:
+        │   │   │           │   │   @ SymbolNode (location: (3,9)-(3,11))
+        │   │   │           │   │   ├── opening_loc: (3,9)-(3,10) = ":"
+        │   │   │           │   │   ├── value_loc: (3,10)-(3,11) = "z"
+        │   │   │           │   │   ├── closing_loc: ∅
+        │   │   │           │   │   └── unescaped: "z"
+        │   │   │           │   ├── value:
+        │   │   │           │   │   @ IntegerNode (location: (3,15)-(3,16))
+        │   │   │           │   │   └── flags: decimal
+        │   │   │           │   └── operator_loc: (3,12)-(3,14) = "=>"
+        │   │   │           └── @ AssocNode (location: (3,18)-(3,25))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (3,18)-(3,20))
+        │   │   │               │   ├── opening_loc: (3,18)-(3,19) = ":"
+        │   │   │               │   ├── value_loc: (3,19)-(3,20) = "w"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "w"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (3,24)-(3,25))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (3,21)-(3,23) = "=>"
+        │   │   └── flags: ∅
         │   └── rparen_loc: ∅
         ├── @ YieldNode (location: (5,0)-(5,13))
         │   ├── keyword_loc: (5,0)-(5,5) = "yield"
         │   ├── lparen_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,6)-(5,13))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (5,6)-(5,13))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (5,6)-(5,7) = "y"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (5,8)-(5,13))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ KeywordHashNode (location: (5,8)-(5,13))
-        │   │           │           └── elements: (length: 1)
-        │   │           │               └── @ AssocNode (location: (5,8)-(5,13))
-        │   │           │                   ├── key:
-        │   │           │                   │   @ SymbolNode (location: (5,8)-(5,10))
-        │   │           │                   │   ├── opening_loc: (5,8)-(5,9) = ":"
-        │   │           │                   │   ├── value_loc: (5,9)-(5,10) = "z"
-        │   │           │                   │   ├── closing_loc: ∅
-        │   │           │                   │   └── unescaped: "z"
-        │   │           │                   ├── value:
-        │   │           │                   │   @ IntegerNode (location: (5,12)-(5,13))
-        │   │           │                   │   └── flags: decimal
-        │   │           │                   └── operator_loc: (5,10)-(5,12) = "=>"
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :y
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (5,6)-(5,13))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (5,6)-(5,7) = "y"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments:
+        │   │   │       │   @ ArgumentsNode (location: (5,8)-(5,13))
+        │   │   │       │   ├── arguments: (length: 1)
+        │   │   │       │   │   └── @ KeywordHashNode (location: (5,8)-(5,13))
+        │   │   │       │   │       └── elements: (length: 1)
+        │   │   │       │   │           └── @ AssocNode (location: (5,8)-(5,13))
+        │   │   │       │   │               ├── key:
+        │   │   │       │   │               │   @ SymbolNode (location: (5,8)-(5,10))
+        │   │   │       │   │               │   ├── opening_loc: (5,8)-(5,9) = ":"
+        │   │   │       │   │               │   ├── value_loc: (5,9)-(5,10) = "z"
+        │   │   │       │   │               │   ├── closing_loc: ∅
+        │   │   │       │   │               │   └── unescaped: "z"
+        │   │   │       │   │               ├── value:
+        │   │   │       │   │               │   @ IntegerNode (location: (5,12)-(5,13))
+        │   │   │       │   │               │   └── flags: decimal
+        │   │   │       │   │               └── operator_loc: (5,10)-(5,12) = "=>"
+        │   │   │       │   └── flags: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :y
+        │   │   └── flags: ∅
         │   └── rparen_loc: ∅
         ├── @ YieldNode (location: (7,0)-(7,11))
         │   ├── keyword_loc: (7,0)-(7,5) = "yield"
         │   ├── lparen_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,6)-(7,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (7,6)-(7,11))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (7,6)-(7,7) = "y"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (7,8)-(7,11))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ KeywordHashNode (location: (7,8)-(7,11))
-        │   │           │           └── elements: (length: 1)
-        │   │           │               └── @ AssocNode (location: (7,8)-(7,11))
-        │   │           │                   ├── key:
-        │   │           │                   │   @ SymbolNode (location: (7,8)-(7,10))
-        │   │           │                   │   ├── opening_loc: ∅
-        │   │           │                   │   ├── value_loc: (7,8)-(7,9) = "z"
-        │   │           │                   │   ├── closing_loc: (7,9)-(7,10) = ":"
-        │   │           │                   │   └── unescaped: "z"
-        │   │           │                   ├── value:
-        │   │           │                   │   @ IntegerNode (location: (7,10)-(7,11))
-        │   │           │                   │   └── flags: decimal
-        │   │           │                   └── operator_loc: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :y
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (7,6)-(7,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (7,6)-(7,7) = "y"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments:
+        │   │   │       │   @ ArgumentsNode (location: (7,8)-(7,11))
+        │   │   │       │   ├── arguments: (length: 1)
+        │   │   │       │   │   └── @ KeywordHashNode (location: (7,8)-(7,11))
+        │   │   │       │   │       └── elements: (length: 1)
+        │   │   │       │   │           └── @ AssocNode (location: (7,8)-(7,11))
+        │   │   │       │   │               ├── key:
+        │   │   │       │   │               │   @ SymbolNode (location: (7,8)-(7,10))
+        │   │   │       │   │               │   ├── opening_loc: ∅
+        │   │   │       │   │               │   ├── value_loc: (7,8)-(7,9) = "z"
+        │   │   │       │   │               │   ├── closing_loc: (7,9)-(7,10) = ":"
+        │   │   │       │   │               │   └── unescaped: "z"
+        │   │   │       │   │               ├── value:
+        │   │   │       │   │               │   @ IntegerNode (location: (7,10)-(7,11))
+        │   │   │       │   │               │   └── flags: decimal
+        │   │   │       │   │               └── operator_loc: ∅
+        │   │   │       │   └── flags: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :y
+        │   │   └── flags: ∅
         │   └── rparen_loc: ∅
         ├── @ YieldNode (location: (9,0)-(9,12))
         │   ├── keyword_loc: (9,0)-(9,5) = "yield"
         │   ├── lparen_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (9,6)-(9,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (9,6)-(9,12))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (9,6)-(9,7) = "y"
-        │   │           ├── opening_loc: (9,7)-(9,8) = "("
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (9,8)-(9,11))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ KeywordHashNode (location: (9,8)-(9,11))
-        │   │           │           └── elements: (length: 1)
-        │   │           │               └── @ AssocNode (location: (9,8)-(9,11))
-        │   │           │                   ├── key:
-        │   │           │                   │   @ SymbolNode (location: (9,8)-(9,10))
-        │   │           │                   │   ├── opening_loc: ∅
-        │   │           │                   │   ├── value_loc: (9,8)-(9,9) = "z"
-        │   │           │                   │   ├── closing_loc: (9,9)-(9,10) = ":"
-        │   │           │                   │   └── unescaped: "z"
-        │   │           │                   ├── value:
-        │   │           │                   │   @ IntegerNode (location: (9,10)-(9,11))
-        │   │           │                   │   └── flags: decimal
-        │   │           │                   └── operator_loc: ∅
-        │   │           ├── closing_loc: (9,11)-(9,12) = ")"
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :y
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (9,6)-(9,12))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (9,6)-(9,7) = "y"
+        │   │   │       ├── opening_loc: (9,7)-(9,8) = "("
+        │   │   │       ├── arguments:
+        │   │   │       │   @ ArgumentsNode (location: (9,8)-(9,11))
+        │   │   │       │   ├── arguments: (length: 1)
+        │   │   │       │   │   └── @ KeywordHashNode (location: (9,8)-(9,11))
+        │   │   │       │   │       └── elements: (length: 1)
+        │   │   │       │   │           └── @ AssocNode (location: (9,8)-(9,11))
+        │   │   │       │   │               ├── key:
+        │   │   │       │   │               │   @ SymbolNode (location: (9,8)-(9,10))
+        │   │   │       │   │               │   ├── opening_loc: ∅
+        │   │   │       │   │               │   ├── value_loc: (9,8)-(9,9) = "z"
+        │   │   │       │   │               │   ├── closing_loc: (9,9)-(9,10) = ":"
+        │   │   │       │   │               │   └── unescaped: "z"
+        │   │   │       │   │               ├── value:
+        │   │   │       │   │               │   @ IntegerNode (location: (9,10)-(9,11))
+        │   │   │       │   │               │   └── flags: decimal
+        │   │   │       │   │               └── operator_loc: ∅
+        │   │   │       │   └── flags: ∅
+        │   │   │       ├── closing_loc: (9,11)-(9,12) = ")"
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :y
+        │   │   └── flags: ∅
         │   └── rparen_loc: ∅
         └── @ YieldNode (location: (11,0)-(11,13))
             ├── keyword_loc: (11,0)-(11,5) = "yield"
             ├── lparen_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (11,6)-(11,13))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (11,6)-(11,13))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (11,6)-(11,7) = "y"
-            │           ├── opening_loc: (11,7)-(11,8) = "("
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (11,8)-(11,12))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ KeywordHashNode (location: (11,8)-(11,12))
-            │           │           └── elements: (length: 1)
-            │           │               └── @ AssocNode (location: (11,8)-(11,12))
-            │           │                   ├── key:
-            │           │                   │   @ CallNode (location: (11,8)-(11,9))
-            │           │                   │   ├── receiver: ∅
-            │           │                   │   ├── call_operator_loc: ∅
-            │           │                   │   ├── message_loc: (11,8)-(11,9) = "z"
-            │           │                   │   ├── opening_loc: ∅
-            │           │                   │   ├── arguments: ∅
-            │           │                   │   ├── closing_loc: ∅
-            │           │                   │   ├── block: ∅
-            │           │                   │   ├── flags: variable_call
-            │           │                   │   └── name: :z
-            │           │                   ├── value:
-            │           │                   │   @ IntegerNode (location: (11,11)-(11,12))
-            │           │                   │   └── flags: decimal
-            │           │                   └── operator_loc: (11,9)-(11,11) = "=>"
-            │           ├── closing_loc: (11,12)-(11,13) = ")"
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :y
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (11,6)-(11,13))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (11,6)-(11,7) = "y"
+            │   │       ├── opening_loc: (11,7)-(11,8) = "("
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (11,8)-(11,12))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ KeywordHashNode (location: (11,8)-(11,12))
+            │   │       │   │       └── elements: (length: 1)
+            │   │       │   │           └── @ AssocNode (location: (11,8)-(11,12))
+            │   │       │   │               ├── key:
+            │   │       │   │               │   @ CallNode (location: (11,8)-(11,9))
+            │   │       │   │               │   ├── receiver: ∅
+            │   │       │   │               │   ├── call_operator_loc: ∅
+            │   │       │   │               │   ├── message_loc: (11,8)-(11,9) = "z"
+            │   │       │   │               │   ├── opening_loc: ∅
+            │   │       │   │               │   ├── arguments: ∅
+            │   │       │   │               │   ├── closing_loc: ∅
+            │   │       │   │               │   ├── block: ∅
+            │   │       │   │               │   ├── flags: variable_call
+            │   │       │   │               │   └── name: :z
+            │   │       │   │               ├── value:
+            │   │       │   │               │   @ IntegerNode (location: (11,11)-(11,12))
+            │   │       │   │               │   └── flags: decimal
+            │   │       │   │               └── operator_loc: (11,9)-(11,11) = "=>"
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: (11,12)-(11,13) = ")"
+            │   │       ├── block: ∅
+            │   │       ├── flags: ∅
+            │   │       └── name: :y
+            │   └── flags: ∅
             └── rparen_loc: ∅

--- a/test/prism/snapshots/spanning_heredoc.txt
+++ b/test/prism/snapshots/spanning_heredoc.txt
@@ -10,48 +10,50 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (4,3)-(7,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (4,3)-(7,7))
-        │   │           ├── receiver:
-        │   │           │   @ StringNode (location: (4,3)-(4,7))
-        │   │           │   ├── flags: ∅
-        │   │           │   ├── opening_loc: (4,3)-(4,7) = "<<-A"
-        │   │           │   ├── content_loc: (5,0)-(5,0) = "a\n"
-        │   │           │   ├── closing_loc: (6,0)-(6,0) = "A\n"
-        │   │           │   └── unescaped: "a\n"
-        │   │           ├── call_operator_loc: (4,7)-(4,8) = "."
-        │   │           ├── message_loc: (4,8)-(4,12) = "gsub"
-        │   │           ├── opening_loc: (4,12)-(4,13) = "("
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (4,13)-(7,6))
-        │   │           │   └── arguments: (length: 2)
-        │   │           │       ├── @ InterpolatedRegularExpressionNode (location: (4,13)-(7,2))
-        │   │           │       │   ├── opening_loc: (4,13)-(4,14) = "/"
-        │   │           │       │   ├── parts: (length: 2)
-        │   │           │       │   │   ├── @ StringNode (location: (4,14)-(4,16))
-        │   │           │       │   │   │   ├── flags: ∅
-        │   │           │       │   │   │   ├── opening_loc: ∅
-        │   │           │       │   │   │   ├── content_loc: (4,14)-(4,16) = "b\\"
-        │   │           │       │   │   │   ├── closing_loc: ∅
-        │   │           │       │   │   │   └── unescaped: "b"
-        │   │           │       │   │   └── @ StringNode (location: (7,0)-(7,1))
-        │   │           │       │   │       ├── flags: ∅
-        │   │           │       │   │       ├── opening_loc: ∅
-        │   │           │       │   │       ├── content_loc: (7,0)-(7,1) = "b"
-        │   │           │       │   │       ├── closing_loc: ∅
-        │   │           │       │   │       └── unescaped: "b"
-        │   │           │       │   ├── closing_loc: (7,1)-(7,2) = "/"
-        │   │           │       │   └── flags: ∅
-        │   │           │       └── @ StringNode (location: (7,4)-(7,6))
-        │   │           │           ├── flags: ∅
-        │   │           │           ├── opening_loc: (7,4)-(7,5) = "\""
-        │   │           │           ├── content_loc: (7,5)-(7,5) = ""
-        │   │           │           ├── closing_loc: (7,5)-(7,6) = "\""
-        │   │           │           └── unescaped: ""
-        │   │           ├── closing_loc: (7,6)-(7,7) = ")"
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :gsub
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (4,3)-(7,7))
+        │   │   │       ├── receiver:
+        │   │   │       │   @ StringNode (location: (4,3)-(4,7))
+        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── opening_loc: (4,3)-(4,7) = "<<-A"
+        │   │   │       │   ├── content_loc: (5,0)-(5,0) = "a\n"
+        │   │   │       │   ├── closing_loc: (6,0)-(6,0) = "A\n"
+        │   │   │       │   └── unescaped: "a\n"
+        │   │   │       ├── call_operator_loc: (4,7)-(4,8) = "."
+        │   │   │       ├── message_loc: (4,8)-(4,12) = "gsub"
+        │   │   │       ├── opening_loc: (4,12)-(4,13) = "("
+        │   │   │       ├── arguments:
+        │   │   │       │   @ ArgumentsNode (location: (4,13)-(7,6))
+        │   │   │       │   ├── arguments: (length: 2)
+        │   │   │       │   │   ├── @ InterpolatedRegularExpressionNode (location: (4,13)-(7,2))
+        │   │   │       │   │   │   ├── opening_loc: (4,13)-(4,14) = "/"
+        │   │   │       │   │   │   ├── parts: (length: 2)
+        │   │   │       │   │   │   │   ├── @ StringNode (location: (4,14)-(4,16))
+        │   │   │       │   │   │   │   │   ├── flags: ∅
+        │   │   │       │   │   │   │   │   ├── opening_loc: ∅
+        │   │   │       │   │   │   │   │   ├── content_loc: (4,14)-(4,16) = "b\\"
+        │   │   │       │   │   │   │   │   ├── closing_loc: ∅
+        │   │   │       │   │   │   │   │   └── unescaped: "b"
+        │   │   │       │   │   │   │   └── @ StringNode (location: (7,0)-(7,1))
+        │   │   │       │   │   │   │       ├── flags: ∅
+        │   │   │       │   │   │   │       ├── opening_loc: ∅
+        │   │   │       │   │   │   │       ├── content_loc: (7,0)-(7,1) = "b"
+        │   │   │       │   │   │   │       ├── closing_loc: ∅
+        │   │   │       │   │   │   │       └── unescaped: "b"
+        │   │   │       │   │   │   ├── closing_loc: (7,1)-(7,2) = "/"
+        │   │   │       │   │   │   └── flags: ∅
+        │   │   │       │   │   └── @ StringNode (location: (7,4)-(7,6))
+        │   │   │       │   │       ├── flags: ∅
+        │   │   │       │   │       ├── opening_loc: (7,4)-(7,5) = "\""
+        │   │   │       │   │       ├── content_loc: (7,5)-(7,5) = ""
+        │   │   │       │   │       ├── closing_loc: (7,5)-(7,6) = "\""
+        │   │   │       │   │       └── unescaped: ""
+        │   │   │       │   └── flags: ∅
+        │   │   │       ├── closing_loc: (7,6)-(7,7) = ")"
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :gsub
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -63,29 +65,30 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (10,3)-(13,2))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ StringNode (location: (10,3)-(10,7))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (10,3)-(10,7) = "<<-A"
-        │   │       │   ├── content_loc: (11,0)-(11,0) = "c\n"
-        │   │       │   ├── closing_loc: (12,0)-(12,0) = "A\n"
-        │   │       │   └── unescaped: "c\n"
-        │   │       └── @ InterpolatedStringNode (location: (10,9)-(13,2))
-        │   │           ├── opening_loc: (10,9)-(10,10) = "\""
-        │   │           ├── parts: (length: 2)
-        │   │           │   ├── @ StringNode (location: (10,10)-(10,12))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (10,10)-(10,12) = "d\\"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "d"
-        │   │           │   └── @ StringNode (location: (13,0)-(13,1))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (13,0)-(13,1) = "d"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "d"
-        │   │           └── closing_loc: (13,1)-(13,2) = "\""
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ StringNode (location: (10,3)-(10,7))
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── opening_loc: (10,3)-(10,7) = "<<-A"
+        │   │   │   │   ├── content_loc: (11,0)-(11,0) = "c\n"
+        │   │   │   │   ├── closing_loc: (12,0)-(12,0) = "A\n"
+        │   │   │   │   └── unescaped: "c\n"
+        │   │   │   └── @ InterpolatedStringNode (location: (10,9)-(13,2))
+        │   │   │       ├── opening_loc: (10,9)-(10,10) = "\""
+        │   │   │       ├── parts: (length: 2)
+        │   │   │       │   ├── @ StringNode (location: (10,10)-(10,12))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (10,10)-(10,12) = "d\\"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "d"
+        │   │   │       │   └── @ StringNode (location: (13,0)-(13,1))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (13,0)-(13,1) = "d"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "d"
+        │   │   │       └── closing_loc: (13,1)-(13,2) = "\""
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -97,29 +100,30 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (16,3)-(19,2))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ StringNode (location: (16,3)-(16,7))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (16,3)-(16,7) = "<<-A"
-        │   │       │   ├── content_loc: (17,0)-(17,0) = "e\n"
-        │   │       │   ├── closing_loc: (18,0)-(18,0) = "A\n"
-        │   │       │   └── unescaped: "e\n"
-        │   │       └── @ InterpolatedStringNode (location: (16,9)-(19,2))
-        │   │           ├── opening_loc: (16,9)-(16,12) = "%q["
-        │   │           ├── parts: (length: 2)
-        │   │           │   ├── @ StringNode (location: (16,12)-(16,14))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (16,12)-(16,14) = "f\\"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "f\\\n"
-        │   │           │   └── @ StringNode (location: (19,0)-(19,1))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (19,0)-(19,1) = "f"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "f"
-        │   │           └── closing_loc: (19,1)-(19,2) = "]"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ StringNode (location: (16,3)-(16,7))
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── opening_loc: (16,3)-(16,7) = "<<-A"
+        │   │   │   │   ├── content_loc: (17,0)-(17,0) = "e\n"
+        │   │   │   │   ├── closing_loc: (18,0)-(18,0) = "A\n"
+        │   │   │   │   └── unescaped: "e\n"
+        │   │   │   └── @ InterpolatedStringNode (location: (16,9)-(19,2))
+        │   │   │       ├── opening_loc: (16,9)-(16,12) = "%q["
+        │   │   │       ├── parts: (length: 2)
+        │   │   │       │   ├── @ StringNode (location: (16,12)-(16,14))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (16,12)-(16,14) = "f\\"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "f\\\n"
+        │   │   │       │   └── @ StringNode (location: (19,0)-(19,1))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (19,0)-(19,1) = "f"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "f"
+        │   │   │       └── closing_loc: (19,1)-(19,2) = "]"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -131,29 +135,30 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (22,3)-(25,2))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ StringNode (location: (22,3)-(22,7))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (22,3)-(22,7) = "<<-A"
-        │   │       │   ├── content_loc: (23,0)-(23,0) = "g\n"
-        │   │       │   ├── closing_loc: (24,0)-(24,0) = "A\n"
-        │   │       │   └── unescaped: "g\n"
-        │   │       └── @ InterpolatedStringNode (location: (22,9)-(25,2))
-        │   │           ├── opening_loc: (22,9)-(22,12) = "%Q["
-        │   │           ├── parts: (length: 2)
-        │   │           │   ├── @ StringNode (location: (22,12)-(22,14))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (22,12)-(22,14) = "h\\"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "h"
-        │   │           │   └── @ StringNode (location: (25,0)-(25,1))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (25,0)-(25,1) = "h"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "h"
-        │   │           └── closing_loc: (25,1)-(25,2) = "]"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ StringNode (location: (22,3)-(22,7))
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── opening_loc: (22,3)-(22,7) = "<<-A"
+        │   │   │   │   ├── content_loc: (23,0)-(23,0) = "g\n"
+        │   │   │   │   ├── closing_loc: (24,0)-(24,0) = "A\n"
+        │   │   │   │   └── unescaped: "g\n"
+        │   │   │   └── @ InterpolatedStringNode (location: (22,9)-(25,2))
+        │   │   │       ├── opening_loc: (22,9)-(22,12) = "%Q["
+        │   │   │       ├── parts: (length: 2)
+        │   │   │       │   ├── @ StringNode (location: (22,12)-(22,14))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (22,12)-(22,14) = "h\\"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "h"
+        │   │   │       │   └── @ StringNode (location: (25,0)-(25,1))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (25,0)-(25,1) = "h"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "h"
+        │   │   │       └── closing_loc: (25,1)-(25,2) = "]"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -165,29 +170,30 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (28,3)-(31,2))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ StringNode (location: (28,3)-(28,7))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (28,3)-(28,7) = "<<-A"
-        │   │       │   ├── content_loc: (29,0)-(29,0) = "i\n"
-        │   │       │   ├── closing_loc: (30,0)-(30,0) = "A\n"
-        │   │       │   └── unescaped: "i\n"
-        │   │       └── @ ArrayNode (location: (28,9)-(31,2))
-        │   │           ├── elements: (length: 2)
-        │   │           │   ├── @ StringNode (location: (28,12)-(28,14))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (28,12)-(28,14) = "j\\"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "j\n"
-        │   │           │   └── @ StringNode (location: (31,0)-(31,1))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (31,0)-(31,1) = "j"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "j"
-        │   │           ├── opening_loc: (28,9)-(28,12) = "%w["
-        │   │           └── closing_loc: (31,1)-(31,2) = "]"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ StringNode (location: (28,3)-(28,7))
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── opening_loc: (28,3)-(28,7) = "<<-A"
+        │   │   │   │   ├── content_loc: (29,0)-(29,0) = "i\n"
+        │   │   │   │   ├── closing_loc: (30,0)-(30,0) = "A\n"
+        │   │   │   │   └── unescaped: "i\n"
+        │   │   │   └── @ ArrayNode (location: (28,9)-(31,2))
+        │   │   │       ├── elements: (length: 2)
+        │   │   │       │   ├── @ StringNode (location: (28,12)-(28,14))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (28,12)-(28,14) = "j\\"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "j\n"
+        │   │   │       │   └── @ StringNode (location: (31,0)-(31,1))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (31,0)-(31,1) = "j"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "j"
+        │   │   │       ├── opening_loc: (28,9)-(28,12) = "%w["
+        │   │   │       └── closing_loc: (31,1)-(31,2) = "]"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -199,33 +205,34 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (35,3)-(38,2))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ StringNode (location: (35,3)-(35,7))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (35,3)-(35,7) = "<<-A"
-        │   │       │   ├── content_loc: (36,0)-(36,0) = "k\n"
-        │   │       │   ├── closing_loc: (37,0)-(37,0) = "A\n"
-        │   │       │   └── unescaped: "k\n"
-        │   │       └── @ ArrayNode (location: (35,9)-(38,2))
-        │   │           ├── elements: (length: 1)
-        │   │           │   └── @ InterpolatedStringNode (location: (35,12)-(38,1))
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── parts: (length: 2)
-        │   │           │       │   ├── @ StringNode (location: (35,12)-(35,14))
-        │   │           │       │   │   ├── flags: ∅
-        │   │           │       │   │   ├── opening_loc: ∅
-        │   │           │       │   │   ├── content_loc: (35,12)-(35,14) = "l\\"
-        │   │           │       │   │   ├── closing_loc: ∅
-        │   │           │       │   │   └── unescaped: "l\n"
-        │   │           │       │   └── @ StringNode (location: (38,0)-(38,1))
-        │   │           │       │       ├── flags: ∅
-        │   │           │       │       ├── opening_loc: ∅
-        │   │           │       │       ├── content_loc: (38,0)-(38,1) = "l"
-        │   │           │       │       ├── closing_loc: ∅
-        │   │           │       │       └── unescaped: "l"
-        │   │           │       └── closing_loc: ∅
-        │   │           ├── opening_loc: (35,9)-(35,12) = "%W["
-        │   │           └── closing_loc: (38,1)-(38,2) = "]"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ StringNode (location: (35,3)-(35,7))
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── opening_loc: (35,3)-(35,7) = "<<-A"
+        │   │   │   │   ├── content_loc: (36,0)-(36,0) = "k\n"
+        │   │   │   │   ├── closing_loc: (37,0)-(37,0) = "A\n"
+        │   │   │   │   └── unescaped: "k\n"
+        │   │   │   └── @ ArrayNode (location: (35,9)-(38,2))
+        │   │   │       ├── elements: (length: 1)
+        │   │   │       │   └── @ InterpolatedStringNode (location: (35,12)-(38,1))
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── parts: (length: 2)
+        │   │   │       │       │   ├── @ StringNode (location: (35,12)-(35,14))
+        │   │   │       │       │   │   ├── flags: ∅
+        │   │   │       │       │   │   ├── opening_loc: ∅
+        │   │   │       │       │   │   ├── content_loc: (35,12)-(35,14) = "l\\"
+        │   │   │       │       │   │   ├── closing_loc: ∅
+        │   │   │       │       │   │   └── unescaped: "l\n"
+        │   │   │       │       │   └── @ StringNode (location: (38,0)-(38,1))
+        │   │   │       │       │       ├── flags: ∅
+        │   │   │       │       │       ├── opening_loc: ∅
+        │   │   │       │       │       ├── content_loc: (38,0)-(38,1) = "l"
+        │   │   │       │       │       ├── closing_loc: ∅
+        │   │   │       │       │       └── unescaped: "l"
+        │   │   │       │       └── closing_loc: ∅
+        │   │   │       ├── opening_loc: (35,9)-(35,12) = "%W["
+        │   │   │       └── closing_loc: (38,1)-(38,2) = "]"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -237,27 +244,28 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (41,3)-(44,2))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ StringNode (location: (41,3)-(41,7))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (41,3)-(41,7) = "<<-A"
-        │   │       │   ├── content_loc: (42,0)-(42,0) = "m\n"
-        │   │       │   ├── closing_loc: (43,0)-(43,0) = "A\n"
-        │   │       │   └── unescaped: "m\n"
-        │   │       └── @ ArrayNode (location: (41,9)-(44,2))
-        │   │           ├── elements: (length: 2)
-        │   │           │   ├── @ SymbolNode (location: (41,12)-(41,14))
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── value_loc: (41,12)-(41,14) = "n\\"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "n\n"
-        │   │           │   └── @ SymbolNode (location: (44,0)-(44,1))
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── value_loc: (44,0)-(44,1) = "n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "n"
-        │   │           ├── opening_loc: (41,9)-(41,12) = "%i["
-        │   │           └── closing_loc: (44,1)-(44,2) = "]"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ StringNode (location: (41,3)-(41,7))
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── opening_loc: (41,3)-(41,7) = "<<-A"
+        │   │   │   │   ├── content_loc: (42,0)-(42,0) = "m\n"
+        │   │   │   │   ├── closing_loc: (43,0)-(43,0) = "A\n"
+        │   │   │   │   └── unescaped: "m\n"
+        │   │   │   └── @ ArrayNode (location: (41,9)-(44,2))
+        │   │   │       ├── elements: (length: 2)
+        │   │   │       │   ├── @ SymbolNode (location: (41,12)-(41,14))
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── value_loc: (41,12)-(41,14) = "n\\"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "n\n"
+        │   │   │       │   └── @ SymbolNode (location: (44,0)-(44,1))
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── value_loc: (44,0)-(44,1) = "n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "n"
+        │   │   │       ├── opening_loc: (41,9)-(41,12) = "%i["
+        │   │   │       └── closing_loc: (44,1)-(44,2) = "]"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -269,32 +277,33 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (48,3)-(51,2))
-            │   └── arguments: (length: 2)
-            │       ├── @ StringNode (location: (48,3)-(48,7))
-            │       │   ├── flags: ∅
-            │       │   ├── opening_loc: (48,3)-(48,7) = "<<-A"
-            │       │   ├── content_loc: (49,0)-(49,0) = "o\n"
-            │       │   ├── closing_loc: (50,0)-(50,0) = "A\n"
-            │       │   └── unescaped: "o\n"
-            │       └── @ ArrayNode (location: (48,9)-(51,2))
-            │           ├── elements: (length: 1)
-            │           │   └── @ InterpolatedSymbolNode (location: (48,12)-(48,14))
-            │           │       ├── opening_loc: ∅
-            │           │       ├── parts: (length: 2)
-            │           │       │   ├── @ SymbolNode (location: (48,12)-(48,14))
-            │           │       │   │   ├── opening_loc: ∅
-            │           │       │   │   ├── value_loc: (48,12)-(48,14) = "p\\"
-            │           │       │   │   ├── closing_loc: ∅
-            │           │       │   │   └── unescaped: "p\n"
-            │           │       │   └── @ StringNode (location: (48,12)-(48,14))
-            │           │       │       ├── flags: ∅
-            │           │       │       ├── opening_loc: ∅
-            │           │       │       ├── content_loc: (48,12)-(48,14) = "p\\"
-            │           │       │       ├── closing_loc: ∅
-            │           │       │       └── unescaped: "p"
-            │           │       └── closing_loc: ∅
-            │           ├── opening_loc: (48,9)-(48,12) = "%I["
-            │           └── closing_loc: (51,1)-(51,2) = "]"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ StringNode (location: (48,3)-(48,7))
+            │   │   │   ├── flags: ∅
+            │   │   │   ├── opening_loc: (48,3)-(48,7) = "<<-A"
+            │   │   │   ├── content_loc: (49,0)-(49,0) = "o\n"
+            │   │   │   ├── closing_loc: (50,0)-(50,0) = "A\n"
+            │   │   │   └── unescaped: "o\n"
+            │   │   └── @ ArrayNode (location: (48,9)-(51,2))
+            │   │       ├── elements: (length: 1)
+            │   │       │   └── @ InterpolatedSymbolNode (location: (48,12)-(48,14))
+            │   │       │       ├── opening_loc: ∅
+            │   │       │       ├── parts: (length: 2)
+            │   │       │       │   ├── @ SymbolNode (location: (48,12)-(48,14))
+            │   │       │       │   │   ├── opening_loc: ∅
+            │   │       │       │   │   ├── value_loc: (48,12)-(48,14) = "p\\"
+            │   │       │       │   │   ├── closing_loc: ∅
+            │   │       │       │   │   └── unescaped: "p\n"
+            │   │       │       │   └── @ StringNode (location: (48,12)-(48,14))
+            │   │       │       │       ├── flags: ∅
+            │   │       │       │       ├── opening_loc: ∅
+            │   │       │       │       ├── content_loc: (48,12)-(48,14) = "p\\"
+            │   │       │       │       ├── closing_loc: ∅
+            │   │       │       │       └── unescaped: "p"
+            │   │       │       └── closing_loc: ∅
+            │   │       ├── opening_loc: (48,9)-(48,12) = "%I["
+            │   │       └── closing_loc: (51,1)-(51,2) = "]"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/strings.txt
+++ b/test/prism/snapshots/strings.txt
@@ -157,13 +157,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (41,0)-(41,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (41,0)-(41,5))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (41,0)-(41,1) = "\""
-        │   │           ├── content_loc: (41,1)-(41,4) = "bar"
-        │   │           ├── closing_loc: (41,4)-(41,5) = "\""
-        │   │           └── unescaped: "bar"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (41,0)-(41,5))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (41,0)-(41,1) = "\""
+        │   │   │       ├── content_loc: (41,1)-(41,4) = "bar"
+        │   │   │       ├── closing_loc: (41,4)-(41,5) = "\""
+        │   │   │       └── unescaped: "bar"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/super.txt
+++ b/test/prism/snapshots/super.txt
@@ -16,9 +16,10 @@
         │   ├── lparen_loc: (5,5)-(5,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,6)-(5,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (5,6)-(5,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (5,6)-(5,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── rparen_loc: (5,7)-(5,8) = ")"
         │   └── block: ∅
         ├── @ SuperNode (location: (7,0)-(7,14))
@@ -26,13 +27,14 @@
         │   ├── lparen_loc: (7,5)-(7,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,6)-(7,13))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ IntegerNode (location: (7,6)-(7,7))
-        │   │       │   └── flags: decimal
-        │   │       ├── @ IntegerNode (location: (7,9)-(7,10))
-        │   │       │   └── flags: decimal
-        │   │       └── @ IntegerNode (location: (7,12)-(7,13))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ IntegerNode (location: (7,6)-(7,7))
+        │   │   │   │   └── flags: decimal
+        │   │   │   ├── @ IntegerNode (location: (7,9)-(7,10))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ IntegerNode (location: (7,12)-(7,13))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── rparen_loc: (7,13)-(7,14) = ")"
         │   └── block: ∅
         ├── @ SuperNode (location: (9,0)-(9,11))
@@ -76,13 +78,14 @@
         │   ├── lparen_loc: (15,5)-(15,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (15,6)-(15,13))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ IntegerNode (location: (15,6)-(15,7))
-        │   │       │   └── flags: decimal
-        │   │       ├── @ IntegerNode (location: (15,9)-(15,10))
-        │   │       │   └── flags: decimal
-        │   │       └── @ IntegerNode (location: (15,12)-(15,13))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ IntegerNode (location: (15,6)-(15,7))
+        │   │   │   │   └── flags: decimal
+        │   │   │   ├── @ IntegerNode (location: (15,9)-(15,10))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ IntegerNode (location: (15,12)-(15,13))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── rparen_loc: (15,13)-(15,14) = ")"
         │   └── block:
         │       @ BlockNode (location: (15,15)-(15,17))
@@ -96,13 +99,14 @@
             ├── lparen_loc: (17,5)-(17,6) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (17,6)-(17,13))
-            │   └── arguments: (length: 3)
-            │       ├── @ IntegerNode (location: (17,6)-(17,7))
-            │       │   └── flags: decimal
-            │       ├── @ IntegerNode (location: (17,9)-(17,10))
-            │       │   └── flags: decimal
-            │       └── @ IntegerNode (location: (17,12)-(17,13))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 3)
+            │   │   ├── @ IntegerNode (location: (17,6)-(17,7))
+            │   │   │   └── flags: decimal
+            │   │   ├── @ IntegerNode (location: (17,9)-(17,10))
+            │   │   │   └── flags: decimal
+            │   │   └── @ IntegerNode (location: (17,12)-(17,13))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── rparen_loc: (17,20)-(17,21) = ")"
             └── block:
                 @ BlockArgumentNode (location: (17,15)-(17,20))

--- a/test/prism/snapshots/unless.txt
+++ b/test/prism/snapshots/unless.txt
@@ -103,17 +103,18 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (14,4)-(14,10))
-            │           │   └── arguments: (length: 2)
-            │           │       ├── @ SymbolNode (location: (14,4)-(14,6))
-            │           │       │   ├── opening_loc: (14,4)-(14,5) = ":"
-            │           │       │   ├── value_loc: (14,5)-(14,6) = "a"
-            │           │       │   ├── closing_loc: ∅
-            │           │       │   └── unescaped: "a"
-            │           │       └── @ SymbolNode (location: (14,8)-(14,10))
-            │           │           ├── opening_loc: (14,8)-(14,9) = ":"
-            │           │           ├── value_loc: (14,9)-(14,10) = "b"
-            │           │           ├── closing_loc: ∅
-            │           │           └── unescaped: "b"
+            │           │   ├── arguments: (length: 2)
+            │           │   │   ├── @ SymbolNode (location: (14,4)-(14,6))
+            │           │   │   │   ├── opening_loc: (14,4)-(14,5) = ":"
+            │           │   │   │   ├── value_loc: (14,5)-(14,6) = "a"
+            │           │   │   │   ├── closing_loc: ∅
+            │           │   │   │   └── unescaped: "a"
+            │           │   │   └── @ SymbolNode (location: (14,8)-(14,10))
+            │           │   │       ├── opening_loc: (14,8)-(14,9) = ":"
+            │           │   │       ├── value_loc: (14,9)-(14,10) = "b"
+            │           │   │       ├── closing_loc: ∅
+            │           │   │       └── unescaped: "b"
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/assignment.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/assignment.txt
@@ -299,13 +299,14 @@
         │   │   │   ├── opening_loc: (15,2)-(15,3) = "["
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (15,3)-(15,7))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ SplatNode (location: (15,3)-(15,7))
-        │   │   │   │           ├── operator_loc: (15,3)-(15,4) = "*"
-        │   │   │   │           └── expression:
-        │   │   │   │               @ LocalVariableReadNode (location: (15,4)-(15,7))
-        │   │   │   │               ├── name: :foo
-        │   │   │   │               └── depth: 0
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ SplatNode (location: (15,3)-(15,7))
+        │   │   │   │   │       ├── operator_loc: (15,3)-(15,4) = "*"
+        │   │   │   │   │       └── expression:
+        │   │   │   │   │           @ LocalVariableReadNode (location: (15,4)-(15,7))
+        │   │   │   │   │           ├── name: :foo
+        │   │   │   │   │           └── depth: 0
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: (15,7)-(15,8) = "]"
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅
@@ -320,9 +321,10 @@
         │   │       ├── opening_loc: (15,11)-(15,12) = "["
         │   │       ├── arguments:
         │   │       │   @ ArgumentsNode (location: (15,12)-(15,13))
-        │   │       │   └── arguments: (length: 1)
-        │   │       │       └── @ IntegerNode (location: (15,12)-(15,13))
-        │   │       │           └── flags: decimal
+        │   │       │   ├── arguments: (length: 1)
+        │   │       │   │   └── @ IntegerNode (location: (15,12)-(15,13))
+        │   │       │   │       └── flags: decimal
+        │   │       │   └── flags: ∅
         │   │       ├── closing_loc: (15,13)-(15,14) = "]"
         │   │       ├── block: ∅
         │   │       ├── flags: ∅
@@ -351,9 +353,10 @@
         │   │   │   ├── opening_loc: (16,2)-(16,3) = "["
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (16,3)-(16,4))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ IntegerNode (location: (16,3)-(16,4))
-        │   │   │   │           └── flags: decimal
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ IntegerNode (location: (16,3)-(16,4))
+        │   │   │   │   │       └── flags: decimal
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: (16,4)-(16,5) = "]"
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅
@@ -368,9 +371,10 @@
         │   │       ├── opening_loc: (16,8)-(16,9) = "["
         │   │       ├── arguments:
         │   │       │   @ ArgumentsNode (location: (16,9)-(16,10))
-        │   │       │   └── arguments: (length: 1)
-        │   │       │       └── @ IntegerNode (location: (16,9)-(16,10))
-        │   │       │           └── flags: decimal
+        │   │       │   ├── arguments: (length: 1)
+        │   │       │   │   └── @ IntegerNode (location: (16,9)-(16,10))
+        │   │       │   │       └── flags: decimal
+        │   │       │   └── flags: ∅
         │   │       ├── closing_loc: (16,10)-(16,11) = "]"
         │   │       ├── block: ∅
         │   │       ├── flags: ∅
@@ -541,11 +545,12 @@
         │   ├── opening_loc: (27,7)-(27,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (27,8)-(27,12))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ IntegerNode (location: (27,8)-(27,9))
-        │   │       │   └── flags: decimal
-        │   │       └── @ IntegerNode (location: (27,11)-(27,12))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ IntegerNode (location: (27,8)-(27,9))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ IntegerNode (location: (27,11)-(27,12))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (27,12)-(27,13) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -560,8 +565,9 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (28,7)-(28,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ TrueNode (location: (28,7)-(28,11))
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ TrueNode (location: (28,7)-(28,11))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -576,30 +582,31 @@
         │   ├── opening_loc: (29,3)-(29,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (29,4)-(29,19))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SplatNode (location: (29,4)-(29,10))
-        │   │       │   ├── operator_loc: (29,4)-(29,5) = "*"
-        │   │       │   └── expression:
-        │   │       │       @ CallNode (location: (29,5)-(29,10))
-        │   │       │       ├── receiver: ∅
-        │   │       │       ├── call_operator_loc: ∅
-        │   │       │       ├── message_loc: (29,5)-(29,10) = "index"
-        │   │       │       ├── opening_loc: ∅
-        │   │       │       ├── arguments: ∅
-        │   │       │       ├── closing_loc: ∅
-        │   │       │       ├── block: ∅
-        │   │       │       ├── flags: variable_call
-        │   │       │       └── name: :index
-        │   │       └── @ CallNode (location: (29,14)-(29,19))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (29,14)-(29,19) = "value"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :value
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SplatNode (location: (29,4)-(29,10))
+        │   │   │   │   ├── operator_loc: (29,4)-(29,5) = "*"
+        │   │   │   │   └── expression:
+        │   │   │   │       @ CallNode (location: (29,5)-(29,10))
+        │   │   │   │       ├── receiver: ∅
+        │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │       ├── message_loc: (29,5)-(29,10) = "index"
+        │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │       ├── arguments: ∅
+        │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │       ├── block: ∅
+        │   │   │   │       ├── flags: variable_call
+        │   │   │   │       └── name: :index
+        │   │   │   └── @ CallNode (location: (29,14)-(29,19))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (29,14)-(29,19) = "value"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :value
+        │   │   └── flags: ∅
         │   ├── closing_loc: (29,10)-(29,11) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -614,26 +621,27 @@
         │   ├── opening_loc: (30,3)-(30,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (30,4)-(30,17))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ RangeNode (location: (30,4)-(30,8))
-        │   │       │   ├── left:
-        │   │       │   │   @ IntegerNode (location: (30,4)-(30,5))
-        │   │       │   │   └── flags: decimal
-        │   │       │   ├── right:
-        │   │       │   │   @ IntegerNode (location: (30,7)-(30,8))
-        │   │       │   │   └── flags: decimal
-        │   │       │   ├── operator_loc: (30,5)-(30,7) = ".."
-        │   │       │   └── flags: ∅
-        │   │       └── @ CallNode (location: (30,12)-(30,17))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (30,12)-(30,17) = "value"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :value
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ RangeNode (location: (30,4)-(30,8))
+        │   │   │   │   ├── left:
+        │   │   │   │   │   @ IntegerNode (location: (30,4)-(30,5))
+        │   │   │   │   │   └── flags: decimal
+        │   │   │   │   ├── right:
+        │   │   │   │   │   @ IntegerNode (location: (30,7)-(30,8))
+        │   │   │   │   │   └── flags: decimal
+        │   │   │   │   ├── operator_loc: (30,5)-(30,7) = ".."
+        │   │   │   │   └── flags: ∅
+        │   │   │   └── @ CallNode (location: (30,12)-(30,17))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (30,12)-(30,17) = "value"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :value
+        │   │   └── flags: ∅
         │   ├── closing_loc: (30,8)-(30,9) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -648,9 +656,10 @@
         │   ├── opening_loc: (31,3)-(31,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (31,8)-(31,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (31,8)-(31,9))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (31,8)-(31,9))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (31,4)-(31,5) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -665,23 +674,24 @@
         │   ├── opening_loc: (32,3)-(32,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (32,4)-(32,17))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ LocalVariableReadNode (location: (32,4)-(32,5))
-        │   │       │   ├── name: :a
-        │   │       │   └── depth: 0
-        │   │       ├── @ LocalVariableReadNode (location: (32,7)-(32,8))
-        │   │       │   ├── name: :b
-        │   │       │   └── depth: 0
-        │   │       └── @ CallNode (location: (32,12)-(32,17))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (32,12)-(32,17) = "value"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :value
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ LocalVariableReadNode (location: (32,4)-(32,5))
+        │   │   │   │   ├── name: :a
+        │   │   │   │   └── depth: 0
+        │   │   │   ├── @ LocalVariableReadNode (location: (32,7)-(32,8))
+        │   │   │   │   ├── name: :b
+        │   │   │   │   └── depth: 0
+        │   │   │   └── @ CallNode (location: (32,12)-(32,17))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (32,12)-(32,17) = "value"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :value
+        │   │   └── flags: ∅
         │   ├── closing_loc: (32,8)-(32,9) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -696,27 +706,28 @@
         │   ├── opening_loc: (33,3)-(33,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (33,4)-(33,18))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (33,4)-(33,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (33,4)-(33,9) = "index"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :index
-        │   │       └── @ CallNode (location: (33,13)-(33,18))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (33,13)-(33,18) = "value"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :value
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (33,4)-(33,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (33,4)-(33,9) = "index"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :index
+        │   │   │   └── @ CallNode (location: (33,13)-(33,18))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (33,13)-(33,18) = "value"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :value
+        │   │   └── flags: ∅
         │   ├── closing_loc: (33,9)-(33,10) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -743,13 +754,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (35,4)-(35,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (35,4)-(35,7))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (35,4)-(35,6) = "%("
-        │   │           ├── content_loc: (35,6)-(35,6) = ""
-        │   │           ├── closing_loc: (35,6)-(35,7) = ")"
-        │   │           └── unescaped: ""
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (35,4)-(35,7))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (35,4)-(35,6) = "%("
+        │   │   │       ├── content_loc: (35,6)-(35,6) = ""
+        │   │   │       ├── closing_loc: (35,6)-(35,7) = ")"
+        │   │   │       └── unescaped: ""
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -764,23 +776,24 @@
         │   ├── opening_loc: (36,1)-(36,2) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (36,2)-(36,12))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ StringNode (location: (36,2)-(36,5))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (36,2)-(36,4) = "%("
-        │   │       │   ├── content_loc: (36,4)-(36,4) = ""
-        │   │       │   ├── closing_loc: (36,4)-(36,5) = ")"
-        │   │       │   └── unescaped: ""
-        │   │       └── @ CallNode (location: (36,9)-(36,12))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (36,9)-(36,12) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ StringNode (location: (36,2)-(36,5))
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── opening_loc: (36,2)-(36,4) = "%("
+        │   │   │   │   ├── content_loc: (36,4)-(36,4) = ""
+        │   │   │   │   ├── closing_loc: (36,4)-(36,5) = ")"
+        │   │   │   │   └── unescaped: ""
+        │   │   │   └── @ CallNode (location: (36,9)-(36,12))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (36,9)-(36,12) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (36,5)-(36,6) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -794,13 +807,14 @@
         │   ├── opening_loc: (37,1)-(37,2) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (37,2)-(37,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (37,2)-(37,5))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (37,2)-(37,4) = "%("
-        │   │           ├── content_loc: (37,4)-(37,4) = ""
-        │   │           ├── closing_loc: (37,4)-(37,5) = ")"
-        │   │           └── unescaped: ""
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (37,2)-(37,5))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (37,2)-(37,4) = "%("
+        │   │   │       ├── content_loc: (37,4)-(37,4) = ""
+        │   │   │       ├── closing_loc: (37,4)-(37,5) = ")"
+        │   │   │       └── unescaped: ""
+        │   │   └── flags: ∅
         │   ├── closing_loc: (37,5)-(37,6) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -863,27 +877,28 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (42,4)-(42,14))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (42,4)-(42,14))
-        │   │           ├── opening_loc: (42,4)-(42,14) = "<<-HEREDOC"
-        │   │           ├── parts: (length: 3)
-        │   │           │   ├── @ StringNode (location: (43,0)-(43,2))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (43,0)-(43,2) = "  "
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "  "
-        │   │           │   ├── @ EmbeddedStatementsNode (location: (43,2)-(43,5))
-        │   │           │   │   ├── opening_loc: (43,2)-(43,4) = "\#{"
-        │   │           │   │   ├── statements: ∅
-        │   │           │   │   └── closing_loc: (43,4)-(43,5) = "}"
-        │   │           │   └── @ StringNode (location: (43,5)-(43,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (43,5)-(43,0) = "\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "\n"
-        │   │           └── closing_loc: (44,0)-(44,0) = "HEREDOC\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (42,4)-(42,14))
+        │   │   │       ├── opening_loc: (42,4)-(42,14) = "<<-HEREDOC"
+        │   │   │       ├── parts: (length: 3)
+        │   │   │       │   ├── @ StringNode (location: (43,0)-(43,2))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (43,0)-(43,2) = "  "
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "  "
+        │   │   │       │   ├── @ EmbeddedStatementsNode (location: (43,2)-(43,5))
+        │   │   │       │   │   ├── opening_loc: (43,2)-(43,4) = "\#{"
+        │   │   │       │   │   ├── statements: ∅
+        │   │   │       │   │   └── closing_loc: (43,4)-(43,5) = "}"
+        │   │   │       │   └── @ StringNode (location: (43,5)-(43,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (43,5)-(43,0) = "\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "\n"
+        │   │   │       └── closing_loc: (44,0)-(44,0) = "HEREDOC\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -898,27 +913,28 @@
         │   ├── opening_loc: (45,1)-(45,2) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (45,6)-(45,16))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (45,6)-(45,16))
-        │   │           ├── opening_loc: (45,6)-(45,16) = "<<-HEREDOC"
-        │   │           ├── parts: (length: 3)
-        │   │           │   ├── @ StringNode (location: (46,0)-(46,2))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (46,0)-(46,2) = "  "
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "  "
-        │   │           │   ├── @ EmbeddedStatementsNode (location: (46,2)-(46,5))
-        │   │           │   │   ├── opening_loc: (46,2)-(46,4) = "\#{"
-        │   │           │   │   ├── statements: ∅
-        │   │           │   │   └── closing_loc: (46,4)-(46,5) = "}"
-        │   │           │   └── @ StringNode (location: (46,5)-(46,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (46,5)-(46,0) = "\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "\n"
-        │   │           └── closing_loc: (47,0)-(47,0) = "HEREDOC\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (45,6)-(45,16))
+        │   │   │       ├── opening_loc: (45,6)-(45,16) = "<<-HEREDOC"
+        │   │   │       ├── parts: (length: 3)
+        │   │   │       │   ├── @ StringNode (location: (46,0)-(46,2))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (46,0)-(46,2) = "  "
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "  "
+        │   │   │       │   ├── @ EmbeddedStatementsNode (location: (46,2)-(46,5))
+        │   │   │       │   │   ├── opening_loc: (46,2)-(46,4) = "\#{"
+        │   │   │       │   │   ├── statements: ∅
+        │   │   │       │   │   └── closing_loc: (46,4)-(46,5) = "}"
+        │   │   │       │   └── @ StringNode (location: (46,5)-(46,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (46,5)-(46,0) = "\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "\n"
+        │   │   │       └── closing_loc: (47,0)-(47,0) = "HEREDOC\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (45,2)-(45,3) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -932,27 +948,28 @@
         │   ├── opening_loc: (48,1)-(48,2) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (48,2)-(48,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (48,2)-(48,12))
-        │   │           ├── opening_loc: (48,2)-(48,12) = "<<-HEREDOC"
-        │   │           ├── parts: (length: 3)
-        │   │           │   ├── @ StringNode (location: (49,0)-(49,2))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (49,0)-(49,2) = "  "
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "  "
-        │   │           │   ├── @ EmbeddedStatementsNode (location: (49,2)-(49,5))
-        │   │           │   │   ├── opening_loc: (49,2)-(49,4) = "\#{"
-        │   │           │   │   ├── statements: ∅
-        │   │           │   │   └── closing_loc: (49,4)-(49,5) = "}"
-        │   │           │   └── @ StringNode (location: (49,5)-(49,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (49,5)-(49,0) = "\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "\n"
-        │   │           └── closing_loc: (50,0)-(50,0) = "HEREDOC\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (48,2)-(48,12))
+        │   │   │       ├── opening_loc: (48,2)-(48,12) = "<<-HEREDOC"
+        │   │   │       ├── parts: (length: 3)
+        │   │   │       │   ├── @ StringNode (location: (49,0)-(49,2))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (49,0)-(49,2) = "  "
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "  "
+        │   │   │       │   ├── @ EmbeddedStatementsNode (location: (49,2)-(49,5))
+        │   │   │       │   │   ├── opening_loc: (49,2)-(49,4) = "\#{"
+        │   │   │       │   │   ├── statements: ∅
+        │   │   │       │   │   └── closing_loc: (49,4)-(49,5) = "}"
+        │   │   │       │   └── @ StringNode (location: (49,5)-(49,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (49,5)-(49,0) = "\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "\n"
+        │   │   │       └── closing_loc: (50,0)-(50,0) = "HEREDOC\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (48,12)-(48,13) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/block.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/block.txt
@@ -162,9 +162,10 @@
         │   ├── opening_loc: (11,3)-(11,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (11,4)-(11,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (11,4)-(11,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (11,4)-(11,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (11,5)-(11,6) = ")"
         │   ├── block:
         │   │   @ BlockNode (location: (11,7)-(13,1))
@@ -1352,10 +1353,11 @@
             │   │           ├── opening_loc: ∅
             │   │           ├── arguments:
             │   │           │   @ ArgumentsNode (location: (95,7)-(95,9))
-            │   │           │   └── arguments: (length: 1)
-            │   │           │       └── @ LocalVariableReadNode (location: (95,7)-(95,9))
-            │   │           │           ├── name: :_2
-            │   │           │           └── depth: 0
+            │   │           │   ├── arguments: (length: 1)
+            │   │           │   │   └── @ LocalVariableReadNode (location: (95,7)-(95,9))
+            │   │           │   │       ├── name: :_2
+            │   │           │   │       └── depth: 0
+            │   │           │   └── flags: ∅
             │   │           ├── closing_loc: ∅
             │   │           ├── block: ∅
             │   │           ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/case.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/case.txt
@@ -361,17 +361,18 @@
         │   │       │           ├── opening_loc: ∅
         │   │       │           ├── arguments:
         │   │       │           │   @ ArgumentsNode (location: (33,12)-(33,15))
-        │   │       │           │   └── arguments: (length: 1)
-        │   │       │           │       └── @ CallNode (location: (33,12)-(33,15))
-        │   │       │           │           ├── receiver: ∅
-        │   │       │           │           ├── call_operator_loc: ∅
-        │   │       │           │           ├── message_loc: (33,12)-(33,15) = "baz"
-        │   │       │           │           ├── opening_loc: ∅
-        │   │       │           │           ├── arguments: ∅
-        │   │       │           │           ├── closing_loc: ∅
-        │   │       │           │           ├── block: ∅
-        │   │       │           │           ├── flags: variable_call
-        │   │       │           │           └── name: :baz
+        │   │       │           │   ├── arguments: (length: 1)
+        │   │       │           │   │   └── @ CallNode (location: (33,12)-(33,15))
+        │   │       │           │   │       ├── receiver: ∅
+        │   │       │           │   │       ├── call_operator_loc: ∅
+        │   │       │           │   │       ├── message_loc: (33,12)-(33,15) = "baz"
+        │   │       │           │   │       ├── opening_loc: ∅
+        │   │       │           │   │       ├── arguments: ∅
+        │   │       │           │   │       ├── closing_loc: ∅
+        │   │       │           │   │       ├── block: ∅
+        │   │       │           │   │       ├── flags: variable_call
+        │   │       │           │   │       └── name: :baz
+        │   │       │           │   └── flags: ∅
         │   │       │           ├── closing_loc: ∅
         │   │       │           ├── block: ∅
         │   │       │           ├── flags: ∅
@@ -416,9 +417,10 @@
             │       │           ├── opening_loc: ∅
             │       │           ├── arguments:
             │       │           │   @ ArgumentsNode (location: (36,14)-(36,15))
-            │       │           │   └── arguments: (length: 1)
-            │       │           │       └── @ IntegerNode (location: (36,14)-(36,15))
-            │       │           │           └── flags: decimal
+            │       │           │   ├── arguments: (length: 1)
+            │       │           │   │   └── @ IntegerNode (location: (36,14)-(36,15))
+            │       │           │   │       └── flags: decimal
+            │       │           │   └── flags: ∅
             │       │           ├── closing_loc: ∅
             │       │           ├── block: ∅
             │       │           ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/class.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/class.txt
@@ -175,19 +175,20 @@
         │   │       │   ├── opening_loc: (27,9)-(27,10) = "("
         │   │       │   ├── arguments:
         │   │       │   │   @ ArgumentsNode (location: (27,10)-(27,15))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (27,10)-(27,15))
-        │   │       │   │           ├── receiver:
-        │   │       │   │           │   @ ConstantReadNode (location: (27,10)-(27,11))
-        │   │       │   │           │   └── name: :B
-        │   │       │   │           ├── call_operator_loc: (27,11)-(27,12) = "."
-        │   │       │   │           ├── message_loc: (27,12)-(27,15) = "new"
-        │   │       │   │           ├── opening_loc: ∅
-        │   │       │   │           ├── arguments: ∅
-        │   │       │   │           ├── closing_loc: ∅
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :new
+        │   │       │   │   ├── arguments: (length: 1)
+        │   │       │   │   │   └── @ CallNode (location: (27,10)-(27,15))
+        │   │       │   │   │       ├── receiver:
+        │   │       │   │   │       │   @ ConstantReadNode (location: (27,10)-(27,11))
+        │   │       │   │   │       │   └── name: :B
+        │   │       │   │   │       ├── call_operator_loc: (27,11)-(27,12) = "."
+        │   │       │   │   │       ├── message_loc: (27,12)-(27,15) = "new"
+        │   │       │   │   │       ├── opening_loc: ∅
+        │   │       │   │   │       ├── arguments: ∅
+        │   │       │   │   │       ├── closing_loc: ∅
+        │   │       │   │   │       ├── block: ∅
+        │   │       │   │   │       ├── flags: ∅
+        │   │       │   │   │       └── name: :new
+        │   │       │   │   └── flags: ∅
         │   │       │   ├── closing_loc: (27,15)-(27,16) = ")"
         │   │       │   ├── block: ∅
         │   │       │   ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/control.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/control.txt
@@ -18,112 +18,118 @@
         │   ├── keyword_loc: (6,0)-(6,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (6,7)-(6,8))
-        │       └── arguments: (length: 1)
-        │           └── @ IntegerNode (location: (6,7)-(6,8))
-        │               └── flags: decimal
+        │       ├── arguments: (length: 1)
+        │       │   └── @ IntegerNode (location: (6,7)-(6,8))
+        │       │       └── flags: decimal
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (7,0)-(7,11))
         │   ├── keyword_loc: (7,0)-(7,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (7,7)-(7,11))
-        │       └── arguments: (length: 2)
-        │           ├── @ IntegerNode (location: (7,7)-(7,8))
-        │           │   └── flags: decimal
-        │           └── @ IntegerNode (location: (7,10)-(7,11))
-        │               └── flags: decimal
+        │       ├── arguments: (length: 2)
+        │       │   ├── @ IntegerNode (location: (7,7)-(7,8))
+        │       │   │   └── flags: decimal
+        │       │   └── @ IntegerNode (location: (7,10)-(7,11))
+        │       │       └── flags: decimal
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (8,0)-(8,19))
         │   ├── keyword_loc: (8,0)-(8,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (8,7)-(8,19))
-        │       └── arguments: (length: 1)
-        │           └── @ IfNode (location: (8,7)-(8,19))
-        │               ├── if_keyword_loc: ∅
-        │               ├── predicate:
-        │               │   @ TrueNode (location: (8,7)-(8,11))
-        │               ├── statements:
-        │               │   @ StatementsNode (location: (8,14)-(8,15))
-        │               │   └── body: (length: 1)
-        │               │       └── @ IntegerNode (location: (8,14)-(8,15))
-        │               │           └── flags: decimal
-        │               ├── consequent:
-        │               │   @ ElseNode (location: (8,16)-(8,19))
-        │               │   ├── else_keyword_loc: (8,16)-(8,17) = ":"
-        │               │   ├── statements:
-        │               │   │   @ StatementsNode (location: (8,18)-(8,19))
-        │               │   │   └── body: (length: 1)
-        │               │   │       └── @ IntegerNode (location: (8,18)-(8,19))
-        │               │   │           └── flags: decimal
-        │               │   └── end_keyword_loc: ∅
-        │               └── end_keyword_loc: ∅
+        │       ├── arguments: (length: 1)
+        │       │   └── @ IfNode (location: (8,7)-(8,19))
+        │       │       ├── if_keyword_loc: ∅
+        │       │       ├── predicate:
+        │       │       │   @ TrueNode (location: (8,7)-(8,11))
+        │       │       ├── statements:
+        │       │       │   @ StatementsNode (location: (8,14)-(8,15))
+        │       │       │   └── body: (length: 1)
+        │       │       │       └── @ IntegerNode (location: (8,14)-(8,15))
+        │       │       │           └── flags: decimal
+        │       │       ├── consequent:
+        │       │       │   @ ElseNode (location: (8,16)-(8,19))
+        │       │       │   ├── else_keyword_loc: (8,16)-(8,17) = ":"
+        │       │       │   ├── statements:
+        │       │       │   │   @ StatementsNode (location: (8,18)-(8,19))
+        │       │       │   │   └── body: (length: 1)
+        │       │       │   │       └── @ IntegerNode (location: (8,18)-(8,19))
+        │       │       │   │           └── flags: decimal
+        │       │       │   └── end_keyword_loc: ∅
+        │       │       └── end_keyword_loc: ∅
+        │       └── flags: ∅
         ├── @ BreakNode (location: (9,0)-(9,18))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (9,6)-(9,18))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IfNode (location: (9,6)-(9,18))
-        │   │           ├── if_keyword_loc: ∅
-        │   │           ├── predicate:
-        │   │           │   @ TrueNode (location: (9,6)-(9,10))
-        │   │           ├── statements:
-        │   │           │   @ StatementsNode (location: (9,13)-(9,14))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (9,13)-(9,14))
-        │   │           │           └── flags: decimal
-        │   │           ├── consequent:
-        │   │           │   @ ElseNode (location: (9,15)-(9,18))
-        │   │           │   ├── else_keyword_loc: (9,15)-(9,16) = ":"
-        │   │           │   ├── statements:
-        │   │           │   │   @ StatementsNode (location: (9,17)-(9,18))
-        │   │           │   │   └── body: (length: 1)
-        │   │           │   │       └── @ IntegerNode (location: (9,17)-(9,18))
-        │   │           │   │           └── flags: decimal
-        │   │           │   └── end_keyword_loc: ∅
-        │   │           └── end_keyword_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IfNode (location: (9,6)-(9,18))
+        │   │   │       ├── if_keyword_loc: ∅
+        │   │   │       ├── predicate:
+        │   │   │       │   @ TrueNode (location: (9,6)-(9,10))
+        │   │   │       ├── statements:
+        │   │   │       │   @ StatementsNode (location: (9,13)-(9,14))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ IntegerNode (location: (9,13)-(9,14))
+        │   │   │       │           └── flags: decimal
+        │   │   │       ├── consequent:
+        │   │   │       │   @ ElseNode (location: (9,15)-(9,18))
+        │   │   │       │   ├── else_keyword_loc: (9,15)-(9,16) = ":"
+        │   │   │       │   ├── statements:
+        │   │   │       │   │   @ StatementsNode (location: (9,17)-(9,18))
+        │   │   │       │   │   └── body: (length: 1)
+        │   │   │       │   │       └── @ IntegerNode (location: (9,17)-(9,18))
+        │   │   │       │   │           └── flags: decimal
+        │   │   │       │   └── end_keyword_loc: ∅
+        │   │   │       └── end_keyword_loc: ∅
+        │   │   └── flags: ∅
         │   └── keyword_loc: (9,0)-(9,5) = "break"
         ├── @ NextNode (location: (10,0)-(10,17))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (10,5)-(10,17))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IfNode (location: (10,5)-(10,17))
-        │   │           ├── if_keyword_loc: ∅
-        │   │           ├── predicate:
-        │   │           │   @ TrueNode (location: (10,5)-(10,9))
-        │   │           ├── statements:
-        │   │           │   @ StatementsNode (location: (10,12)-(10,13))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (10,12)-(10,13))
-        │   │           │           └── flags: decimal
-        │   │           ├── consequent:
-        │   │           │   @ ElseNode (location: (10,14)-(10,17))
-        │   │           │   ├── else_keyword_loc: (10,14)-(10,15) = ":"
-        │   │           │   ├── statements:
-        │   │           │   │   @ StatementsNode (location: (10,16)-(10,17))
-        │   │           │   │   └── body: (length: 1)
-        │   │           │   │       └── @ IntegerNode (location: (10,16)-(10,17))
-        │   │           │   │           └── flags: decimal
-        │   │           │   └── end_keyword_loc: ∅
-        │   │           └── end_keyword_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IfNode (location: (10,5)-(10,17))
+        │   │   │       ├── if_keyword_loc: ∅
+        │   │   │       ├── predicate:
+        │   │   │       │   @ TrueNode (location: (10,5)-(10,9))
+        │   │   │       ├── statements:
+        │   │   │       │   @ StatementsNode (location: (10,12)-(10,13))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ IntegerNode (location: (10,12)-(10,13))
+        │   │   │       │           └── flags: decimal
+        │   │   │       ├── consequent:
+        │   │   │       │   @ ElseNode (location: (10,14)-(10,17))
+        │   │   │       │   ├── else_keyword_loc: (10,14)-(10,15) = ":"
+        │   │   │       │   ├── statements:
+        │   │   │       │   │   @ StatementsNode (location: (10,16)-(10,17))
+        │   │   │       │   │   └── body: (length: 1)
+        │   │   │       │   │       └── @ IntegerNode (location: (10,16)-(10,17))
+        │   │   │       │   │           └── flags: decimal
+        │   │   │       │   └── end_keyword_loc: ∅
+        │   │   │       └── end_keyword_loc: ∅
+        │   │   └── flags: ∅
         │   └── keyword_loc: (10,0)-(10,4) = "next"
         └── @ ReturnNode (location: (11,0)-(15,3))
             ├── keyword_loc: (11,0)-(11,6) = "return"
             └── arguments:
                 @ ArgumentsNode (location: (11,7)-(15,3))
-                └── arguments: (length: 2)
-                    ├── @ TrueNode (location: (11,7)-(11,11))
-                    └── @ IfNode (location: (11,13)-(15,3))
-                        ├── if_keyword_loc: (11,13)-(11,15) = "if"
-                        ├── predicate:
-                        │   @ TrueNode (location: (11,16)-(11,20))
-                        ├── statements:
-                        │   @ StatementsNode (location: (12,2)-(12,3))
-                        │   └── body: (length: 1)
-                        │       └── @ IntegerNode (location: (12,2)-(12,3))
-                        │           └── flags: decimal
-                        ├── consequent:
-                        │   @ ElseNode (location: (13,0)-(15,3))
-                        │   ├── else_keyword_loc: (13,0)-(13,4) = "else"
-                        │   ├── statements:
-                        │   │   @ StatementsNode (location: (14,2)-(14,3))
-                        │   │   └── body: (length: 1)
-                        │   │       └── @ IntegerNode (location: (14,2)-(14,3))
-                        │   │           └── flags: decimal
-                        │   └── end_keyword_loc: (15,0)-(15,3) = "end"
-                        └── end_keyword_loc: (15,0)-(15,3) = "end"
+                ├── arguments: (length: 2)
+                │   ├── @ TrueNode (location: (11,7)-(11,11))
+                │   └── @ IfNode (location: (11,13)-(15,3))
+                │       ├── if_keyword_loc: (11,13)-(11,15) = "if"
+                │       ├── predicate:
+                │       │   @ TrueNode (location: (11,16)-(11,20))
+                │       ├── statements:
+                │       │   @ StatementsNode (location: (12,2)-(12,3))
+                │       │   └── body: (length: 1)
+                │       │       └── @ IntegerNode (location: (12,2)-(12,3))
+                │       │           └── flags: decimal
+                │       ├── consequent:
+                │       │   @ ElseNode (location: (13,0)-(15,3))
+                │       │   ├── else_keyword_loc: (13,0)-(13,4) = "else"
+                │       │   ├── statements:
+                │       │   │   @ StatementsNode (location: (14,2)-(14,3))
+                │       │   │   └── body: (length: 1)
+                │       │   │       └── @ IntegerNode (location: (14,2)-(14,3))
+                │       │   │           └── flags: decimal
+                │       │   └── end_keyword_loc: (15,0)-(15,3) = "end"
+                │       └── end_keyword_loc: (15,0)-(15,3) = "end"
+                └── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/defs.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/defs.txt
@@ -179,9 +179,10 @@
         │   │   │   ├── opening_loc: (22,8)-(22,9) = "("
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (22,9)-(22,10))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ IntegerNode (location: (22,9)-(22,10))
-        │   │   │   │           └── flags: decimal
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ IntegerNode (location: (22,9)-(22,10))
+        │   │   │   │   │       └── flags: decimal
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: (22,10)-(22,11) = ")"
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/dstr.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/dstr.txt
@@ -195,31 +195,32 @@
         │   │           ├── keyword_loc: (27,2)-(27,8) = "return"
         │   │           └── arguments:
         │   │               @ ArgumentsNode (location: (27,9)-(27,19))
-        │   │               └── arguments: (length: 1)
-        │   │                   └── @ InterpolatedStringNode (location: (27,9)-(27,19))
-        │   │                       ├── opening_loc: (27,9)-(27,19) = "<<-HEREDOC"
-        │   │                       ├── parts: (length: 3)
-        │   │                       │   ├── @ StringNode (location: (28,0)-(28,4))
-        │   │                       │   │   ├── flags: ∅
-        │   │                       │   │   ├── opening_loc: ∅
-        │   │                       │   │   ├── content_loc: (28,0)-(28,4) = "    "
-        │   │                       │   │   ├── closing_loc: ∅
-        │   │                       │   │   └── unescaped: "    "
-        │   │                       │   ├── @ EmbeddedStatementsNode (location: (28,4)-(28,9))
-        │   │                       │   │   ├── opening_loc: (28,4)-(28,6) = "\#{"
-        │   │                       │   │   ├── statements:
-        │   │                       │   │   │   @ StatementsNode (location: (28,6)-(28,8))
-        │   │                       │   │   │   └── body: (length: 1)
-        │   │                       │   │   │       └── @ IntegerNode (location: (28,6)-(28,8))
-        │   │                       │   │   │           └── flags: decimal
-        │   │                       │   │   └── closing_loc: (28,8)-(28,9) = "}"
-        │   │                       │   └── @ StringNode (location: (28,9)-(28,0))
-        │   │                       │       ├── flags: ∅
-        │   │                       │       ├── opening_loc: ∅
-        │   │                       │       ├── content_loc: (28,9)-(28,0) = "\n"
-        │   │                       │       ├── closing_loc: ∅
-        │   │                       │       └── unescaped: "\n"
-        │   │                       └── closing_loc: (29,0)-(29,0) = "  HEREDOC\n"
+        │   │               ├── arguments: (length: 1)
+        │   │               │   └── @ InterpolatedStringNode (location: (27,9)-(27,19))
+        │   │               │       ├── opening_loc: (27,9)-(27,19) = "<<-HEREDOC"
+        │   │               │       ├── parts: (length: 3)
+        │   │               │       │   ├── @ StringNode (location: (28,0)-(28,4))
+        │   │               │       │   │   ├── flags: ∅
+        │   │               │       │   │   ├── opening_loc: ∅
+        │   │               │       │   │   ├── content_loc: (28,0)-(28,4) = "    "
+        │   │               │       │   │   ├── closing_loc: ∅
+        │   │               │       │   │   └── unescaped: "    "
+        │   │               │       │   ├── @ EmbeddedStatementsNode (location: (28,4)-(28,9))
+        │   │               │       │   │   ├── opening_loc: (28,4)-(28,6) = "\#{"
+        │   │               │       │   │   ├── statements:
+        │   │               │       │   │   │   @ StatementsNode (location: (28,6)-(28,8))
+        │   │               │       │   │   │   └── body: (length: 1)
+        │   │               │       │   │   │       └── @ IntegerNode (location: (28,6)-(28,8))
+        │   │               │       │   │   │           └── flags: decimal
+        │   │               │       │   │   └── closing_loc: (28,8)-(28,9) = "}"
+        │   │               │       │   └── @ StringNode (location: (28,9)-(28,0))
+        │   │               │       │       ├── flags: ∅
+        │   │               │       │       ├── opening_loc: ∅
+        │   │               │       │       ├── content_loc: (28,9)-(28,0) = "\n"
+        │   │               │       │       ├── closing_loc: ∅
+        │   │               │       │       └── unescaped: "\n"
+        │   │               │       └── closing_loc: (29,0)-(29,0) = "  HEREDOC\n"
+        │   │               └── flags: ∅
         │   ├── consequent: ∅
         │   └── end_keyword_loc: (30,0)-(30,3) = "end"
         ├── @ CallNode (location: (31,0)-(31,15))
@@ -229,39 +230,40 @@
         │   ├── opening_loc: (31,3)-(31,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (31,4)-(31,14))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (31,4)-(31,14))
-        │   │           ├── opening_loc: (31,4)-(31,14) = "<<-HEREDOC"
-        │   │           ├── parts: (length: 3)
-        │   │           │   ├── @ StringNode (location: (32,0)-(32,2))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (32,0)-(32,2) = "  "
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "  "
-        │   │           │   ├── @ EmbeddedStatementsNode (location: (32,2)-(32,8))
-        │   │           │   │   ├── opening_loc: (32,2)-(32,4) = "\#{"
-        │   │           │   │   ├── statements:
-        │   │           │   │   │   @ StatementsNode (location: (32,4)-(32,7))
-        │   │           │   │   │   └── body: (length: 1)
-        │   │           │   │   │       └── @ CallNode (location: (32,4)-(32,7))
-        │   │           │   │   │           ├── receiver: ∅
-        │   │           │   │   │           ├── call_operator_loc: ∅
-        │   │           │   │   │           ├── message_loc: (32,4)-(32,7) = "bar"
-        │   │           │   │   │           ├── opening_loc: ∅
-        │   │           │   │   │           ├── arguments: ∅
-        │   │           │   │   │           ├── closing_loc: ∅
-        │   │           │   │   │           ├── block: ∅
-        │   │           │   │   │           ├── flags: variable_call
-        │   │           │   │   │           └── name: :bar
-        │   │           │   │   └── closing_loc: (32,7)-(32,8) = "}"
-        │   │           │   └── @ StringNode (location: (32,8)-(32,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (32,8)-(32,0) = "\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "\n"
-        │   │           └── closing_loc: (33,0)-(33,0) = "HEREDOC\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (31,4)-(31,14))
+        │   │   │       ├── opening_loc: (31,4)-(31,14) = "<<-HEREDOC"
+        │   │   │       ├── parts: (length: 3)
+        │   │   │       │   ├── @ StringNode (location: (32,0)-(32,2))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (32,0)-(32,2) = "  "
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "  "
+        │   │   │       │   ├── @ EmbeddedStatementsNode (location: (32,2)-(32,8))
+        │   │   │       │   │   ├── opening_loc: (32,2)-(32,4) = "\#{"
+        │   │   │       │   │   ├── statements:
+        │   │   │       │   │   │   @ StatementsNode (location: (32,4)-(32,7))
+        │   │   │       │   │   │   └── body: (length: 1)
+        │   │   │       │   │   │       └── @ CallNode (location: (32,4)-(32,7))
+        │   │   │       │   │   │           ├── receiver: ∅
+        │   │   │       │   │   │           ├── call_operator_loc: ∅
+        │   │   │       │   │   │           ├── message_loc: (32,4)-(32,7) = "bar"
+        │   │   │       │   │   │           ├── opening_loc: ∅
+        │   │   │       │   │   │           ├── arguments: ∅
+        │   │   │       │   │   │           ├── closing_loc: ∅
+        │   │   │       │   │   │           ├── block: ∅
+        │   │   │       │   │   │           ├── flags: variable_call
+        │   │   │       │   │   │           └── name: :bar
+        │   │   │       │   │   └── closing_loc: (32,7)-(32,8) = "}"
+        │   │   │       │   └── @ StringNode (location: (32,8)-(32,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (32,8)-(32,0) = "\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "\n"
+        │   │   │       └── closing_loc: (33,0)-(33,0) = "HEREDOC\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (31,14)-(31,15) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -273,39 +275,40 @@
             ├── opening_loc: (34,3)-(34,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (34,4)-(34,14))
-            │   └── arguments: (length: 1)
-            │       └── @ InterpolatedStringNode (location: (34,4)-(34,14))
-            │           ├── opening_loc: (34,4)-(34,14) = "<<-HEREDOC"
-            │           ├── parts: (length: 3)
-            │           │   ├── @ StringNode (location: (35,0)-(35,2))
-            │           │   │   ├── flags: ∅
-            │           │   │   ├── opening_loc: ∅
-            │           │   │   ├── content_loc: (35,0)-(35,2) = "  "
-            │           │   │   ├── closing_loc: ∅
-            │           │   │   └── unescaped: "  "
-            │           │   ├── @ EmbeddedStatementsNode (location: (35,2)-(35,8))
-            │           │   │   ├── opening_loc: (35,2)-(35,4) = "\#{"
-            │           │   │   ├── statements:
-            │           │   │   │   @ StatementsNode (location: (35,4)-(35,7))
-            │           │   │   │   └── body: (length: 1)
-            │           │   │   │       └── @ CallNode (location: (35,4)-(35,7))
-            │           │   │   │           ├── receiver: ∅
-            │           │   │   │           ├── call_operator_loc: ∅
-            │           │   │   │           ├── message_loc: (35,4)-(35,7) = "bar"
-            │           │   │   │           ├── opening_loc: ∅
-            │           │   │   │           ├── arguments: ∅
-            │           │   │   │           ├── closing_loc: ∅
-            │           │   │   │           ├── block: ∅
-            │           │   │   │           ├── flags: variable_call
-            │           │   │   │           └── name: :bar
-            │           │   │   └── closing_loc: (35,7)-(35,8) = "}"
-            │           │   └── @ StringNode (location: (35,8)-(35,0))
-            │           │       ├── flags: ∅
-            │           │       ├── opening_loc: ∅
-            │           │       ├── content_loc: (35,8)-(35,0) = "\n"
-            │           │       ├── closing_loc: ∅
-            │           │       └── unescaped: "\n"
-            │           └── closing_loc: (36,0)-(36,0) = "HEREDOC\n"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ InterpolatedStringNode (location: (34,4)-(34,14))
+            │   │       ├── opening_loc: (34,4)-(34,14) = "<<-HEREDOC"
+            │   │       ├── parts: (length: 3)
+            │   │       │   ├── @ StringNode (location: (35,0)-(35,2))
+            │   │       │   │   ├── flags: ∅
+            │   │       │   │   ├── opening_loc: ∅
+            │   │       │   │   ├── content_loc: (35,0)-(35,2) = "  "
+            │   │       │   │   ├── closing_loc: ∅
+            │   │       │   │   └── unescaped: "  "
+            │   │       │   ├── @ EmbeddedStatementsNode (location: (35,2)-(35,8))
+            │   │       │   │   ├── opening_loc: (35,2)-(35,4) = "\#{"
+            │   │       │   │   ├── statements:
+            │   │       │   │   │   @ StatementsNode (location: (35,4)-(35,7))
+            │   │       │   │   │   └── body: (length: 1)
+            │   │       │   │   │       └── @ CallNode (location: (35,4)-(35,7))
+            │   │       │   │   │           ├── receiver: ∅
+            │   │       │   │   │           ├── call_operator_loc: ∅
+            │   │       │   │   │           ├── message_loc: (35,4)-(35,7) = "bar"
+            │   │       │   │   │           ├── opening_loc: ∅
+            │   │       │   │   │           ├── arguments: ∅
+            │   │       │   │   │           ├── closing_loc: ∅
+            │   │       │   │   │           ├── block: ∅
+            │   │       │   │   │           ├── flags: variable_call
+            │   │       │   │   │           └── name: :bar
+            │   │       │   │   └── closing_loc: (35,7)-(35,8) = "}"
+            │   │       │   └── @ StringNode (location: (35,8)-(35,0))
+            │   │       │       ├── flags: ∅
+            │   │       │       ├── opening_loc: ∅
+            │   │       │       ├── content_loc: (35,8)-(35,0) = "\n"
+            │   │       │       ├── closing_loc: ∅
+            │   │       │       └── unescaped: "\n"
+            │   │       └── closing_loc: (36,0)-(36,0) = "HEREDOC\n"
+            │   └── flags: ∅
             ├── closing_loc: (34,14)-(34,15) = ")"
             ├── block:
             │   @ BlockNode (location: (34,16)-(37,1))

--- a/test/prism/snapshots/unparser/corpus/literal/flipflop.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/flipflop.txt
@@ -33,9 +33,10 @@
         │   │   │           │   │           ├── opening_loc: ∅
         │   │   │           │   │           ├── arguments:
         │   │   │           │   │           │   @ ArgumentsNode (location: (1,10)-(1,11))
-        │   │   │           │   │           │   └── arguments: (length: 1)
-        │   │   │           │   │           │       └── @ IntegerNode (location: (1,10)-(1,11))
-        │   │   │           │   │           │           └── flags: decimal
+        │   │   │           │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │           │   │   └── @ IntegerNode (location: (1,10)-(1,11))
+        │   │   │           │   │           │   │       └── flags: decimal
+        │   │   │           │   │           │   └── flags: ∅
         │   │   │           │   │           ├── closing_loc: ∅
         │   │   │           │   │           ├── block: ∅
         │   │   │           │   │           ├── flags: ∅
@@ -64,9 +65,10 @@
         │   │   │           │   │           ├── opening_loc: ∅
         │   │   │           │   │           ├── arguments:
         │   │   │           │   │           │   @ ArgumentsNode (location: (1,20)-(1,21))
-        │   │   │           │   │           │   └── arguments: (length: 1)
-        │   │   │           │   │           │       └── @ IntegerNode (location: (1,20)-(1,21))
-        │   │   │           │   │           │           └── flags: decimal
+        │   │   │           │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │           │   │   └── @ IntegerNode (location: (1,20)-(1,21))
+        │   │   │           │   │           │   │       └── flags: decimal
+        │   │   │           │   │           │   └── flags: ∅
         │   │   │           │   │           ├── closing_loc: ∅
         │   │   │           │   │           ├── block: ∅
         │   │   │           │   │           ├── flags: ∅
@@ -122,9 +124,10 @@
             │   │           │   │           ├── opening_loc: ∅
             │   │           │   │           ├── arguments:
             │   │           │   │           │   @ ArgumentsNode (location: (4,10)-(4,11))
-            │   │           │   │           │   └── arguments: (length: 1)
-            │   │           │   │           │       └── @ IntegerNode (location: (4,10)-(4,11))
-            │   │           │   │           │           └── flags: decimal
+            │   │           │   │           │   ├── arguments: (length: 1)
+            │   │           │   │           │   │   └── @ IntegerNode (location: (4,10)-(4,11))
+            │   │           │   │           │   │       └── flags: decimal
+            │   │           │   │           │   └── flags: ∅
             │   │           │   │           ├── closing_loc: ∅
             │   │           │   │           ├── block: ∅
             │   │           │   │           ├── flags: ∅
@@ -153,9 +156,10 @@
             │   │           │   │           ├── opening_loc: ∅
             │   │           │   │           ├── arguments:
             │   │           │   │           │   @ ArgumentsNode (location: (4,21)-(4,22))
-            │   │           │   │           │   └── arguments: (length: 1)
-            │   │           │   │           │       └── @ IntegerNode (location: (4,21)-(4,22))
-            │   │           │   │           │           └── flags: decimal
+            │   │           │   │           │   ├── arguments: (length: 1)
+            │   │           │   │           │   │   └── @ IntegerNode (location: (4,21)-(4,22))
+            │   │           │   │           │   │       └── flags: decimal
+            │   │           │   │           │   └── flags: ∅
             │   │           │   │           ├── closing_loc: ∅
             │   │           │   │           ├── block: ∅
             │   │           │   │           ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/for.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/for.txt
@@ -10,40 +10,41 @@
         │   ├── opening_loc: (1,3)-(1,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,4)-(3,3))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ForNode (location: (1,4)-(3,3))
-        │   │           ├── index:
-        │   │           │   @ LocalVariableTargetNode (location: (1,8)-(1,9))
-        │   │           │   ├── name: :a
-        │   │           │   └── depth: 1
-        │   │           ├── collection:
-        │   │           │   @ CallNode (location: (1,13)-(1,16))
-        │   │           │   ├── receiver: ∅
-        │   │           │   ├── call_operator_loc: ∅
-        │   │           │   ├── message_loc: (1,13)-(1,16) = "bar"
-        │   │           │   ├── opening_loc: ∅
-        │   │           │   ├── arguments: ∅
-        │   │           │   ├── closing_loc: ∅
-        │   │           │   ├── block: ∅
-        │   │           │   ├── flags: variable_call
-        │   │           │   └── name: :bar
-        │   │           ├── statements:
-        │   │           │   @ StatementsNode (location: (2,2)-(2,5))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (2,2)-(2,5))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (2,2)-(2,5) = "baz"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block: ∅
-        │   │           │           ├── flags: variable_call
-        │   │           │           └── name: :baz
-        │   │           ├── for_keyword_loc: (1,4)-(1,7) = "for"
-        │   │           ├── in_keyword_loc: (1,10)-(1,12) = "in"
-        │   │           ├── do_keyword_loc: (1,17)-(1,19) = "do"
-        │   │           └── end_keyword_loc: (3,0)-(3,3) = "end"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ForNode (location: (1,4)-(3,3))
+        │   │   │       ├── index:
+        │   │   │       │   @ LocalVariableTargetNode (location: (1,8)-(1,9))
+        │   │   │       │   ├── name: :a
+        │   │   │       │   └── depth: 1
+        │   │   │       ├── collection:
+        │   │   │       │   @ CallNode (location: (1,13)-(1,16))
+        │   │   │       │   ├── receiver: ∅
+        │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │       │   ├── message_loc: (1,13)-(1,16) = "bar"
+        │   │   │       │   ├── opening_loc: ∅
+        │   │   │       │   ├── arguments: ∅
+        │   │   │       │   ├── closing_loc: ∅
+        │   │   │       │   ├── block: ∅
+        │   │   │       │   ├── flags: variable_call
+        │   │   │       │   └── name: :bar
+        │   │   │       ├── statements:
+        │   │   │       │   @ StatementsNode (location: (2,2)-(2,5))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (2,2)-(2,5))
+        │   │   │       │           ├── receiver: ∅
+        │   │   │       │           ├── call_operator_loc: ∅
+        │   │   │       │           ├── message_loc: (2,2)-(2,5) = "baz"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block: ∅
+        │   │   │       │           ├── flags: variable_call
+        │   │   │       │           └── name: :baz
+        │   │   │       ├── for_keyword_loc: (1,4)-(1,7) = "for"
+        │   │   │       ├── in_keyword_loc: (1,10)-(1,12) = "in"
+        │   │   │       ├── do_keyword_loc: (1,17)-(1,19) = "do"
+        │   │   │       └── end_keyword_loc: (3,0)-(3,3) = "end"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (3,3)-(3,4) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/kwbegin.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/kwbegin.txt
@@ -326,9 +326,10 @@
         │   │           │   ├── opening_loc: (56,7)-(56,8) = "("
         │   │           │   ├── arguments:
         │   │           │   │   @ ArgumentsNode (location: (56,8)-(56,17))
-        │   │           │   │   └── arguments: (length: 1)
-        │   │           │   │       └── @ ConstantReadNode (location: (56,8)-(56,17))
-        │   │           │   │           └── name: :Exception
+        │   │           │   │   ├── arguments: (length: 1)
+        │   │           │   │   │   └── @ ConstantReadNode (location: (56,8)-(56,17))
+        │   │           │   │   │       └── name: :Exception
+        │   │           │   │   └── flags: ∅
         │   │           │   ├── closing_loc: (56,17)-(56,18) = ")"
         │   │           │   ├── block: ∅
         │   │           │   ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/literal.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/literal.txt
@@ -112,27 +112,28 @@
         │   │   ├── opening_loc: (6,1)-(6,2) = "("
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (6,2)-(6,12))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ InterpolatedStringNode (location: (6,2)-(6,12))
-        │   │   │           ├── opening_loc: (6,2)-(6,12) = "<<-HEREDOC"
-        │   │   │           ├── parts: (length: 3)
-        │   │   │           │   ├── @ StringNode (location: (7,0)-(7,2))
-        │   │   │           │   │   ├── flags: ∅
-        │   │   │           │   │   ├── opening_loc: ∅
-        │   │   │           │   │   ├── content_loc: (7,0)-(7,2) = "  "
-        │   │   │           │   │   ├── closing_loc: ∅
-        │   │   │           │   │   └── unescaped: "  "
-        │   │   │           │   ├── @ EmbeddedStatementsNode (location: (7,2)-(7,5))
-        │   │   │           │   │   ├── opening_loc: (7,2)-(7,4) = "\#{"
-        │   │   │           │   │   ├── statements: ∅
-        │   │   │           │   │   └── closing_loc: (7,4)-(7,5) = "}"
-        │   │   │           │   └── @ StringNode (location: (7,5)-(7,0))
-        │   │   │           │       ├── flags: ∅
-        │   │   │           │       ├── opening_loc: ∅
-        │   │   │           │       ├── content_loc: (7,5)-(7,0) = "\n"
-        │   │   │           │       ├── closing_loc: ∅
-        │   │   │           │       └── unescaped: "\n"
-        │   │   │           └── closing_loc: (8,0)-(8,0) = "HEREDOC\n"
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ InterpolatedStringNode (location: (6,2)-(6,12))
+        │   │   │   │       ├── opening_loc: (6,2)-(6,12) = "<<-HEREDOC"
+        │   │   │   │       ├── parts: (length: 3)
+        │   │   │   │       │   ├── @ StringNode (location: (7,0)-(7,2))
+        │   │   │   │       │   │   ├── flags: ∅
+        │   │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │   │       │   │   ├── content_loc: (7,0)-(7,2) = "  "
+        │   │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │   │       │   │   └── unescaped: "  "
+        │   │   │   │       │   ├── @ EmbeddedStatementsNode (location: (7,2)-(7,5))
+        │   │   │   │       │   │   ├── opening_loc: (7,2)-(7,4) = "\#{"
+        │   │   │   │       │   │   ├── statements: ∅
+        │   │   │   │       │   │   └── closing_loc: (7,4)-(7,5) = "}"
+        │   │   │   │       │   └── @ StringNode (location: (7,5)-(7,0))
+        │   │   │   │       │       ├── flags: ∅
+        │   │   │   │       │       ├── opening_loc: ∅
+        │   │   │   │       │       ├── content_loc: (7,5)-(7,0) = "\n"
+        │   │   │   │       │       ├── closing_loc: ∅
+        │   │   │   │       │       └── unescaped: "\n"
+        │   │   │   │       └── closing_loc: (8,0)-(8,0) = "HEREDOC\n"
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: (6,12)-(6,13) = ")"
         │   │   ├── block: ∅
         │   │   ├── flags: ∅
@@ -154,13 +155,14 @@
         │   │   ├── opening_loc: (9,1)-(9,2) = "("
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (9,2)-(9,5))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ StringNode (location: (9,2)-(9,5))
-        │   │   │           ├── flags: ∅
-        │   │   │           ├── opening_loc: (9,2)-(9,4) = "%("
-        │   │   │           ├── content_loc: (9,4)-(9,4) = ""
-        │   │   │           ├── closing_loc: (9,4)-(9,5) = ")"
-        │   │   │           └── unescaped: ""
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ StringNode (location: (9,2)-(9,5))
+        │   │   │   │       ├── flags: ∅
+        │   │   │   │       ├── opening_loc: (9,2)-(9,4) = "%("
+        │   │   │   │       ├── content_loc: (9,4)-(9,4) = ""
+        │   │   │   │       ├── closing_loc: (9,4)-(9,5) = ")"
+        │   │   │   │       └── unescaped: ""
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: (9,5)-(9,6) = ")"
         │   │   ├── block: ∅
         │   │   ├── flags: ∅
@@ -688,8 +690,9 @@
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (60,7)-(60,10))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ FloatNode (location: (60,7)-(60,10))
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ FloatNode (location: (60,7)-(60,10))
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅
@@ -718,8 +721,9 @@
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (61,10)-(61,13))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ FloatNode (location: (61,10)-(61,13))
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ FloatNode (location: (61,10)-(61,13))
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅
@@ -742,8 +746,9 @@
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (62,7)-(62,10))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ FloatNode (location: (62,7)-(62,10))
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ FloatNode (location: (62,7)-(62,10))
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/module.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/module.txt
@@ -64,19 +64,20 @@
             │       │   ├── opening_loc: (11,9)-(11,10) = "("
             │       │   ├── arguments:
             │       │   │   @ ArgumentsNode (location: (11,10)-(11,15))
-            │       │   │   └── arguments: (length: 1)
-            │       │   │       └── @ CallNode (location: (11,10)-(11,15))
-            │       │   │           ├── receiver:
-            │       │   │           │   @ ConstantReadNode (location: (11,10)-(11,11))
-            │       │   │           │   └── name: :B
-            │       │   │           ├── call_operator_loc: (11,11)-(11,12) = "."
-            │       │   │           ├── message_loc: (11,12)-(11,15) = "new"
-            │       │   │           ├── opening_loc: ∅
-            │       │   │           ├── arguments: ∅
-            │       │   │           ├── closing_loc: ∅
-            │       │   │           ├── block: ∅
-            │       │   │           ├── flags: ∅
-            │       │   │           └── name: :new
+            │       │   │   ├── arguments: (length: 1)
+            │       │   │   │   └── @ CallNode (location: (11,10)-(11,15))
+            │       │   │   │       ├── receiver:
+            │       │   │   │       │   @ ConstantReadNode (location: (11,10)-(11,11))
+            │       │   │   │       │   └── name: :B
+            │       │   │   │       ├── call_operator_loc: (11,11)-(11,12) = "."
+            │       │   │   │       ├── message_loc: (11,12)-(11,15) = "new"
+            │       │   │   │       ├── opening_loc: ∅
+            │       │   │   │       ├── arguments: ∅
+            │       │   │   │       ├── closing_loc: ∅
+            │       │   │   │       ├── block: ∅
+            │       │   │   │       ├── flags: ∅
+            │       │   │   │       └── name: :new
+            │       │   │   └── flags: ∅
             │       │   ├── closing_loc: (11,15)-(11,16) = ")"
             │       │   ├── block: ∅
             │       │   ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/opasgn.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/opasgn.txt
@@ -119,27 +119,28 @@
         │   ├── opening_loc: (9,10)-(9,11) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (9,11)-(9,17))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (9,11)-(9,12))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (9,11)-(9,12) = "k"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :k
-        │   │       └── @ CallNode (location: (9,16)-(9,17))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (9,16)-(9,17) = "v"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :v
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (9,11)-(9,12))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (9,11)-(9,12) = "k"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :k
+        │   │   │   └── @ CallNode (location: (9,16)-(9,17))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (9,16)-(9,17) = "v"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :v
+        │   │   └── flags: ∅
         │   ├── closing_loc: (9,12)-(9,13) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -264,17 +265,18 @@
         │   ├── opening_loc: (17,1)-(17,2) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (17,2)-(17,3))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (17,2)-(17,3))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (17,2)-(17,3) = "b"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :b
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (17,2)-(17,3))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (17,2)-(17,3) = "b"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :b
+        │   │   └── flags: ∅
         │   ├── closing_loc: (17,3)-(17,4) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -292,17 +294,18 @@
         │   ├── opening_loc: (18,1)-(18,2) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (18,2)-(18,3))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (18,2)-(18,3))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (18,2)-(18,3) = "b"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :b
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (18,2)-(18,3))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (18,2)-(18,3) = "b"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :b
+        │   │   └── flags: ∅
         │   ├── closing_loc: (18,3)-(18,4) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -320,17 +323,18 @@
         │   ├── opening_loc: (19,1)-(19,2) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (19,2)-(19,3))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (19,2)-(19,3))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (19,2)-(19,3) = "b"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :b
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (19,2)-(19,3))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (19,2)-(19,3) = "b"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :b
+        │   │   └── flags: ∅
         │   ├── closing_loc: (19,3)-(19,4) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -348,17 +352,18 @@
         │   ├── opening_loc: (20,1)-(20,2) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (20,2)-(20,3))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (20,2)-(20,3))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (20,2)-(20,3) = "b"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :b
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (20,2)-(20,3))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (20,2)-(20,3) = "b"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :b
+        │   │   └── flags: ∅
         │   ├── closing_loc: (20,3)-(20,4) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -376,17 +381,18 @@
         │   ├── opening_loc: (21,1)-(21,2) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (21,2)-(21,3))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (21,2)-(21,3))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (21,2)-(21,3) = "b"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :b
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (21,2)-(21,3))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (21,2)-(21,3) = "b"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :b
+        │   │   └── flags: ∅
         │   ├── closing_loc: (21,3)-(21,4) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -404,17 +410,18 @@
         │   ├── opening_loc: (22,1)-(22,2) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (22,2)-(22,3))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (22,2)-(22,3))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (22,2)-(22,3) = "b"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :b
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (22,2)-(22,3))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (22,2)-(22,3) = "b"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :b
+        │   │   └── flags: ∅
         │   ├── closing_loc: (22,3)-(22,4) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -439,17 +446,18 @@
         │   ├── opening_loc: (23,1)-(23,2) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (23,2)-(23,3))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (23,2)-(23,3))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (23,2)-(23,3) = "b"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :b
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (23,2)-(23,3))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (23,2)-(23,3) = "b"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :b
+        │   │   └── flags: ∅
         │   ├── closing_loc: (23,3)-(23,4) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/rescue.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/rescue.txt
@@ -45,17 +45,18 @@
         │       ├── keyword_loc: (2,11)-(2,17) = "return"
         │       └── arguments:
         │           @ ArgumentsNode (location: (2,18)-(2,21))
-        │           └── arguments: (length: 1)
-        │               └── @ CallNode (location: (2,18)-(2,21))
-        │                   ├── receiver: ∅
-        │                   ├── call_operator_loc: ∅
-        │                   ├── message_loc: (2,18)-(2,21) = "bar"
-        │                   ├── opening_loc: ∅
-        │                   ├── arguments: ∅
-        │                   ├── closing_loc: ∅
-        │                   ├── block: ∅
-        │                   ├── flags: variable_call
-        │                   └── name: :bar
+        │           ├── arguments: (length: 1)
+        │           │   └── @ CallNode (location: (2,18)-(2,21))
+        │           │       ├── receiver: ∅
+        │           │       ├── call_operator_loc: ∅
+        │           │       ├── message_loc: (2,18)-(2,21) = "bar"
+        │           │       ├── opening_loc: ∅
+        │           │       ├── arguments: ∅
+        │           │       ├── closing_loc: ∅
+        │           │       ├── block: ∅
+        │           │       ├── flags: variable_call
+        │           │       └── name: :bar
+        │           └── flags: ∅
         └── @ LocalVariableWriteNode (location: (3,0)-(3,27))
             ├── name: :x
             ├── depth: 0
@@ -83,17 +84,18 @@
             │   │               ├── keyword_loc: (3,16)-(3,22) = "return"
             │   │               └── arguments:
             │   │                   @ ArgumentsNode (location: (3,23)-(3,26))
-            │   │                   └── arguments: (length: 1)
-            │   │                       └── @ CallNode (location: (3,23)-(3,26))
-            │   │                           ├── receiver: ∅
-            │   │                           ├── call_operator_loc: ∅
-            │   │                           ├── message_loc: (3,23)-(3,26) = "bar"
-            │   │                           ├── opening_loc: ∅
-            │   │                           ├── arguments: ∅
-            │   │                           ├── closing_loc: ∅
-            │   │                           ├── block: ∅
-            │   │                           ├── flags: variable_call
-            │   │                           └── name: :bar
+            │   │                   ├── arguments: (length: 1)
+            │   │                   │   └── @ CallNode (location: (3,23)-(3,26))
+            │   │                   │       ├── receiver: ∅
+            │   │                   │       ├── call_operator_loc: ∅
+            │   │                   │       ├── message_loc: (3,23)-(3,26) = "bar"
+            │   │                   │       ├── opening_loc: ∅
+            │   │                   │       ├── arguments: ∅
+            │   │                   │       ├── closing_loc: ∅
+            │   │                   │       ├── block: ∅
+            │   │                   │       ├── flags: variable_call
+            │   │                   │       └── name: :bar
+            │   │                   └── flags: ∅
             │   ├── opening_loc: (3,4)-(3,5) = "("
             │   └── closing_loc: (3,26)-(3,27) = ")"
             └── operator_loc: (3,2)-(3,3) = "="

--- a/test/prism/snapshots/unparser/corpus/literal/send.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/send.txt
@@ -426,12 +426,13 @@
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (37,10)-(37,14))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ SymbolNode (location: (37,10)-(37,14))
-        │   │   │           │           ├── opening_loc: (37,10)-(37,11) = ":"
-        │   │   │           │           ├── value_loc: (37,11)-(37,14) = "foo"
-        │   │   │           │           ├── closing_loc: ∅
-        │   │   │           │           └── unescaped: "foo"
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ SymbolNode (location: (37,10)-(37,14))
+        │   │   │           │   │       ├── opening_loc: (37,10)-(37,11) = ":"
+        │   │   │           │   │       ├── value_loc: (37,11)-(37,14) = "foo"
+        │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │           │   │       └── unescaped: "foo"
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅
@@ -494,13 +495,14 @@
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (39,8)-(39,13))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ RegularExpressionNode (location: (39,8)-(39,13))
-        │   │   │           │           ├── opening_loc: (39,8)-(39,9) = "/"
-        │   │   │           │           ├── content_loc: (39,9)-(39,12) = "bar"
-        │   │   │           │           ├── closing_loc: (39,12)-(39,13) = "/"
-        │   │   │           │           ├── unescaped: "bar"
-        │   │   │           │           └── flags: ∅
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ RegularExpressionNode (location: (39,8)-(39,13))
+        │   │   │           │   │       ├── opening_loc: (39,8)-(39,9) = "/"
+        │   │   │           │   │       ├── content_loc: (39,9)-(39,12) = "bar"
+        │   │   │           │   │       ├── closing_loc: (39,12)-(39,13) = "/"
+        │   │   │           │   │       ├── unescaped: "bar"
+        │   │   │           │   │       └── flags: ∅
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅
@@ -528,12 +530,13 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (40,9)-(40,13))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SymbolNode (location: (40,9)-(40,13))
-        │   │           ├── opening_loc: (40,9)-(40,10) = ":"
-        │   │           ├── value_loc: (40,10)-(40,13) = "foo"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "foo"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SymbolNode (location: (40,9)-(40,13))
+        │   │   │       ├── opening_loc: (40,9)-(40,10) = ":"
+        │   │   │       ├── value_loc: (40,10)-(40,13) = "foo"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "foo"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -551,17 +554,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (41,9)-(41,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (41,9)-(41,12))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (41,9)-(41,12) = "foo"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :foo
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (41,9)-(41,12))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (41,9)-(41,12) = "foo"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :foo
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -674,45 +678,47 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (48,7)-(48,18))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (48,7)-(48,18))
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (48,8)-(48,17))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (48,8)-(48,17))
-        │   │           │           ├── receiver:
-        │   │           │           │   @ CallNode (location: (48,8)-(48,11))
-        │   │           │           │   ├── receiver: ∅
-        │   │           │           │   ├── call_operator_loc: ∅
-        │   │           │           │   ├── message_loc: (48,8)-(48,11) = "bar"
-        │   │           │           │   ├── opening_loc: ∅
-        │   │           │           │   ├── arguments: ∅
-        │   │           │           │   ├── closing_loc: ∅
-        │   │           │           │   ├── block: ∅
-        │   │           │           │   ├── flags: variable_call
-        │   │           │           │   └── name: :bar
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (48,12)-(48,13) = "*"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments:
-        │   │           │           │   @ ArgumentsNode (location: (48,14)-(48,17))
-        │   │           │           │   └── arguments: (length: 1)
-        │   │           │           │       └── @ CallNode (location: (48,14)-(48,17))
-        │   │           │           │           ├── receiver: ∅
-        │   │           │           │           ├── call_operator_loc: ∅
-        │   │           │           │           ├── message_loc: (48,14)-(48,17) = "baz"
-        │   │           │           │           ├── opening_loc: ∅
-        │   │           │           │           ├── arguments: ∅
-        │   │           │           │           ├── closing_loc: ∅
-        │   │           │           │           ├── block: ∅
-        │   │           │           │           ├── flags: variable_call
-        │   │           │           │           └── name: :baz
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block: ∅
-        │   │           │           ├── flags: ∅
-        │   │           │           └── name: :*
-        │   │           ├── opening_loc: (48,7)-(48,8) = "("
-        │   │           └── closing_loc: (48,17)-(48,18) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (48,7)-(48,18))
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (48,8)-(48,17))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (48,8)-(48,17))
+        │   │   │       │           ├── receiver:
+        │   │   │       │           │   @ CallNode (location: (48,8)-(48,11))
+        │   │   │       │           │   ├── receiver: ∅
+        │   │   │       │           │   ├── call_operator_loc: ∅
+        │   │   │       │           │   ├── message_loc: (48,8)-(48,11) = "bar"
+        │   │   │       │           │   ├── opening_loc: ∅
+        │   │   │       │           │   ├── arguments: ∅
+        │   │   │       │           │   ├── closing_loc: ∅
+        │   │   │       │           │   ├── block: ∅
+        │   │   │       │           │   ├── flags: variable_call
+        │   │   │       │           │   └── name: :bar
+        │   │   │       │           ├── call_operator_loc: ∅
+        │   │   │       │           ├── message_loc: (48,12)-(48,13) = "*"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments:
+        │   │   │       │           │   @ ArgumentsNode (location: (48,14)-(48,17))
+        │   │   │       │           │   ├── arguments: (length: 1)
+        │   │   │       │           │   │   └── @ CallNode (location: (48,14)-(48,17))
+        │   │   │       │           │   │       ├── receiver: ∅
+        │   │   │       │           │   │       ├── call_operator_loc: ∅
+        │   │   │       │           │   │       ├── message_loc: (48,14)-(48,17) = "baz"
+        │   │   │       │           │   │       ├── opening_loc: ∅
+        │   │   │       │           │   │       ├── arguments: ∅
+        │   │   │       │           │   │       ├── closing_loc: ∅
+        │   │   │       │           │   │       ├── block: ∅
+        │   │   │       │           │   │       ├── flags: variable_call
+        │   │   │       │           │   │       └── name: :baz
+        │   │   │       │           │   └── flags: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block: ∅
+        │   │   │       │           ├── flags: ∅
+        │   │   │       │           └── name: :*
+        │   │   │       ├── opening_loc: (48,7)-(48,8) = "("
+        │   │   │       └── closing_loc: (48,17)-(48,18) = ")"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -734,13 +740,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (49,7)-(49,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ RegularExpressionNode (location: (49,7)-(49,12))
-        │   │           ├── opening_loc: (49,7)-(49,8) = "/"
-        │   │           ├── content_loc: (49,8)-(49,11) = "bar"
-        │   │           ├── closing_loc: (49,11)-(49,12) = "/"
-        │   │           ├── unescaped: "bar"
-        │   │           └── flags: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ RegularExpressionNode (location: (49,7)-(49,12))
+        │   │   │       ├── opening_loc: (49,7)-(49,8) = "/"
+        │   │   │       ├── content_loc: (49,8)-(49,11) = "bar"
+        │   │   │       ├── closing_loc: (49,11)-(49,12) = "/"
+        │   │   │       ├── unescaped: "bar"
+        │   │   │       └── flags: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -818,20 +825,21 @@
         │   ├── opening_loc: (52,3)-(52,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (52,4)-(52,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SplatNode (location: (52,4)-(52,9))
-        │   │           ├── operator_loc: (52,4)-(52,5) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (52,5)-(52,9))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (52,5)-(52,9) = "args"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :args
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SplatNode (location: (52,4)-(52,9))
+        │   │   │       ├── operator_loc: (52,4)-(52,5) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (52,5)-(52,9))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (52,5)-(52,9) = "args"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :args
+        │   │   └── flags: ∅
         │   ├── closing_loc: (52,17)-(52,18) = ")"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (52,11)-(52,17))
@@ -856,20 +864,21 @@
         │   ├── opening_loc: (53,3)-(53,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (53,4)-(53,14))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SplatNode (location: (53,4)-(53,14))
-        │   │           ├── operator_loc: (53,4)-(53,5) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (53,5)-(53,14))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (53,5)-(53,14) = "arguments"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :arguments
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SplatNode (location: (53,4)-(53,14))
+        │   │   │       ├── operator_loc: (53,4)-(53,5) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (53,5)-(53,14))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (53,5)-(53,14) = "arguments"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :arguments
+        │   │   └── flags: ∅
         │   ├── closing_loc: (53,14)-(53,15) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -881,11 +890,12 @@
         │   ├── opening_loc: (54,3)-(54,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (54,4)-(54,8))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ IntegerNode (location: (54,4)-(54,5))
-        │   │       │   └── flags: decimal
-        │   │       └── @ IntegerNode (location: (54,7)-(54,8))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ IntegerNode (location: (54,4)-(54,5))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ IntegerNode (location: (54,7)-(54,8))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (54,8)-(54,9) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -897,17 +907,18 @@
         │   ├── opening_loc: (55,3)-(55,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (55,4)-(55,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (55,4)-(55,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (55,4)-(55,7) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (55,4)-(55,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (55,4)-(55,7) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (55,7)-(55,8) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -919,30 +930,31 @@
         │   ├── opening_loc: (56,3)-(56,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (56,4)-(56,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (56,4)-(56,7))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (56,4)-(56,7) = "bar"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :bar
-        │   │       └── @ SplatNode (location: (56,9)-(56,14))
-        │   │           ├── operator_loc: (56,9)-(56,10) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (56,10)-(56,14))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (56,10)-(56,14) = "args"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :args
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (56,4)-(56,7))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (56,4)-(56,7) = "bar"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :bar
+        │   │   │   └── @ SplatNode (location: (56,9)-(56,14))
+        │   │   │       ├── operator_loc: (56,9)-(56,10) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (56,10)-(56,14))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (56,10)-(56,14) = "args"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :args
+        │   │   └── flags: ∅
         │   ├── closing_loc: (56,14)-(56,15) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -954,35 +966,37 @@
         │   ├── opening_loc: (57,3)-(57,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (57,4)-(57,16))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (57,4)-(57,16))
-        │   │           ├── receiver:
-        │   │           │   @ CallNode (location: (57,4)-(57,7))
-        │   │           │   ├── receiver: ∅
-        │   │           │   ├── call_operator_loc: ∅
-        │   │           │   ├── message_loc: (57,4)-(57,7) = "foo"
-        │   │           │   ├── opening_loc: ∅
-        │   │           │   ├── arguments: ∅
-        │   │           │   ├── closing_loc: ∅
-        │   │           │   ├── block: ∅
-        │   │           │   ├── flags: variable_call
-        │   │           │   └── name: :foo
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (57,8)-(57,10) = "=~"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (57,11)-(57,16))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ RegularExpressionNode (location: (57,11)-(57,16))
-        │   │           │           ├── opening_loc: (57,11)-(57,12) = "/"
-        │   │           │           ├── content_loc: (57,12)-(57,15) = "bar"
-        │   │           │           ├── closing_loc: (57,15)-(57,16) = "/"
-        │   │           │           ├── unescaped: "bar"
-        │   │           │           └── flags: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :=~
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (57,4)-(57,16))
+        │   │   │       ├── receiver:
+        │   │   │       │   @ CallNode (location: (57,4)-(57,7))
+        │   │   │       │   ├── receiver: ∅
+        │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │       │   ├── message_loc: (57,4)-(57,7) = "foo"
+        │   │   │       │   ├── opening_loc: ∅
+        │   │   │       │   ├── arguments: ∅
+        │   │   │       │   ├── closing_loc: ∅
+        │   │   │       │   ├── block: ∅
+        │   │   │       │   ├── flags: variable_call
+        │   │   │       │   └── name: :foo
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (57,8)-(57,10) = "=~"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments:
+        │   │   │       │   @ ArgumentsNode (location: (57,11)-(57,16))
+        │   │   │       │   ├── arguments: (length: 1)
+        │   │   │       │   │   └── @ RegularExpressionNode (location: (57,11)-(57,16))
+        │   │   │       │   │       ├── opening_loc: (57,11)-(57,12) = "/"
+        │   │   │       │   │       ├── content_loc: (57,12)-(57,15) = "bar"
+        │   │   │       │   │       ├── closing_loc: (57,15)-(57,16) = "/"
+        │   │   │       │   │       ├── unescaped: "bar"
+        │   │   │       │   │       └── flags: ∅
+        │   │   │       │   └── flags: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :=~
+        │   │   └── flags: ∅
         │   ├── closing_loc: (57,16)-(57,17) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1037,43 +1051,44 @@
         │   ├── opening_loc: (59,7)-(59,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (59,8)-(59,25))
-        │   │   └── arguments: (length: 3)
-        │   │       ├── @ SplatNode (location: (59,8)-(59,13))
-        │   │       │   ├── operator_loc: (59,8)-(59,9) = "*"
-        │   │       │   └── expression:
-        │   │       │       @ CallNode (location: (59,9)-(59,13))
-        │   │       │       ├── receiver: ∅
-        │   │       │       ├── call_operator_loc: ∅
-        │   │       │       ├── message_loc: (59,9)-(59,13) = "arga"
-        │   │       │       ├── opening_loc: ∅
-        │   │       │       ├── arguments: ∅
-        │   │       │       ├── closing_loc: ∅
-        │   │       │       ├── block: ∅
-        │   │       │       ├── flags: variable_call
-        │   │       │       └── name: :arga
-        │   │       ├── @ CallNode (location: (59,15)-(59,18))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (59,15)-(59,18) = "foo"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :foo
-        │   │       └── @ SplatNode (location: (59,20)-(59,25))
-        │   │           ├── operator_loc: (59,20)-(59,21) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (59,21)-(59,25))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (59,21)-(59,25) = "argb"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :argb
+        │   │   ├── arguments: (length: 3)
+        │   │   │   ├── @ SplatNode (location: (59,8)-(59,13))
+        │   │   │   │   ├── operator_loc: (59,8)-(59,9) = "*"
+        │   │   │   │   └── expression:
+        │   │   │   │       @ CallNode (location: (59,9)-(59,13))
+        │   │   │   │       ├── receiver: ∅
+        │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │       ├── message_loc: (59,9)-(59,13) = "arga"
+        │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │       ├── arguments: ∅
+        │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │       ├── block: ∅
+        │   │   │   │       ├── flags: variable_call
+        │   │   │   │       └── name: :arga
+        │   │   │   ├── @ CallNode (location: (59,15)-(59,18))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (59,15)-(59,18) = "foo"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :foo
+        │   │   │   └── @ SplatNode (location: (59,20)-(59,25))
+        │   │   │       ├── operator_loc: (59,20)-(59,21) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (59,21)-(59,25))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (59,21)-(59,25) = "argb"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :argb
+        │   │   └── flags: ∅
         │   ├── closing_loc: (59,25)-(59,26) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1095,20 +1110,21 @@
         │   ├── opening_loc: (60,7)-(60,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (60,8)-(60,13))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SplatNode (location: (60,8)-(60,13))
-        │   │           ├── operator_loc: (60,8)-(60,9) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (60,9)-(60,13))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (60,9)-(60,13) = "args"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :args
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SplatNode (location: (60,8)-(60,13))
+        │   │   │       ├── operator_loc: (60,8)-(60,9) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (60,9)-(60,13))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (60,9)-(60,13) = "args"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :args
+        │   │   └── flags: ∅
         │   ├── closing_loc: (60,13)-(60,14) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1130,30 +1146,31 @@
         │   ├── opening_loc: (61,7)-(61,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (61,8)-(61,18))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SplatNode (location: (61,8)-(61,13))
-        │   │       │   ├── operator_loc: (61,8)-(61,9) = "*"
-        │   │       │   └── expression:
-        │   │       │       @ CallNode (location: (61,9)-(61,13))
-        │   │       │       ├── receiver: ∅
-        │   │       │       ├── call_operator_loc: ∅
-        │   │       │       ├── message_loc: (61,9)-(61,13) = "args"
-        │   │       │       ├── opening_loc: ∅
-        │   │       │       ├── arguments: ∅
-        │   │       │       ├── closing_loc: ∅
-        │   │       │       ├── block: ∅
-        │   │       │       ├── flags: variable_call
-        │   │       │       └── name: :args
-        │   │       └── @ CallNode (location: (61,15)-(61,18))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (61,15)-(61,18) = "foo"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :foo
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SplatNode (location: (61,8)-(61,13))
+        │   │   │   │   ├── operator_loc: (61,8)-(61,9) = "*"
+        │   │   │   │   └── expression:
+        │   │   │   │       @ CallNode (location: (61,9)-(61,13))
+        │   │   │   │       ├── receiver: ∅
+        │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │       ├── message_loc: (61,9)-(61,13) = "args"
+        │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │       ├── arguments: ∅
+        │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │       ├── block: ∅
+        │   │   │   │       ├── flags: variable_call
+        │   │   │   │       └── name: :args
+        │   │   │   └── @ CallNode (location: (61,15)-(61,18))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (61,15)-(61,18) = "foo"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :foo
+        │   │   └── flags: ∅
         │   ├── closing_loc: (61,18)-(61,19) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1175,12 +1192,13 @@
         │   ├── opening_loc: (62,7)-(62,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (62,8)-(62,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SymbolNode (location: (62,8)-(62,12))
-        │   │           ├── opening_loc: (62,8)-(62,9) = ":"
-        │   │           ├── value_loc: (62,9)-(62,12) = "baz"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "baz"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SymbolNode (location: (62,8)-(62,12))
+        │   │   │       ├── opening_loc: (62,8)-(62,9) = ":"
+        │   │   │       ├── value_loc: (62,9)-(62,12) = "baz"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "baz"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (62,18)-(62,19) = ")"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (62,14)-(62,18))
@@ -1215,28 +1233,29 @@
         │   ├── opening_loc: (63,7)-(63,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (63,8)-(63,16))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (63,8)-(63,16))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (63,8)-(63,16))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (63,8)-(63,12))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (63,8)-(63,11) = "baz"
-        │   │                   │   ├── closing_loc: (63,11)-(63,12) = ":"
-        │   │                   │   └── unescaped: "baz"
-        │   │                   ├── value:
-        │   │                   │   @ CallNode (location: (63,13)-(63,16))
-        │   │                   │   ├── receiver: ∅
-        │   │                   │   ├── call_operator_loc: ∅
-        │   │                   │   ├── message_loc: (63,13)-(63,16) = "boz"
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── arguments: ∅
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   ├── block: ∅
-        │   │                   │   ├── flags: variable_call
-        │   │                   │   └── name: :boz
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (63,8)-(63,16))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (63,8)-(63,16))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (63,8)-(63,12))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (63,8)-(63,11) = "baz"
+        │   │   │               │   ├── closing_loc: (63,11)-(63,12) = ":"
+        │   │   │               │   └── unescaped: "baz"
+        │   │   │               ├── value:
+        │   │   │               │   @ CallNode (location: (63,13)-(63,16))
+        │   │   │               │   ├── receiver: ∅
+        │   │   │               │   ├── call_operator_loc: ∅
+        │   │   │               │   ├── message_loc: (63,13)-(63,16) = "boz"
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── arguments: ∅
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   ├── block: ∅
+        │   │   │               │   ├── flags: variable_call
+        │   │   │               │   └── name: :boz
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: (63,16)-(63,17) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1258,39 +1277,40 @@
         │   ├── opening_loc: (64,7)-(64,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (64,8)-(64,25))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (64,8)-(64,11))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (64,8)-(64,11) = "foo"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :foo
-        │   │       └── @ KeywordHashNode (location: (64,13)-(64,25))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (64,13)-(64,25))
-        │   │                   ├── key:
-        │   │                   │   @ StringNode (location: (64,13)-(64,18))
-        │   │                   │   ├── flags: ∅
-        │   │                   │   ├── opening_loc: (64,13)-(64,14) = "\""
-        │   │                   │   ├── content_loc: (64,14)-(64,17) = "baz"
-        │   │                   │   ├── closing_loc: (64,17)-(64,18) = "\""
-        │   │                   │   └── unescaped: "baz"
-        │   │                   ├── value:
-        │   │                   │   @ CallNode (location: (64,22)-(64,25))
-        │   │                   │   ├── receiver: ∅
-        │   │                   │   ├── call_operator_loc: ∅
-        │   │                   │   ├── message_loc: (64,22)-(64,25) = "boz"
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── arguments: ∅
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   ├── block: ∅
-        │   │                   │   ├── flags: variable_call
-        │   │                   │   └── name: :boz
-        │   │                   └── operator_loc: (64,19)-(64,21) = "=>"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (64,8)-(64,11))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (64,8)-(64,11) = "foo"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :foo
+        │   │   │   └── @ KeywordHashNode (location: (64,13)-(64,25))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (64,13)-(64,25))
+        │   │   │               ├── key:
+        │   │   │               │   @ StringNode (location: (64,13)-(64,18))
+        │   │   │               │   ├── flags: ∅
+        │   │   │               │   ├── opening_loc: (64,13)-(64,14) = "\""
+        │   │   │               │   ├── content_loc: (64,14)-(64,17) = "baz"
+        │   │   │               │   ├── closing_loc: (64,17)-(64,18) = "\""
+        │   │   │               │   └── unescaped: "baz"
+        │   │   │               ├── value:
+        │   │   │               │   @ CallNode (location: (64,22)-(64,25))
+        │   │   │               │   ├── receiver: ∅
+        │   │   │               │   ├── call_operator_loc: ∅
+        │   │   │               │   ├── message_loc: (64,22)-(64,25) = "boz"
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── arguments: ∅
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   ├── block: ∅
+        │   │   │               │   ├── flags: variable_call
+        │   │   │               │   └── name: :boz
+        │   │   │               └── operator_loc: (64,19)-(64,21) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (64,25)-(64,26) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1312,30 +1332,31 @@
         │   ├── opening_loc: (65,7)-(65,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (65,8)-(65,18))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (65,8)-(65,11))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (65,8)-(65,11) = "foo"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :foo
-        │   │       └── @ SplatNode (location: (65,13)-(65,18))
-        │   │           ├── operator_loc: (65,13)-(65,14) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (65,14)-(65,18))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (65,14)-(65,18) = "args"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :args
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (65,8)-(65,11))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (65,8)-(65,11) = "foo"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :foo
+        │   │   │   └── @ SplatNode (location: (65,13)-(65,18))
+        │   │   │       ├── operator_loc: (65,13)-(65,14) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (65,14)-(65,18))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (65,14)-(65,18) = "args"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :args
+        │   │   └── flags: ∅
         │   ├── closing_loc: (65,18)-(65,19) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1357,30 +1378,31 @@
         │   ├── opening_loc: (66,7)-(66,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (66,8)-(66,18))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (66,8)-(66,11))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (66,8)-(66,11) = "foo"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :foo
-        │   │       └── @ SplatNode (location: (66,13)-(66,18))
-        │   │           ├── operator_loc: (66,13)-(66,14) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (66,14)-(66,18))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (66,14)-(66,18) = "args"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :args
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (66,8)-(66,11))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (66,8)-(66,11) = "foo"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :foo
+        │   │   │   └── @ SplatNode (location: (66,13)-(66,18))
+        │   │   │       ├── operator_loc: (66,13)-(66,14) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (66,14)-(66,18))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (66,14)-(66,18) = "args"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :args
+        │   │   └── flags: ∅
         │   ├── closing_loc: (66,26)-(66,27) = ")"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (66,20)-(66,26))
@@ -1415,21 +1437,22 @@
         │   ├── opening_loc: (67,7)-(67,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (67,8)-(67,15))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (67,8)-(67,11))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (67,8)-(67,11) = "foo"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :foo
-        │   │       └── @ HashNode (location: (67,13)-(67,15))
-        │   │           ├── opening_loc: (67,13)-(67,14) = "{"
-        │   │           ├── elements: (length: 0)
-        │   │           └── closing_loc: (67,14)-(67,15) = "}"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (67,8)-(67,11))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (67,8)-(67,11) = "foo"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :foo
+        │   │   │   └── @ HashNode (location: (67,13)-(67,15))
+        │   │   │       ├── opening_loc: (67,13)-(67,14) = "{"
+        │   │   │       ├── elements: (length: 0)
+        │   │   │       └── closing_loc: (67,14)-(67,15) = "}"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (67,15)-(67,16) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1451,40 +1474,41 @@
         │   ├── opening_loc: (68,7)-(68,8) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (68,8)-(68,25))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ HashNode (location: (68,8)-(68,20))
-        │   │       │   ├── opening_loc: (68,8)-(68,9) = "{"
-        │   │       │   ├── elements: (length: 1)
-        │   │       │   │   └── @ AssocNode (location: (68,10)-(68,18))
-        │   │       │   │       ├── key:
-        │   │       │   │       │   @ SymbolNode (location: (68,10)-(68,14))
-        │   │       │   │       │   ├── opening_loc: ∅
-        │   │       │   │       │   ├── value_loc: (68,10)-(68,13) = "foo"
-        │   │       │   │       │   ├── closing_loc: (68,13)-(68,14) = ":"
-        │   │       │   │       │   └── unescaped: "foo"
-        │   │       │   │       ├── value:
-        │   │       │   │       │   @ CallNode (location: (68,15)-(68,18))
-        │   │       │   │       │   ├── receiver: ∅
-        │   │       │   │       │   ├── call_operator_loc: ∅
-        │   │       │   │       │   ├── message_loc: (68,15)-(68,18) = "boz"
-        │   │       │   │       │   ├── opening_loc: ∅
-        │   │       │   │       │   ├── arguments: ∅
-        │   │       │   │       │   ├── closing_loc: ∅
-        │   │       │   │       │   ├── block: ∅
-        │   │       │   │       │   ├── flags: variable_call
-        │   │       │   │       │   └── name: :boz
-        │   │       │   │       └── operator_loc: ∅
-        │   │       │   └── closing_loc: (68,19)-(68,20) = "}"
-        │   │       └── @ CallNode (location: (68,22)-(68,25))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (68,22)-(68,25) = "boz"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :boz
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ HashNode (location: (68,8)-(68,20))
+        │   │   │   │   ├── opening_loc: (68,8)-(68,9) = "{"
+        │   │   │   │   ├── elements: (length: 1)
+        │   │   │   │   │   └── @ AssocNode (location: (68,10)-(68,18))
+        │   │   │   │   │       ├── key:
+        │   │   │   │   │       │   @ SymbolNode (location: (68,10)-(68,14))
+        │   │   │   │   │       │   ├── opening_loc: ∅
+        │   │   │   │   │       │   ├── value_loc: (68,10)-(68,13) = "foo"
+        │   │   │   │   │       │   ├── closing_loc: (68,13)-(68,14) = ":"
+        │   │   │   │   │       │   └── unescaped: "foo"
+        │   │   │   │   │       ├── value:
+        │   │   │   │   │       │   @ CallNode (location: (68,15)-(68,18))
+        │   │   │   │   │       │   ├── receiver: ∅
+        │   │   │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │   │   │       │   ├── message_loc: (68,15)-(68,18) = "boz"
+        │   │   │   │   │       │   ├── opening_loc: ∅
+        │   │   │   │   │       │   ├── arguments: ∅
+        │   │   │   │   │       │   ├── closing_loc: ∅
+        │   │   │   │   │       │   ├── block: ∅
+        │   │   │   │   │       │   ├── flags: variable_call
+        │   │   │   │   │       │   └── name: :boz
+        │   │   │   │   │       └── operator_loc: ∅
+        │   │   │   │   └── closing_loc: (68,19)-(68,20) = "}"
+        │   │   │   └── @ CallNode (location: (68,22)-(68,25))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (68,22)-(68,25) = "boz"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :boz
+        │   │   └── flags: ∅
         │   ├── closing_loc: (68,25)-(68,26) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1506,12 +1530,13 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (69,8)-(69,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SymbolNode (location: (69,8)-(69,12))
-        │   │           ├── opening_loc: (69,8)-(69,9) = ":"
-        │   │           ├── value_loc: (69,9)-(69,12) = "baz"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "baz"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SymbolNode (location: (69,8)-(69,12))
+        │   │   │       ├── opening_loc: (69,8)-(69,9) = ":"
+        │   │   │       ├── value_loc: (69,9)-(69,12) = "baz"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "baz"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1523,28 +1548,29 @@
         │   ├── opening_loc: (70,3)-(70,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (70,4)-(70,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (70,4)-(70,8))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (70,4)-(70,8))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (70,4)-(70,6))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (70,4)-(70,5) = "a"
-        │   │                   │   ├── closing_loc: (70,5)-(70,6) = ":"
-        │   │                   │   └── unescaped: "a"
-        │   │                   ├── value:
-        │   │                   │   @ CallNode (location: (70,7)-(70,8))
-        │   │                   │   ├── receiver: ∅
-        │   │                   │   ├── call_operator_loc: ∅
-        │   │                   │   ├── message_loc: (70,7)-(70,8) = "b"
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── arguments: ∅
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   ├── block: ∅
-        │   │                   │   ├── flags: variable_call
-        │   │                   │   └── name: :b
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (70,4)-(70,8))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (70,4)-(70,8))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (70,4)-(70,6))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (70,4)-(70,5) = "a"
+        │   │   │               │   ├── closing_loc: (70,5)-(70,6) = ":"
+        │   │   │               │   └── unescaped: "a"
+        │   │   │               ├── value:
+        │   │   │               │   @ CallNode (location: (70,7)-(70,8))
+        │   │   │               │   ├── receiver: ∅
+        │   │   │               │   ├── call_operator_loc: ∅
+        │   │   │               │   ├── message_loc: (70,7)-(70,8) = "b"
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── arguments: ∅
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   ├── block: ∅
+        │   │   │               │   ├── flags: variable_call
+        │   │   │               │   └── name: :b
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: (70,8)-(70,9) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1566,28 +1592,29 @@
         │   ├── opening_loc: (71,5)-(71,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (71,6)-(71,10))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (71,6)-(71,10))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (71,6)-(71,10))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (71,6)-(71,8))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (71,6)-(71,7) = "a"
-        │   │                   │   ├── closing_loc: (71,7)-(71,8) = ":"
-        │   │                   │   └── unescaped: "a"
-        │   │                   ├── value:
-        │   │                   │   @ CallNode (location: (71,9)-(71,10))
-        │   │                   │   ├── receiver: ∅
-        │   │                   │   ├── call_operator_loc: ∅
-        │   │                   │   ├── message_loc: (71,9)-(71,10) = "b"
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── arguments: ∅
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   ├── block: ∅
-        │   │                   │   ├── flags: variable_call
-        │   │                   │   └── name: :b
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (71,6)-(71,10))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (71,6)-(71,10))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (71,6)-(71,8))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (71,6)-(71,7) = "a"
+        │   │   │               │   ├── closing_loc: (71,7)-(71,8) = ":"
+        │   │   │               │   └── unescaped: "a"
+        │   │   │               ├── value:
+        │   │   │               │   @ CallNode (location: (71,9)-(71,10))
+        │   │   │               │   ├── receiver: ∅
+        │   │   │               │   ├── call_operator_loc: ∅
+        │   │   │               │   ├── message_loc: (71,9)-(71,10) = "b"
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── arguments: ∅
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   ├── block: ∅
+        │   │   │               │   ├── flags: variable_call
+        │   │   │               │   └── name: :b
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: (71,10)-(71,11) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1609,22 +1636,23 @@
         │   ├── opening_loc: (72,5)-(72,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (72,6)-(72,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (72,6)-(72,9))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocSplatNode (location: (72,6)-(72,9))
-        │   │                   ├── value:
-        │   │                   │   @ CallNode (location: (72,8)-(72,9))
-        │   │                   │   ├── receiver: ∅
-        │   │                   │   ├── call_operator_loc: ∅
-        │   │                   │   ├── message_loc: (72,8)-(72,9) = "a"
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── arguments: ∅
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   ├── block: ∅
-        │   │                   │   ├── flags: variable_call
-        │   │                   │   └── name: :a
-        │   │                   └── operator_loc: (72,6)-(72,8) = "**"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (72,6)-(72,9))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocSplatNode (location: (72,6)-(72,9))
+        │   │   │               ├── value:
+        │   │   │               │   @ CallNode (location: (72,8)-(72,9))
+        │   │   │               │   ├── receiver: ∅
+        │   │   │               │   ├── call_operator_loc: ∅
+        │   │   │               │   ├── message_loc: (72,8)-(72,9) = "a"
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── arguments: ∅
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   ├── block: ∅
+        │   │   │               │   ├── flags: variable_call
+        │   │   │               │   └── name: :a
+        │   │   │               └── operator_loc: (72,6)-(72,8) = "**"
+        │   │   └── flags: keyword_splat
         │   ├── closing_loc: (72,9)-(72,10) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1646,20 +1674,21 @@
         │   ├── opening_loc: (73,3)-(73,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (73,4)-(73,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SplatNode (location: (73,4)-(73,8))
-        │   │           ├── operator_loc: (73,4)-(73,5) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (73,5)-(73,8))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (73,5)-(73,8) = "baz"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :baz
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SplatNode (location: (73,4)-(73,8))
+        │   │   │       ├── operator_loc: (73,4)-(73,5) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (73,5)-(73,8))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (73,5)-(73,8) = "baz"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :baz
+        │   │   └── flags: ∅
         │   ├── closing_loc: (73,8)-(73,9) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1681,11 +1710,12 @@
         │   ├── opening_loc: (74,3)-(74,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (74,4)-(74,8))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ IntegerNode (location: (74,4)-(74,5))
-        │   │       │   └── flags: decimal
-        │   │       └── @ IntegerNode (location: (74,7)-(74,8))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ IntegerNode (location: (74,4)-(74,5))
+        │   │   │   │   └── flags: decimal
+        │   │   │   └── @ IntegerNode (location: (74,7)-(74,8))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (74,8)-(74,9) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1729,12 +1759,13 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (77,9)-(77,13))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SymbolNode (location: (77,9)-(77,13))
-        │   │           ├── opening_loc: (77,9)-(77,10) = ":"
-        │   │           ├── value_loc: (77,10)-(77,13) = "bar"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "bar"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SymbolNode (location: (77,9)-(77,13))
+        │   │   │       ├── opening_loc: (77,9)-(77,10) = ":"
+        │   │   │       ├── value_loc: (77,10)-(77,13) = "bar"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "bar"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1762,17 +1793,18 @@
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (78,5)-(78,6))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ CallNode (location: (78,5)-(78,6))
-        │   │   │           │           ├── receiver: ∅
-        │   │   │           │           ├── call_operator_loc: ∅
-        │   │   │           │           ├── message_loc: (78,5)-(78,6) = "b"
-        │   │   │           │           ├── opening_loc: ∅
-        │   │   │           │           ├── arguments: ∅
-        │   │   │           │           ├── closing_loc: ∅
-        │   │   │           │           ├── block: ∅
-        │   │   │           │           ├── flags: variable_call
-        │   │   │           │           └── name: :b
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ CallNode (location: (78,5)-(78,6))
+        │   │   │           │   │       ├── receiver: ∅
+        │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │           │   │       ├── message_loc: (78,5)-(78,6) = "b"
+        │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │           │   │       ├── arguments: ∅
+        │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │           │   │       ├── block: ∅
+        │   │   │           │   │       ├── flags: variable_call
+        │   │   │           │   │       └── name: :b
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅
@@ -1784,45 +1816,47 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (78,10)-(78,17))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (78,10)-(78,17))
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (78,11)-(78,16))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ CallNode (location: (78,11)-(78,16))
-        │   │           │           ├── receiver:
-        │   │           │           │   @ CallNode (location: (78,11)-(78,12))
-        │   │           │           │   ├── receiver: ∅
-        │   │           │           │   ├── call_operator_loc: ∅
-        │   │           │           │   ├── message_loc: (78,11)-(78,12) = "c"
-        │   │           │           │   ├── opening_loc: ∅
-        │   │           │           │   ├── arguments: ∅
-        │   │           │           │   ├── closing_loc: ∅
-        │   │           │           │   ├── block: ∅
-        │   │           │           │   ├── flags: variable_call
-        │   │           │           │   └── name: :c
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (78,13)-(78,14) = "-"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments:
-        │   │           │           │   @ ArgumentsNode (location: (78,15)-(78,16))
-        │   │           │           │   └── arguments: (length: 1)
-        │   │           │           │       └── @ CallNode (location: (78,15)-(78,16))
-        │   │           │           │           ├── receiver: ∅
-        │   │           │           │           ├── call_operator_loc: ∅
-        │   │           │           │           ├── message_loc: (78,15)-(78,16) = "d"
-        │   │           │           │           ├── opening_loc: ∅
-        │   │           │           │           ├── arguments: ∅
-        │   │           │           │           ├── closing_loc: ∅
-        │   │           │           │           ├── block: ∅
-        │   │           │           │           ├── flags: variable_call
-        │   │           │           │           └── name: :d
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block: ∅
-        │   │           │           ├── flags: ∅
-        │   │           │           └── name: :-
-        │   │           ├── opening_loc: (78,10)-(78,11) = "("
-        │   │           └── closing_loc: (78,16)-(78,17) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (78,10)-(78,17))
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (78,11)-(78,16))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ CallNode (location: (78,11)-(78,16))
+        │   │   │       │           ├── receiver:
+        │   │   │       │           │   @ CallNode (location: (78,11)-(78,12))
+        │   │   │       │           │   ├── receiver: ∅
+        │   │   │       │           │   ├── call_operator_loc: ∅
+        │   │   │       │           │   ├── message_loc: (78,11)-(78,12) = "c"
+        │   │   │       │           │   ├── opening_loc: ∅
+        │   │   │       │           │   ├── arguments: ∅
+        │   │   │       │           │   ├── closing_loc: ∅
+        │   │   │       │           │   ├── block: ∅
+        │   │   │       │           │   ├── flags: variable_call
+        │   │   │       │           │   └── name: :c
+        │   │   │       │           ├── call_operator_loc: ∅
+        │   │   │       │           ├── message_loc: (78,13)-(78,14) = "-"
+        │   │   │       │           ├── opening_loc: ∅
+        │   │   │       │           ├── arguments:
+        │   │   │       │           │   @ ArgumentsNode (location: (78,15)-(78,16))
+        │   │   │       │           │   ├── arguments: (length: 1)
+        │   │   │       │           │   │   └── @ CallNode (location: (78,15)-(78,16))
+        │   │   │       │           │   │       ├── receiver: ∅
+        │   │   │       │           │   │       ├── call_operator_loc: ∅
+        │   │   │       │           │   │       ├── message_loc: (78,15)-(78,16) = "d"
+        │   │   │       │           │   │       ├── opening_loc: ∅
+        │   │   │       │           │   │       ├── arguments: ∅
+        │   │   │       │           │   │       ├── closing_loc: ∅
+        │   │   │       │           │   │       ├── block: ∅
+        │   │   │       │           │   │       ├── flags: variable_call
+        │   │   │       │           │   │       └── name: :d
+        │   │   │       │           │   └── flags: ∅
+        │   │   │       │           ├── closing_loc: ∅
+        │   │   │       │           ├── block: ∅
+        │   │   │       │           ├── flags: ∅
+        │   │   │       │           └── name: :-
+        │   │   │       ├── opening_loc: (78,10)-(78,11) = "("
+        │   │   │       └── closing_loc: (78,16)-(78,17) = ")"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1850,17 +1884,18 @@
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (79,5)-(79,6))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ CallNode (location: (79,5)-(79,6))
-        │   │   │           │           ├── receiver: ∅
-        │   │   │           │           ├── call_operator_loc: ∅
-        │   │   │           │           ├── message_loc: (79,5)-(79,6) = "b"
-        │   │   │           │           ├── opening_loc: ∅
-        │   │   │           │           ├── arguments: ∅
-        │   │   │           │           ├── closing_loc: ∅
-        │   │   │           │           ├── block: ∅
-        │   │   │           │           ├── flags: variable_call
-        │   │   │           │           └── name: :b
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ CallNode (location: (79,5)-(79,6))
+        │   │   │           │   │       ├── receiver: ∅
+        │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │           │   │       ├── message_loc: (79,5)-(79,6) = "b"
+        │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │           │   │       ├── arguments: ∅
+        │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │           │   │       ├── block: ∅
+        │   │   │           │   │       ├── flags: variable_call
+        │   │   │           │   │       └── name: :b
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅
@@ -1872,49 +1907,51 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (79,10)-(79,19))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (79,10)-(79,19))
-        │   │           ├── receiver:
-        │   │           │   @ CallNode (location: (79,10)-(79,11))
-        │   │           │   ├── receiver: ∅
-        │   │           │   ├── call_operator_loc: ∅
-        │   │           │   ├── message_loc: (79,10)-(79,11) = "c"
-        │   │           │   ├── opening_loc: ∅
-        │   │           │   ├── arguments: ∅
-        │   │           │   ├── closing_loc: ∅
-        │   │           │   ├── block: ∅
-        │   │           │   ├── flags: variable_call
-        │   │           │   └── name: :c
-        │   │           ├── call_operator_loc: (79,11)-(79,12) = "."
-        │   │           ├── message_loc: (79,12)-(79,13) = "-"
-        │   │           ├── opening_loc: (79,13)-(79,14) = "("
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (79,14)-(79,18))
-        │   │           │   └── arguments: (length: 2)
-        │   │           │       ├── @ CallNode (location: (79,14)-(79,15))
-        │   │           │       │   ├── receiver: ∅
-        │   │           │       │   ├── call_operator_loc: ∅
-        │   │           │       │   ├── message_loc: (79,14)-(79,15) = "e"
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── arguments: ∅
-        │   │           │       │   ├── closing_loc: ∅
-        │   │           │       │   ├── block: ∅
-        │   │           │       │   ├── flags: variable_call
-        │   │           │       │   └── name: :e
-        │   │           │       └── @ CallNode (location: (79,17)-(79,18))
-        │   │           │           ├── receiver: ∅
-        │   │           │           ├── call_operator_loc: ∅
-        │   │           │           ├── message_loc: (79,17)-(79,18) = "f"
-        │   │           │           ├── opening_loc: ∅
-        │   │           │           ├── arguments: ∅
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           ├── block: ∅
-        │   │           │           ├── flags: variable_call
-        │   │           │           └── name: :f
-        │   │           ├── closing_loc: (79,18)-(79,19) = ")"
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :-
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (79,10)-(79,19))
+        │   │   │       ├── receiver:
+        │   │   │       │   @ CallNode (location: (79,10)-(79,11))
+        │   │   │       │   ├── receiver: ∅
+        │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │       │   ├── message_loc: (79,10)-(79,11) = "c"
+        │   │   │       │   ├── opening_loc: ∅
+        │   │   │       │   ├── arguments: ∅
+        │   │   │       │   ├── closing_loc: ∅
+        │   │   │       │   ├── block: ∅
+        │   │   │       │   ├── flags: variable_call
+        │   │   │       │   └── name: :c
+        │   │   │       ├── call_operator_loc: (79,11)-(79,12) = "."
+        │   │   │       ├── message_loc: (79,12)-(79,13) = "-"
+        │   │   │       ├── opening_loc: (79,13)-(79,14) = "("
+        │   │   │       ├── arguments:
+        │   │   │       │   @ ArgumentsNode (location: (79,14)-(79,18))
+        │   │   │       │   ├── arguments: (length: 2)
+        │   │   │       │   │   ├── @ CallNode (location: (79,14)-(79,15))
+        │   │   │       │   │   │   ├── receiver: ∅
+        │   │   │       │   │   │   ├── call_operator_loc: ∅
+        │   │   │       │   │   │   ├── message_loc: (79,14)-(79,15) = "e"
+        │   │   │       │   │   │   ├── opening_loc: ∅
+        │   │   │       │   │   │   ├── arguments: ∅
+        │   │   │       │   │   │   ├── closing_loc: ∅
+        │   │   │       │   │   │   ├── block: ∅
+        │   │   │       │   │   │   ├── flags: variable_call
+        │   │   │       │   │   │   └── name: :e
+        │   │   │       │   │   └── @ CallNode (location: (79,17)-(79,18))
+        │   │   │       │   │       ├── receiver: ∅
+        │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │       │   │       ├── message_loc: (79,17)-(79,18) = "f"
+        │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │       │   │       ├── arguments: ∅
+        │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │       │   │       ├── block: ∅
+        │   │   │       │   │       ├── flags: variable_call
+        │   │   │       │   │       └── name: :f
+        │   │   │       │   └── flags: ∅
+        │   │   │       ├── closing_loc: (79,18)-(79,19) = ")"
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :-
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1942,17 +1979,18 @@
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (80,5)-(80,6))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ CallNode (location: (80,5)-(80,6))
-        │   │   │           │           ├── receiver: ∅
-        │   │   │           │           ├── call_operator_loc: ∅
-        │   │   │           │           ├── message_loc: (80,5)-(80,6) = "b"
-        │   │   │           │           ├── opening_loc: ∅
-        │   │   │           │           ├── arguments: ∅
-        │   │   │           │           ├── closing_loc: ∅
-        │   │   │           │           ├── block: ∅
-        │   │   │           │           ├── flags: variable_call
-        │   │   │           │           └── name: :b
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ CallNode (location: (80,5)-(80,6))
+        │   │   │           │   │       ├── receiver: ∅
+        │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │           │   │       ├── message_loc: (80,5)-(80,6) = "b"
+        │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │           │   │       ├── arguments: ∅
+        │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │           │   │       ├── block: ∅
+        │   │   │           │   │       ├── flags: variable_call
+        │   │   │           │   │       └── name: :b
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅
@@ -1964,42 +2002,44 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (80,10)-(80,17))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (80,10)-(80,17))
-        │   │           ├── receiver:
-        │   │           │   @ CallNode (location: (80,10)-(80,11))
-        │   │           │   ├── receiver: ∅
-        │   │           │   ├── call_operator_loc: ∅
-        │   │           │   ├── message_loc: (80,10)-(80,11) = "c"
-        │   │           │   ├── opening_loc: ∅
-        │   │           │   ├── arguments: ∅
-        │   │           │   ├── closing_loc: ∅
-        │   │           │   ├── block: ∅
-        │   │           │   ├── flags: variable_call
-        │   │           │   └── name: :c
-        │   │           ├── call_operator_loc: (80,11)-(80,12) = "."
-        │   │           ├── message_loc: (80,12)-(80,13) = "-"
-        │   │           ├── opening_loc: (80,13)-(80,14) = "("
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (80,14)-(80,16))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ SplatNode (location: (80,14)-(80,16))
-        │   │           │           ├── operator_loc: (80,14)-(80,15) = "*"
-        │   │           │           └── expression:
-        │   │           │               @ CallNode (location: (80,15)-(80,16))
-        │   │           │               ├── receiver: ∅
-        │   │           │               ├── call_operator_loc: ∅
-        │   │           │               ├── message_loc: (80,15)-(80,16) = "f"
-        │   │           │               ├── opening_loc: ∅
-        │   │           │               ├── arguments: ∅
-        │   │           │               ├── closing_loc: ∅
-        │   │           │               ├── block: ∅
-        │   │           │               ├── flags: variable_call
-        │   │           │               └── name: :f
-        │   │           ├── closing_loc: (80,16)-(80,17) = ")"
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :-
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (80,10)-(80,17))
+        │   │   │       ├── receiver:
+        │   │   │       │   @ CallNode (location: (80,10)-(80,11))
+        │   │   │       │   ├── receiver: ∅
+        │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │       │   ├── message_loc: (80,10)-(80,11) = "c"
+        │   │   │       │   ├── opening_loc: ∅
+        │   │   │       │   ├── arguments: ∅
+        │   │   │       │   ├── closing_loc: ∅
+        │   │   │       │   ├── block: ∅
+        │   │   │       │   ├── flags: variable_call
+        │   │   │       │   └── name: :c
+        │   │   │       ├── call_operator_loc: (80,11)-(80,12) = "."
+        │   │   │       ├── message_loc: (80,12)-(80,13) = "-"
+        │   │   │       ├── opening_loc: (80,13)-(80,14) = "("
+        │   │   │       ├── arguments:
+        │   │   │       │   @ ArgumentsNode (location: (80,14)-(80,16))
+        │   │   │       │   ├── arguments: (length: 1)
+        │   │   │       │   │   └── @ SplatNode (location: (80,14)-(80,16))
+        │   │   │       │   │       ├── operator_loc: (80,14)-(80,15) = "*"
+        │   │   │       │   │       └── expression:
+        │   │   │       │   │           @ CallNode (location: (80,15)-(80,16))
+        │   │   │       │   │           ├── receiver: ∅
+        │   │   │       │   │           ├── call_operator_loc: ∅
+        │   │   │       │   │           ├── message_loc: (80,15)-(80,16) = "f"
+        │   │   │       │   │           ├── opening_loc: ∅
+        │   │   │       │   │           ├── arguments: ∅
+        │   │   │       │   │           ├── closing_loc: ∅
+        │   │   │       │   │           ├── block: ∅
+        │   │   │       │   │           ├── flags: variable_call
+        │   │   │       │   │           └── name: :f
+        │   │   │       │   └── flags: ∅
+        │   │   │       ├── closing_loc: (80,16)-(80,17) = ")"
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :-
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -2011,22 +2051,23 @@
         │   ├── opening_loc: (81,1)-(81,2) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (81,2)-(81,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (81,2)-(81,7))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocSplatNode (location: (81,2)-(81,7))
-        │   │                   ├── value:
-        │   │                   │   @ CallNode (location: (81,4)-(81,7))
-        │   │                   │   ├── receiver: ∅
-        │   │                   │   ├── call_operator_loc: ∅
-        │   │                   │   ├── message_loc: (81,4)-(81,7) = "foo"
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── arguments: ∅
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   ├── block: ∅
-        │   │                   │   ├── flags: variable_call
-        │   │                   │   └── name: :foo
-        │   │                   └── operator_loc: (81,2)-(81,4) = "**"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (81,2)-(81,7))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocSplatNode (location: (81,2)-(81,7))
+        │   │   │               ├── value:
+        │   │   │               │   @ CallNode (location: (81,4)-(81,7))
+        │   │   │               │   ├── receiver: ∅
+        │   │   │               │   ├── call_operator_loc: ∅
+        │   │   │               │   ├── message_loc: (81,4)-(81,7) = "foo"
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── arguments: ∅
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   ├── block: ∅
+        │   │   │               │   ├── flags: variable_call
+        │   │   │               │   └── name: :foo
+        │   │   │               └── operator_loc: (81,2)-(81,4) = "**"
+        │   │   └── flags: keyword_splat
         │   ├── closing_loc: (81,7)-(81,8) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -2068,17 +2109,18 @@
         │   ├── opening_loc: (83,5)-(83,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (83,6)-(83,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (83,6)-(83,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (83,6)-(83,7) = "b"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :b
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (83,6)-(83,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (83,6)-(83,7) = "b"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :b
+        │   │   └── flags: ∅
         │   ├── closing_loc: (83,7)-(83,8) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -2100,17 +2142,18 @@
             ├── opening_loc: (84,4)-(84,5) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (84,5)-(84,6))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (84,5)-(84,6))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (84,5)-(84,6) = "b"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :b
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (84,5)-(84,6))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (84,5)-(84,6) = "b"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :b
+            │   └── flags: ∅
             ├── closing_loc: (84,6)-(84,7) = ")"
             ├── block: ∅
             ├── flags: safe_navigation

--- a/test/prism/snapshots/unparser/corpus/literal/since/27.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/since/27.txt
@@ -22,10 +22,11 @@
         │               ├── opening_loc: ∅
         │               ├── arguments:
         │               │   @ ArgumentsNode (location: (2,7)-(2,9))
-        │               │   └── arguments: (length: 1)
-        │               │       └── @ LocalVariableReadNode (location: (2,7)-(2,9))
-        │               │           ├── name: :_2
-        │               │           └── depth: 0
+        │               │   ├── arguments: (length: 1)
+        │               │   │   └── @ LocalVariableReadNode (location: (2,7)-(2,9))
+        │               │   │       ├── name: :_2
+        │               │   │       └── depth: 0
+        │               │   └── flags: ∅
         │               ├── closing_loc: ∅
         │               ├── block: ∅
         │               ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/since/32.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/since/32.txt
@@ -32,15 +32,16 @@
         │   │           ├── opening_loc: (2,5)-(2,6) = "("
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (2,6)-(2,18))
-        │   │           │   └── arguments: (length: 2)
-        │   │           │       ├── @ LocalVariableReadNode (location: (2,6)-(2,14))
-        │   │           │       │   ├── name: :argument
-        │   │           │       │   └── depth: 0
-        │   │           │       └── @ KeywordHashNode (location: (2,16)-(2,18))
-        │   │           │           └── elements: (length: 1)
-        │   │           │               └── @ AssocSplatNode (location: (2,16)-(2,18))
-        │   │           │                   ├── value: ∅
-        │   │           │                   └── operator_loc: (2,16)-(2,18) = "**"
+        │   │           │   ├── arguments: (length: 2)
+        │   │           │   │   ├── @ LocalVariableReadNode (location: (2,6)-(2,14))
+        │   │           │   │   │   ├── name: :argument
+        │   │           │   │   │   └── depth: 0
+        │   │           │   │   └── @ KeywordHashNode (location: (2,16)-(2,18))
+        │   │           │   │       └── elements: (length: 1)
+        │   │           │   │           └── @ AssocSplatNode (location: (2,16)-(2,18))
+        │   │           │   │               ├── value: ∅
+        │   │           │   │               └── operator_loc: (2,16)-(2,18) = "**"
+        │   │           │   └── flags: keyword_splat
         │   │           ├── closing_loc: (2,18)-(2,19) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -81,13 +82,14 @@
             │           ├── opening_loc: (6,5)-(6,6) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (6,6)-(6,17))
-            │           │   └── arguments: (length: 2)
-            │           │       ├── @ LocalVariableReadNode (location: (6,6)-(6,14))
-            │           │       │   ├── name: :argument
-            │           │       │   └── depth: 0
-            │           │       └── @ SplatNode (location: (6,16)-(6,17))
-            │           │           ├── operator_loc: (6,16)-(6,17) = "*"
-            │           │           └── expression: ∅
+            │           │   ├── arguments: (length: 2)
+            │           │   │   ├── @ LocalVariableReadNode (location: (6,6)-(6,14))
+            │           │   │   │   ├── name: :argument
+            │           │   │   │   └── depth: 0
+            │           │   │   └── @ SplatNode (location: (6,16)-(6,17))
+            │           │   │       ├── operator_loc: (6,16)-(6,17) = "*"
+            │           │   │       └── expression: ∅
+            │           │   └── flags: ∅
             │           ├── closing_loc: (6,17)-(6,18) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/super.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/super.txt
@@ -16,17 +16,18 @@
         │   ├── lparen_loc: (3,5)-(3,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,6)-(3,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (3,6)-(3,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (3,6)-(3,7) = "a"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :a
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (3,6)-(3,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (3,6)-(3,7) = "a"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :a
+        │   │   └── flags: ∅
         │   ├── rparen_loc: (3,7)-(3,8) = ")"
         │   └── block: ∅
         ├── @ SuperNode (location: (4,0)-(4,11))
@@ -34,27 +35,28 @@
         │   ├── lparen_loc: (4,5)-(4,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (4,6)-(4,10))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (4,6)-(4,7))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (4,6)-(4,7) = "a"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :a
-        │   │       └── @ CallNode (location: (4,9)-(4,10))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (4,9)-(4,10) = "b"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :b
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (4,6)-(4,7))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (4,6)-(4,7) = "a"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :a
+        │   │   │   └── @ CallNode (location: (4,9)-(4,10))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (4,9)-(4,10) = "b"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :b
+        │   │   └── flags: ∅
         │   ├── rparen_loc: (4,10)-(4,11) = ")"
         │   └── block: ∅
         ├── @ SuperNode (location: (5,0)-(5,12))
@@ -81,17 +83,18 @@
         │   ├── lparen_loc: (6,5)-(6,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (6,6)-(6,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (6,6)-(6,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (6,6)-(6,7) = "a"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :a
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (6,6)-(6,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (6,6)-(6,7) = "a"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :a
+        │   │   └── flags: ∅
         │   ├── rparen_loc: (6,15)-(6,16) = ")"
         │   └── block:
         │       @ BlockArgumentNode (location: (6,9)-(6,15))
@@ -112,35 +115,36 @@
         │   ├── lparen_loc: (7,5)-(7,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,6)-(9,1))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (7,6)-(9,1))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (7,6)-(7,7) = "a"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block:
-        │   │           │   @ BlockNode (location: (7,8)-(9,1))
-        │   │           │   ├── locals: []
-        │   │           │   ├── parameters: ∅
-        │   │           │   ├── body:
-        │   │           │   │   @ StatementsNode (location: (8,2)-(8,5))
-        │   │           │   │   └── body: (length: 1)
-        │   │           │   │       └── @ CallNode (location: (8,2)-(8,5))
-        │   │           │   │           ├── receiver: ∅
-        │   │           │   │           ├── call_operator_loc: ∅
-        │   │           │   │           ├── message_loc: (8,2)-(8,5) = "foo"
-        │   │           │   │           ├── opening_loc: ∅
-        │   │           │   │           ├── arguments: ∅
-        │   │           │   │           ├── closing_loc: ∅
-        │   │           │   │           ├── block: ∅
-        │   │           │   │           ├── flags: variable_call
-        │   │           │   │           └── name: :foo
-        │   │           │   ├── opening_loc: (7,8)-(7,9) = "{"
-        │   │           │   └── closing_loc: (9,0)-(9,1) = "}"
-        │   │           ├── flags: ∅
-        │   │           └── name: :a
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (7,6)-(9,1))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (7,6)-(7,7) = "a"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block:
+        │   │   │       │   @ BlockNode (location: (7,8)-(9,1))
+        │   │   │       │   ├── locals: []
+        │   │   │       │   ├── parameters: ∅
+        │   │   │       │   ├── body:
+        │   │   │       │   │   @ StatementsNode (location: (8,2)-(8,5))
+        │   │   │       │   │   └── body: (length: 1)
+        │   │   │       │   │       └── @ CallNode (location: (8,2)-(8,5))
+        │   │   │       │   │           ├── receiver: ∅
+        │   │   │       │   │           ├── call_operator_loc: ∅
+        │   │   │       │   │           ├── message_loc: (8,2)-(8,5) = "foo"
+        │   │   │       │   │           ├── opening_loc: ∅
+        │   │   │       │   │           ├── arguments: ∅
+        │   │   │       │   │           ├── closing_loc: ∅
+        │   │   │       │   │           ├── block: ∅
+        │   │   │       │   │           ├── flags: variable_call
+        │   │   │       │   │           └── name: :foo
+        │   │   │       │   ├── opening_loc: (7,8)-(7,9) = "{"
+        │   │   │       │   └── closing_loc: (9,0)-(9,1) = "}"
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :a
+        │   │   └── flags: ∅
         │   ├── rparen_loc: (9,1)-(9,2) = ")"
         │   └── block: ∅
         ├── @ ForwardingSuperNode (location: (10,0)-(12,1))
@@ -168,17 +172,18 @@
         │   ├── lparen_loc: (13,5)-(13,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (13,6)-(13,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (13,6)-(13,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (13,6)-(13,7) = "a"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :a
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (13,6)-(13,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (13,6)-(13,7) = "a"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :a
+        │   │   └── flags: ∅
         │   ├── rparen_loc: (13,7)-(13,8) = ")"
         │   └── block:
         │       @ BlockNode (location: (13,9)-(15,1))
@@ -228,27 +233,28 @@
             ├── lparen_loc: (19,5)-(19,6) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (19,6)-(19,10))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (19,6)-(19,7))
-            │       │   ├── receiver: ∅
-            │       │   ├── call_operator_loc: ∅
-            │       │   ├── message_loc: (19,6)-(19,7) = "a"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block: ∅
-            │       │   ├── flags: variable_call
-            │       │   └── name: :a
-            │       └── @ CallNode (location: (19,9)-(19,10))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (19,9)-(19,10) = "b"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :b
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (19,6)-(19,7))
+            │   │   │   ├── receiver: ∅
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── message_loc: (19,6)-(19,7) = "a"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block: ∅
+            │   │   │   ├── flags: variable_call
+            │   │   │   └── name: :a
+            │   │   └── @ CallNode (location: (19,9)-(19,10))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (19,9)-(19,10) = "b"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :b
+            │   └── flags: ∅
             ├── rparen_loc: (19,10)-(19,11) = ")"
             └── block:
                 @ BlockNode (location: (19,12)-(21,1))

--- a/test/prism/snapshots/unparser/corpus/literal/while.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/while.txt
@@ -96,17 +96,18 @@
         │   │           │   ├── opening_loc: ∅
         │   │           │   ├── arguments:
         │   │           │   │   @ ArgumentsNode (location: (10,25)-(10,28))
-        │   │           │   │   └── arguments: (length: 1)
-        │   │           │   │       └── @ CallNode (location: (10,25)-(10,28))
-        │   │           │   │           ├── receiver: ∅
-        │   │           │   │           ├── call_operator_loc: ∅
-        │   │           │   │           ├── message_loc: (10,25)-(10,28) = "baz"
-        │   │           │   │           ├── opening_loc: ∅
-        │   │           │   │           ├── arguments: ∅
-        │   │           │   │           ├── closing_loc: ∅
-        │   │           │   │           ├── block: ∅
-        │   │           │   │           ├── flags: variable_call
-        │   │           │   │           └── name: :baz
+        │   │           │   │   ├── arguments: (length: 1)
+        │   │           │   │   │   └── @ CallNode (location: (10,25)-(10,28))
+        │   │           │   │   │       ├── receiver: ∅
+        │   │           │   │   │       ├── call_operator_loc: ∅
+        │   │           │   │   │       ├── message_loc: (10,25)-(10,28) = "baz"
+        │   │           │   │   │       ├── opening_loc: ∅
+        │   │           │   │   │       ├── arguments: ∅
+        │   │           │   │   │       ├── closing_loc: ∅
+        │   │           │   │   │       ├── block: ∅
+        │   │           │   │   │       ├── flags: variable_call
+        │   │           │   │   │       └── name: :baz
+        │   │           │   │   └── flags: ∅
         │   │           │   ├── closing_loc: ∅
         │   │           │   ├── block: ∅
         │   │           │   ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/yield.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/yield.txt
@@ -13,42 +13,44 @@
         │   ├── lparen_loc: (2,5)-(2,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (2,6)-(2,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (2,6)-(2,7))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (2,6)-(2,7) = "a"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :a
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (2,6)-(2,7))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (2,6)-(2,7) = "a"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :a
+        │   │   └── flags: ∅
         │   └── rparen_loc: (2,7)-(2,8) = ")"
         └── @ YieldNode (location: (3,0)-(3,11))
             ├── keyword_loc: (3,0)-(3,5) = "yield"
             ├── lparen_loc: (3,5)-(3,6) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (3,6)-(3,10))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (3,6)-(3,7))
-            │       │   ├── receiver: ∅
-            │       │   ├── call_operator_loc: ∅
-            │       │   ├── message_loc: (3,6)-(3,7) = "a"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block: ∅
-            │       │   ├── flags: variable_call
-            │       │   └── name: :a
-            │       └── @ CallNode (location: (3,9)-(3,10))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (3,9)-(3,10) = "b"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :b
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (3,6)-(3,7))
+            │   │   │   ├── receiver: ∅
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── message_loc: (3,6)-(3,7) = "a"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block: ∅
+            │   │   │   ├── flags: variable_call
+            │   │   │   └── name: :a
+            │   │   └── @ CallNode (location: (3,9)-(3,10))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (3,9)-(3,10) = "b"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :b
+            │   └── flags: ∅
             └── rparen_loc: (3,10)-(3,11) = ")"

--- a/test/prism/snapshots/unparser/corpus/semantic/block.txt
+++ b/test/prism/snapshots/unparser/corpus/semantic/block.txt
@@ -112,13 +112,14 @@
         │   ├── opening_loc: (16,3)-(16,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (16,4)-(16,10))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (16,4)-(16,10))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (16,4)-(16,10) = "<<-DOC"
-        │   │           ├── content_loc: (17,0)-(17,0) = "  b\n"
-        │   │           ├── closing_loc: (18,0)-(18,0) = "DOC\n"
-        │   │           └── unescaped: "  b\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (16,4)-(16,10))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (16,4)-(16,10) = "<<-DOC"
+        │   │   │       ├── content_loc: (17,0)-(17,0) = "  b\n"
+        │   │   │       ├── closing_loc: (18,0)-(18,0) = "DOC\n"
+        │   │   │       └── unescaped: "  b\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (16,10)-(16,11) = ")"
         │   ├── block:
         │   │   @ BlockNode (location: (16,12)-(20,3))
@@ -156,13 +157,14 @@
             ├── opening_loc: (22,3)-(22,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (22,4)-(22,10))
-            │   └── arguments: (length: 1)
-            │       └── @ StringNode (location: (22,4)-(22,10))
-            │           ├── flags: ∅
-            │           ├── opening_loc: (22,4)-(22,10) = "<<-DOC"
-            │           ├── content_loc: (23,0)-(23,0) = "  b\n"
-            │           ├── closing_loc: (24,0)-(24,0) = "DOC\n"
-            │           └── unescaped: "  b\n"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ StringNode (location: (22,4)-(22,10))
+            │   │       ├── flags: ∅
+            │   │       ├── opening_loc: (22,4)-(22,10) = "<<-DOC"
+            │   │       ├── content_loc: (23,0)-(23,0) = "  b\n"
+            │   │       ├── closing_loc: (24,0)-(24,0) = "DOC\n"
+            │   │       └── unescaped: "  b\n"
+            │   └── flags: ∅
             ├── closing_loc: (22,10)-(22,11) = ")"
             ├── block:
             │   @ BlockNode (location: (22,12)-(26,3))

--- a/test/prism/snapshots/unparser/corpus/semantic/def.txt
+++ b/test/prism/snapshots/unparser/corpus/semantic/def.txt
@@ -32,17 +32,18 @@
         │   │           │           ├── opening_loc: ∅
         │   │           │           ├── arguments:
         │   │           │           │   @ ArgumentsNode (location: (2,7)-(2,8))
-        │   │           │           │   └── arguments: (length: 1)
-        │   │           │           │       └── @ CallNode (location: (2,7)-(2,8))
-        │   │           │           │           ├── receiver: ∅
-        │   │           │           │           ├── call_operator_loc: ∅
-        │   │           │           │           ├── message_loc: (2,7)-(2,8) = "b"
-        │   │           │           │           ├── opening_loc: ∅
-        │   │           │           │           ├── arguments: ∅
-        │   │           │           │           ├── closing_loc: ∅
-        │   │           │           │           ├── block: ∅
-        │   │           │           │           ├── flags: variable_call
-        │   │           │           │           └── name: :b
+        │   │           │           │   ├── arguments: (length: 1)
+        │   │           │           │   │   └── @ CallNode (location: (2,7)-(2,8))
+        │   │           │           │   │       ├── receiver: ∅
+        │   │           │           │   │       ├── call_operator_loc: ∅
+        │   │           │           │   │       ├── message_loc: (2,7)-(2,8) = "b"
+        │   │           │           │   │       ├── opening_loc: ∅
+        │   │           │           │   │       ├── arguments: ∅
+        │   │           │           │   │       ├── closing_loc: ∅
+        │   │           │           │   │       ├── block: ∅
+        │   │           │           │   │       ├── flags: variable_call
+        │   │           │           │   │       └── name: :b
+        │   │           │           │   └── flags: ∅
         │   │           │           ├── closing_loc: ∅
         │   │           │           ├── block: ∅
         │   │           │           ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/semantic/literal.txt
+++ b/test/prism/snapshots/unparser/corpus/semantic/literal.txt
@@ -63,29 +63,31 @@
             ├── opening_loc: (14,1)-(14,2) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (14,2)-(14,9))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (14,2)-(14,9))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (14,2)-(14,5) = "foo"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (14,6)-(14,9))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ CallNode (location: (14,6)-(14,9))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (14,6)-(14,9) = "bar"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: variable_call
-            │           │           └── name: :bar
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :foo
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (14,2)-(14,9))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (14,2)-(14,5) = "foo"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (14,6)-(14,9))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ CallNode (location: (14,6)-(14,9))
+            │   │       │   │       ├── receiver: ∅
+            │   │       │   │       ├── call_operator_loc: ∅
+            │   │       │   │       ├── message_loc: (14,6)-(14,9) = "bar"
+            │   │       │   │       ├── opening_loc: ∅
+            │   │       │   │       ├── arguments: ∅
+            │   │       │   │       ├── closing_loc: ∅
+            │   │       │   │       ├── block: ∅
+            │   │       │   │       ├── flags: variable_call
+            │   │       │   │       └── name: :bar
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: ∅
+            │   │       └── name: :foo
+            │   └── flags: ∅
             ├── closing_loc: (14,9)-(14,10) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/semantic/send.txt
+++ b/test/prism/snapshots/unparser/corpus/semantic/send.txt
@@ -20,9 +20,10 @@
         │   ├── opening_loc: (2,3)-(2,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (2,4)-(2,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (2,4)-(2,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (2,4)-(2,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (2,5)-(2,6) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -48,17 +49,18 @@
         │   │   │   ├── opening_loc: (4,5)-(4,6) = "("
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (4,6)-(4,7))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ CallNode (location: (4,6)-(4,7))
-        │   │   │   │           ├── receiver: ∅
-        │   │   │   │           ├── call_operator_loc: ∅
-        │   │   │   │           ├── message_loc: (4,6)-(4,7) = "b"
-        │   │   │   │           ├── opening_loc: ∅
-        │   │   │   │           ├── arguments: ∅
-        │   │   │   │           ├── closing_loc: ∅
-        │   │   │   │           ├── block: ∅
-        │   │   │   │           ├── flags: variable_call
-        │   │   │   │           └── name: :b
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ CallNode (location: (4,6)-(4,7))
+        │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │       ├── message_loc: (4,6)-(4,7) = "b"
+        │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │       ├── arguments: ∅
+        │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │       ├── flags: variable_call
+        │   │   │   │   │       └── name: :b
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: (4,7)-(4,8) = ")"
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅
@@ -76,17 +78,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (4,14)-(4,15))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (4,14)-(4,15))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (4,14)-(4,15) = "d"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :d
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (4,14)-(4,15))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (4,14)-(4,15) = "d"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :d
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -108,49 +111,51 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (6,5)-(6,15))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (6,5)-(6,15))
-            │           ├── receiver:
-            │           │   @ CallNode (location: (6,5)-(6,8))
-            │           │   ├── receiver:
-            │           │   │   @ CallNode (location: (6,5)-(6,6))
-            │           │   │   ├── receiver: ∅
-            │           │   │   ├── call_operator_loc: ∅
-            │           │   │   ├── message_loc: (6,5)-(6,6) = "d"
-            │           │   │   ├── opening_loc: ∅
-            │           │   │   ├── arguments: ∅
-            │           │   │   ├── closing_loc: ∅
-            │           │   │   ├── block: ∅
-            │           │   │   ├── flags: variable_call
-            │           │   │   └── name: :d
-            │           │   ├── call_operator_loc: (6,6)-(6,7) = "."
-            │           │   ├── message_loc: (6,7)-(6,8) = "c"
-            │           │   ├── opening_loc: ∅
-            │           │   ├── arguments: ∅
-            │           │   ├── closing_loc: ∅
-            │           │   ├── block: ∅
-            │           │   ├── flags: ∅
-            │           │   └── name: :c
-            │           ├── call_operator_loc: (6,8)-(6,9) = "."
-            │           ├── message_loc: (6,9)-(6,12) = "==="
-            │           ├── opening_loc: (6,12)-(6,13) = "("
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (6,13)-(6,14))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ CallNode (location: (6,13)-(6,14))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (6,13)-(6,14) = "c"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: variable_call
-            │           │           └── name: :c
-            │           ├── closing_loc: (6,14)-(6,15) = ")"
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :===
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (6,5)-(6,15))
+            │   │       ├── receiver:
+            │   │       │   @ CallNode (location: (6,5)-(6,8))
+            │   │       │   ├── receiver:
+            │   │       │   │   @ CallNode (location: (6,5)-(6,6))
+            │   │       │   │   ├── receiver: ∅
+            │   │       │   │   ├── call_operator_loc: ∅
+            │   │       │   │   ├── message_loc: (6,5)-(6,6) = "d"
+            │   │       │   │   ├── opening_loc: ∅
+            │   │       │   │   ├── arguments: ∅
+            │   │       │   │   ├── closing_loc: ∅
+            │   │       │   │   ├── block: ∅
+            │   │       │   │   ├── flags: variable_call
+            │   │       │   │   └── name: :d
+            │   │       │   ├── call_operator_loc: (6,6)-(6,7) = "."
+            │   │       │   ├── message_loc: (6,7)-(6,8) = "c"
+            │   │       │   ├── opening_loc: ∅
+            │   │       │   ├── arguments: ∅
+            │   │       │   ├── closing_loc: ∅
+            │   │       │   ├── block: ∅
+            │   │       │   ├── flags: ∅
+            │   │       │   └── name: :c
+            │   │       ├── call_operator_loc: (6,8)-(6,9) = "."
+            │   │       ├── message_loc: (6,9)-(6,12) = "==="
+            │   │       ├── opening_loc: (6,12)-(6,13) = "("
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (6,13)-(6,14))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ CallNode (location: (6,13)-(6,14))
+            │   │       │   │       ├── receiver: ∅
+            │   │       │   │       ├── call_operator_loc: ∅
+            │   │       │   │       ├── message_loc: (6,13)-(6,14) = "c"
+            │   │       │   │       ├── opening_loc: ∅
+            │   │       │   │       ├── arguments: ∅
+            │   │       │   │       ├── closing_loc: ∅
+            │   │       │   │       ├── block: ∅
+            │   │       │   │       ├── flags: variable_call
+            │   │       │   │       └── name: :c
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: (6,14)-(6,15) = ")"
+            │   │       ├── block: ∅
+            │   │       ├── flags: ∅
+            │   │       └── name: :===
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/semantic/while.txt
+++ b/test/prism/snapshots/unparser/corpus/semantic/while.txt
@@ -184,13 +184,14 @@
         │   │   ├── opening_loc: (15,9)-(15,10) = "("
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (15,10)-(15,16))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ StringNode (location: (15,10)-(15,16))
-        │   │   │           ├── flags: ∅
-        │   │   │           ├── opening_loc: (15,10)-(15,16) = "<<-FOO"
-        │   │   │           ├── content_loc: (16,0)-(15,0) = ""
-        │   │   │           ├── closing_loc: (16,0)-(16,0) = "FOO\n"
-        │   │   │           └── unescaped: ""
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ StringNode (location: (15,10)-(15,16))
+        │   │   │   │       ├── flags: ∅
+        │   │   │   │       ├── opening_loc: (15,10)-(15,16) = "<<-FOO"
+        │   │   │   │       ├── content_loc: (16,0)-(15,0) = ""
+        │   │   │   │       ├── closing_loc: (16,0)-(16,0) = "FOO\n"
+        │   │   │   │       └── unescaped: ""
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: (15,16)-(15,17) = ")"
         │   │   ├── block:
         │   │   │   @ BlockNode (location: (15,18)-(18,3))

--- a/test/prism/snapshots/until.txt
+++ b/test/prism/snapshots/until.txt
@@ -85,17 +85,18 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (11,4)-(11,10))
-            │           │   └── arguments: (length: 2)
-            │           │       ├── @ SymbolNode (location: (11,4)-(11,6))
-            │           │       │   ├── opening_loc: (11,4)-(11,5) = ":"
-            │           │       │   ├── value_loc: (11,5)-(11,6) = "a"
-            │           │       │   ├── closing_loc: ∅
-            │           │       │   └── unescaped: "a"
-            │           │       └── @ SymbolNode (location: (11,8)-(11,10))
-            │           │           ├── opening_loc: (11,8)-(11,9) = ":"
-            │           │           ├── value_loc: (11,9)-(11,10) = "b"
-            │           │           ├── closing_loc: ∅
-            │           │           └── unescaped: "b"
+            │           │   ├── arguments: (length: 2)
+            │           │   │   ├── @ SymbolNode (location: (11,4)-(11,6))
+            │           │   │   │   ├── opening_loc: (11,4)-(11,5) = ":"
+            │           │   │   │   ├── value_loc: (11,5)-(11,6) = "a"
+            │           │   │   │   ├── closing_loc: ∅
+            │           │   │   │   └── unescaped: "a"
+            │           │   │   └── @ SymbolNode (location: (11,8)-(11,10))
+            │           │   │       ├── opening_loc: (11,8)-(11,9) = ":"
+            │           │   │       ├── value_loc: (11,9)-(11,10) = "b"
+            │           │   │       ├── closing_loc: ∅
+            │           │   │       └── unescaped: "b"
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/while.txt
+++ b/test/prism/snapshots/while.txt
@@ -85,17 +85,18 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (11,4)-(11,10))
-        │   │           │   └── arguments: (length: 2)
-        │   │           │       ├── @ SymbolNode (location: (11,4)-(11,6))
-        │   │           │       │   ├── opening_loc: (11,4)-(11,5) = ":"
-        │   │           │       │   ├── value_loc: (11,5)-(11,6) = "a"
-        │   │           │       │   ├── closing_loc: ∅
-        │   │           │       │   └── unescaped: "a"
-        │   │           │       └── @ SymbolNode (location: (11,8)-(11,10))
-        │   │           │           ├── opening_loc: (11,8)-(11,9) = ":"
-        │   │           │           ├── value_loc: (11,9)-(11,10) = "b"
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           └── unescaped: "b"
+        │   │           │   ├── arguments: (length: 2)
+        │   │           │   │   ├── @ SymbolNode (location: (11,4)-(11,6))
+        │   │           │   │   │   ├── opening_loc: (11,4)-(11,5) = ":"
+        │   │           │   │   │   ├── value_loc: (11,5)-(11,6) = "a"
+        │   │           │   │   │   ├── closing_loc: ∅
+        │   │           │   │   │   └── unescaped: "a"
+        │   │           │   │   └── @ SymbolNode (location: (11,8)-(11,10))
+        │   │           │   │       ├── opening_loc: (11,8)-(11,9) = ":"
+        │   │           │   │       ├── value_loc: (11,9)-(11,10) = "b"
+        │   │           │   │       ├── closing_loc: ∅
+        │   │           │   │       └── unescaped: "b"
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/ambiuous_quoted_label_in_ternary_operator.txt
+++ b/test/prism/snapshots/whitequark/ambiuous_quoted_label_in_ternary_operator.txt
@@ -36,13 +36,14 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,8)-(1,10))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ StringNode (location: (1,8)-(1,10))
-            │           │           ├── flags: ∅
-            │           │           ├── opening_loc: (1,8)-(1,9) = "'"
-            │           │           ├── content_loc: (1,9)-(1,9) = ""
-            │           │           ├── closing_loc: (1,9)-(1,10) = "'"
-            │           │           └── unescaped: ""
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ StringNode (location: (1,8)-(1,10))
+            │           │   │       ├── flags: ∅
+            │           │   │       ├── opening_loc: (1,8)-(1,9) = "'"
+            │           │   │       ├── content_loc: (1,9)-(1,9) = ""
+            │           │   │       ├── closing_loc: (1,9)-(1,10) = "'"
+            │           │   │       └── unescaped: ""
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/and_asgn.txt
+++ b/test/prism/snapshots/whitequark/and_asgn.txt
@@ -40,11 +40,12 @@
             ├── opening_loc: (3,3)-(3,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (3,4)-(3,8))
-            │   └── arguments: (length: 2)
-            │       ├── @ IntegerNode (location: (3,4)-(3,5))
-            │       │   └── flags: decimal
-            │       └── @ IntegerNode (location: (3,7)-(3,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ IntegerNode (location: (3,4)-(3,5))
+            │   │   │   └── flags: decimal
+            │   │   └── @ IntegerNode (location: (3,7)-(3,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (3,8)-(3,9) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/arg_label.txt
+++ b/test/prism/snapshots/whitequark/arg_label.txt
@@ -18,12 +18,13 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (2,2)-(2,4))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ SymbolNode (location: (2,2)-(2,4))
-        │   │           │           ├── opening_loc: (2,2)-(2,3) = ":"
-        │   │           │           ├── value_loc: (2,3)-(2,4) = "b"
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           └── unescaped: "b"
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ SymbolNode (location: (2,2)-(2,4))
+        │   │           │   │       ├── opening_loc: (2,2)-(2,3) = ":"
+        │   │           │   │       ├── value_loc: (2,3)-(2,4) = "b"
+        │   │           │   │       ├── closing_loc: ∅
+        │   │           │   │       └── unescaped: "b"
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -50,12 +51,13 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (4,11)-(4,13))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ SymbolNode (location: (4,11)-(4,13))
-        │   │           │           ├── opening_loc: (4,11)-(4,12) = ":"
-        │   │           │           ├── value_loc: (4,12)-(4,13) = "b"
-        │   │           │           ├── closing_loc: ∅
-        │   │           │           └── unescaped: "b"
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ SymbolNode (location: (4,11)-(4,13))
+        │   │           │   │       ├── opening_loc: (4,11)-(4,12) = ":"
+        │   │           │   │       ├── value_loc: (4,12)-(4,13) = "b"
+        │   │           │   │       ├── closing_loc: ∅
+        │   │           │   │       └── unescaped: "b"
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -93,12 +95,13 @@
             │   │           ├── opening_loc: ∅
             │   │           ├── arguments:
             │   │           │   @ ArgumentsNode (location: (6,8)-(6,10))
-            │   │           │   └── arguments: (length: 1)
-            │   │           │       └── @ SymbolNode (location: (6,8)-(6,10))
-            │   │           │           ├── opening_loc: (6,8)-(6,9) = ":"
-            │   │           │           ├── value_loc: (6,9)-(6,10) = "b"
-            │   │           │           ├── closing_loc: ∅
-            │   │           │           └── unescaped: "b"
+            │   │           │   ├── arguments: (length: 1)
+            │   │           │   │   └── @ SymbolNode (location: (6,8)-(6,10))
+            │   │           │   │       ├── opening_loc: (6,8)-(6,9) = ":"
+            │   │           │   │       ├── value_loc: (6,9)-(6,10) = "b"
+            │   │           │   │       ├── closing_loc: ∅
+            │   │           │   │       └── unescaped: "b"
+            │   │           │   └── flags: ∅
             │   │           ├── closing_loc: ∅
             │   │           ├── block: ∅
             │   │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/args_args_assocs.txt
+++ b/test/prism/snapshots/whitequark/args_args_assocs.txt
@@ -10,30 +10,31 @@
         │   ├── opening_loc: (1,3)-(1,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,4)-(1,18))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (1,4)-(1,7))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (1,4)-(1,7) = "foo"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :foo
-        │   │       └── @ KeywordHashNode (location: (1,9)-(1,18))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (1,9)-(1,18))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (1,9)-(1,13))
-        │   │                   │   ├── opening_loc: (1,9)-(1,10) = ":"
-        │   │                   │   ├── value_loc: (1,10)-(1,13) = "foo"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "foo"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (1,17)-(1,18))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (1,14)-(1,16) = "=>"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (1,4)-(1,7))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (1,4)-(1,7) = "foo"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :foo
+        │   │   │   └── @ KeywordHashNode (location: (1,9)-(1,18))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (1,9)-(1,18))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (1,9)-(1,13))
+        │   │   │               │   ├── opening_loc: (1,9)-(1,10) = ":"
+        │   │   │               │   ├── value_loc: (1,10)-(1,13) = "foo"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "foo"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (1,17)-(1,18))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (1,14)-(1,16) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (1,18)-(1,19) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -45,30 +46,31 @@
             ├── opening_loc: (3,3)-(3,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (3,4)-(3,18))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (3,4)-(3,7))
-            │       │   ├── receiver: ∅
-            │       │   ├── call_operator_loc: ∅
-            │       │   ├── message_loc: (3,4)-(3,7) = "foo"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block: ∅
-            │       │   ├── flags: variable_call
-            │       │   └── name: :foo
-            │       └── @ KeywordHashNode (location: (3,9)-(3,18))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (3,9)-(3,18))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (3,9)-(3,13))
-            │                   │   ├── opening_loc: (3,9)-(3,10) = ":"
-            │                   │   ├── value_loc: (3,10)-(3,13) = "foo"
-            │                   │   ├── closing_loc: ∅
-            │                   │   └── unescaped: "foo"
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (3,17)-(3,18))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (3,14)-(3,16) = "=>"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (3,4)-(3,7))
+            │   │   │   ├── receiver: ∅
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── message_loc: (3,4)-(3,7) = "foo"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block: ∅
+            │   │   │   ├── flags: variable_call
+            │   │   │   └── name: :foo
+            │   │   └── @ KeywordHashNode (location: (3,9)-(3,18))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (3,9)-(3,18))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (3,9)-(3,13))
+            │   │               │   ├── opening_loc: (3,9)-(3,10) = ":"
+            │   │               │   ├── value_loc: (3,10)-(3,13) = "foo"
+            │   │               │   ├── closing_loc: ∅
+            │   │               │   └── unescaped: "foo"
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (3,17)-(3,18))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (3,14)-(3,16) = "=>"
+            │   └── flags: ∅
             ├── closing_loc: (3,24)-(3,25) = ")"
             ├── block:
             │   @ BlockArgumentNode (location: (3,20)-(3,24))

--- a/test/prism/snapshots/whitequark/args_args_assocs_comma.txt
+++ b/test/prism/snapshots/whitequark/args_args_assocs_comma.txt
@@ -20,30 +20,31 @@
             ├── opening_loc: (1,3)-(1,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,18))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (1,4)-(1,7))
-            │       │   ├── receiver: ∅
-            │       │   ├── call_operator_loc: ∅
-            │       │   ├── message_loc: (1,4)-(1,7) = "bar"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block: ∅
-            │       │   ├── flags: variable_call
-            │       │   └── name: :bar
-            │       └── @ KeywordHashNode (location: (1,9)-(1,18))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,9)-(1,18))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (1,9)-(1,13))
-            │                   │   ├── opening_loc: (1,9)-(1,10) = ":"
-            │                   │   ├── value_loc: (1,10)-(1,13) = "baz"
-            │                   │   ├── closing_loc: ∅
-            │                   │   └── unescaped: "baz"
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,17)-(1,18))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (1,14)-(1,16) = "=>"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (1,4)-(1,7))
+            │   │   │   ├── receiver: ∅
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── message_loc: (1,4)-(1,7) = "bar"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block: ∅
+            │   │   │   ├── flags: variable_call
+            │   │   │   └── name: :bar
+            │   │   └── @ KeywordHashNode (location: (1,9)-(1,18))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,9)-(1,18))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (1,9)-(1,13))
+            │   │               │   ├── opening_loc: (1,9)-(1,10) = ":"
+            │   │               │   ├── value_loc: (1,10)-(1,13) = "baz"
+            │   │               │   ├── closing_loc: ∅
+            │   │               │   └── unescaped: "baz"
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,17)-(1,18))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (1,14)-(1,16) = "=>"
+            │   └── flags: ∅
             ├── closing_loc: (1,19)-(1,20) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/args_args_comma.txt
+++ b/test/prism/snapshots/whitequark/args_args_comma.txt
@@ -20,17 +20,18 @@
             ├── opening_loc: (1,3)-(1,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,7))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,4)-(1,7))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,4)-(1,7) = "bar"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :bar
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,4)-(1,7))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,4)-(1,7) = "bar"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :bar
+            │   └── flags: ∅
             ├── closing_loc: (1,8)-(1,9) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/args_args_star.txt
+++ b/test/prism/snapshots/whitequark/args_args_star.txt
@@ -10,30 +10,31 @@
         │   ├── opening_loc: (1,3)-(1,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,4)-(1,13))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (1,4)-(1,7))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (1,4)-(1,7) = "foo"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :foo
-        │   │       └── @ SplatNode (location: (1,9)-(1,13))
-        │   │           ├── operator_loc: (1,9)-(1,10) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (1,10)-(1,13))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (1,10)-(1,13) = "bar"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :bar
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (1,4)-(1,7))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (1,4)-(1,7) = "foo"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :foo
+        │   │   │   └── @ SplatNode (location: (1,9)-(1,13))
+        │   │   │       ├── operator_loc: (1,9)-(1,10) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (1,10)-(1,13))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (1,10)-(1,13) = "bar"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (1,13)-(1,14) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -45,30 +46,31 @@
             ├── opening_loc: (3,3)-(3,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (3,4)-(3,13))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (3,4)-(3,7))
-            │       │   ├── receiver: ∅
-            │       │   ├── call_operator_loc: ∅
-            │       │   ├── message_loc: (3,4)-(3,7) = "foo"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block: ∅
-            │       │   ├── flags: variable_call
-            │       │   └── name: :foo
-            │       └── @ SplatNode (location: (3,9)-(3,13))
-            │           ├── operator_loc: (3,9)-(3,10) = "*"
-            │           └── expression:
-            │               @ CallNode (location: (3,10)-(3,13))
-            │               ├── receiver: ∅
-            │               ├── call_operator_loc: ∅
-            │               ├── message_loc: (3,10)-(3,13) = "bar"
-            │               ├── opening_loc: ∅
-            │               ├── arguments: ∅
-            │               ├── closing_loc: ∅
-            │               ├── block: ∅
-            │               ├── flags: variable_call
-            │               └── name: :bar
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (3,4)-(3,7))
+            │   │   │   ├── receiver: ∅
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── message_loc: (3,4)-(3,7) = "foo"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block: ∅
+            │   │   │   ├── flags: variable_call
+            │   │   │   └── name: :foo
+            │   │   └── @ SplatNode (location: (3,9)-(3,13))
+            │   │       ├── operator_loc: (3,9)-(3,10) = "*"
+            │   │       └── expression:
+            │   │           @ CallNode (location: (3,10)-(3,13))
+            │   │           ├── receiver: ∅
+            │   │           ├── call_operator_loc: ∅
+            │   │           ├── message_loc: (3,10)-(3,13) = "bar"
+            │   │           ├── opening_loc: ∅
+            │   │           ├── arguments: ∅
+            │   │           ├── closing_loc: ∅
+            │   │           ├── block: ∅
+            │   │           ├── flags: variable_call
+            │   │           └── name: :bar
+            │   └── flags: ∅
             ├── closing_loc: (3,19)-(3,20) = ")"
             ├── block:
             │   @ BlockArgumentNode (location: (3,15)-(3,19))

--- a/test/prism/snapshots/whitequark/args_assocs.txt
+++ b/test/prism/snapshots/whitequark/args_assocs.txt
@@ -10,20 +10,21 @@
         │   ├── opening_loc: (1,3)-(1,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,4)-(1,13))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (1,4)-(1,13))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (1,4)-(1,13))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (1,4)-(1,8))
-        │   │                   │   ├── opening_loc: (1,4)-(1,5) = ":"
-        │   │                   │   ├── value_loc: (1,5)-(1,8) = "foo"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "foo"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (1,12)-(1,13))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (1,9)-(1,11) = "=>"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (1,4)-(1,13))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (1,4)-(1,13))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (1,4)-(1,8))
+        │   │   │               │   ├── opening_loc: (1,4)-(1,5) = ":"
+        │   │   │               │   ├── value_loc: (1,5)-(1,8) = "foo"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "foo"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (1,12)-(1,13))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (1,9)-(1,11) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (1,13)-(1,14) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -35,20 +36,21 @@
         │   ├── opening_loc: (3,3)-(3,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,4)-(3,13))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (3,4)-(3,13))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (3,4)-(3,13))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (3,4)-(3,8))
-        │   │                   │   ├── opening_loc: (3,4)-(3,5) = ":"
-        │   │                   │   ├── value_loc: (3,5)-(3,8) = "foo"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "foo"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (3,12)-(3,13))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (3,9)-(3,11) = "=>"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (3,4)-(3,13))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (3,4)-(3,13))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (3,4)-(3,8))
+        │   │   │               │   ├── opening_loc: (3,4)-(3,5) = ":"
+        │   │   │               │   ├── value_loc: (3,5)-(3,8) = "foo"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "foo"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (3,12)-(3,13))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (3,9)-(3,11) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (3,19)-(3,20) = ")"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (3,15)-(3,19))
@@ -74,30 +76,31 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,9)-(5,21))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (5,9)-(5,12))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (5,9)-(5,12) = "foo"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :foo
-        │   │       └── @ KeywordHashNode (location: (5,14)-(5,21))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (5,14)-(5,21))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (5,14)-(5,16))
-        │   │                   │   ├── opening_loc: (5,14)-(5,15) = ":"
-        │   │                   │   ├── value_loc: (5,15)-(5,16) = "a"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "a"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (5,20)-(5,21))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (5,17)-(5,19) = "=>"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (5,9)-(5,12))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (5,9)-(5,12) = "foo"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :foo
+        │   │   │   └── @ KeywordHashNode (location: (5,14)-(5,21))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (5,14)-(5,21))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (5,14)-(5,16))
+        │   │   │               │   ├── opening_loc: (5,14)-(5,15) = ":"
+        │   │   │               │   ├── value_loc: (5,15)-(5,16) = "a"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "a"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (5,20)-(5,21))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (5,17)-(5,19) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -110,20 +113,21 @@
         │   ├── opening_loc: (7,4)-(7,5) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,5)-(7,14))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (7,5)-(7,14))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (7,5)-(7,14))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (7,5)-(7,9))
-        │   │                   │   ├── opening_loc: (7,5)-(7,6) = ":"
-        │   │                   │   ├── value_loc: (7,6)-(7,9) = "bar"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "bar"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (7,13)-(7,14))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (7,10)-(7,12) = "=>"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (7,5)-(7,14))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (7,5)-(7,14))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (7,5)-(7,9))
+        │   │   │               │   ├── opening_loc: (7,5)-(7,6) = ":"
+        │   │   │               │   ├── value_loc: (7,6)-(7,9) = "bar"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "bar"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (7,13)-(7,14))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (7,10)-(7,12) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (7,14)-(7,15) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -133,20 +137,21 @@
         │   ├── lparen_loc: (9,5)-(9,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (9,6)-(9,16))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (9,6)-(9,16))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (9,6)-(9,16))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (9,6)-(9,10))
-        │   │                   │   ├── opening_loc: (9,6)-(9,7) = ":"
-        │   │                   │   ├── value_loc: (9,7)-(9,10) = "foo"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "foo"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (9,14)-(9,16))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (9,11)-(9,13) = "=>"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (9,6)-(9,16))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (9,6)-(9,16))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (9,6)-(9,10))
+        │   │   │               │   ├── opening_loc: (9,6)-(9,7) = ":"
+        │   │   │               │   ├── value_loc: (9,7)-(9,10) = "foo"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "foo"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (9,14)-(9,16))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (9,11)-(9,13) = "=>"
+        │   │   └── flags: ∅
         │   ├── rparen_loc: (9,16)-(9,17) = ")"
         │   └── block: ∅
         └── @ YieldNode (location: (11,0)-(11,17))
@@ -154,18 +159,19 @@
             ├── lparen_loc: (11,5)-(11,6) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (11,6)-(11,16))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (11,6)-(11,16))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (11,6)-(11,16))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (11,6)-(11,10))
-            │                   │   ├── opening_loc: (11,6)-(11,7) = ":"
-            │                   │   ├── value_loc: (11,7)-(11,10) = "foo"
-            │                   │   ├── closing_loc: ∅
-            │                   │   └── unescaped: "foo"
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (11,14)-(11,16))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (11,11)-(11,13) = "=>"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (11,6)-(11,16))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (11,6)-(11,16))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (11,6)-(11,10))
+            │   │               │   ├── opening_loc: (11,6)-(11,7) = ":"
+            │   │               │   ├── value_loc: (11,7)-(11,10) = "foo"
+            │   │               │   ├── closing_loc: ∅
+            │   │               │   └── unescaped: "foo"
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (11,14)-(11,16))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (11,11)-(11,13) = "=>"
+            │   └── flags: ∅
             └── rparen_loc: (11,16)-(11,17) = ")"

--- a/test/prism/snapshots/whitequark/args_assocs_comma.txt
+++ b/test/prism/snapshots/whitequark/args_assocs_comma.txt
@@ -20,20 +20,21 @@
             ├── opening_loc: (1,3)-(1,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,13))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,4)-(1,13))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,4)-(1,13))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (1,4)-(1,8))
-            │                   │   ├── opening_loc: (1,4)-(1,5) = ":"
-            │                   │   ├── value_loc: (1,5)-(1,8) = "baz"
-            │                   │   ├── closing_loc: ∅
-            │                   │   └── unescaped: "baz"
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,12)-(1,13))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (1,9)-(1,11) = "=>"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,4)-(1,13))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,4)-(1,13))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (1,4)-(1,8))
+            │   │               │   ├── opening_loc: (1,4)-(1,5) = ":"
+            │   │               │   ├── value_loc: (1,5)-(1,8) = "baz"
+            │   │               │   ├── closing_loc: ∅
+            │   │               │   └── unescaped: "baz"
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,12)-(1,13))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (1,9)-(1,11) = "=>"
+            │   └── flags: ∅
             ├── closing_loc: (1,14)-(1,15) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/args_assocs_legacy.txt
+++ b/test/prism/snapshots/whitequark/args_assocs_legacy.txt
@@ -10,20 +10,21 @@
         │   ├── opening_loc: (1,3)-(1,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,4)-(1,13))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (1,4)-(1,13))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (1,4)-(1,13))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (1,4)-(1,8))
-        │   │                   │   ├── opening_loc: (1,4)-(1,5) = ":"
-        │   │                   │   ├── value_loc: (1,5)-(1,8) = "foo"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "foo"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (1,12)-(1,13))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (1,9)-(1,11) = "=>"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (1,4)-(1,13))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (1,4)-(1,13))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (1,4)-(1,8))
+        │   │   │               │   ├── opening_loc: (1,4)-(1,5) = ":"
+        │   │   │               │   ├── value_loc: (1,5)-(1,8) = "foo"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "foo"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (1,12)-(1,13))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (1,9)-(1,11) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (1,13)-(1,14) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -35,20 +36,21 @@
         │   ├── opening_loc: (3,3)-(3,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,4)-(3,13))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (3,4)-(3,13))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (3,4)-(3,13))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (3,4)-(3,8))
-        │   │                   │   ├── opening_loc: (3,4)-(3,5) = ":"
-        │   │                   │   ├── value_loc: (3,5)-(3,8) = "foo"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "foo"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (3,12)-(3,13))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (3,9)-(3,11) = "=>"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (3,4)-(3,13))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (3,4)-(3,13))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (3,4)-(3,8))
+        │   │   │               │   ├── opening_loc: (3,4)-(3,5) = ":"
+        │   │   │               │   ├── value_loc: (3,5)-(3,8) = "foo"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "foo"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (3,12)-(3,13))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (3,9)-(3,11) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (3,19)-(3,20) = ")"
         │   ├── block:
         │   │   @ BlockArgumentNode (location: (3,15)-(3,19))
@@ -74,30 +76,31 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,9)-(5,21))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (5,9)-(5,12))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (5,9)-(5,12) = "foo"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: variable_call
-        │   │       │   └── name: :foo
-        │   │       └── @ KeywordHashNode (location: (5,14)-(5,21))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (5,14)-(5,21))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (5,14)-(5,16))
-        │   │                   │   ├── opening_loc: (5,14)-(5,15) = ":"
-        │   │                   │   ├── value_loc: (5,15)-(5,16) = "a"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "a"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (5,20)-(5,21))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (5,17)-(5,19) = "=>"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (5,9)-(5,12))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (5,9)-(5,12) = "foo"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: variable_call
+        │   │   │   │   └── name: :foo
+        │   │   │   └── @ KeywordHashNode (location: (5,14)-(5,21))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (5,14)-(5,21))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (5,14)-(5,16))
+        │   │   │               │   ├── opening_loc: (5,14)-(5,15) = ":"
+        │   │   │               │   ├── value_loc: (5,15)-(5,16) = "a"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "a"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (5,20)-(5,21))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (5,17)-(5,19) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -110,20 +113,21 @@
         │   ├── opening_loc: (7,4)-(7,5) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,5)-(7,14))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (7,5)-(7,14))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (7,5)-(7,14))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (7,5)-(7,9))
-        │   │                   │   ├── opening_loc: (7,5)-(7,6) = ":"
-        │   │                   │   ├── value_loc: (7,6)-(7,9) = "bar"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "bar"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (7,13)-(7,14))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (7,10)-(7,12) = "=>"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (7,5)-(7,14))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (7,5)-(7,14))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (7,5)-(7,9))
+        │   │   │               │   ├── opening_loc: (7,5)-(7,6) = ":"
+        │   │   │               │   ├── value_loc: (7,6)-(7,9) = "bar"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "bar"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (7,13)-(7,14))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (7,10)-(7,12) = "=>"
+        │   │   └── flags: ∅
         │   ├── closing_loc: (7,14)-(7,15) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -133,20 +137,21 @@
         │   ├── lparen_loc: (9,5)-(9,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (9,6)-(9,16))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (9,6)-(9,16))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (9,6)-(9,16))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (9,6)-(9,10))
-        │   │                   │   ├── opening_loc: (9,6)-(9,7) = ":"
-        │   │                   │   ├── value_loc: (9,7)-(9,10) = "foo"
-        │   │                   │   ├── closing_loc: ∅
-        │   │                   │   └── unescaped: "foo"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (9,14)-(9,16))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: (9,11)-(9,13) = "=>"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (9,6)-(9,16))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (9,6)-(9,16))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (9,6)-(9,10))
+        │   │   │               │   ├── opening_loc: (9,6)-(9,7) = ":"
+        │   │   │               │   ├── value_loc: (9,7)-(9,10) = "foo"
+        │   │   │               │   ├── closing_loc: ∅
+        │   │   │               │   └── unescaped: "foo"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (9,14)-(9,16))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: (9,11)-(9,13) = "=>"
+        │   │   └── flags: ∅
         │   ├── rparen_loc: (9,16)-(9,17) = ")"
         │   └── block: ∅
         └── @ YieldNode (location: (11,0)-(11,17))
@@ -154,18 +159,19 @@
             ├── lparen_loc: (11,5)-(11,6) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (11,6)-(11,16))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (11,6)-(11,16))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (11,6)-(11,16))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (11,6)-(11,10))
-            │                   │   ├── opening_loc: (11,6)-(11,7) = ":"
-            │                   │   ├── value_loc: (11,7)-(11,10) = "foo"
-            │                   │   ├── closing_loc: ∅
-            │                   │   └── unescaped: "foo"
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (11,14)-(11,16))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: (11,11)-(11,13) = "=>"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (11,6)-(11,16))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (11,6)-(11,16))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (11,6)-(11,10))
+            │   │               │   ├── opening_loc: (11,6)-(11,7) = ":"
+            │   │               │   ├── value_loc: (11,7)-(11,10) = "foo"
+            │   │               │   ├── closing_loc: ∅
+            │   │               │   └── unescaped: "foo"
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (11,14)-(11,16))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: (11,11)-(11,13) = "=>"
+            │   └── flags: ∅
             └── rparen_loc: (11,16)-(11,17) = ")"

--- a/test/prism/snapshots/whitequark/args_cmd.txt
+++ b/test/prism/snapshots/whitequark/args_cmd.txt
@@ -10,29 +10,31 @@
             ├── opening_loc: (1,3)-(1,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,9))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,4)-(1,9))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,4)-(1,5) = "f"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (1,6)-(1,9))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ CallNode (location: (1,6)-(1,9))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (1,6)-(1,9) = "bar"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: variable_call
-            │           │           └── name: :bar
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :f
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,4)-(1,9))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,4)-(1,5) = "f"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (1,6)-(1,9))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ CallNode (location: (1,6)-(1,9))
+            │   │       │   │       ├── receiver: ∅
+            │   │       │   │       ├── call_operator_loc: ∅
+            │   │       │   │       ├── message_loc: (1,6)-(1,9) = "bar"
+            │   │       │   │       ├── opening_loc: ∅
+            │   │       │   │       ├── arguments: ∅
+            │   │       │   │       ├── closing_loc: ∅
+            │   │       │   │       ├── block: ∅
+            │   │       │   │       ├── flags: variable_call
+            │   │       │   │       └── name: :bar
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: ∅
+            │   │       └── name: :f
+            │   └── flags: ∅
             ├── closing_loc: (1,9)-(1,10) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/args_star.txt
+++ b/test/prism/snapshots/whitequark/args_star.txt
@@ -10,20 +10,21 @@
         │   ├── opening_loc: (1,3)-(1,4) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,4)-(1,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ SplatNode (location: (1,4)-(1,8))
-        │   │           ├── operator_loc: (1,4)-(1,5) = "*"
-        │   │           └── expression:
-        │   │               @ CallNode (location: (1,5)-(1,8))
-        │   │               ├── receiver: ∅
-        │   │               ├── call_operator_loc: ∅
-        │   │               ├── message_loc: (1,5)-(1,8) = "bar"
-        │   │               ├── opening_loc: ∅
-        │   │               ├── arguments: ∅
-        │   │               ├── closing_loc: ∅
-        │   │               ├── block: ∅
-        │   │               ├── flags: variable_call
-        │   │               └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ SplatNode (location: (1,4)-(1,8))
+        │   │   │       ├── operator_loc: (1,4)-(1,5) = "*"
+        │   │   │       └── expression:
+        │   │   │           @ CallNode (location: (1,5)-(1,8))
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── message_loc: (1,5)-(1,8) = "bar"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           ├── block: ∅
+        │   │   │           ├── flags: variable_call
+        │   │   │           └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (1,8)-(1,9) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -35,20 +36,21 @@
             ├── opening_loc: (3,3)-(3,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (3,4)-(3,8))
-            │   └── arguments: (length: 1)
-            │       └── @ SplatNode (location: (3,4)-(3,8))
-            │           ├── operator_loc: (3,4)-(3,5) = "*"
-            │           └── expression:
-            │               @ CallNode (location: (3,5)-(3,8))
-            │               ├── receiver: ∅
-            │               ├── call_operator_loc: ∅
-            │               ├── message_loc: (3,5)-(3,8) = "bar"
-            │               ├── opening_loc: ∅
-            │               ├── arguments: ∅
-            │               ├── closing_loc: ∅
-            │               ├── block: ∅
-            │               ├── flags: variable_call
-            │               └── name: :bar
+            │   ├── arguments: (length: 1)
+            │   │   └── @ SplatNode (location: (3,4)-(3,8))
+            │   │       ├── operator_loc: (3,4)-(3,5) = "*"
+            │   │       └── expression:
+            │   │           @ CallNode (location: (3,5)-(3,8))
+            │   │           ├── receiver: ∅
+            │   │           ├── call_operator_loc: ∅
+            │   │           ├── message_loc: (3,5)-(3,8) = "bar"
+            │   │           ├── opening_loc: ∅
+            │   │           ├── arguments: ∅
+            │   │           ├── closing_loc: ∅
+            │   │           ├── block: ∅
+            │   │           ├── flags: variable_call
+            │   │           └── name: :bar
+            │   └── flags: ∅
             ├── closing_loc: (3,14)-(3,15) = ")"
             ├── block:
             │   @ BlockArgumentNode (location: (3,10)-(3,14))

--- a/test/prism/snapshots/whitequark/asgn_cmd.txt
+++ b/test/prism/snapshots/whitequark/asgn_cmd.txt
@@ -20,10 +20,11 @@
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (1,14)-(1,17))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ LocalVariableReadNode (location: (1,14)-(1,17))
-        │   │   │   │           ├── name: :foo
-        │   │   │   │           └── depth: 0
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ LocalVariableReadNode (location: (1,14)-(1,17))
+        │   │   │   │   │       ├── name: :foo
+        │   │   │   │   │       └── depth: 0
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: ∅
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅
@@ -42,10 +43,11 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (3,8)-(3,11))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ LocalVariableReadNode (location: (3,8)-(3,11))
-            │   │           ├── name: :foo
-            │   │           └── depth: 0
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ LocalVariableReadNode (location: (3,8)-(3,11))
+            │   │   │       ├── name: :foo
+            │   │   │       └── depth: 0
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/bang_cmd.txt
+++ b/test/prism/snapshots/whitequark/bang_cmd.txt
@@ -12,17 +12,18 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,3)-(1,6))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ CallNode (location: (1,3)-(1,6))
-            │   │           ├── receiver: ∅
-            │   │           ├── call_operator_loc: ∅
-            │   │           ├── message_loc: (1,3)-(1,6) = "foo"
-            │   │           ├── opening_loc: ∅
-            │   │           ├── arguments: ∅
-            │   │           ├── closing_loc: ∅
-            │   │           ├── block: ∅
-            │   │           ├── flags: variable_call
-            │   │           └── name: :foo
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ CallNode (location: (1,3)-(1,6))
+            │   │   │       ├── receiver: ∅
+            │   │   │       ├── call_operator_loc: ∅
+            │   │   │       ├── message_loc: (1,3)-(1,6) = "foo"
+            │   │   │       ├── opening_loc: ∅
+            │   │   │       ├── arguments: ∅
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       ├── block: ∅
+            │   │   │       ├── flags: variable_call
+            │   │   │       └── name: :foo
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/begin_cmdarg.txt
+++ b/test/prism/snapshots/whitequark/begin_cmdarg.txt
@@ -10,38 +10,39 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,28))
-            │   └── arguments: (length: 1)
-            │       └── @ BeginNode (location: (1,2)-(1,28))
-            │           ├── begin_keyword_loc: (1,2)-(1,7) = "begin"
-            │           ├── statements:
-            │           │   @ StatementsNode (location: (1,8)-(1,24))
-            │           │   └── body: (length: 1)
-            │           │       └── @ CallNode (location: (1,8)-(1,24))
-            │           │           ├── receiver:
-            │           │           │   @ IntegerNode (location: (1,8)-(1,9))
-            │           │           │   └── flags: decimal
-            │           │           ├── call_operator_loc: (1,9)-(1,10) = "."
-            │           │           ├── message_loc: (1,10)-(1,15) = "times"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block:
-            │           │           │   @ BlockNode (location: (1,16)-(1,24))
-            │           │           │   ├── locals: []
-            │           │           │   ├── parameters: ∅
-            │           │           │   ├── body:
-            │           │           │   │   @ StatementsNode (location: (1,19)-(1,20))
-            │           │           │   │   └── body: (length: 1)
-            │           │           │   │       └── @ IntegerNode (location: (1,19)-(1,20))
-            │           │           │   │           └── flags: decimal
-            │           │           │   ├── opening_loc: (1,16)-(1,18) = "do"
-            │           │           │   └── closing_loc: (1,21)-(1,24) = "end"
-            │           │           ├── flags: ∅
-            │           │           └── name: :times
-            │           ├── rescue_clause: ∅
-            │           ├── else_clause: ∅
-            │           ├── ensure_clause: ∅
-            │           └── end_keyword_loc: (1,25)-(1,28) = "end"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ BeginNode (location: (1,2)-(1,28))
+            │   │       ├── begin_keyword_loc: (1,2)-(1,7) = "begin"
+            │   │       ├── statements:
+            │   │       │   @ StatementsNode (location: (1,8)-(1,24))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ CallNode (location: (1,8)-(1,24))
+            │   │       │           ├── receiver:
+            │   │       │           │   @ IntegerNode (location: (1,8)-(1,9))
+            │   │       │           │   └── flags: decimal
+            │   │       │           ├── call_operator_loc: (1,9)-(1,10) = "."
+            │   │       │           ├── message_loc: (1,10)-(1,15) = "times"
+            │   │       │           ├── opening_loc: ∅
+            │   │       │           ├── arguments: ∅
+            │   │       │           ├── closing_loc: ∅
+            │   │       │           ├── block:
+            │   │       │           │   @ BlockNode (location: (1,16)-(1,24))
+            │   │       │           │   ├── locals: []
+            │   │       │           │   ├── parameters: ∅
+            │   │       │           │   ├── body:
+            │   │       │           │   │   @ StatementsNode (location: (1,19)-(1,20))
+            │   │       │           │   │   └── body: (length: 1)
+            │   │       │           │   │       └── @ IntegerNode (location: (1,19)-(1,20))
+            │   │       │           │   │           └── flags: decimal
+            │   │       │           │   ├── opening_loc: (1,16)-(1,18) = "do"
+            │   │       │           │   └── closing_loc: (1,21)-(1,24) = "end"
+            │   │       │           ├── flags: ∅
+            │   │       │           └── name: :times
+            │   │       ├── rescue_clause: ∅
+            │   │       ├── else_clause: ∅
+            │   │       ├── ensure_clause: ∅
+            │   │       └── end_keyword_loc: (1,25)-(1,28) = "end"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/break.txt
+++ b/test/prism/snapshots/whitequark/break.txt
@@ -9,45 +9,48 @@
         ├── @ BreakNode (location: (3,0)-(3,9))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,6)-(3,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (3,6)-(3,9))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (3,6)-(3,9) = "foo"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :foo
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (3,6)-(3,9))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (3,6)-(3,9) = "foo"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :foo
+        │   │   └── flags: ∅
         │   └── keyword_loc: (3,0)-(3,5) = "break"
         ├── @ BreakNode (location: (5,0)-(5,7))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,5)-(5,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (5,5)-(5,7))
-        │   │           ├── body: ∅
-        │   │           ├── opening_loc: (5,5)-(5,6) = "("
-        │   │           └── closing_loc: (5,6)-(5,7) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (5,5)-(5,7))
+        │   │   │       ├── body: ∅
+        │   │   │       ├── opening_loc: (5,5)-(5,6) = "("
+        │   │   │       └── closing_loc: (5,6)-(5,7) = ")"
+        │   │   └── flags: ∅
         │   └── keyword_loc: (5,0)-(5,5) = "break"
         └── @ BreakNode (location: (7,0)-(7,10))
             ├── arguments:
             │   @ ArgumentsNode (location: (7,5)-(7,10))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (7,5)-(7,10))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (7,6)-(7,9))
-            │           │   └── body: (length: 1)
-            │           │       └── @ CallNode (location: (7,6)-(7,9))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (7,6)-(7,9) = "foo"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: variable_call
-            │           │           └── name: :foo
-            │           ├── opening_loc: (7,5)-(7,6) = "("
-            │           └── closing_loc: (7,9)-(7,10) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (7,5)-(7,10))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (7,6)-(7,9))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ CallNode (location: (7,6)-(7,9))
+            │   │       │           ├── receiver: ∅
+            │   │       │           ├── call_operator_loc: ∅
+            │   │       │           ├── message_loc: (7,6)-(7,9) = "foo"
+            │   │       │           ├── opening_loc: ∅
+            │   │       │           ├── arguments: ∅
+            │   │       │           ├── closing_loc: ∅
+            │   │       │           ├── block: ∅
+            │   │       │           ├── flags: variable_call
+            │   │       │           └── name: :foo
+            │   │       ├── opening_loc: (7,5)-(7,6) = "("
+            │   │       └── closing_loc: (7,9)-(7,10) = ")"
+            │   └── flags: ∅
             └── keyword_loc: (7,0)-(7,5) = "break"

--- a/test/prism/snapshots/whitequark/break_block.txt
+++ b/test/prism/snapshots/whitequark/break_block.txt
@@ -6,33 +6,35 @@
         └── @ BreakNode (location: (1,0)-(1,20))
             ├── arguments:
             │   @ ArgumentsNode (location: (1,6)-(1,20))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,6)-(1,20))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,6)-(1,9) = "fun"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (1,10)-(1,13))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ CallNode (location: (1,10)-(1,13))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (1,10)-(1,13) = "foo"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: variable_call
-            │           │           └── name: :foo
-            │           ├── closing_loc: ∅
-            │           ├── block:
-            │           │   @ BlockNode (location: (1,14)-(1,20))
-            │           │   ├── locals: []
-            │           │   ├── parameters: ∅
-            │           │   ├── body: ∅
-            │           │   ├── opening_loc: (1,14)-(1,16) = "do"
-            │           │   └── closing_loc: (1,17)-(1,20) = "end"
-            │           ├── flags: ∅
-            │           └── name: :fun
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,6)-(1,20))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,6)-(1,9) = "fun"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (1,10)-(1,13))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ CallNode (location: (1,10)-(1,13))
+            │   │       │   │       ├── receiver: ∅
+            │   │       │   │       ├── call_operator_loc: ∅
+            │   │       │   │       ├── message_loc: (1,10)-(1,13) = "foo"
+            │   │       │   │       ├── opening_loc: ∅
+            │   │       │   │       ├── arguments: ∅
+            │   │       │   │       ├── closing_loc: ∅
+            │   │       │   │       ├── block: ∅
+            │   │       │   │       ├── flags: variable_call
+            │   │       │   │       └── name: :foo
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block:
+            │   │       │   @ BlockNode (location: (1,14)-(1,20))
+            │   │       │   ├── locals: []
+            │   │       │   ├── parameters: ∅
+            │   │       │   ├── body: ∅
+            │   │       │   ├── opening_loc: (1,14)-(1,16) = "do"
+            │   │       │   └── closing_loc: (1,17)-(1,20) = "end"
+            │   │       ├── flags: ∅
+            │   │       └── name: :fun
+            │   └── flags: ∅
             └── keyword_loc: (1,0)-(1,5) = "break"

--- a/test/prism/snapshots/whitequark/bug_447.txt
+++ b/test/prism/snapshots/whitequark/bug_447.txt
@@ -10,11 +10,12 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,4))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ArrayNode (location: (1,2)-(1,4))
-        │   │           ├── elements: (length: 0)
-        │   │           ├── opening_loc: (1,2)-(1,3) = "["
-        │   │           └── closing_loc: (1,3)-(1,4) = "]"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ArrayNode (location: (1,2)-(1,4))
+        │   │   │       ├── elements: (length: 0)
+        │   │   │       ├── opening_loc: (1,2)-(1,3) = "["
+        │   │   │       └── closing_loc: (1,3)-(1,4) = "]"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (1,5)-(1,11))
@@ -32,13 +33,14 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (3,2)-(3,7))
-            │   └── arguments: (length: 2)
-            │       ├── @ ArrayNode (location: (3,2)-(3,4))
-            │       │   ├── elements: (length: 0)
-            │       │   ├── opening_loc: (3,2)-(3,3) = "["
-            │       │   └── closing_loc: (3,3)-(3,4) = "]"
-            │       └── @ IntegerNode (location: (3,6)-(3,7))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ ArrayNode (location: (3,2)-(3,4))
+            │   │   │   ├── elements: (length: 0)
+            │   │   │   ├── opening_loc: (3,2)-(3,3) = "["
+            │   │   │   └── closing_loc: (3,3)-(3,4) = "]"
+            │   │   └── @ IntegerNode (location: (3,6)-(3,7))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (3,8)-(3,14))

--- a/test/prism/snapshots/whitequark/bug_452.txt
+++ b/test/prism/snapshots/whitequark/bug_452.txt
@@ -10,25 +10,26 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,3)-(1,21))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (1,3)-(1,21))
-        │   │           ├── receiver:
-        │   │           │   @ ParenthesesNode (location: (1,3)-(1,10))
-        │   │           │   ├── body:
-        │   │           │   │   @ StatementsNode (location: (1,4)-(1,9))
-        │   │           │   │   └── body: (length: 1)
-        │   │           │   │       └── @ IntegerNode (location: (1,4)-(1,9))
-        │   │           │   │           └── flags: decimal
-        │   │           │   ├── opening_loc: (1,3)-(1,4) = "("
-        │   │           │   └── closing_loc: (1,9)-(1,10) = ")"
-        │   │           ├── call_operator_loc: (1,10)-(1,11) = "."
-        │   │           ├── message_loc: (1,11)-(1,19) = "toString"
-        │   │           ├── opening_loc: (1,19)-(1,20) = "("
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: (1,20)-(1,21) = ")"
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :toString
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (1,3)-(1,21))
+        │   │   │       ├── receiver:
+        │   │   │       │   @ ParenthesesNode (location: (1,3)-(1,10))
+        │   │   │       │   ├── body:
+        │   │   │       │   │   @ StatementsNode (location: (1,4)-(1,9))
+        │   │   │       │   │   └── body: (length: 1)
+        │   │   │       │   │       └── @ IntegerNode (location: (1,4)-(1,9))
+        │   │   │       │   │           └── flags: decimal
+        │   │   │       │   ├── opening_loc: (1,3)-(1,4) = "("
+        │   │   │       │   └── closing_loc: (1,9)-(1,10) = ")"
+        │   │   │       ├── call_operator_loc: (1,10)-(1,11) = "."
+        │   │   │       ├── message_loc: (1,11)-(1,19) = "toString"
+        │   │   │       ├── opening_loc: (1,19)-(1,20) = "("
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: (1,20)-(1,21) = ")"
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :toString
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/bug_466.txt
+++ b/test/prism/snapshots/whitequark/bug_466.txt
@@ -10,49 +10,51 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,19))
-            │   └── arguments: (length: 1)
-            │       └── @ InterpolatedStringNode (location: (1,4)-(1,19))
-            │           ├── opening_loc: (1,4)-(1,5) = "\""
-            │           ├── parts: (length: 1)
-            │           │   └── @ EmbeddedStatementsNode (location: (1,5)-(1,18))
-            │           │       ├── opening_loc: (1,5)-(1,7) = "\#{"
-            │           │       ├── statements:
-            │           │       │   @ StatementsNode (location: (1,7)-(1,17))
-            │           │       │   └── body: (length: 1)
-            │           │       │       └── @ CallNode (location: (1,7)-(1,17))
-            │           │       │           ├── receiver:
-            │           │       │           │   @ ParenthesesNode (location: (1,7)-(1,12))
-            │           │       │           │   ├── body:
-            │           │       │           │   │   @ StatementsNode (location: (1,8)-(1,11))
-            │           │       │           │   │   └── body: (length: 1)
-            │           │       │           │   │       └── @ CallNode (location: (1,8)-(1,11))
-            │           │       │           │   │           ├── receiver:
-            │           │       │           │   │           │   @ IntegerNode (location: (1,8)-(1,9))
-            │           │       │           │   │           │   └── flags: decimal
-            │           │       │           │   │           ├── call_operator_loc: ∅
-            │           │       │           │   │           ├── message_loc: (1,9)-(1,10) = "+"
-            │           │       │           │   │           ├── opening_loc: ∅
-            │           │       │           │   │           ├── arguments:
-            │           │       │           │   │           │   @ ArgumentsNode (location: (1,10)-(1,11))
-            │           │       │           │   │           │   └── arguments: (length: 1)
-            │           │       │           │   │           │       └── @ IntegerNode (location: (1,10)-(1,11))
-            │           │       │           │   │           │           └── flags: decimal
-            │           │       │           │   │           ├── closing_loc: ∅
-            │           │       │           │   │           ├── block: ∅
-            │           │       │           │   │           ├── flags: ∅
-            │           │       │           │   │           └── name: :+
-            │           │       │           │   ├── opening_loc: (1,7)-(1,8) = "("
-            │           │       │           │   └── closing_loc: (1,11)-(1,12) = ")"
-            │           │       │           ├── call_operator_loc: (1,12)-(1,13) = "."
-            │           │       │           ├── message_loc: (1,13)-(1,17) = "to_i"
-            │           │       │           ├── opening_loc: ∅
-            │           │       │           ├── arguments: ∅
-            │           │       │           ├── closing_loc: ∅
-            │           │       │           ├── block: ∅
-            │           │       │           ├── flags: ∅
-            │           │       │           └── name: :to_i
-            │           │       └── closing_loc: (1,17)-(1,18) = "}"
-            │           └── closing_loc: (1,18)-(1,19) = "\""
+            │   ├── arguments: (length: 1)
+            │   │   └── @ InterpolatedStringNode (location: (1,4)-(1,19))
+            │   │       ├── opening_loc: (1,4)-(1,5) = "\""
+            │   │       ├── parts: (length: 1)
+            │   │       │   └── @ EmbeddedStatementsNode (location: (1,5)-(1,18))
+            │   │       │       ├── opening_loc: (1,5)-(1,7) = "\#{"
+            │   │       │       ├── statements:
+            │   │       │       │   @ StatementsNode (location: (1,7)-(1,17))
+            │   │       │       │   └── body: (length: 1)
+            │   │       │       │       └── @ CallNode (location: (1,7)-(1,17))
+            │   │       │       │           ├── receiver:
+            │   │       │       │           │   @ ParenthesesNode (location: (1,7)-(1,12))
+            │   │       │       │           │   ├── body:
+            │   │       │       │           │   │   @ StatementsNode (location: (1,8)-(1,11))
+            │   │       │       │           │   │   └── body: (length: 1)
+            │   │       │       │           │   │       └── @ CallNode (location: (1,8)-(1,11))
+            │   │       │       │           │   │           ├── receiver:
+            │   │       │       │           │   │           │   @ IntegerNode (location: (1,8)-(1,9))
+            │   │       │       │           │   │           │   └── flags: decimal
+            │   │       │       │           │   │           ├── call_operator_loc: ∅
+            │   │       │       │           │   │           ├── message_loc: (1,9)-(1,10) = "+"
+            │   │       │       │           │   │           ├── opening_loc: ∅
+            │   │       │       │           │   │           ├── arguments:
+            │   │       │       │           │   │           │   @ ArgumentsNode (location: (1,10)-(1,11))
+            │   │       │       │           │   │           │   ├── arguments: (length: 1)
+            │   │       │       │           │   │           │   │   └── @ IntegerNode (location: (1,10)-(1,11))
+            │   │       │       │           │   │           │   │       └── flags: decimal
+            │   │       │       │           │   │           │   └── flags: ∅
+            │   │       │       │           │   │           ├── closing_loc: ∅
+            │   │       │       │           │   │           ├── block: ∅
+            │   │       │       │           │   │           ├── flags: ∅
+            │   │       │       │           │   │           └── name: :+
+            │   │       │       │           │   ├── opening_loc: (1,7)-(1,8) = "("
+            │   │       │       │           │   └── closing_loc: (1,11)-(1,12) = ")"
+            │   │       │       │           ├── call_operator_loc: (1,12)-(1,13) = "."
+            │   │       │       │           ├── message_loc: (1,13)-(1,17) = "to_i"
+            │   │       │       │           ├── opening_loc: ∅
+            │   │       │       │           ├── arguments: ∅
+            │   │       │       │           ├── closing_loc: ∅
+            │   │       │       │           ├── block: ∅
+            │   │       │       │           ├── flags: ∅
+            │   │       │       │           └── name: :to_i
+            │   │       │       └── closing_loc: (1,17)-(1,18) = "}"
+            │   │       └── closing_loc: (1,18)-(1,19) = "\""
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,20)-(1,27))

--- a/test/prism/snapshots/whitequark/bug_473.txt
+++ b/test/prism/snapshots/whitequark/bug_473.txt
@@ -10,21 +10,22 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,9))
-            │   └── arguments: (length: 1)
-            │       └── @ InterpolatedStringNode (location: (1,2)-(1,9))
-            │           ├── opening_loc: (1,2)-(1,3) = "\""
-            │           ├── parts: (length: 1)
-            │           │   └── @ EmbeddedStatementsNode (location: (1,3)-(1,8))
-            │           │       ├── opening_loc: (1,3)-(1,5) = "\#{"
-            │           │       ├── statements:
-            │           │       │   @ StatementsNode (location: (1,5)-(1,7))
-            │           │       │   └── body: (length: 1)
-            │           │       │       └── @ ArrayNode (location: (1,5)-(1,7))
-            │           │       │           ├── elements: (length: 0)
-            │           │       │           ├── opening_loc: (1,5)-(1,6) = "["
-            │           │       │           └── closing_loc: (1,6)-(1,7) = "]"
-            │           │       └── closing_loc: (1,7)-(1,8) = "}"
-            │           └── closing_loc: (1,8)-(1,9) = "\""
+            │   ├── arguments: (length: 1)
+            │   │   └── @ InterpolatedStringNode (location: (1,2)-(1,9))
+            │   │       ├── opening_loc: (1,2)-(1,3) = "\""
+            │   │       ├── parts: (length: 1)
+            │   │       │   └── @ EmbeddedStatementsNode (location: (1,3)-(1,8))
+            │   │       │       ├── opening_loc: (1,3)-(1,5) = "\#{"
+            │   │       │       ├── statements:
+            │   │       │       │   @ StatementsNode (location: (1,5)-(1,7))
+            │   │       │       │   └── body: (length: 1)
+            │   │       │       │       └── @ ArrayNode (location: (1,5)-(1,7))
+            │   │       │       │           ├── elements: (length: 0)
+            │   │       │       │           ├── opening_loc: (1,5)-(1,6) = "["
+            │   │       │       │           └── closing_loc: (1,6)-(1,7) = "]"
+            │   │       │       └── closing_loc: (1,7)-(1,8) = "}"
+            │   │       └── closing_loc: (1,8)-(1,9) = "\""
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/bug_480.txt
+++ b/test/prism/snapshots/whitequark/bug_480.txt
@@ -10,25 +10,26 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,12))
-            │   └── arguments: (length: 1)
-            │       └── @ InterpolatedStringNode (location: (1,2)-(1,12))
-            │           ├── opening_loc: (1,2)-(1,3) = "\""
-            │           ├── parts: (length: 2)
-            │           │   ├── @ EmbeddedStatementsNode (location: (1,3)-(1,6))
-            │           │   │   ├── opening_loc: (1,3)-(1,5) = "\#{"
-            │           │   │   ├── statements: ∅
-            │           │   │   └── closing_loc: (1,5)-(1,6) = "}"
-            │           │   └── @ EmbeddedStatementsNode (location: (1,6)-(1,11))
-            │           │       ├── opening_loc: (1,6)-(1,8) = "\#{"
-            │           │       ├── statements:
-            │           │       │   @ StatementsNode (location: (1,8)-(1,10))
-            │           │       │   └── body: (length: 1)
-            │           │       │       └── @ ParenthesesNode (location: (1,8)-(1,10))
-            │           │       │           ├── body: ∅
-            │           │       │           ├── opening_loc: (1,8)-(1,9) = "("
-            │           │       │           └── closing_loc: (1,9)-(1,10) = ")"
-            │           │       └── closing_loc: (1,10)-(1,11) = "}"
-            │           └── closing_loc: (1,11)-(1,12) = "\""
+            │   ├── arguments: (length: 1)
+            │   │   └── @ InterpolatedStringNode (location: (1,2)-(1,12))
+            │   │       ├── opening_loc: (1,2)-(1,3) = "\""
+            │   │       ├── parts: (length: 2)
+            │   │       │   ├── @ EmbeddedStatementsNode (location: (1,3)-(1,6))
+            │   │       │   │   ├── opening_loc: (1,3)-(1,5) = "\#{"
+            │   │       │   │   ├── statements: ∅
+            │   │       │   │   └── closing_loc: (1,5)-(1,6) = "}"
+            │   │       │   └── @ EmbeddedStatementsNode (location: (1,6)-(1,11))
+            │   │       │       ├── opening_loc: (1,6)-(1,8) = "\#{"
+            │   │       │       ├── statements:
+            │   │       │       │   @ StatementsNode (location: (1,8)-(1,10))
+            │   │       │       │   └── body: (length: 1)
+            │   │       │       │       └── @ ParenthesesNode (location: (1,8)-(1,10))
+            │   │       │       │           ├── body: ∅
+            │   │       │       │           ├── opening_loc: (1,8)-(1,9) = "("
+            │   │       │       │           └── closing_loc: (1,9)-(1,10) = ")"
+            │   │       │       └── closing_loc: (1,10)-(1,11) = "}"
+            │   │       └── closing_loc: (1,11)-(1,12) = "\""
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/bug_481.txt
+++ b/test/prism/snapshots/whitequark/bug_481.txt
@@ -10,20 +10,21 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,14))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ DefNode (location: (1,2)-(1,14))
-        │   │           ├── name: :x
-        │   │           ├── name_loc: (1,6)-(1,7) = "x"
-        │   │           ├── receiver: ∅
-        │   │           ├── parameters: ∅
-        │   │           ├── body: ∅
-        │   │           ├── locals: []
-        │   │           ├── def_keyword_loc: (1,2)-(1,5) = "def"
-        │   │           ├── operator_loc: ∅
-        │   │           ├── lparen_loc: (1,7)-(1,8) = "("
-        │   │           ├── rparen_loc: (1,8)-(1,9) = ")"
-        │   │           ├── equal_loc: ∅
-        │   │           └── end_keyword_loc: (1,11)-(1,14) = "end"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ DefNode (location: (1,2)-(1,14))
+        │   │   │       ├── name: :x
+        │   │   │       ├── name_loc: (1,6)-(1,7) = "x"
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── parameters: ∅
+        │   │   │       ├── body: ∅
+        │   │   │       ├── locals: []
+        │   │   │       ├── def_keyword_loc: (1,2)-(1,5) = "def"
+        │   │   │       ├── operator_loc: ∅
+        │   │   │       ├── lparen_loc: (1,7)-(1,8) = "("
+        │   │   │       ├── rparen_loc: (1,8)-(1,9) = ")"
+        │   │   │       ├── equal_loc: ∅
+        │   │   │       └── end_keyword_loc: (1,11)-(1,14) = "end"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/bug_cmd_string_lookahead.txt
+++ b/test/prism/snapshots/whitequark/bug_cmd_string_lookahead.txt
@@ -10,13 +10,14 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,10))
-            │   └── arguments: (length: 1)
-            │       └── @ StringNode (location: (1,5)-(1,10))
-            │           ├── flags: ∅
-            │           ├── opening_loc: (1,5)-(1,6) = "\""
-            │           ├── content_loc: (1,6)-(1,9) = "foo"
-            │           ├── closing_loc: (1,9)-(1,10) = "\""
-            │           └── unescaped: "foo"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ StringNode (location: (1,5)-(1,10))
+            │   │       ├── flags: ∅
+            │   │       ├── opening_loc: (1,5)-(1,6) = "\""
+            │   │       ├── content_loc: (1,6)-(1,9) = "foo"
+            │   │       ├── closing_loc: (1,9)-(1,10) = "\""
+            │   │       └── unescaped: "foo"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,11)-(1,17))

--- a/test/prism/snapshots/whitequark/bug_cmdarg.txt
+++ b/test/prism/snapshots/whitequark/bug_cmdarg.txt
@@ -10,19 +10,20 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,7)-(1,15))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (1,7)-(1,15))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (1,7)-(1,15))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (1,7)-(1,10))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (1,7)-(1,9) = "do"
-        │   │                   │   ├── closing_loc: (1,9)-(1,10) = ":"
-        │   │                   │   └── unescaped: "do"
-        │   │                   ├── value:
-        │   │                   │   @ TrueNode (location: (1,11)-(1,15))
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (1,7)-(1,15))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (1,7)-(1,15))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (1,7)-(1,10))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (1,7)-(1,9) = "do"
+        │   │   │               │   ├── closing_loc: (1,9)-(1,10) = ":"
+        │   │   │               │   └── unescaped: "do"
+        │   │   │               ├── value:
+        │   │   │               │   @ TrueNode (location: (1,11)-(1,15))
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -34,17 +35,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,7)-(3,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (3,7)-(3,11))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (3,7)-(3,11) = "dogs"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :dogs
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (3,7)-(3,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (3,7)-(3,11) = "dogs"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :dogs
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -56,43 +58,44 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (5,2)-(5,26))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (5,2)-(5,26))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (5,2)-(5,26))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (5,2)-(5,4))
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── value_loc: (5,2)-(5,3) = "x"
-            │                   │   ├── closing_loc: (5,3)-(5,4) = ":"
-            │                   │   └── unescaped: "x"
-            │                   ├── value:
-            │                   │   @ LambdaNode (location: (5,5)-(5,26))
-            │                   │   ├── locals: []
-            │                   │   ├── operator_loc: (5,5)-(5,7) = "->"
-            │                   │   ├── opening_loc: (5,8)-(5,10) = "do"
-            │                   │   ├── closing_loc: (5,23)-(5,26) = "end"
-            │                   │   ├── parameters: ∅
-            │                   │   └── body:
-            │                   │       @ StatementsNode (location: (5,11)-(5,22))
-            │                   │       └── body: (length: 1)
-            │                   │           └── @ CallNode (location: (5,11)-(5,22))
-            │                   │               ├── receiver: ∅
-            │                   │               ├── call_operator_loc: ∅
-            │                   │               ├── message_loc: (5,11)-(5,15) = "meth"
-            │                   │               ├── opening_loc: ∅
-            │                   │               ├── arguments: ∅
-            │                   │               ├── closing_loc: ∅
-            │                   │               ├── block:
-            │                   │               │   @ BlockNode (location: (5,16)-(5,22))
-            │                   │               │   ├── locals: []
-            │                   │               │   ├── parameters: ∅
-            │                   │               │   ├── body: ∅
-            │                   │               │   ├── opening_loc: (5,16)-(5,18) = "do"
-            │                   │               │   └── closing_loc: (5,19)-(5,22) = "end"
-            │                   │               ├── flags: ∅
-            │                   │               └── name: :meth
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (5,2)-(5,26))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (5,2)-(5,26))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (5,2)-(5,4))
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── value_loc: (5,2)-(5,3) = "x"
+            │   │               │   ├── closing_loc: (5,3)-(5,4) = ":"
+            │   │               │   └── unescaped: "x"
+            │   │               ├── value:
+            │   │               │   @ LambdaNode (location: (5,5)-(5,26))
+            │   │               │   ├── locals: []
+            │   │               │   ├── operator_loc: (5,5)-(5,7) = "->"
+            │   │               │   ├── opening_loc: (5,8)-(5,10) = "do"
+            │   │               │   ├── closing_loc: (5,23)-(5,26) = "end"
+            │   │               │   ├── parameters: ∅
+            │   │               │   └── body:
+            │   │               │       @ StatementsNode (location: (5,11)-(5,22))
+            │   │               │       └── body: (length: 1)
+            │   │               │           └── @ CallNode (location: (5,11)-(5,22))
+            │   │               │               ├── receiver: ∅
+            │   │               │               ├── call_operator_loc: ∅
+            │   │               │               ├── message_loc: (5,11)-(5,15) = "meth"
+            │   │               │               ├── opening_loc: ∅
+            │   │               │               ├── arguments: ∅
+            │   │               │               ├── closing_loc: ∅
+            │   │               │               ├── block:
+            │   │               │               │   @ BlockNode (location: (5,16)-(5,22))
+            │   │               │               │   ├── locals: []
+            │   │               │               │   ├── parameters: ∅
+            │   │               │               │   ├── body: ∅
+            │   │               │               │   ├── opening_loc: (5,16)-(5,18) = "do"
+            │   │               │               │   └── closing_loc: (5,19)-(5,22) = "end"
+            │   │               │               ├── flags: ∅
+            │   │               │               └── name: :meth
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/bug_do_block_in_call_args.txt
+++ b/test/prism/snapshots/whitequark/bug_do_block_in_call_args.txt
@@ -10,39 +10,40 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,33))
-            │   └── arguments: (length: 1)
-            │       └── @ DefNode (location: (1,4)-(1,33))
-            │           ├── name: :foo
-            │           ├── name_loc: (1,8)-(1,11) = "foo"
-            │           ├── receiver: ∅
-            │           ├── parameters: ∅
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,13)-(1,29))
-            │           │   └── body: (length: 1)
-            │           │       └── @ CallNode (location: (1,13)-(1,29))
-            │           │           ├── receiver:
-            │           │           │   @ SelfNode (location: (1,13)-(1,17))
-            │           │           ├── call_operator_loc: (1,17)-(1,18) = "."
-            │           │           ├── message_loc: (1,18)-(1,22) = "each"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block:
-            │           │           │   @ BlockNode (location: (1,23)-(1,29))
-            │           │           │   ├── locals: []
-            │           │           │   ├── parameters: ∅
-            │           │           │   ├── body: ∅
-            │           │           │   ├── opening_loc: (1,23)-(1,25) = "do"
-            │           │           │   └── closing_loc: (1,26)-(1,29) = "end"
-            │           │           ├── flags: ∅
-            │           │           └── name: :each
-            │           ├── locals: []
-            │           ├── def_keyword_loc: (1,4)-(1,7) = "def"
-            │           ├── operator_loc: ∅
-            │           ├── lparen_loc: ∅
-            │           ├── rparen_loc: ∅
-            │           ├── equal_loc: ∅
-            │           └── end_keyword_loc: (1,30)-(1,33) = "end"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ DefNode (location: (1,4)-(1,33))
+            │   │       ├── name: :foo
+            │   │       ├── name_loc: (1,8)-(1,11) = "foo"
+            │   │       ├── receiver: ∅
+            │   │       ├── parameters: ∅
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,13)-(1,29))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ CallNode (location: (1,13)-(1,29))
+            │   │       │           ├── receiver:
+            │   │       │           │   @ SelfNode (location: (1,13)-(1,17))
+            │   │       │           ├── call_operator_loc: (1,17)-(1,18) = "."
+            │   │       │           ├── message_loc: (1,18)-(1,22) = "each"
+            │   │       │           ├── opening_loc: ∅
+            │   │       │           ├── arguments: ∅
+            │   │       │           ├── closing_loc: ∅
+            │   │       │           ├── block:
+            │   │       │           │   @ BlockNode (location: (1,23)-(1,29))
+            │   │       │           │   ├── locals: []
+            │   │       │           │   ├── parameters: ∅
+            │   │       │           │   ├── body: ∅
+            │   │       │           │   ├── opening_loc: (1,23)-(1,25) = "do"
+            │   │       │           │   └── closing_loc: (1,26)-(1,29) = "end"
+            │   │       │           ├── flags: ∅
+            │   │       │           └── name: :each
+            │   │       ├── locals: []
+            │   │       ├── def_keyword_loc: (1,4)-(1,7) = "def"
+            │   │       ├── operator_loc: ∅
+            │   │       ├── lparen_loc: ∅
+            │   │       ├── rparen_loc: ∅
+            │   │       ├── equal_loc: ∅
+            │   │       └── end_keyword_loc: (1,30)-(1,33) = "end"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/bug_do_block_in_cmdarg.txt
+++ b/test/prism/snapshots/whitequark/bug_do_block_in_cmdarg.txt
@@ -10,29 +10,30 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,17))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,4)-(1,17))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,5)-(1,16))
-            │           │   └── body: (length: 1)
-            │           │       └── @ CallNode (location: (1,5)-(1,16))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (1,5)-(1,9) = "proc"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block:
-            │           │           │   @ BlockNode (location: (1,10)-(1,16))
-            │           │           │   ├── locals: []
-            │           │           │   ├── parameters: ∅
-            │           │           │   ├── body: ∅
-            │           │           │   ├── opening_loc: (1,10)-(1,12) = "do"
-            │           │           │   └── closing_loc: (1,13)-(1,16) = "end"
-            │           │           ├── flags: ∅
-            │           │           └── name: :proc
-            │           ├── opening_loc: (1,4)-(1,5) = "("
-            │           └── closing_loc: (1,16)-(1,17) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,4)-(1,17))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,5)-(1,16))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ CallNode (location: (1,5)-(1,16))
+            │   │       │           ├── receiver: ∅
+            │   │       │           ├── call_operator_loc: ∅
+            │   │       │           ├── message_loc: (1,5)-(1,9) = "proc"
+            │   │       │           ├── opening_loc: ∅
+            │   │       │           ├── arguments: ∅
+            │   │       │           ├── closing_loc: ∅
+            │   │       │           ├── block:
+            │   │       │           │   @ BlockNode (location: (1,10)-(1,16))
+            │   │       │           │   ├── locals: []
+            │   │       │           │   ├── parameters: ∅
+            │   │       │           │   ├── body: ∅
+            │   │       │           │   ├── opening_loc: (1,10)-(1,12) = "do"
+            │   │       │           │   └── closing_loc: (1,13)-(1,16) = "end"
+            │   │       │           ├── flags: ∅
+            │   │       │           └── name: :proc
+            │   │       ├── opening_loc: (1,4)-(1,5) = "("
+            │   │       └── closing_loc: (1,16)-(1,17) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/bug_do_block_in_hash_brace.txt
+++ b/test/prism/snapshots/whitequark/bug_do_block_in_hash_brace.txt
@@ -10,66 +10,67 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,42))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SymbolNode (location: (1,2)-(1,6))
-        │   │       │   ├── opening_loc: (1,2)-(1,3) = ":"
-        │   │       │   ├── value_loc: (1,3)-(1,6) = "foo"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "foo"
-        │   │       └── @ HashNode (location: (1,8)-(1,42))
-        │   │           ├── opening_loc: (1,8)-(1,9) = "{"
-        │   │           ├── elements: (length: 2)
-        │   │           │   ├── @ AssocNode (location: (1,9)-(1,25))
-        │   │           │   │   ├── key:
-        │   │           │   │   │   @ SymbolNode (location: (1,9)-(1,13))
-        │   │           │   │   │   ├── opening_loc: (1,9)-(1,10) = "\""
-        │   │           │   │   │   ├── value_loc: (1,10)-(1,11) = "a"
-        │   │           │   │   │   ├── closing_loc: (1,11)-(1,13) = "\":"
-        │   │           │   │   │   └── unescaped: "a"
-        │   │           │   │   ├── value:
-        │   │           │   │   │   @ CallNode (location: (1,14)-(1,25))
-        │   │           │   │   │   ├── receiver: ∅
-        │   │           │   │   │   ├── call_operator_loc: ∅
-        │   │           │   │   │   ├── message_loc: (1,14)-(1,18) = "proc"
-        │   │           │   │   │   ├── opening_loc: ∅
-        │   │           │   │   │   ├── arguments: ∅
-        │   │           │   │   │   ├── closing_loc: ∅
-        │   │           │   │   │   ├── block:
-        │   │           │   │   │   │   @ BlockNode (location: (1,19)-(1,25))
-        │   │           │   │   │   │   ├── locals: []
-        │   │           │   │   │   │   ├── parameters: ∅
-        │   │           │   │   │   │   ├── body: ∅
-        │   │           │   │   │   │   ├── opening_loc: (1,19)-(1,21) = "do"
-        │   │           │   │   │   │   └── closing_loc: (1,22)-(1,25) = "end"
-        │   │           │   │   │   ├── flags: ∅
-        │   │           │   │   │   └── name: :proc
-        │   │           │   │   └── operator_loc: ∅
-        │   │           │   └── @ AssocNode (location: (1,27)-(1,41))
-        │   │           │       ├── key:
-        │   │           │       │   @ SymbolNode (location: (1,27)-(1,29))
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── value_loc: (1,27)-(1,28) = "b"
-        │   │           │       │   ├── closing_loc: (1,28)-(1,29) = ":"
-        │   │           │       │   └── unescaped: "b"
-        │   │           │       ├── value:
-        │   │           │       │   @ CallNode (location: (1,30)-(1,41))
-        │   │           │       │   ├── receiver: ∅
-        │   │           │       │   ├── call_operator_loc: ∅
-        │   │           │       │   ├── message_loc: (1,30)-(1,34) = "proc"
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── arguments: ∅
-        │   │           │       │   ├── closing_loc: ∅
-        │   │           │       │   ├── block:
-        │   │           │       │   │   @ BlockNode (location: (1,35)-(1,41))
-        │   │           │       │   │   ├── locals: []
-        │   │           │       │   │   ├── parameters: ∅
-        │   │           │       │   │   ├── body: ∅
-        │   │           │       │   │   ├── opening_loc: (1,35)-(1,37) = "do"
-        │   │           │       │   │   └── closing_loc: (1,38)-(1,41) = "end"
-        │   │           │       │   ├── flags: ∅
-        │   │           │       │   └── name: :proc
-        │   │           │       └── operator_loc: ∅
-        │   │           └── closing_loc: (1,41)-(1,42) = "}"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SymbolNode (location: (1,2)-(1,6))
+        │   │   │   │   ├── opening_loc: (1,2)-(1,3) = ":"
+        │   │   │   │   ├── value_loc: (1,3)-(1,6) = "foo"
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── unescaped: "foo"
+        │   │   │   └── @ HashNode (location: (1,8)-(1,42))
+        │   │   │       ├── opening_loc: (1,8)-(1,9) = "{"
+        │   │   │       ├── elements: (length: 2)
+        │   │   │       │   ├── @ AssocNode (location: (1,9)-(1,25))
+        │   │   │       │   │   ├── key:
+        │   │   │       │   │   │   @ SymbolNode (location: (1,9)-(1,13))
+        │   │   │       │   │   │   ├── opening_loc: (1,9)-(1,10) = "\""
+        │   │   │       │   │   │   ├── value_loc: (1,10)-(1,11) = "a"
+        │   │   │       │   │   │   ├── closing_loc: (1,11)-(1,13) = "\":"
+        │   │   │       │   │   │   └── unescaped: "a"
+        │   │   │       │   │   ├── value:
+        │   │   │       │   │   │   @ CallNode (location: (1,14)-(1,25))
+        │   │   │       │   │   │   ├── receiver: ∅
+        │   │   │       │   │   │   ├── call_operator_loc: ∅
+        │   │   │       │   │   │   ├── message_loc: (1,14)-(1,18) = "proc"
+        │   │   │       │   │   │   ├── opening_loc: ∅
+        │   │   │       │   │   │   ├── arguments: ∅
+        │   │   │       │   │   │   ├── closing_loc: ∅
+        │   │   │       │   │   │   ├── block:
+        │   │   │       │   │   │   │   @ BlockNode (location: (1,19)-(1,25))
+        │   │   │       │   │   │   │   ├── locals: []
+        │   │   │       │   │   │   │   ├── parameters: ∅
+        │   │   │       │   │   │   │   ├── body: ∅
+        │   │   │       │   │   │   │   ├── opening_loc: (1,19)-(1,21) = "do"
+        │   │   │       │   │   │   │   └── closing_loc: (1,22)-(1,25) = "end"
+        │   │   │       │   │   │   ├── flags: ∅
+        │   │   │       │   │   │   └── name: :proc
+        │   │   │       │   │   └── operator_loc: ∅
+        │   │   │       │   └── @ AssocNode (location: (1,27)-(1,41))
+        │   │   │       │       ├── key:
+        │   │   │       │       │   @ SymbolNode (location: (1,27)-(1,29))
+        │   │   │       │       │   ├── opening_loc: ∅
+        │   │   │       │       │   ├── value_loc: (1,27)-(1,28) = "b"
+        │   │   │       │       │   ├── closing_loc: (1,28)-(1,29) = ":"
+        │   │   │       │       │   └── unescaped: "b"
+        │   │   │       │       ├── value:
+        │   │   │       │       │   @ CallNode (location: (1,30)-(1,41))
+        │   │   │       │       │   ├── receiver: ∅
+        │   │   │       │       │   ├── call_operator_loc: ∅
+        │   │   │       │       │   ├── message_loc: (1,30)-(1,34) = "proc"
+        │   │   │       │       │   ├── opening_loc: ∅
+        │   │   │       │       │   ├── arguments: ∅
+        │   │   │       │       │   ├── closing_loc: ∅
+        │   │   │       │       │   ├── block:
+        │   │   │       │       │   │   @ BlockNode (location: (1,35)-(1,41))
+        │   │   │       │       │   │   ├── locals: []
+        │   │   │       │       │   │   ├── parameters: ∅
+        │   │   │       │       │   │   ├── body: ∅
+        │   │   │       │       │   │   ├── opening_loc: (1,35)-(1,37) = "do"
+        │   │   │       │       │   │   └── closing_loc: (1,38)-(1,41) = "end"
+        │   │   │       │       │   ├── flags: ∅
+        │   │   │       │       │   └── name: :proc
+        │   │   │       │       └── operator_loc: ∅
+        │   │   │       └── closing_loc: (1,41)-(1,42) = "}"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -81,60 +82,61 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,2)-(3,40))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SymbolNode (location: (3,2)-(3,6))
-        │   │       │   ├── opening_loc: (3,2)-(3,3) = ":"
-        │   │       │   ├── value_loc: (3,3)-(3,6) = "foo"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "foo"
-        │   │       └── @ HashNode (location: (3,8)-(3,40))
-        │   │           ├── opening_loc: (3,8)-(3,9) = "{"
-        │   │           ├── elements: (length: 2)
-        │   │           │   ├── @ AssocSplatNode (location: (3,9)-(3,23))
-        │   │           │   │   ├── value:
-        │   │           │   │   │   @ CallNode (location: (3,12)-(3,23))
-        │   │           │   │   │   ├── receiver: ∅
-        │   │           │   │   │   ├── call_operator_loc: ∅
-        │   │           │   │   │   ├── message_loc: (3,12)-(3,16) = "proc"
-        │   │           │   │   │   ├── opening_loc: ∅
-        │   │           │   │   │   ├── arguments: ∅
-        │   │           │   │   │   ├── closing_loc: ∅
-        │   │           │   │   │   ├── block:
-        │   │           │   │   │   │   @ BlockNode (location: (3,17)-(3,23))
-        │   │           │   │   │   │   ├── locals: []
-        │   │           │   │   │   │   ├── parameters: ∅
-        │   │           │   │   │   │   ├── body: ∅
-        │   │           │   │   │   │   ├── opening_loc: (3,17)-(3,19) = "do"
-        │   │           │   │   │   │   └── closing_loc: (3,20)-(3,23) = "end"
-        │   │           │   │   │   ├── flags: ∅
-        │   │           │   │   │   └── name: :proc
-        │   │           │   │   └── operator_loc: (3,9)-(3,11) = "**"
-        │   │           │   └── @ AssocNode (location: (3,25)-(3,39))
-        │   │           │       ├── key:
-        │   │           │       │   @ SymbolNode (location: (3,25)-(3,27))
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── value_loc: (3,25)-(3,26) = "b"
-        │   │           │       │   ├── closing_loc: (3,26)-(3,27) = ":"
-        │   │           │       │   └── unescaped: "b"
-        │   │           │       ├── value:
-        │   │           │       │   @ CallNode (location: (3,28)-(3,39))
-        │   │           │       │   ├── receiver: ∅
-        │   │           │       │   ├── call_operator_loc: ∅
-        │   │           │       │   ├── message_loc: (3,28)-(3,32) = "proc"
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── arguments: ∅
-        │   │           │       │   ├── closing_loc: ∅
-        │   │           │       │   ├── block:
-        │   │           │       │   │   @ BlockNode (location: (3,33)-(3,39))
-        │   │           │       │   │   ├── locals: []
-        │   │           │       │   │   ├── parameters: ∅
-        │   │           │       │   │   ├── body: ∅
-        │   │           │       │   │   ├── opening_loc: (3,33)-(3,35) = "do"
-        │   │           │       │   │   └── closing_loc: (3,36)-(3,39) = "end"
-        │   │           │       │   ├── flags: ∅
-        │   │           │       │   └── name: :proc
-        │   │           │       └── operator_loc: ∅
-        │   │           └── closing_loc: (3,39)-(3,40) = "}"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SymbolNode (location: (3,2)-(3,6))
+        │   │   │   │   ├── opening_loc: (3,2)-(3,3) = ":"
+        │   │   │   │   ├── value_loc: (3,3)-(3,6) = "foo"
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── unescaped: "foo"
+        │   │   │   └── @ HashNode (location: (3,8)-(3,40))
+        │   │   │       ├── opening_loc: (3,8)-(3,9) = "{"
+        │   │   │       ├── elements: (length: 2)
+        │   │   │       │   ├── @ AssocSplatNode (location: (3,9)-(3,23))
+        │   │   │       │   │   ├── value:
+        │   │   │       │   │   │   @ CallNode (location: (3,12)-(3,23))
+        │   │   │       │   │   │   ├── receiver: ∅
+        │   │   │       │   │   │   ├── call_operator_loc: ∅
+        │   │   │       │   │   │   ├── message_loc: (3,12)-(3,16) = "proc"
+        │   │   │       │   │   │   ├── opening_loc: ∅
+        │   │   │       │   │   │   ├── arguments: ∅
+        │   │   │       │   │   │   ├── closing_loc: ∅
+        │   │   │       │   │   │   ├── block:
+        │   │   │       │   │   │   │   @ BlockNode (location: (3,17)-(3,23))
+        │   │   │       │   │   │   │   ├── locals: []
+        │   │   │       │   │   │   │   ├── parameters: ∅
+        │   │   │       │   │   │   │   ├── body: ∅
+        │   │   │       │   │   │   │   ├── opening_loc: (3,17)-(3,19) = "do"
+        │   │   │       │   │   │   │   └── closing_loc: (3,20)-(3,23) = "end"
+        │   │   │       │   │   │   ├── flags: ∅
+        │   │   │       │   │   │   └── name: :proc
+        │   │   │       │   │   └── operator_loc: (3,9)-(3,11) = "**"
+        │   │   │       │   └── @ AssocNode (location: (3,25)-(3,39))
+        │   │   │       │       ├── key:
+        │   │   │       │       │   @ SymbolNode (location: (3,25)-(3,27))
+        │   │   │       │       │   ├── opening_loc: ∅
+        │   │   │       │       │   ├── value_loc: (3,25)-(3,26) = "b"
+        │   │   │       │       │   ├── closing_loc: (3,26)-(3,27) = ":"
+        │   │   │       │       │   └── unescaped: "b"
+        │   │   │       │       ├── value:
+        │   │   │       │       │   @ CallNode (location: (3,28)-(3,39))
+        │   │   │       │       │   ├── receiver: ∅
+        │   │   │       │       │   ├── call_operator_loc: ∅
+        │   │   │       │       │   ├── message_loc: (3,28)-(3,32) = "proc"
+        │   │   │       │       │   ├── opening_loc: ∅
+        │   │   │       │       │   ├── arguments: ∅
+        │   │   │       │       │   ├── closing_loc: ∅
+        │   │   │       │       │   ├── block:
+        │   │   │       │       │   │   @ BlockNode (location: (3,33)-(3,39))
+        │   │   │       │       │   │   ├── locals: []
+        │   │   │       │       │   │   ├── parameters: ∅
+        │   │   │       │       │   │   ├── body: ∅
+        │   │   │       │       │   │   ├── opening_loc: (3,33)-(3,35) = "do"
+        │   │   │       │       │   │   └── closing_loc: (3,36)-(3,39) = "end"
+        │   │   │       │       │   ├── flags: ∅
+        │   │   │       │       │   └── name: :proc
+        │   │   │       │       └── operator_loc: ∅
+        │   │   │       └── closing_loc: (3,39)-(3,40) = "}"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -146,66 +148,67 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,2)-(5,43))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SymbolNode (location: (5,2)-(5,6))
-        │   │       │   ├── opening_loc: (5,2)-(5,3) = ":"
-        │   │       │   ├── value_loc: (5,3)-(5,6) = "foo"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "foo"
-        │   │       └── @ HashNode (location: (5,8)-(5,43))
-        │   │           ├── opening_loc: (5,8)-(5,9) = "{"
-        │   │           ├── elements: (length: 2)
-        │   │           │   ├── @ AssocNode (location: (5,9)-(5,26))
-        │   │           │   │   ├── key:
-        │   │           │   │   │   @ SymbolNode (location: (5,9)-(5,11))
-        │   │           │   │   │   ├── opening_loc: (5,9)-(5,10) = ":"
-        │   │           │   │   │   ├── value_loc: (5,10)-(5,11) = "a"
-        │   │           │   │   │   ├── closing_loc: ∅
-        │   │           │   │   │   └── unescaped: "a"
-        │   │           │   │   ├── value:
-        │   │           │   │   │   @ CallNode (location: (5,15)-(5,26))
-        │   │           │   │   │   ├── receiver: ∅
-        │   │           │   │   │   ├── call_operator_loc: ∅
-        │   │           │   │   │   ├── message_loc: (5,15)-(5,19) = "proc"
-        │   │           │   │   │   ├── opening_loc: ∅
-        │   │           │   │   │   ├── arguments: ∅
-        │   │           │   │   │   ├── closing_loc: ∅
-        │   │           │   │   │   ├── block:
-        │   │           │   │   │   │   @ BlockNode (location: (5,20)-(5,26))
-        │   │           │   │   │   │   ├── locals: []
-        │   │           │   │   │   │   ├── parameters: ∅
-        │   │           │   │   │   │   ├── body: ∅
-        │   │           │   │   │   │   ├── opening_loc: (5,20)-(5,22) = "do"
-        │   │           │   │   │   │   └── closing_loc: (5,23)-(5,26) = "end"
-        │   │           │   │   │   ├── flags: ∅
-        │   │           │   │   │   └── name: :proc
-        │   │           │   │   └── operator_loc: (5,12)-(5,14) = "=>"
-        │   │           │   └── @ AssocNode (location: (5,28)-(5,42))
-        │   │           │       ├── key:
-        │   │           │       │   @ SymbolNode (location: (5,28)-(5,30))
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── value_loc: (5,28)-(5,29) = "b"
-        │   │           │       │   ├── closing_loc: (5,29)-(5,30) = ":"
-        │   │           │       │   └── unescaped: "b"
-        │   │           │       ├── value:
-        │   │           │       │   @ CallNode (location: (5,31)-(5,42))
-        │   │           │       │   ├── receiver: ∅
-        │   │           │       │   ├── call_operator_loc: ∅
-        │   │           │       │   ├── message_loc: (5,31)-(5,35) = "proc"
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── arguments: ∅
-        │   │           │       │   ├── closing_loc: ∅
-        │   │           │       │   ├── block:
-        │   │           │       │   │   @ BlockNode (location: (5,36)-(5,42))
-        │   │           │       │   │   ├── locals: []
-        │   │           │       │   │   ├── parameters: ∅
-        │   │           │       │   │   ├── body: ∅
-        │   │           │       │   │   ├── opening_loc: (5,36)-(5,38) = "do"
-        │   │           │       │   │   └── closing_loc: (5,39)-(5,42) = "end"
-        │   │           │       │   ├── flags: ∅
-        │   │           │       │   └── name: :proc
-        │   │           │       └── operator_loc: ∅
-        │   │           └── closing_loc: (5,42)-(5,43) = "}"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SymbolNode (location: (5,2)-(5,6))
+        │   │   │   │   ├── opening_loc: (5,2)-(5,3) = ":"
+        │   │   │   │   ├── value_loc: (5,3)-(5,6) = "foo"
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── unescaped: "foo"
+        │   │   │   └── @ HashNode (location: (5,8)-(5,43))
+        │   │   │       ├── opening_loc: (5,8)-(5,9) = "{"
+        │   │   │       ├── elements: (length: 2)
+        │   │   │       │   ├── @ AssocNode (location: (5,9)-(5,26))
+        │   │   │       │   │   ├── key:
+        │   │   │       │   │   │   @ SymbolNode (location: (5,9)-(5,11))
+        │   │   │       │   │   │   ├── opening_loc: (5,9)-(5,10) = ":"
+        │   │   │       │   │   │   ├── value_loc: (5,10)-(5,11) = "a"
+        │   │   │       │   │   │   ├── closing_loc: ∅
+        │   │   │       │   │   │   └── unescaped: "a"
+        │   │   │       │   │   ├── value:
+        │   │   │       │   │   │   @ CallNode (location: (5,15)-(5,26))
+        │   │   │       │   │   │   ├── receiver: ∅
+        │   │   │       │   │   │   ├── call_operator_loc: ∅
+        │   │   │       │   │   │   ├── message_loc: (5,15)-(5,19) = "proc"
+        │   │   │       │   │   │   ├── opening_loc: ∅
+        │   │   │       │   │   │   ├── arguments: ∅
+        │   │   │       │   │   │   ├── closing_loc: ∅
+        │   │   │       │   │   │   ├── block:
+        │   │   │       │   │   │   │   @ BlockNode (location: (5,20)-(5,26))
+        │   │   │       │   │   │   │   ├── locals: []
+        │   │   │       │   │   │   │   ├── parameters: ∅
+        │   │   │       │   │   │   │   ├── body: ∅
+        │   │   │       │   │   │   │   ├── opening_loc: (5,20)-(5,22) = "do"
+        │   │   │       │   │   │   │   └── closing_loc: (5,23)-(5,26) = "end"
+        │   │   │       │   │   │   ├── flags: ∅
+        │   │   │       │   │   │   └── name: :proc
+        │   │   │       │   │   └── operator_loc: (5,12)-(5,14) = "=>"
+        │   │   │       │   └── @ AssocNode (location: (5,28)-(5,42))
+        │   │   │       │       ├── key:
+        │   │   │       │       │   @ SymbolNode (location: (5,28)-(5,30))
+        │   │   │       │       │   ├── opening_loc: ∅
+        │   │   │       │       │   ├── value_loc: (5,28)-(5,29) = "b"
+        │   │   │       │       │   ├── closing_loc: (5,29)-(5,30) = ":"
+        │   │   │       │       │   └── unescaped: "b"
+        │   │   │       │       ├── value:
+        │   │   │       │       │   @ CallNode (location: (5,31)-(5,42))
+        │   │   │       │       │   ├── receiver: ∅
+        │   │   │       │       │   ├── call_operator_loc: ∅
+        │   │   │       │       │   ├── message_loc: (5,31)-(5,35) = "proc"
+        │   │   │       │       │   ├── opening_loc: ∅
+        │   │   │       │       │   ├── arguments: ∅
+        │   │   │       │       │   ├── closing_loc: ∅
+        │   │   │       │       │   ├── block:
+        │   │   │       │       │   │   @ BlockNode (location: (5,36)-(5,42))
+        │   │   │       │       │   │   ├── locals: []
+        │   │   │       │       │   │   ├── parameters: ∅
+        │   │   │       │       │   │   ├── body: ∅
+        │   │   │       │       │   │   ├── opening_loc: (5,36)-(5,38) = "do"
+        │   │   │       │       │   │   └── closing_loc: (5,39)-(5,42) = "end"
+        │   │   │       │       │   ├── flags: ∅
+        │   │   │       │       │   └── name: :proc
+        │   │   │       │       └── operator_loc: ∅
+        │   │   │       └── closing_loc: (5,42)-(5,43) = "}"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -217,66 +220,67 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,2)-(7,40))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ SymbolNode (location: (7,2)-(7,6))
-        │   │       │   ├── opening_loc: (7,2)-(7,3) = ":"
-        │   │       │   ├── value_loc: (7,3)-(7,6) = "foo"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "foo"
-        │   │       └── @ HashNode (location: (7,8)-(7,40))
-        │   │           ├── opening_loc: (7,8)-(7,9) = "{"
-        │   │           ├── elements: (length: 2)
-        │   │           │   ├── @ AssocNode (location: (7,9)-(7,23))
-        │   │           │   │   ├── key:
-        │   │           │   │   │   @ SymbolNode (location: (7,9)-(7,11))
-        │   │           │   │   │   ├── opening_loc: ∅
-        │   │           │   │   │   ├── value_loc: (7,9)-(7,10) = "a"
-        │   │           │   │   │   ├── closing_loc: (7,10)-(7,11) = ":"
-        │   │           │   │   │   └── unescaped: "a"
-        │   │           │   │   ├── value:
-        │   │           │   │   │   @ CallNode (location: (7,12)-(7,23))
-        │   │           │   │   │   ├── receiver: ∅
-        │   │           │   │   │   ├── call_operator_loc: ∅
-        │   │           │   │   │   ├── message_loc: (7,12)-(7,16) = "proc"
-        │   │           │   │   │   ├── opening_loc: ∅
-        │   │           │   │   │   ├── arguments: ∅
-        │   │           │   │   │   ├── closing_loc: ∅
-        │   │           │   │   │   ├── block:
-        │   │           │   │   │   │   @ BlockNode (location: (7,17)-(7,23))
-        │   │           │   │   │   │   ├── locals: []
-        │   │           │   │   │   │   ├── parameters: ∅
-        │   │           │   │   │   │   ├── body: ∅
-        │   │           │   │   │   │   ├── opening_loc: (7,17)-(7,19) = "do"
-        │   │           │   │   │   │   └── closing_loc: (7,20)-(7,23) = "end"
-        │   │           │   │   │   ├── flags: ∅
-        │   │           │   │   │   └── name: :proc
-        │   │           │   │   └── operator_loc: ∅
-        │   │           │   └── @ AssocNode (location: (7,25)-(7,39))
-        │   │           │       ├── key:
-        │   │           │       │   @ SymbolNode (location: (7,25)-(7,27))
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── value_loc: (7,25)-(7,26) = "b"
-        │   │           │       │   ├── closing_loc: (7,26)-(7,27) = ":"
-        │   │           │       │   └── unescaped: "b"
-        │   │           │       ├── value:
-        │   │           │       │   @ CallNode (location: (7,28)-(7,39))
-        │   │           │       │   ├── receiver: ∅
-        │   │           │       │   ├── call_operator_loc: ∅
-        │   │           │       │   ├── message_loc: (7,28)-(7,32) = "proc"
-        │   │           │       │   ├── opening_loc: ∅
-        │   │           │       │   ├── arguments: ∅
-        │   │           │       │   ├── closing_loc: ∅
-        │   │           │       │   ├── block:
-        │   │           │       │   │   @ BlockNode (location: (7,33)-(7,39))
-        │   │           │       │   │   ├── locals: []
-        │   │           │       │   │   ├── parameters: ∅
-        │   │           │       │   │   ├── body: ∅
-        │   │           │       │   │   ├── opening_loc: (7,33)-(7,35) = "do"
-        │   │           │       │   │   └── closing_loc: (7,36)-(7,39) = "end"
-        │   │           │       │   ├── flags: ∅
-        │   │           │       │   └── name: :proc
-        │   │           │       └── operator_loc: ∅
-        │   │           └── closing_loc: (7,39)-(7,40) = "}"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ SymbolNode (location: (7,2)-(7,6))
+        │   │   │   │   ├── opening_loc: (7,2)-(7,3) = ":"
+        │   │   │   │   ├── value_loc: (7,3)-(7,6) = "foo"
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── unescaped: "foo"
+        │   │   │   └── @ HashNode (location: (7,8)-(7,40))
+        │   │   │       ├── opening_loc: (7,8)-(7,9) = "{"
+        │   │   │       ├── elements: (length: 2)
+        │   │   │       │   ├── @ AssocNode (location: (7,9)-(7,23))
+        │   │   │       │   │   ├── key:
+        │   │   │       │   │   │   @ SymbolNode (location: (7,9)-(7,11))
+        │   │   │       │   │   │   ├── opening_loc: ∅
+        │   │   │       │   │   │   ├── value_loc: (7,9)-(7,10) = "a"
+        │   │   │       │   │   │   ├── closing_loc: (7,10)-(7,11) = ":"
+        │   │   │       │   │   │   └── unescaped: "a"
+        │   │   │       │   │   ├── value:
+        │   │   │       │   │   │   @ CallNode (location: (7,12)-(7,23))
+        │   │   │       │   │   │   ├── receiver: ∅
+        │   │   │       │   │   │   ├── call_operator_loc: ∅
+        │   │   │       │   │   │   ├── message_loc: (7,12)-(7,16) = "proc"
+        │   │   │       │   │   │   ├── opening_loc: ∅
+        │   │   │       │   │   │   ├── arguments: ∅
+        │   │   │       │   │   │   ├── closing_loc: ∅
+        │   │   │       │   │   │   ├── block:
+        │   │   │       │   │   │   │   @ BlockNode (location: (7,17)-(7,23))
+        │   │   │       │   │   │   │   ├── locals: []
+        │   │   │       │   │   │   │   ├── parameters: ∅
+        │   │   │       │   │   │   │   ├── body: ∅
+        │   │   │       │   │   │   │   ├── opening_loc: (7,17)-(7,19) = "do"
+        │   │   │       │   │   │   │   └── closing_loc: (7,20)-(7,23) = "end"
+        │   │   │       │   │   │   ├── flags: ∅
+        │   │   │       │   │   │   └── name: :proc
+        │   │   │       │   │   └── operator_loc: ∅
+        │   │   │       │   └── @ AssocNode (location: (7,25)-(7,39))
+        │   │   │       │       ├── key:
+        │   │   │       │       │   @ SymbolNode (location: (7,25)-(7,27))
+        │   │   │       │       │   ├── opening_loc: ∅
+        │   │   │       │       │   ├── value_loc: (7,25)-(7,26) = "b"
+        │   │   │       │       │   ├── closing_loc: (7,26)-(7,27) = ":"
+        │   │   │       │       │   └── unescaped: "b"
+        │   │   │       │       ├── value:
+        │   │   │       │       │   @ CallNode (location: (7,28)-(7,39))
+        │   │   │       │       │   ├── receiver: ∅
+        │   │   │       │       │   ├── call_operator_loc: ∅
+        │   │   │       │       │   ├── message_loc: (7,28)-(7,32) = "proc"
+        │   │   │       │       │   ├── opening_loc: ∅
+        │   │   │       │       │   ├── arguments: ∅
+        │   │   │       │       │   ├── closing_loc: ∅
+        │   │   │       │       │   ├── block:
+        │   │   │       │       │   │   @ BlockNode (location: (7,33)-(7,39))
+        │   │   │       │       │   │   ├── locals: []
+        │   │   │       │       │   │   ├── parameters: ∅
+        │   │   │       │       │   │   ├── body: ∅
+        │   │   │       │       │   │   ├── opening_loc: (7,33)-(7,35) = "do"
+        │   │   │       │       │   │   └── closing_loc: (7,36)-(7,39) = "end"
+        │   │   │       │       │   ├── flags: ∅
+        │   │   │       │       │   └── name: :proc
+        │   │   │       │       └── operator_loc: ∅
+        │   │   │       └── closing_loc: (7,39)-(7,40) = "}"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -288,77 +292,78 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (9,2)-(9,52))
-            │   └── arguments: (length: 2)
-            │       ├── @ SymbolNode (location: (9,2)-(9,6))
-            │       │   ├── opening_loc: (9,2)-(9,3) = ":"
-            │       │   ├── value_loc: (9,3)-(9,6) = "foo"
-            │       │   ├── closing_loc: ∅
-            │       │   └── unescaped: "foo"
-            │       └── @ HashNode (location: (9,8)-(9,52))
-            │           ├── opening_loc: (9,8)-(9,9) = "{"
-            │           ├── elements: (length: 2)
-            │           │   ├── @ AssocNode (location: (9,9)-(9,35))
-            │           │   │   ├── key:
-            │           │   │   │   @ CallNode (location: (9,9)-(9,20))
-            │           │   │   │   ├── receiver: ∅
-            │           │   │   │   ├── call_operator_loc: ∅
-            │           │   │   │   ├── message_loc: (9,9)-(9,13) = "proc"
-            │           │   │   │   ├── opening_loc: ∅
-            │           │   │   │   ├── arguments: ∅
-            │           │   │   │   ├── closing_loc: ∅
-            │           │   │   │   ├── block:
-            │           │   │   │   │   @ BlockNode (location: (9,14)-(9,20))
-            │           │   │   │   │   ├── locals: []
-            │           │   │   │   │   ├── parameters: ∅
-            │           │   │   │   │   ├── body: ∅
-            │           │   │   │   │   ├── opening_loc: (9,14)-(9,16) = "do"
-            │           │   │   │   │   └── closing_loc: (9,17)-(9,20) = "end"
-            │           │   │   │   ├── flags: ∅
-            │           │   │   │   └── name: :proc
-            │           │   │   ├── value:
-            │           │   │   │   @ CallNode (location: (9,24)-(9,35))
-            │           │   │   │   ├── receiver: ∅
-            │           │   │   │   ├── call_operator_loc: ∅
-            │           │   │   │   ├── message_loc: (9,24)-(9,28) = "proc"
-            │           │   │   │   ├── opening_loc: ∅
-            │           │   │   │   ├── arguments: ∅
-            │           │   │   │   ├── closing_loc: ∅
-            │           │   │   │   ├── block:
-            │           │   │   │   │   @ BlockNode (location: (9,29)-(9,35))
-            │           │   │   │   │   ├── locals: []
-            │           │   │   │   │   ├── parameters: ∅
-            │           │   │   │   │   ├── body: ∅
-            │           │   │   │   │   ├── opening_loc: (9,29)-(9,31) = "do"
-            │           │   │   │   │   └── closing_loc: (9,32)-(9,35) = "end"
-            │           │   │   │   ├── flags: ∅
-            │           │   │   │   └── name: :proc
-            │           │   │   └── operator_loc: (9,21)-(9,23) = "=>"
-            │           │   └── @ AssocNode (location: (9,37)-(9,51))
-            │           │       ├── key:
-            │           │       │   @ SymbolNode (location: (9,37)-(9,39))
-            │           │       │   ├── opening_loc: ∅
-            │           │       │   ├── value_loc: (9,37)-(9,38) = "b"
-            │           │       │   ├── closing_loc: (9,38)-(9,39) = ":"
-            │           │       │   └── unescaped: "b"
-            │           │       ├── value:
-            │           │       │   @ CallNode (location: (9,40)-(9,51))
-            │           │       │   ├── receiver: ∅
-            │           │       │   ├── call_operator_loc: ∅
-            │           │       │   ├── message_loc: (9,40)-(9,44) = "proc"
-            │           │       │   ├── opening_loc: ∅
-            │           │       │   ├── arguments: ∅
-            │           │       │   ├── closing_loc: ∅
-            │           │       │   ├── block:
-            │           │       │   │   @ BlockNode (location: (9,45)-(9,51))
-            │           │       │   │   ├── locals: []
-            │           │       │   │   ├── parameters: ∅
-            │           │       │   │   ├── body: ∅
-            │           │       │   │   ├── opening_loc: (9,45)-(9,47) = "do"
-            │           │       │   │   └── closing_loc: (9,48)-(9,51) = "end"
-            │           │       │   ├── flags: ∅
-            │           │       │   └── name: :proc
-            │           │       └── operator_loc: ∅
-            │           └── closing_loc: (9,51)-(9,52) = "}"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ SymbolNode (location: (9,2)-(9,6))
+            │   │   │   ├── opening_loc: (9,2)-(9,3) = ":"
+            │   │   │   ├── value_loc: (9,3)-(9,6) = "foo"
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   └── unescaped: "foo"
+            │   │   └── @ HashNode (location: (9,8)-(9,52))
+            │   │       ├── opening_loc: (9,8)-(9,9) = "{"
+            │   │       ├── elements: (length: 2)
+            │   │       │   ├── @ AssocNode (location: (9,9)-(9,35))
+            │   │       │   │   ├── key:
+            │   │       │   │   │   @ CallNode (location: (9,9)-(9,20))
+            │   │       │   │   │   ├── receiver: ∅
+            │   │       │   │   │   ├── call_operator_loc: ∅
+            │   │       │   │   │   ├── message_loc: (9,9)-(9,13) = "proc"
+            │   │       │   │   │   ├── opening_loc: ∅
+            │   │       │   │   │   ├── arguments: ∅
+            │   │       │   │   │   ├── closing_loc: ∅
+            │   │       │   │   │   ├── block:
+            │   │       │   │   │   │   @ BlockNode (location: (9,14)-(9,20))
+            │   │       │   │   │   │   ├── locals: []
+            │   │       │   │   │   │   ├── parameters: ∅
+            │   │       │   │   │   │   ├── body: ∅
+            │   │       │   │   │   │   ├── opening_loc: (9,14)-(9,16) = "do"
+            │   │       │   │   │   │   └── closing_loc: (9,17)-(9,20) = "end"
+            │   │       │   │   │   ├── flags: ∅
+            │   │       │   │   │   └── name: :proc
+            │   │       │   │   ├── value:
+            │   │       │   │   │   @ CallNode (location: (9,24)-(9,35))
+            │   │       │   │   │   ├── receiver: ∅
+            │   │       │   │   │   ├── call_operator_loc: ∅
+            │   │       │   │   │   ├── message_loc: (9,24)-(9,28) = "proc"
+            │   │       │   │   │   ├── opening_loc: ∅
+            │   │       │   │   │   ├── arguments: ∅
+            │   │       │   │   │   ├── closing_loc: ∅
+            │   │       │   │   │   ├── block:
+            │   │       │   │   │   │   @ BlockNode (location: (9,29)-(9,35))
+            │   │       │   │   │   │   ├── locals: []
+            │   │       │   │   │   │   ├── parameters: ∅
+            │   │       │   │   │   │   ├── body: ∅
+            │   │       │   │   │   │   ├── opening_loc: (9,29)-(9,31) = "do"
+            │   │       │   │   │   │   └── closing_loc: (9,32)-(9,35) = "end"
+            │   │       │   │   │   ├── flags: ∅
+            │   │       │   │   │   └── name: :proc
+            │   │       │   │   └── operator_loc: (9,21)-(9,23) = "=>"
+            │   │       │   └── @ AssocNode (location: (9,37)-(9,51))
+            │   │       │       ├── key:
+            │   │       │       │   @ SymbolNode (location: (9,37)-(9,39))
+            │   │       │       │   ├── opening_loc: ∅
+            │   │       │       │   ├── value_loc: (9,37)-(9,38) = "b"
+            │   │       │       │   ├── closing_loc: (9,38)-(9,39) = ":"
+            │   │       │       │   └── unescaped: "b"
+            │   │       │       ├── value:
+            │   │       │       │   @ CallNode (location: (9,40)-(9,51))
+            │   │       │       │   ├── receiver: ∅
+            │   │       │       │   ├── call_operator_loc: ∅
+            │   │       │       │   ├── message_loc: (9,40)-(9,44) = "proc"
+            │   │       │       │   ├── opening_loc: ∅
+            │   │       │       │   ├── arguments: ∅
+            │   │       │       │   ├── closing_loc: ∅
+            │   │       │       │   ├── block:
+            │   │       │       │   │   @ BlockNode (location: (9,45)-(9,51))
+            │   │       │       │   │   ├── locals: []
+            │   │       │       │   │   ├── parameters: ∅
+            │   │       │       │   │   ├── body: ∅
+            │   │       │       │   │   ├── opening_loc: (9,45)-(9,47) = "do"
+            │   │       │       │   │   └── closing_loc: (9,48)-(9,51) = "end"
+            │   │       │       │   ├── flags: ∅
+            │   │       │       │   └── name: :proc
+            │   │       │       └── operator_loc: ∅
+            │   │       └── closing_loc: (9,51)-(9,52) = "}"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/bug_heredoc_do.txt
+++ b/test/prism/snapshots/whitequark/bug_heredoc_do.txt
@@ -10,13 +10,14 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,10))
-            │   └── arguments: (length: 1)
-            │       └── @ StringNode (location: (1,2)-(1,10))
-            │           ├── flags: ∅
-            │           ├── opening_loc: (1,2)-(1,10) = "<<-TABLE"
-            │           ├── content_loc: (2,0)-(1,0) = ""
-            │           ├── closing_loc: (2,0)-(2,0) = "TABLE\n"
-            │           └── unescaped: ""
+            │   ├── arguments: (length: 1)
+            │   │   └── @ StringNode (location: (1,2)-(1,10))
+            │   │       ├── flags: ∅
+            │   │       ├── opening_loc: (1,2)-(1,10) = "<<-TABLE"
+            │   │       ├── content_loc: (2,0)-(1,0) = ""
+            │   │       ├── closing_loc: (2,0)-(2,0) = "TABLE\n"
+            │   │       └── unescaped: ""
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,11)-(3,3))

--- a/test/prism/snapshots/whitequark/class_super_label.txt
+++ b/test/prism/snapshots/whitequark/class_super_label.txt
@@ -18,12 +18,13 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,13)-(1,15))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ SymbolNode (location: (1,13)-(1,15))
-            │   │           ├── opening_loc: (1,13)-(1,14) = ":"
-            │   │           ├── value_loc: (1,14)-(1,15) = "b"
-            │   │           ├── closing_loc: ∅
-            │   │           └── unescaped: "b"
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ SymbolNode (location: (1,13)-(1,15))
+            │   │   │       ├── opening_loc: (1,13)-(1,14) = ":"
+            │   │   │       ├── value_loc: (1,14)-(1,15) = "b"
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       └── unescaped: "b"
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/dedenting_heredoc.txt
+++ b/test/prism/snapshots/whitequark/dedenting_heredoc.txt
@@ -10,35 +10,36 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (1,2)-(1,8))
-        │   │           ├── opening_loc: (1,2)-(1,8) = "<<~\"E\""
-        │   │           ├── parts: (length: 3)
-        │   │           │   ├── @ StringNode (location: (2,0)-(2,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (2,0)-(2,0) = "    x\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "  x\n"
-        │   │           │   ├── @ EmbeddedStatementsNode (location: (3,2)-(3,10))
-        │   │           │   │   ├── opening_loc: (3,2)-(3,4) = "\#{"
-        │   │           │   │   ├── statements:
-        │   │           │   │   │   @ StatementsNode (location: (3,4)-(3,9))
-        │   │           │   │   │   └── body: (length: 1)
-        │   │           │   │   │       └── @ StringNode (location: (3,4)-(3,9))
-        │   │           │   │   │           ├── flags: ∅
-        │   │           │   │   │           ├── opening_loc: (3,4)-(3,5) = "\""
-        │   │           │   │   │           ├── content_loc: (3,5)-(3,8) = "  y"
-        │   │           │   │   │           ├── closing_loc: (3,8)-(3,9) = "\""
-        │   │           │   │   │           └── unescaped: "  y"
-        │   │           │   │   └── closing_loc: (3,9)-(3,10) = "}"
-        │   │           │   └── @ StringNode (location: (3,10)-(3,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (3,10)-(3,0) = "\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "\n"
-        │   │           └── closing_loc: (4,0)-(4,0) = "E\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (1,2)-(1,8))
+        │   │   │       ├── opening_loc: (1,2)-(1,8) = "<<~\"E\""
+        │   │   │       ├── parts: (length: 3)
+        │   │   │       │   ├── @ StringNode (location: (2,0)-(2,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (2,0)-(2,0) = "    x\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "  x\n"
+        │   │   │       │   ├── @ EmbeddedStatementsNode (location: (3,2)-(3,10))
+        │   │   │       │   │   ├── opening_loc: (3,2)-(3,4) = "\#{"
+        │   │   │       │   │   ├── statements:
+        │   │   │       │   │   │   @ StatementsNode (location: (3,4)-(3,9))
+        │   │   │       │   │   │   └── body: (length: 1)
+        │   │   │       │   │   │       └── @ StringNode (location: (3,4)-(3,9))
+        │   │   │       │   │   │           ├── flags: ∅
+        │   │   │       │   │   │           ├── opening_loc: (3,4)-(3,5) = "\""
+        │   │   │       │   │   │           ├── content_loc: (3,5)-(3,8) = "  y"
+        │   │   │       │   │   │           ├── closing_loc: (3,8)-(3,9) = "\""
+        │   │   │       │   │   │           └── unescaped: "  y"
+        │   │   │       │   │   └── closing_loc: (3,9)-(3,10) = "}"
+        │   │   │       │   └── @ StringNode (location: (3,10)-(3,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (3,10)-(3,0) = "\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "\n"
+        │   │   │       └── closing_loc: (4,0)-(4,0) = "E\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -50,39 +51,40 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (6,2)-(6,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (6,2)-(6,8))
-        │   │           ├── opening_loc: (6,2)-(6,8) = "<<~\"E\""
-        │   │           ├── parts: (length: 3)
-        │   │           │   ├── @ StringNode (location: (7,0)-(7,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (7,0)-(7,0) = "    x\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "  x\n"
-        │   │           │   ├── @ EmbeddedStatementsNode (location: (8,2)-(8,8))
-        │   │           │   │   ├── opening_loc: (8,2)-(8,4) = "\#{"
-        │   │           │   │   ├── statements:
-        │   │           │   │   │   @ StatementsNode (location: (8,4)-(8,7))
-        │   │           │   │   │   └── body: (length: 1)
-        │   │           │   │   │       └── @ CallNode (location: (8,4)-(8,7))
-        │   │           │   │   │           ├── receiver: ∅
-        │   │           │   │   │           ├── call_operator_loc: ∅
-        │   │           │   │   │           ├── message_loc: (8,4)-(8,7) = "foo"
-        │   │           │   │   │           ├── opening_loc: ∅
-        │   │           │   │   │           ├── arguments: ∅
-        │   │           │   │   │           ├── closing_loc: ∅
-        │   │           │   │   │           ├── block: ∅
-        │   │           │   │   │           ├── flags: variable_call
-        │   │           │   │   │           └── name: :foo
-        │   │           │   │   └── closing_loc: (8,7)-(8,8) = "}"
-        │   │           │   └── @ StringNode (location: (8,8)-(8,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (8,8)-(8,0) = "\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "\n"
-        │   │           └── closing_loc: (9,0)-(9,0) = "E\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (6,2)-(6,8))
+        │   │   │       ├── opening_loc: (6,2)-(6,8) = "<<~\"E\""
+        │   │   │       ├── parts: (length: 3)
+        │   │   │       │   ├── @ StringNode (location: (7,0)-(7,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (7,0)-(7,0) = "    x\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "  x\n"
+        │   │   │       │   ├── @ EmbeddedStatementsNode (location: (8,2)-(8,8))
+        │   │   │       │   │   ├── opening_loc: (8,2)-(8,4) = "\#{"
+        │   │   │       │   │   ├── statements:
+        │   │   │       │   │   │   @ StatementsNode (location: (8,4)-(8,7))
+        │   │   │       │   │   │   └── body: (length: 1)
+        │   │   │       │   │   │       └── @ CallNode (location: (8,4)-(8,7))
+        │   │   │       │   │   │           ├── receiver: ∅
+        │   │   │       │   │   │           ├── call_operator_loc: ∅
+        │   │   │       │   │   │           ├── message_loc: (8,4)-(8,7) = "foo"
+        │   │   │       │   │   │           ├── opening_loc: ∅
+        │   │   │       │   │   │           ├── arguments: ∅
+        │   │   │       │   │   │           ├── closing_loc: ∅
+        │   │   │       │   │   │           ├── block: ∅
+        │   │   │       │   │   │           ├── flags: variable_call
+        │   │   │       │   │   │           └── name: :foo
+        │   │   │       │   │   └── closing_loc: (8,7)-(8,8) = "}"
+        │   │   │       │   └── @ StringNode (location: (8,8)-(8,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (8,8)-(8,0) = "\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "\n"
+        │   │   │       └── closing_loc: (9,0)-(9,0) = "E\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -94,23 +96,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (11,2)-(11,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (11,2)-(11,6))
-        │   │           ├── opening_loc: (11,2)-(11,6) = "<<~E"
-        │   │           ├── parts: (length: 2)
-        │   │           │   ├── @ StringNode (location: (12,0)-(12,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (12,0)-(12,0) = "\tx\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "x\n"
-        │   │           │   └── @ StringNode (location: (13,0)-(13,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (13,0)-(13,0) = "        y\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "y\n"
-        │   │           └── closing_loc: (14,0)-(14,0) = "E\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (11,2)-(11,6))
+        │   │   │       ├── opening_loc: (11,2)-(11,6) = "<<~E"
+        │   │   │       ├── parts: (length: 2)
+        │   │   │       │   ├── @ StringNode (location: (12,0)-(12,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (12,0)-(12,0) = "\tx\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "x\n"
+        │   │   │       │   └── @ StringNode (location: (13,0)-(13,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (13,0)-(13,0) = "        y\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "y\n"
+        │   │   │       └── closing_loc: (14,0)-(14,0) = "E\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -122,23 +125,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (16,2)-(16,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (16,2)-(16,6))
-        │   │           ├── opening_loc: (16,2)-(16,6) = "<<~E"
-        │   │           ├── parts: (length: 2)
-        │   │           │   ├── @ StringNode (location: (17,0)-(17,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (17,0)-(17,0) = "\tx\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "\tx\n"
-        │   │           │   └── @ StringNode (location: (18,0)-(18,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (18,0)-(18,0) = "    y\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "y\n"
-        │   │           └── closing_loc: (19,0)-(19,0) = "E\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (16,2)-(16,6))
+        │   │   │       ├── opening_loc: (16,2)-(16,6) = "<<~E"
+        │   │   │       ├── parts: (length: 2)
+        │   │   │       │   ├── @ StringNode (location: (17,0)-(17,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (17,0)-(17,0) = "\tx\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "\tx\n"
+        │   │   │       │   └── @ StringNode (location: (18,0)-(18,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (18,0)-(18,0) = "    y\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "y\n"
+        │   │   │       └── closing_loc: (19,0)-(19,0) = "E\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -150,23 +154,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (21,2)-(21,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (21,2)-(21,6))
-        │   │           ├── opening_loc: (21,2)-(21,6) = "<<~E"
-        │   │           ├── parts: (length: 2)
-        │   │           │   ├── @ StringNode (location: (22,0)-(22,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (22,0)-(22,0) = "    \tx\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "x\n"
-        │   │           │   └── @ StringNode (location: (23,0)-(23,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (23,0)-(23,0) = "        y\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "y\n"
-        │   │           └── closing_loc: (24,0)-(24,0) = "E\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (21,2)-(21,6))
+        │   │   │       ├── opening_loc: (21,2)-(21,6) = "<<~E"
+        │   │   │       ├── parts: (length: 2)
+        │   │   │       │   ├── @ StringNode (location: (22,0)-(22,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (22,0)-(22,0) = "    \tx\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "x\n"
+        │   │   │       │   └── @ StringNode (location: (23,0)-(23,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (23,0)-(23,0) = "        y\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "y\n"
+        │   │   │       └── closing_loc: (24,0)-(24,0) = "E\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -178,23 +183,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (26,2)-(26,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (26,2)-(26,6))
-        │   │           ├── opening_loc: (26,2)-(26,6) = "<<~E"
-        │   │           ├── parts: (length: 2)
-        │   │           │   ├── @ StringNode (location: (27,0)-(27,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (27,0)-(27,0) = "        \tx\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "\tx\n"
-        │   │           │   └── @ StringNode (location: (28,0)-(28,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (28,0)-(28,0) = "\ty\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "y\n"
-        │   │           └── closing_loc: (29,0)-(29,0) = "E\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (26,2)-(26,6))
+        │   │   │       ├── opening_loc: (26,2)-(26,6) = "<<~E"
+        │   │   │       ├── parts: (length: 2)
+        │   │   │       │   ├── @ StringNode (location: (27,0)-(27,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (27,0)-(27,0) = "        \tx\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "\tx\n"
+        │   │   │       │   └── @ StringNode (location: (28,0)-(28,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (28,0)-(28,0) = "\ty\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "y\n"
+        │   │   │       └── closing_loc: (29,0)-(29,0) = "E\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -206,23 +212,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (31,2)-(31,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (31,2)-(31,6))
-        │   │           ├── opening_loc: (31,2)-(31,6) = "<<~E"
-        │   │           ├── parts: (length: 2)
-        │   │           │   ├── @ StringNode (location: (32,0)-(32,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (32,0)-(32,0) = "    x\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "  x\n"
-        │   │           │   └── @ StringNode (location: (33,0)-(33,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (33,0)-(33,0) = "  \\\ty\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "\ty\n"
-        │   │           └── closing_loc: (34,0)-(34,0) = "E\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (31,2)-(31,6))
+        │   │   │       ├── opening_loc: (31,2)-(31,6) = "<<~E"
+        │   │   │       ├── parts: (length: 2)
+        │   │   │       │   ├── @ StringNode (location: (32,0)-(32,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (32,0)-(32,0) = "    x\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "  x\n"
+        │   │   │       │   └── @ StringNode (location: (33,0)-(33,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (33,0)-(33,0) = "  \\\ty\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "\ty\n"
+        │   │   │       └── closing_loc: (34,0)-(34,0) = "E\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -234,23 +241,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (36,2)-(36,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (36,2)-(36,6))
-        │   │           ├── opening_loc: (36,2)-(36,6) = "<<~E"
-        │   │           ├── parts: (length: 2)
-        │   │           │   ├── @ StringNode (location: (37,0)-(37,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (37,0)-(37,0) = "    x\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "  x\n"
-        │   │           │   └── @ StringNode (location: (38,0)-(38,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (38,0)-(38,0) = "  \\  y\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "  y\n"
-        │   │           └── closing_loc: (39,0)-(39,0) = "E\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (36,2)-(36,6))
+        │   │   │       ├── opening_loc: (36,2)-(36,6) = "<<~E"
+        │   │   │       ├── parts: (length: 2)
+        │   │   │       │   ├── @ StringNode (location: (37,0)-(37,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (37,0)-(37,0) = "    x\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "  x\n"
+        │   │   │       │   └── @ StringNode (location: (38,0)-(38,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (38,0)-(38,0) = "  \\  y\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "  y\n"
+        │   │   │       └── closing_loc: (39,0)-(39,0) = "E\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -262,13 +270,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (41,2)-(41,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (41,2)-(41,6))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (41,2)-(41,6) = "<<~E"
-        │   │           ├── content_loc: (42,0)-(41,0) = ""
-        │   │           ├── closing_loc: (42,0)-(42,0) = "  E\n"
-        │   │           └── unescaped: ""
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (41,2)-(41,6))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (41,2)-(41,6) = "<<~E"
+        │   │   │       ├── content_loc: (42,0)-(41,0) = ""
+        │   │   │       ├── closing_loc: (42,0)-(42,0) = "  E\n"
+        │   │   │       └── unescaped: ""
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -280,29 +289,30 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (44,2)-(44,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (44,2)-(44,6))
-        │   │           ├── opening_loc: (44,2)-(44,6) = "<<~E"
-        │   │           ├── parts: (length: 3)
-        │   │           │   ├── @ StringNode (location: (45,0)-(45,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (45,0)-(45,0) = "  x\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "  x\n"
-        │   │           │   ├── @ StringNode (location: (46,0)-(46,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (46,0)-(46,0) = "\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "\n"
-        │   │           │   └── @ StringNode (location: (47,0)-(47,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (47,0)-(47,0) = "y\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "y\n"
-        │   │           └── closing_loc: (48,0)-(48,0) = "E\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (44,2)-(44,6))
+        │   │   │       ├── opening_loc: (44,2)-(44,6) = "<<~E"
+        │   │   │       ├── parts: (length: 3)
+        │   │   │       │   ├── @ StringNode (location: (45,0)-(45,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (45,0)-(45,0) = "  x\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "  x\n"
+        │   │   │       │   ├── @ StringNode (location: (46,0)-(46,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (46,0)-(46,0) = "\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "\n"
+        │   │   │       │   └── @ StringNode (location: (47,0)-(47,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (47,0)-(47,0) = "y\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "y\n"
+        │   │   │       └── closing_loc: (48,0)-(48,0) = "E\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -314,29 +324,30 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (50,2)-(50,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (50,2)-(50,6))
-        │   │           ├── opening_loc: (50,2)-(50,6) = "<<~E"
-        │   │           ├── parts: (length: 3)
-        │   │           │   ├── @ StringNode (location: (51,0)-(51,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (51,0)-(51,0) = "  x\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "x\n"
-        │   │           │   ├── @ StringNode (location: (52,0)-(52,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (52,0)-(52,0) = "    \n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "  \n"
-        │   │           │   └── @ StringNode (location: (53,0)-(53,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (53,0)-(53,0) = "  y\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "y\n"
-        │   │           └── closing_loc: (54,0)-(54,0) = "E\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (50,2)-(50,6))
+        │   │   │       ├── opening_loc: (50,2)-(50,6) = "<<~E"
+        │   │   │       ├── parts: (length: 3)
+        │   │   │       │   ├── @ StringNode (location: (51,0)-(51,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (51,0)-(51,0) = "  x\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "x\n"
+        │   │   │       │   ├── @ StringNode (location: (52,0)-(52,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (52,0)-(52,0) = "    \n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "  \n"
+        │   │   │       │   └── @ StringNode (location: (53,0)-(53,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (53,0)-(53,0) = "  y\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "y\n"
+        │   │   │       └── closing_loc: (54,0)-(54,0) = "E\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -348,23 +359,24 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (56,2)-(56,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (56,2)-(56,6))
-        │   │           ├── opening_loc: (56,2)-(56,6) = "<<~E"
-        │   │           ├── parts: (length: 2)
-        │   │           │   ├── @ StringNode (location: (57,0)-(57,0))
-        │   │           │   │   ├── flags: ∅
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (57,0)-(57,0) = "  x\n"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "x\n"
-        │   │           │   └── @ StringNode (location: (58,0)-(58,0))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: ∅
-        │   │           │       ├── content_loc: (58,0)-(58,0) = "    y\n"
-        │   │           │       ├── closing_loc: ∅
-        │   │           │       └── unescaped: "  y\n"
-        │   │           └── closing_loc: (59,0)-(59,0) = "E\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ InterpolatedStringNode (location: (56,2)-(56,6))
+        │   │   │       ├── opening_loc: (56,2)-(56,6) = "<<~E"
+        │   │   │       ├── parts: (length: 2)
+        │   │   │       │   ├── @ StringNode (location: (57,0)-(57,0))
+        │   │   │       │   │   ├── flags: ∅
+        │   │   │       │   │   ├── opening_loc: ∅
+        │   │   │       │   │   ├── content_loc: (57,0)-(57,0) = "  x\n"
+        │   │   │       │   │   ├── closing_loc: ∅
+        │   │   │       │   │   └── unescaped: "x\n"
+        │   │   │       │   └── @ StringNode (location: (58,0)-(58,0))
+        │   │   │       │       ├── flags: ∅
+        │   │   │       │       ├── opening_loc: ∅
+        │   │   │       │       ├── content_loc: (58,0)-(58,0) = "    y\n"
+        │   │   │       │       ├── closing_loc: ∅
+        │   │   │       │       └── unescaped: "  y\n"
+        │   │   │       └── closing_loc: (59,0)-(59,0) = "E\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -376,13 +388,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (61,2)-(61,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (61,2)-(61,6))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (61,2)-(61,6) = "<<~E"
-        │   │           ├── content_loc: (62,0)-(62,0) = "  x\n"
-        │   │           ├── closing_loc: (63,0)-(63,0) = "E\n"
-        │   │           └── unescaped: "x\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (61,2)-(61,6))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (61,2)-(61,6) = "<<~E"
+        │   │   │       ├── content_loc: (62,0)-(62,0) = "  x\n"
+        │   │   │       ├── closing_loc: (63,0)-(63,0) = "E\n"
+        │   │   │       └── unescaped: "x\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -394,13 +407,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (65,2)-(65,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (65,2)-(65,6))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (65,2)-(65,6) = "<<~E"
-        │   │           ├── content_loc: (66,0)-(66,0) = "  ð\n"
-        │   │           ├── closing_loc: (67,0)-(67,0) = "E\n"
-        │   │           └── unescaped: "ð\n"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (65,2)-(65,6))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (65,2)-(65,6) = "<<~E"
+        │   │   │       ├── content_loc: (66,0)-(66,0) = "  ð\n"
+        │   │   │       ├── closing_loc: (67,0)-(67,0) = "E\n"
+        │   │   │       └── unescaped: "ð\n"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -412,13 +426,14 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (69,2)-(69,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ StringNode (location: (69,2)-(69,6))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (69,2)-(69,6) = "<<~E"
-        │   │           ├── content_loc: (70,0)-(69,0) = ""
-        │   │           ├── closing_loc: (70,0)-(70,0) = "E\n"
-        │   │           └── unescaped: ""
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ StringNode (location: (69,2)-(69,6))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (69,2)-(69,6) = "<<~E"
+        │   │   │       ├── content_loc: (70,0)-(69,0) = ""
+        │   │   │       ├── closing_loc: (70,0)-(70,0) = "E\n"
+        │   │   │       └── unescaped: ""
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -430,39 +445,40 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (72,2)-(72,8))
-            │   └── arguments: (length: 1)
-            │       └── @ InterpolatedXStringNode (location: (72,2)-(72,8))
-            │           ├── opening_loc: (72,2)-(72,8) = "<<~`E`"
-            │           ├── parts: (length: 3)
-            │           │   ├── @ StringNode (location: (73,0)-(73,0))
-            │           │   │   ├── flags: ∅
-            │           │   │   ├── opening_loc: ∅
-            │           │   │   ├── content_loc: (73,0)-(73,0) = "    x\n"
-            │           │   │   ├── closing_loc: ∅
-            │           │   │   └── unescaped: "  x\n"
-            │           │   ├── @ EmbeddedStatementsNode (location: (74,2)-(74,8))
-            │           │   │   ├── opening_loc: (74,2)-(74,4) = "\#{"
-            │           │   │   ├── statements:
-            │           │   │   │   @ StatementsNode (location: (74,4)-(74,7))
-            │           │   │   │   └── body: (length: 1)
-            │           │   │   │       └── @ CallNode (location: (74,4)-(74,7))
-            │           │   │   │           ├── receiver: ∅
-            │           │   │   │           ├── call_operator_loc: ∅
-            │           │   │   │           ├── message_loc: (74,4)-(74,7) = "foo"
-            │           │   │   │           ├── opening_loc: ∅
-            │           │   │   │           ├── arguments: ∅
-            │           │   │   │           ├── closing_loc: ∅
-            │           │   │   │           ├── block: ∅
-            │           │   │   │           ├── flags: variable_call
-            │           │   │   │           └── name: :foo
-            │           │   │   └── closing_loc: (74,7)-(74,8) = "}"
-            │           │   └── @ StringNode (location: (74,8)-(74,0))
-            │           │       ├── flags: ∅
-            │           │       ├── opening_loc: ∅
-            │           │       ├── content_loc: (74,8)-(74,0) = "\n"
-            │           │       ├── closing_loc: ∅
-            │           │       └── unescaped: "\n"
-            │           └── closing_loc: (75,0)-(75,0) = "E\n"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ InterpolatedXStringNode (location: (72,2)-(72,8))
+            │   │       ├── opening_loc: (72,2)-(72,8) = "<<~`E`"
+            │   │       ├── parts: (length: 3)
+            │   │       │   ├── @ StringNode (location: (73,0)-(73,0))
+            │   │       │   │   ├── flags: ∅
+            │   │       │   │   ├── opening_loc: ∅
+            │   │       │   │   ├── content_loc: (73,0)-(73,0) = "    x\n"
+            │   │       │   │   ├── closing_loc: ∅
+            │   │       │   │   └── unescaped: "  x\n"
+            │   │       │   ├── @ EmbeddedStatementsNode (location: (74,2)-(74,8))
+            │   │       │   │   ├── opening_loc: (74,2)-(74,4) = "\#{"
+            │   │       │   │   ├── statements:
+            │   │       │   │   │   @ StatementsNode (location: (74,4)-(74,7))
+            │   │       │   │   │   └── body: (length: 1)
+            │   │       │   │   │       └── @ CallNode (location: (74,4)-(74,7))
+            │   │       │   │   │           ├── receiver: ∅
+            │   │       │   │   │           ├── call_operator_loc: ∅
+            │   │       │   │   │           ├── message_loc: (74,4)-(74,7) = "foo"
+            │   │       │   │   │           ├── opening_loc: ∅
+            │   │       │   │   │           ├── arguments: ∅
+            │   │       │   │   │           ├── closing_loc: ∅
+            │   │       │   │   │           ├── block: ∅
+            │   │       │   │   │           ├── flags: variable_call
+            │   │       │   │   │           └── name: :foo
+            │   │       │   │   └── closing_loc: (74,7)-(74,8) = "}"
+            │   │       │   └── @ StringNode (location: (74,8)-(74,0))
+            │   │       │       ├── flags: ∅
+            │   │       │       ├── opening_loc: ∅
+            │   │       │       ├── content_loc: (74,8)-(74,0) = "\n"
+            │   │       │       ├── closing_loc: ∅
+            │   │       │       └── unescaped: "\n"
+            │   │       └── closing_loc: (75,0)-(75,0) = "E\n"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/endless_method.txt
+++ b/test/prism/snapshots/whitequark/endless_method.txt
@@ -48,9 +48,10 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (3,17)-(3,18))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (3,17)-(3,18))
-        │   │           │           └── flags: decimal
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ IntegerNode (location: (3,17)-(3,18))
+        │   │           │   │       └── flags: decimal
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -127,9 +128,10 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (7,21)-(7,22))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ IntegerNode (location: (7,21)-(7,22))
-            │           │           └── flags: decimal
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ IntegerNode (location: (7,21)-(7,22))
+            │           │   │       └── flags: decimal
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/endless_method_command_syntax.txt
+++ b/test/prism/snapshots/whitequark/endless_method_command_syntax.txt
@@ -18,13 +18,14 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (1,15)-(1,22))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ StringNode (location: (1,15)-(1,22))
-        │   │           │           ├── flags: ∅
-        │   │           │           ├── opening_loc: (1,15)-(1,16) = "\""
-        │   │           │           ├── content_loc: (1,16)-(1,21) = "Hello"
-        │   │           │           ├── closing_loc: (1,21)-(1,22) = "\""
-        │   │           │           └── unescaped: "Hello"
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ StringNode (location: (1,15)-(1,22))
+        │   │           │   │       ├── flags: ∅
+        │   │           │   │       ├── opening_loc: (1,15)-(1,16) = "\""
+        │   │           │   │       ├── content_loc: (1,16)-(1,21) = "Hello"
+        │   │           │   │       ├── closing_loc: (1,21)-(1,22) = "\""
+        │   │           │   │       └── unescaped: "Hello"
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -51,13 +52,14 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (3,17)-(3,24))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ StringNode (location: (3,17)-(3,24))
-        │   │           │           ├── flags: ∅
-        │   │           │           ├── opening_loc: (3,17)-(3,18) = "\""
-        │   │           │           ├── content_loc: (3,18)-(3,23) = "Hello"
-        │   │           │           ├── closing_loc: (3,23)-(3,24) = "\""
-        │   │           │           └── unescaped: "Hello"
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ StringNode (location: (3,17)-(3,24))
+        │   │           │   │       ├── flags: ∅
+        │   │           │   │       ├── opening_loc: (3,17)-(3,18) = "\""
+        │   │           │   │       ├── content_loc: (3,18)-(3,23) = "Hello"
+        │   │           │   │       ├── closing_loc: (3,23)-(3,24) = "\""
+        │   │           │   │       └── unescaped: "Hello"
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -94,10 +96,11 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (5,18)-(5,19))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ LocalVariableReadNode (location: (5,18)-(5,19))
-        │   │           │           ├── name: :x
-        │   │           │           └── depth: 0
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ LocalVariableReadNode (location: (5,18)-(5,19))
+        │   │           │   │       ├── name: :x
+        │   │           │   │       └── depth: 0
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -134,13 +137,14 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (7,19)-(7,26))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ StringNode (location: (7,19)-(7,26))
-        │   │           │           ├── flags: ∅
-        │   │           │           ├── opening_loc: (7,19)-(7,20) = "\""
-        │   │           │           ├── content_loc: (7,20)-(7,25) = "Hello"
-        │   │           │           ├── closing_loc: (7,25)-(7,26) = "\""
-        │   │           │           └── unescaped: "Hello"
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ StringNode (location: (7,19)-(7,26))
+        │   │           │   │       ├── flags: ∅
+        │   │           │   │       ├── opening_loc: (7,19)-(7,20) = "\""
+        │   │           │   │       ├── content_loc: (7,20)-(7,25) = "Hello"
+        │   │           │   │       ├── closing_loc: (7,25)-(7,26) = "\""
+        │   │           │   │       └── unescaped: "Hello"
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -177,13 +181,14 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (9,21)-(9,28))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ StringNode (location: (9,21)-(9,28))
-        │   │           │           ├── flags: ∅
-        │   │           │           ├── opening_loc: (9,21)-(9,22) = "\""
-        │   │           │           ├── content_loc: (9,22)-(9,27) = "Hello"
-        │   │           │           ├── closing_loc: (9,27)-(9,28) = "\""
-        │   │           │           └── unescaped: "Hello"
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ StringNode (location: (9,21)-(9,28))
+        │   │           │   │       ├── flags: ∅
+        │   │           │   │       ├── opening_loc: (9,21)-(9,22) = "\""
+        │   │           │   │       ├── content_loc: (9,22)-(9,27) = "Hello"
+        │   │           │   │       ├── closing_loc: (9,27)-(9,28) = "\""
+        │   │           │   │       └── unescaped: "Hello"
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -230,10 +235,11 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (11,22)-(11,23))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ LocalVariableReadNode (location: (11,22)-(11,23))
-        │   │           │           ├── name: :x
-        │   │           │           └── depth: 0
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ LocalVariableReadNode (location: (11,22)-(11,23))
+        │   │           │   │       ├── name: :x
+        │   │           │   │       └── depth: 0
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -270,36 +276,37 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (13,23)-(13,60))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ RescueModifierNode (location: (13,23)-(13,60))
-        │   │           │           ├── expression:
-        │   │           │           │   @ StringNode (location: (13,23)-(13,37))
-        │   │           │           │   ├── flags: ∅
-        │   │           │           │   ├── opening_loc: (13,23)-(13,24) = "\""
-        │   │           │           │   ├── content_loc: (13,24)-(13,36) = "to be caught"
-        │   │           │           │   ├── closing_loc: (13,36)-(13,37) = "\""
-        │   │           │           │   └── unescaped: "to be caught"
-        │   │           │           ├── keyword_loc: (13,38)-(13,44) = "rescue"
-        │   │           │           └── rescue_expression:
-        │   │           │               @ InterpolatedStringNode (location: (13,45)-(13,60))
-        │   │           │               ├── opening_loc: (13,45)-(13,46) = "\""
-        │   │           │               ├── parts: (length: 2)
-        │   │           │               │   ├── @ StringNode (location: (13,46)-(13,55))
-        │   │           │               │   │   ├── flags: ∅
-        │   │           │               │   │   ├── opening_loc: ∅
-        │   │           │               │   │   ├── content_loc: (13,46)-(13,55) = "instance "
-        │   │           │               │   │   ├── closing_loc: ∅
-        │   │           │               │   │   └── unescaped: "instance "
-        │   │           │               │   └── @ EmbeddedStatementsNode (location: (13,55)-(13,59))
-        │   │           │               │       ├── opening_loc: (13,55)-(13,57) = "\#{"
-        │   │           │               │       ├── statements:
-        │   │           │               │       │   @ StatementsNode (location: (13,57)-(13,58))
-        │   │           │               │       │   └── body: (length: 1)
-        │   │           │               │       │       └── @ LocalVariableReadNode (location: (13,57)-(13,58))
-        │   │           │               │       │           ├── name: :x
-        │   │           │               │       │           └── depth: 0
-        │   │           │               │       └── closing_loc: (13,58)-(13,59) = "}"
-        │   │           │               └── closing_loc: (13,59)-(13,60) = "\""
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ RescueModifierNode (location: (13,23)-(13,60))
+        │   │           │   │       ├── expression:
+        │   │           │   │       │   @ StringNode (location: (13,23)-(13,37))
+        │   │           │   │       │   ├── flags: ∅
+        │   │           │   │       │   ├── opening_loc: (13,23)-(13,24) = "\""
+        │   │           │   │       │   ├── content_loc: (13,24)-(13,36) = "to be caught"
+        │   │           │   │       │   ├── closing_loc: (13,36)-(13,37) = "\""
+        │   │           │   │       │   └── unescaped: "to be caught"
+        │   │           │   │       ├── keyword_loc: (13,38)-(13,44) = "rescue"
+        │   │           │   │       └── rescue_expression:
+        │   │           │   │           @ InterpolatedStringNode (location: (13,45)-(13,60))
+        │   │           │   │           ├── opening_loc: (13,45)-(13,46) = "\""
+        │   │           │   │           ├── parts: (length: 2)
+        │   │           │   │           │   ├── @ StringNode (location: (13,46)-(13,55))
+        │   │           │   │           │   │   ├── flags: ∅
+        │   │           │   │           │   │   ├── opening_loc: ∅
+        │   │           │   │           │   │   ├── content_loc: (13,46)-(13,55) = "instance "
+        │   │           │   │           │   │   ├── closing_loc: ∅
+        │   │           │   │           │   │   └── unescaped: "instance "
+        │   │           │   │           │   └── @ EmbeddedStatementsNode (location: (13,55)-(13,59))
+        │   │           │   │           │       ├── opening_loc: (13,55)-(13,57) = "\#{"
+        │   │           │   │           │       ├── statements:
+        │   │           │   │           │       │   @ StatementsNode (location: (13,57)-(13,58))
+        │   │           │   │           │       │   └── body: (length: 1)
+        │   │           │   │           │       │       └── @ LocalVariableReadNode (location: (13,57)-(13,58))
+        │   │           │   │           │       │           ├── name: :x
+        │   │           │   │           │       │           └── depth: 0
+        │   │           │   │           │       └── closing_loc: (13,58)-(13,59) = "}"
+        │   │           │   │           └── closing_loc: (13,59)-(13,60) = "\""
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -337,36 +344,37 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (15,28)-(15,62))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ RescueModifierNode (location: (15,28)-(15,62))
-            │           │           ├── expression:
-            │           │           │   @ StringNode (location: (15,28)-(15,42))
-            │           │           │   ├── flags: ∅
-            │           │           │   ├── opening_loc: (15,28)-(15,29) = "\""
-            │           │           │   ├── content_loc: (15,29)-(15,41) = "to be caught"
-            │           │           │   ├── closing_loc: (15,41)-(15,42) = "\""
-            │           │           │   └── unescaped: "to be caught"
-            │           │           ├── keyword_loc: (15,43)-(15,49) = "rescue"
-            │           │           └── rescue_expression:
-            │           │               @ InterpolatedStringNode (location: (15,50)-(15,62))
-            │           │               ├── opening_loc: (15,50)-(15,51) = "\""
-            │           │               ├── parts: (length: 2)
-            │           │               │   ├── @ StringNode (location: (15,51)-(15,57))
-            │           │               │   │   ├── flags: ∅
-            │           │               │   │   ├── opening_loc: ∅
-            │           │               │   │   ├── content_loc: (15,51)-(15,57) = "class "
-            │           │               │   │   ├── closing_loc: ∅
-            │           │               │   │   └── unescaped: "class "
-            │           │               │   └── @ EmbeddedStatementsNode (location: (15,57)-(15,61))
-            │           │               │       ├── opening_loc: (15,57)-(15,59) = "\#{"
-            │           │               │       ├── statements:
-            │           │               │       │   @ StatementsNode (location: (15,59)-(15,60))
-            │           │               │       │   └── body: (length: 1)
-            │           │               │       │       └── @ LocalVariableReadNode (location: (15,59)-(15,60))
-            │           │               │       │           ├── name: :x
-            │           │               │       │           └── depth: 0
-            │           │               │       └── closing_loc: (15,60)-(15,61) = "}"
-            │           │               └── closing_loc: (15,61)-(15,62) = "\""
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ RescueModifierNode (location: (15,28)-(15,62))
+            │           │   │       ├── expression:
+            │           │   │       │   @ StringNode (location: (15,28)-(15,42))
+            │           │   │       │   ├── flags: ∅
+            │           │   │       │   ├── opening_loc: (15,28)-(15,29) = "\""
+            │           │   │       │   ├── content_loc: (15,29)-(15,41) = "to be caught"
+            │           │   │       │   ├── closing_loc: (15,41)-(15,42) = "\""
+            │           │   │       │   └── unescaped: "to be caught"
+            │           │   │       ├── keyword_loc: (15,43)-(15,49) = "rescue"
+            │           │   │       └── rescue_expression:
+            │           │   │           @ InterpolatedStringNode (location: (15,50)-(15,62))
+            │           │   │           ├── opening_loc: (15,50)-(15,51) = "\""
+            │           │   │           ├── parts: (length: 2)
+            │           │   │           │   ├── @ StringNode (location: (15,51)-(15,57))
+            │           │   │           │   │   ├── flags: ∅
+            │           │   │           │   │   ├── opening_loc: ∅
+            │           │   │           │   │   ├── content_loc: (15,51)-(15,57) = "class "
+            │           │   │           │   │   ├── closing_loc: ∅
+            │           │   │           │   │   └── unescaped: "class "
+            │           │   │           │   └── @ EmbeddedStatementsNode (location: (15,57)-(15,61))
+            │           │   │           │       ├── opening_loc: (15,57)-(15,59) = "\#{"
+            │           │   │           │       ├── statements:
+            │           │   │           │       │   @ StatementsNode (location: (15,59)-(15,60))
+            │           │   │           │       │   └── body: (length: 1)
+            │           │   │           │       │       └── @ LocalVariableReadNode (location: (15,59)-(15,60))
+            │           │   │           │       │           ├── name: :x
+            │           │   │           │       │           └── depth: 0
+            │           │   │           │       └── closing_loc: (15,60)-(15,61) = "}"
+            │           │   │           └── closing_loc: (15,61)-(15,62) = "\""
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/endless_method_forwarded_args_legacy.txt
+++ b/test/prism/snapshots/whitequark/endless_method_forwarded_args_legacy.txt
@@ -27,8 +27,9 @@
             │           ├── opening_loc: (1,18)-(1,19) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,19)-(1,22))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ ForwardingArgumentsNode (location: (1,19)-(1,22))
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ ForwardingArgumentsNode (location: (1,19)-(1,22))
+            │           │   └── flags: ∅
             │           ├── closing_loc: (1,22)-(1,23) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/for.txt
+++ b/test/prism/snapshots/whitequark/for.txt
@@ -29,10 +29,11 @@
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (1,18)-(1,19))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ LocalVariableReadNode (location: (1,18)-(1,19))
-        │   │           │           ├── name: :a
-        │   │           │           └── depth: 1
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ LocalVariableReadNode (location: (1,18)-(1,19))
+        │   │           │   │       ├── name: :a
+        │   │           │   │       └── depth: 1
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -67,10 +68,11 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (3,16)-(3,17))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ LocalVariableReadNode (location: (3,16)-(3,17))
-            │           │           ├── name: :a
-            │           │           └── depth: 1
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ LocalVariableReadNode (location: (3,16)-(3,17))
+            │           │   │       ├── name: :a
+            │           │   │       └── depth: 1
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/for_mlhs.txt
+++ b/test/prism/snapshots/whitequark/for_mlhs.txt
@@ -36,13 +36,14 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,19)-(1,23))
-            │           │   └── arguments: (length: 2)
-            │           │       ├── @ LocalVariableReadNode (location: (1,19)-(1,20))
-            │           │       │   ├── name: :a
-            │           │       │   └── depth: 1
-            │           │       └── @ LocalVariableReadNode (location: (1,22)-(1,23))
-            │           │           ├── name: :b
-            │           │           └── depth: 1
+            │           │   ├── arguments: (length: 2)
+            │           │   │   ├── @ LocalVariableReadNode (location: (1,19)-(1,20))
+            │           │   │   │   ├── name: :a
+            │           │   │   │   └── depth: 1
+            │           │   │   └── @ LocalVariableReadNode (location: (1,22)-(1,23))
+            │           │   │       ├── name: :b
+            │           │   │       └── depth: 1
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/forward_arg.txt
+++ b/test/prism/snapshots/whitequark/forward_arg.txt
@@ -27,8 +27,9 @@
             │           ├── opening_loc: (1,17)-(1,18) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,18)-(1,21))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ ForwardingArgumentsNode (location: (1,18)-(1,21))
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ ForwardingArgumentsNode (location: (1,18)-(1,21))
+            │           │   └── flags: ∅
             │           ├── closing_loc: (1,21)-(1,22) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/forward_arg_with_open_args.txt
+++ b/test/prism/snapshots/whitequark/forward_arg_with_open_args.txt
@@ -31,8 +31,9 @@
         │   │           │           ├── opening_loc: (2,5)-(2,6) = "("
         │   │           │           ├── arguments:
         │   │           │           │   @ ArgumentsNode (location: (2,6)-(2,9))
-        │   │           │           │   └── arguments: (length: 1)
-        │   │           │           │       └── @ ForwardingArgumentsNode (location: (2,6)-(2,9))
+        │   │           │           │   ├── arguments: (length: 1)
+        │   │           │           │   │   └── @ ForwardingArgumentsNode (location: (2,6)-(2,9))
+        │   │           │           │   └── flags: ∅
         │   │           │           ├── closing_loc: (2,9)-(2,10) = ")"
         │   │           │           ├── block: ∅
         │   │           │           ├── flags: ∅
@@ -74,8 +75,9 @@
         │   │           │           ├── opening_loc: (5,17)-(5,18) = "("
         │   │           │           ├── arguments:
         │   │           │           │   @ ArgumentsNode (location: (5,18)-(5,21))
-        │   │           │           │   └── arguments: (length: 1)
-        │   │           │           │       └── @ ForwardingArgumentsNode (location: (5,18)-(5,21))
+        │   │           │           │   ├── arguments: (length: 1)
+        │   │           │           │   │   └── @ ForwardingArgumentsNode (location: (5,18)-(5,21))
+        │   │           │           │   └── flags: ∅
         │   │           │           ├── closing_loc: (5,21)-(5,22) = ")"
         │   │           │           ├── block: ∅
         │   │           │           ├── flags: ∅
@@ -135,8 +137,9 @@
         │   │           ├── opening_loc: (10,16)-(10,17) = "("
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (10,17)-(10,20))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ ForwardingArgumentsNode (location: (10,17)-(10,20))
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ ForwardingArgumentsNode (location: (10,17)-(10,20))
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: (10,20)-(10,21) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -174,8 +177,9 @@
         │   │           ├── opening_loc: (13,5)-(13,6) = "("
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (13,6)-(13,9))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ ForwardingArgumentsNode (location: (13,6)-(13,9))
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ ForwardingArgumentsNode (location: (13,6)-(13,9))
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: (13,9)-(13,10) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -213,8 +217,9 @@
         │   │           ├── opening_loc: (16,19)-(16,20) = "("
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (16,20)-(16,23))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ ForwardingArgumentsNode (location: (16,20)-(16,23))
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ ForwardingArgumentsNode (location: (16,20)-(16,23))
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: (16,23)-(16,24) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -288,8 +293,9 @@
         │   │           ├── opening_loc: (22,5)-(22,6) = "("
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (22,6)-(22,9))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ ForwardingArgumentsNode (location: (22,6)-(22,9))
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ ForwardingArgumentsNode (location: (22,6)-(22,9))
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: (22,9)-(22,10) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -332,8 +338,9 @@
         │   │           ├── opening_loc: (25,23)-(25,24) = "("
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (25,24)-(25,27))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ ForwardingArgumentsNode (location: (25,24)-(25,27))
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ ForwardingArgumentsNode (location: (25,24)-(25,27))
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: (25,27)-(25,28) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -371,8 +378,9 @@
             │           ├── opening_loc: (27,19)-(27,20) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (27,20)-(27,23))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ ForwardingArgumentsNode (location: (27,20)-(27,23))
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ ForwardingArgumentsNode (location: (27,20)-(27,23))
+            │           │   └── flags: ∅
             │           ├── closing_loc: (27,23)-(27,24) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/forward_args_legacy.txt
+++ b/test/prism/snapshots/whitequark/forward_args_legacy.txt
@@ -27,8 +27,9 @@
         │   │           ├── opening_loc: (1,17)-(1,18) = "("
         │   │           ├── arguments:
         │   │           │   @ ArgumentsNode (location: (1,18)-(1,21))
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ ForwardingArgumentsNode (location: (1,18)-(1,21))
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ ForwardingArgumentsNode (location: (1,18)-(1,21))
+        │   │           │   └── flags: ∅
         │   │           ├── closing_loc: (1,21)-(1,22) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
@@ -84,8 +85,9 @@
             │           ├── lparen_loc: (5,19)-(5,20) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (5,20)-(5,23))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ ForwardingArgumentsNode (location: (5,20)-(5,23))
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ ForwardingArgumentsNode (location: (5,20)-(5,23))
+            │           │   └── flags: ∅
             │           ├── rparen_loc: (5,23)-(5,24) = ")"
             │           └── block: ∅
             ├── locals: [:*, :&, :"..."]

--- a/test/prism/snapshots/whitequark/forwarded_argument_with_kwrestarg.txt
+++ b/test/prism/snapshots/whitequark/forwarded_argument_with_kwrestarg.txt
@@ -32,15 +32,16 @@
             │           ├── opening_loc: (1,26)-(1,27) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,27)-(1,39))
-            │           │   └── arguments: (length: 2)
-            │           │       ├── @ LocalVariableReadNode (location: (1,27)-(1,35))
-            │           │       │   ├── name: :argument
-            │           │       │   └── depth: 0
-            │           │       └── @ KeywordHashNode (location: (1,37)-(1,39))
-            │           │           └── elements: (length: 1)
-            │           │               └── @ AssocSplatNode (location: (1,37)-(1,39))
-            │           │                   ├── value: ∅
-            │           │                   └── operator_loc: (1,37)-(1,39) = "**"
+            │           │   ├── arguments: (length: 2)
+            │           │   │   ├── @ LocalVariableReadNode (location: (1,27)-(1,35))
+            │           │   │   │   ├── name: :argument
+            │           │   │   │   └── depth: 0
+            │           │   │   └── @ KeywordHashNode (location: (1,37)-(1,39))
+            │           │   │       └── elements: (length: 1)
+            │           │   │           └── @ AssocSplatNode (location: (1,37)-(1,39))
+            │           │   │               ├── value: ∅
+            │           │   │               └── operator_loc: (1,37)-(1,39) = "**"
+            │           │   └── flags: keyword_splat
             │           ├── closing_loc: (1,39)-(1,40) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/forwarded_argument_with_restarg.txt
+++ b/test/prism/snapshots/whitequark/forwarded_argument_with_restarg.txt
@@ -32,13 +32,14 @@
             │           ├── opening_loc: (1,25)-(1,26) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,26)-(1,37))
-            │           │   └── arguments: (length: 2)
-            │           │       ├── @ LocalVariableReadNode (location: (1,26)-(1,34))
-            │           │       │   ├── name: :argument
-            │           │       │   └── depth: 0
-            │           │       └── @ SplatNode (location: (1,36)-(1,37))
-            │           │           ├── operator_loc: (1,36)-(1,37) = "*"
-            │           │           └── expression: ∅
+            │           │   ├── arguments: (length: 2)
+            │           │   │   ├── @ LocalVariableReadNode (location: (1,26)-(1,34))
+            │           │   │   │   ├── name: :argument
+            │           │   │   │   └── depth: 0
+            │           │   │   └── @ SplatNode (location: (1,36)-(1,37))
+            │           │   │       ├── operator_loc: (1,36)-(1,37) = "*"
+            │           │   │       └── expression: ∅
+            │           │   └── flags: ∅
             │           ├── closing_loc: (1,37)-(1,38) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/forwarded_kwrestarg.txt
+++ b/test/prism/snapshots/whitequark/forwarded_kwrestarg.txt
@@ -30,12 +30,13 @@
             │           ├── opening_loc: (1,16)-(1,17) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,17)-(1,19))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ KeywordHashNode (location: (1,17)-(1,19))
-            │           │           └── elements: (length: 1)
-            │           │               └── @ AssocSplatNode (location: (1,17)-(1,19))
-            │           │                   ├── value: ∅
-            │           │                   └── operator_loc: (1,17)-(1,19) = "**"
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ KeywordHashNode (location: (1,17)-(1,19))
+            │           │   │       └── elements: (length: 1)
+            │           │   │           └── @ AssocSplatNode (location: (1,17)-(1,19))
+            │           │   │               ├── value: ∅
+            │           │   │               └── operator_loc: (1,17)-(1,19) = "**"
+            │           │   └── flags: keyword_splat
             │           ├── closing_loc: (1,19)-(1,20) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/forwarded_kwrestarg_with_additional_kwarg.txt
+++ b/test/prism/snapshots/whitequark/forwarded_kwrestarg_with_additional_kwarg.txt
@@ -30,22 +30,23 @@
             │           ├── opening_loc: (1,16)-(1,17) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,17)-(1,35))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ KeywordHashNode (location: (1,17)-(1,35))
-            │           │           └── elements: (length: 2)
-            │           │               ├── @ AssocSplatNode (location: (1,17)-(1,19))
-            │           │               │   ├── value: ∅
-            │           │               │   └── operator_loc: (1,17)-(1,19) = "**"
-            │           │               └── @ AssocNode (location: (1,21)-(1,35))
-            │           │                   ├── key:
-            │           │                   │   @ SymbolNode (location: (1,21)-(1,30))
-            │           │                   │   ├── opening_loc: ∅
-            │           │                   │   ├── value_loc: (1,21)-(1,29) = "from_foo"
-            │           │                   │   ├── closing_loc: (1,29)-(1,30) = ":"
-            │           │                   │   └── unescaped: "from_foo"
-            │           │                   ├── value:
-            │           │                   │   @ TrueNode (location: (1,31)-(1,35))
-            │           │                   └── operator_loc: ∅
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ KeywordHashNode (location: (1,17)-(1,35))
+            │           │   │       └── elements: (length: 2)
+            │           │   │           ├── @ AssocSplatNode (location: (1,17)-(1,19))
+            │           │   │           │   ├── value: ∅
+            │           │   │           │   └── operator_loc: (1,17)-(1,19) = "**"
+            │           │   │           └── @ AssocNode (location: (1,21)-(1,35))
+            │           │   │               ├── key:
+            │           │   │               │   @ SymbolNode (location: (1,21)-(1,30))
+            │           │   │               │   ├── opening_loc: ∅
+            │           │   │               │   ├── value_loc: (1,21)-(1,29) = "from_foo"
+            │           │   │               │   ├── closing_loc: (1,29)-(1,30) = ":"
+            │           │   │               │   └── unescaped: "from_foo"
+            │           │   │               ├── value:
+            │           │   │               │   @ TrueNode (location: (1,31)-(1,35))
+            │           │   │               └── operator_loc: ∅
+            │           │   └── flags: keyword_splat
             │           ├── closing_loc: (1,35)-(1,36) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/forwarded_restarg.txt
+++ b/test/prism/snapshots/whitequark/forwarded_restarg.txt
@@ -30,10 +30,11 @@
             │           ├── opening_loc: (1,15)-(1,16) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,16)-(1,17))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ SplatNode (location: (1,16)-(1,17))
-            │           │           ├── operator_loc: (1,16)-(1,17) = "*"
-            │           │           └── expression: ∅
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ SplatNode (location: (1,16)-(1,17))
+            │           │   │       ├── operator_loc: (1,16)-(1,17) = "*"
+            │           │   │       └── expression: ∅
+            │           │   └── flags: ∅
             │           ├── closing_loc: (1,17)-(1,18) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/hash_label_end.txt
+++ b/test/prism/snapshots/whitequark/hash_label_end.txt
@@ -10,39 +10,40 @@
         │   ├── opening_loc: (1,1)-(1,2) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IfNode (location: (1,2)-(1,11))
-        │   │           ├── if_keyword_loc: ∅
-        │   │           ├── predicate:
-        │   │           │   @ CallNode (location: (1,2)-(1,3))
-        │   │           │   ├── receiver: ∅
-        │   │           │   ├── call_operator_loc: ∅
-        │   │           │   ├── message_loc: (1,2)-(1,3) = "a"
-        │   │           │   ├── opening_loc: ∅
-        │   │           │   ├── arguments: ∅
-        │   │           │   ├── closing_loc: ∅
-        │   │           │   ├── block: ∅
-        │   │           │   ├── flags: variable_call
-        │   │           │   └── name: :a
-        │   │           ├── statements:
-        │   │           │   @ StatementsNode (location: (1,6)-(1,9))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ StringNode (location: (1,6)-(1,9))
-        │   │           │           ├── flags: ∅
-        │   │           │           ├── opening_loc: (1,6)-(1,7) = "\""
-        │   │           │           ├── content_loc: (1,7)-(1,8) = "a"
-        │   │           │           ├── closing_loc: (1,8)-(1,9) = "\""
-        │   │           │           └── unescaped: "a"
-        │   │           ├── consequent:
-        │   │           │   @ ElseNode (location: (1,9)-(1,11))
-        │   │           │   ├── else_keyword_loc: (1,9)-(1,10) = ":"
-        │   │           │   ├── statements:
-        │   │           │   │   @ StatementsNode (location: (1,10)-(1,11))
-        │   │           │   │   └── body: (length: 1)
-        │   │           │   │       └── @ IntegerNode (location: (1,10)-(1,11))
-        │   │           │   │           └── flags: decimal
-        │   │           │   └── end_keyword_loc: ∅
-        │   │           └── end_keyword_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IfNode (location: (1,2)-(1,11))
+        │   │   │       ├── if_keyword_loc: ∅
+        │   │   │       ├── predicate:
+        │   │   │       │   @ CallNode (location: (1,2)-(1,3))
+        │   │   │       │   ├── receiver: ∅
+        │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │       │   ├── message_loc: (1,2)-(1,3) = "a"
+        │   │   │       │   ├── opening_loc: ∅
+        │   │   │       │   ├── arguments: ∅
+        │   │   │       │   ├── closing_loc: ∅
+        │   │   │       │   ├── block: ∅
+        │   │   │       │   ├── flags: variable_call
+        │   │   │       │   └── name: :a
+        │   │   │       ├── statements:
+        │   │   │       │   @ StatementsNode (location: (1,6)-(1,9))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ StringNode (location: (1,6)-(1,9))
+        │   │   │       │           ├── flags: ∅
+        │   │   │       │           ├── opening_loc: (1,6)-(1,7) = "\""
+        │   │   │       │           ├── content_loc: (1,7)-(1,8) = "a"
+        │   │   │       │           ├── closing_loc: (1,8)-(1,9) = "\""
+        │   │   │       │           └── unescaped: "a"
+        │   │   │       ├── consequent:
+        │   │   │       │   @ ElseNode (location: (1,9)-(1,11))
+        │   │   │       │   ├── else_keyword_loc: (1,9)-(1,10) = ":"
+        │   │   │       │   ├── statements:
+        │   │   │       │   │   @ StatementsNode (location: (1,10)-(1,11))
+        │   │   │       │   │   └── body: (length: 1)
+        │   │   │       │   │       └── @ IntegerNode (location: (1,10)-(1,11))
+        │   │   │       │   │           └── flags: decimal
+        │   │   │       │   └── end_keyword_loc: ∅
+        │   │   │       └── end_keyword_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: (1,11)-(1,12) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/if_while_after_class__since_32.txt
+++ b/test/prism/snapshots/whitequark/if_while_after_class__since_32.txt
@@ -46,9 +46,10 @@
         │   │   │   │       └── @ BreakNode (location: (3,18)-(3,30))
         │   │   │   │           ├── arguments:
         │   │   │   │           │   @ ArgumentsNode (location: (3,24)-(3,30))
-        │   │   │   │           │   └── arguments: (length: 1)
-        │   │   │   │           │       └── @ ConstantReadNode (location: (3,24)-(3,30))
-        │   │   │   │           │           └── name: :Object
+        │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │           │   │   └── @ ConstantReadNode (location: (3,24)-(3,30))
+        │   │   │   │           │   │       └── name: :Object
+        │   │   │   │           │   └── flags: ∅
         │   │   │   │           └── keyword_loc: (3,18)-(3,23) = "break"
         │   │   │   └── flags: ∅
         │   │   ├── child:
@@ -101,9 +102,10 @@
             │   │   │       └── @ BreakNode (location: (7,19)-(7,31))
             │   │   │           ├── arguments:
             │   │   │           │   @ ArgumentsNode (location: (7,25)-(7,31))
-            │   │   │           │   └── arguments: (length: 1)
-            │   │   │           │       └── @ ConstantReadNode (location: (7,25)-(7,31))
-            │   │   │           │           └── name: :Object
+            │   │   │           │   ├── arguments: (length: 1)
+            │   │   │           │   │   └── @ ConstantReadNode (location: (7,25)-(7,31))
+            │   │   │           │   │       └── name: :Object
+            │   │   │           │   └── flags: ∅
             │   │   │           └── keyword_loc: (7,19)-(7,24) = "break"
             │   │   └── flags: ∅
             │   ├── child:

--- a/test/prism/snapshots/whitequark/keyword_argument_omission.txt
+++ b/test/prism/snapshots/whitequark/keyword_argument_omission.txt
@@ -10,51 +10,52 @@
             ├── opening_loc: (1,3)-(1,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,10))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,4)-(1,10))
-            │           └── elements: (length: 2)
-            │               ├── @ AssocNode (location: (1,4)-(1,6))
-            │               │   ├── key:
-            │               │   │   @ SymbolNode (location: (1,4)-(1,6))
-            │               │   │   ├── opening_loc: ∅
-            │               │   │   ├── value_loc: (1,4)-(1,5) = "a"
-            │               │   │   ├── closing_loc: (1,5)-(1,6) = ":"
-            │               │   │   └── unescaped: "a"
-            │               │   ├── value:
-            │               │   │   @ ImplicitNode (location: (1,4)-(1,6))
-            │               │   │   └── value:
-            │               │   │       @ CallNode (location: (1,4)-(1,6))
-            │               │   │       ├── receiver: ∅
-            │               │   │       ├── call_operator_loc: ∅
-            │               │   │       ├── message_loc: (1,4)-(1,5) = "a"
-            │               │   │       ├── opening_loc: ∅
-            │               │   │       ├── arguments: ∅
-            │               │   │       ├── closing_loc: ∅
-            │               │   │       ├── block: ∅
-            │               │   │       ├── flags: ∅
-            │               │   │       └── name: :a
-            │               │   └── operator_loc: ∅
-            │               └── @ AssocNode (location: (1,8)-(1,10))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (1,8)-(1,10))
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── value_loc: (1,8)-(1,9) = "b"
-            │                   │   ├── closing_loc: (1,9)-(1,10) = ":"
-            │                   │   └── unescaped: "b"
-            │                   ├── value:
-            │                   │   @ ImplicitNode (location: (1,8)-(1,10))
-            │                   │   └── value:
-            │                   │       @ CallNode (location: (1,8)-(1,10))
-            │                   │       ├── receiver: ∅
-            │                   │       ├── call_operator_loc: ∅
-            │                   │       ├── message_loc: (1,8)-(1,9) = "b"
-            │                   │       ├── opening_loc: ∅
-            │                   │       ├── arguments: ∅
-            │                   │       ├── closing_loc: ∅
-            │                   │       ├── block: ∅
-            │                   │       ├── flags: ∅
-            │                   │       └── name: :b
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,4)-(1,10))
+            │   │       └── elements: (length: 2)
+            │   │           ├── @ AssocNode (location: (1,4)-(1,6))
+            │   │           │   ├── key:
+            │   │           │   │   @ SymbolNode (location: (1,4)-(1,6))
+            │   │           │   │   ├── opening_loc: ∅
+            │   │           │   │   ├── value_loc: (1,4)-(1,5) = "a"
+            │   │           │   │   ├── closing_loc: (1,5)-(1,6) = ":"
+            │   │           │   │   └── unescaped: "a"
+            │   │           │   ├── value:
+            │   │           │   │   @ ImplicitNode (location: (1,4)-(1,6))
+            │   │           │   │   └── value:
+            │   │           │   │       @ CallNode (location: (1,4)-(1,6))
+            │   │           │   │       ├── receiver: ∅
+            │   │           │   │       ├── call_operator_loc: ∅
+            │   │           │   │       ├── message_loc: (1,4)-(1,5) = "a"
+            │   │           │   │       ├── opening_loc: ∅
+            │   │           │   │       ├── arguments: ∅
+            │   │           │   │       ├── closing_loc: ∅
+            │   │           │   │       ├── block: ∅
+            │   │           │   │       ├── flags: ∅
+            │   │           │   │       └── name: :a
+            │   │           │   └── operator_loc: ∅
+            │   │           └── @ AssocNode (location: (1,8)-(1,10))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (1,8)-(1,10))
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── value_loc: (1,8)-(1,9) = "b"
+            │   │               │   ├── closing_loc: (1,9)-(1,10) = ":"
+            │   │               │   └── unescaped: "b"
+            │   │               ├── value:
+            │   │               │   @ ImplicitNode (location: (1,8)-(1,10))
+            │   │               │   └── value:
+            │   │               │       @ CallNode (location: (1,8)-(1,10))
+            │   │               │       ├── receiver: ∅
+            │   │               │       ├── call_operator_loc: ∅
+            │   │               │       ├── message_loc: (1,8)-(1,9) = "b"
+            │   │               │       ├── opening_loc: ∅
+            │   │               │       ├── arguments: ∅
+            │   │               │       ├── closing_loc: ∅
+            │   │               │       ├── block: ∅
+            │   │               │       ├── flags: ∅
+            │   │               │       └── name: :b
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: (1,10)-(1,11) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/kwoptarg_with_kwrestarg_and_forwarded_args.txt
+++ b/test/prism/snapshots/whitequark/kwoptarg_with_kwrestarg_and_forwarded_args.txt
@@ -35,12 +35,13 @@
             │           ├── opening_loc: (1,20)-(1,21) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,21)-(1,23))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ KeywordHashNode (location: (1,21)-(1,23))
-            │           │           └── elements: (length: 1)
-            │           │               └── @ AssocSplatNode (location: (1,21)-(1,23))
-            │           │                   ├── value: ∅
-            │           │                   └── operator_loc: (1,21)-(1,23) = "**"
+            │           │   ├── arguments: (length: 1)
+            │           │   │   └── @ KeywordHashNode (location: (1,21)-(1,23))
+            │           │   │       └── elements: (length: 1)
+            │           │   │           └── @ AssocSplatNode (location: (1,21)-(1,23))
+            │           │   │               ├── value: ∅
+            │           │   │               └── operator_loc: (1,21)-(1,23) = "**"
+            │           │   └── flags: keyword_splat
             │           ├── closing_loc: (1,23)-(1,24) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/lbrace_arg_after_command_args.txt
+++ b/test/prism/snapshots/whitequark/lbrace_arg_after_command_args.txt
@@ -10,18 +10,19 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,8))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,4)-(1,8))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,5)-(1,7))
-            │           │   └── body: (length: 1)
-            │           │       └── @ SymbolNode (location: (1,5)-(1,7))
-            │           │           ├── opening_loc: (1,5)-(1,6) = ":"
-            │           │           ├── value_loc: (1,6)-(1,7) = "a"
-            │           │           ├── closing_loc: ∅
-            │           │           └── unescaped: "a"
-            │           ├── opening_loc: (1,4)-(1,5) = "("
-            │           └── closing_loc: (1,7)-(1,8) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,4)-(1,8))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,5)-(1,7))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ SymbolNode (location: (1,5)-(1,7))
+            │   │       │           ├── opening_loc: (1,5)-(1,6) = ":"
+            │   │       │           ├── value_loc: (1,6)-(1,7) = "a"
+            │   │       │           ├── closing_loc: ∅
+            │   │       │           └── unescaped: "a"
+            │   │       ├── opening_loc: (1,4)-(1,5) = "("
+            │   │       └── closing_loc: (1,7)-(1,8) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,9)-(1,22))

--- a/test/prism/snapshots/whitequark/lparenarg_after_lvar__since_25.txt
+++ b/test/prism/snapshots/whitequark/lparenarg_after_lvar__since_25.txt
@@ -10,24 +10,25 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,4)-(1,14))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (1,4)-(1,14))
-        │   │           ├── receiver:
-        │   │           │   @ ParenthesesNode (location: (1,4)-(1,10))
-        │   │           │   ├── body:
-        │   │           │   │   @ StatementsNode (location: (1,5)-(1,9))
-        │   │           │   │   └── body: (length: 1)
-        │   │           │   │       └── @ FloatNode (location: (1,5)-(1,9))
-        │   │           │   ├── opening_loc: (1,4)-(1,5) = "("
-        │   │           │   └── closing_loc: (1,9)-(1,10) = ")"
-        │   │           ├── call_operator_loc: (1,10)-(1,11) = "."
-        │   │           ├── message_loc: (1,11)-(1,14) = "abs"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :abs
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (1,4)-(1,14))
+        │   │   │       ├── receiver:
+        │   │   │       │   @ ParenthesesNode (location: (1,4)-(1,10))
+        │   │   │       │   ├── body:
+        │   │   │       │   │   @ StatementsNode (location: (1,5)-(1,9))
+        │   │   │       │   │   └── body: (length: 1)
+        │   │   │       │   │       └── @ FloatNode (location: (1,5)-(1,9))
+        │   │   │       │   ├── opening_loc: (1,4)-(1,5) = "("
+        │   │   │       │   └── closing_loc: (1,9)-(1,10) = ")"
+        │   │   │       ├── call_operator_loc: (1,10)-(1,11) = "."
+        │   │   │       ├── message_loc: (1,11)-(1,14) = "abs"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :abs
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -39,24 +40,25 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (3,5)-(3,15))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (3,5)-(3,15))
-            │           ├── receiver:
-            │           │   @ ParenthesesNode (location: (3,5)-(3,11))
-            │           │   ├── body:
-            │           │   │   @ StatementsNode (location: (3,6)-(3,10))
-            │           │   │   └── body: (length: 1)
-            │           │   │       └── @ FloatNode (location: (3,6)-(3,10))
-            │           │   ├── opening_loc: (3,5)-(3,6) = "("
-            │           │   └── closing_loc: (3,10)-(3,11) = ")"
-            │           ├── call_operator_loc: (3,11)-(3,12) = "."
-            │           ├── message_loc: (3,12)-(3,15) = "abs"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :abs
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (3,5)-(3,15))
+            │   │       ├── receiver:
+            │   │       │   @ ParenthesesNode (location: (3,5)-(3,11))
+            │   │       │   ├── body:
+            │   │       │   │   @ StatementsNode (location: (3,6)-(3,10))
+            │   │       │   │   └── body: (length: 1)
+            │   │       │   │       └── @ FloatNode (location: (3,6)-(3,10))
+            │   │       │   ├── opening_loc: (3,5)-(3,6) = "("
+            │   │       │   └── closing_loc: (3,10)-(3,11) = ")"
+            │   │       ├── call_operator_loc: (3,11)-(3,12) = "."
+            │   │       ├── message_loc: (3,12)-(3,15) = "abs"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: ∅
+            │   │       └── name: :abs
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/lvar_injecting_match.txt
+++ b/test/prism/snapshots/whitequark/lvar_injecting_match.txt
@@ -18,13 +18,14 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (1,19)-(1,24))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ StringNode (location: (1,19)-(1,24))
-        │   │   │           ├── flags: ∅
-        │   │   │           ├── opening_loc: (1,19)-(1,20) = "'"
-        │   │   │           ├── content_loc: (1,20)-(1,23) = "bar"
-        │   │   │           ├── closing_loc: (1,23)-(1,24) = "'"
-        │   │   │           └── unescaped: "bar"
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ StringNode (location: (1,19)-(1,24))
+        │   │   │   │       ├── flags: ∅
+        │   │   │   │       ├── opening_loc: (1,19)-(1,20) = "'"
+        │   │   │   │       ├── content_loc: (1,20)-(1,23) = "bar"
+        │   │   │   │       ├── closing_loc: (1,23)-(1,24) = "'"
+        │   │   │   │       └── unescaped: "bar"
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block: ∅
         │   │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/masgn_attr.txt
+++ b/test/prism/snapshots/whitequark/masgn_attr.txt
@@ -47,11 +47,12 @@
         │   │       ├── opening_loc: (3,12)-(3,13) = "["
         │   │       ├── arguments:
         │   │       │   @ ArgumentsNode (location: (3,13)-(3,17))
-        │   │       │   └── arguments: (length: 2)
-        │   │       │       ├── @ IntegerNode (location: (3,13)-(3,14))
-        │   │       │       │   └── flags: decimal
-        │   │       │       └── @ IntegerNode (location: (3,16)-(3,17))
-        │   │       │           └── flags: decimal
+        │   │       │   ├── arguments: (length: 2)
+        │   │       │   │   ├── @ IntegerNode (location: (3,13)-(3,14))
+        │   │       │   │   │   └── flags: decimal
+        │   │       │   │   └── @ IntegerNode (location: (3,16)-(3,17))
+        │   │       │   │       └── flags: decimal
+        │   │       │   └── flags: ∅
         │   │       ├── closing_loc: (3,17)-(3,18) = "]"
         │   │       ├── block: ∅
         │   │       ├── flags: ∅

--- a/test/prism/snapshots/whitequark/masgn_cmd.txt
+++ b/test/prism/snapshots/whitequark/masgn_cmd.txt
@@ -22,10 +22,11 @@
                 ├── opening_loc: ∅
                 ├── arguments:
                 │   @ ArgumentsNode (location: (1,13)-(1,16))
-                │   └── arguments: (length: 1)
-                │       └── @ LocalVariableReadNode (location: (1,13)-(1,16))
-                │           ├── name: :foo
-                │           └── depth: 0
+                │   ├── arguments: (length: 1)
+                │   │   └── @ LocalVariableReadNode (location: (1,13)-(1,16))
+                │   │       ├── name: :foo
+                │   │       └── depth: 0
+                │   └── flags: ∅
                 ├── closing_loc: ∅
                 ├── block: ∅
                 ├── flags: ∅

--- a/test/prism/snapshots/whitequark/newline_in_hash_argument.txt
+++ b/test/prism/snapshots/whitequark/newline_in_hash_argument.txt
@@ -86,20 +86,21 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (10,8)-(11,1))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (10,8)-(11,1))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (10,8)-(11,1))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (10,8)-(10,14))
-        │   │                   │   ├── opening_loc: (10,8)-(10,9) = "\""
-        │   │                   │   ├── value_loc: (10,9)-(10,12) = "foo"
-        │   │                   │   ├── closing_loc: (10,12)-(10,14) = "\":"
-        │   │                   │   └── unescaped: "foo"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (11,0)-(11,1))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (10,8)-(11,1))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (10,8)-(11,1))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (10,8)-(10,14))
+        │   │   │               │   ├── opening_loc: (10,8)-(10,9) = "\""
+        │   │   │               │   ├── value_loc: (10,9)-(10,12) = "foo"
+        │   │   │               │   ├── closing_loc: (10,12)-(10,14) = "\":"
+        │   │   │               │   └── unescaped: "foo"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (11,0)-(11,1))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -121,20 +122,21 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (13,8)-(14,1))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (13,8)-(14,1))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (13,8)-(14,1))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (13,8)-(13,12))
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── value_loc: (13,8)-(13,11) = "foo"
-            │                   │   ├── closing_loc: (13,11)-(13,12) = ":"
-            │                   │   └── unescaped: "foo"
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (14,0)-(14,1))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (13,8)-(14,1))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (13,8)-(14,1))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (13,8)-(13,12))
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── value_loc: (13,8)-(13,11) = "foo"
+            │   │               │   ├── closing_loc: (13,11)-(13,12) = ":"
+            │   │               │   └── unescaped: "foo"
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (14,0)-(14,1))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/next.txt
+++ b/test/prism/snapshots/whitequark/next.txt
@@ -9,45 +9,48 @@
         ├── @ NextNode (location: (3,0)-(3,8))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,5)-(3,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (3,5)-(3,8))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (3,5)-(3,8) = "foo"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :foo
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (3,5)-(3,8))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (3,5)-(3,8) = "foo"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :foo
+        │   │   └── flags: ∅
         │   └── keyword_loc: (3,0)-(3,4) = "next"
         ├── @ NextNode (location: (5,0)-(5,6))
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,4)-(5,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (5,4)-(5,6))
-        │   │           ├── body: ∅
-        │   │           ├── opening_loc: (5,4)-(5,5) = "("
-        │   │           └── closing_loc: (5,5)-(5,6) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (5,4)-(5,6))
+        │   │   │       ├── body: ∅
+        │   │   │       ├── opening_loc: (5,4)-(5,5) = "("
+        │   │   │       └── closing_loc: (5,5)-(5,6) = ")"
+        │   │   └── flags: ∅
         │   └── keyword_loc: (5,0)-(5,4) = "next"
         └── @ NextNode (location: (7,0)-(7,9))
             ├── arguments:
             │   @ ArgumentsNode (location: (7,4)-(7,9))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (7,4)-(7,9))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (7,5)-(7,8))
-            │           │   └── body: (length: 1)
-            │           │       └── @ CallNode (location: (7,5)-(7,8))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (7,5)-(7,8) = "foo"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: variable_call
-            │           │           └── name: :foo
-            │           ├── opening_loc: (7,4)-(7,5) = "("
-            │           └── closing_loc: (7,8)-(7,9) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (7,4)-(7,9))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (7,5)-(7,8))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ CallNode (location: (7,5)-(7,8))
+            │   │       │           ├── receiver: ∅
+            │   │       │           ├── call_operator_loc: ∅
+            │   │       │           ├── message_loc: (7,5)-(7,8) = "foo"
+            │   │       │           ├── opening_loc: ∅
+            │   │       │           ├── arguments: ∅
+            │   │       │           ├── closing_loc: ∅
+            │   │       │           ├── block: ∅
+            │   │       │           ├── flags: variable_call
+            │   │       │           └── name: :foo
+            │   │       ├── opening_loc: (7,4)-(7,5) = "("
+            │   │       └── closing_loc: (7,8)-(7,9) = ")"
+            │   └── flags: ∅
             └── keyword_loc: (7,0)-(7,4) = "next"

--- a/test/prism/snapshots/whitequark/next_block.txt
+++ b/test/prism/snapshots/whitequark/next_block.txt
@@ -6,33 +6,35 @@
         └── @ NextNode (location: (1,0)-(1,19))
             ├── arguments:
             │   @ ArgumentsNode (location: (1,5)-(1,19))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,5)-(1,19))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,5)-(1,8) = "fun"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (1,9)-(1,12))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ CallNode (location: (1,9)-(1,12))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (1,9)-(1,12) = "foo"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: variable_call
-            │           │           └── name: :foo
-            │           ├── closing_loc: ∅
-            │           ├── block:
-            │           │   @ BlockNode (location: (1,13)-(1,19))
-            │           │   ├── locals: []
-            │           │   ├── parameters: ∅
-            │           │   ├── body: ∅
-            │           │   ├── opening_loc: (1,13)-(1,15) = "do"
-            │           │   └── closing_loc: (1,16)-(1,19) = "end"
-            │           ├── flags: ∅
-            │           └── name: :fun
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,5)-(1,19))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,5)-(1,8) = "fun"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (1,9)-(1,12))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ CallNode (location: (1,9)-(1,12))
+            │   │       │   │       ├── receiver: ∅
+            │   │       │   │       ├── call_operator_loc: ∅
+            │   │       │   │       ├── message_loc: (1,9)-(1,12) = "foo"
+            │   │       │   │       ├── opening_loc: ∅
+            │   │       │   │       ├── arguments: ∅
+            │   │       │   │       ├── closing_loc: ∅
+            │   │       │   │       ├── block: ∅
+            │   │       │   │       ├── flags: variable_call
+            │   │       │   │       └── name: :foo
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block:
+            │   │       │   @ BlockNode (location: (1,13)-(1,19))
+            │   │       │   ├── locals: []
+            │   │       │   ├── parameters: ∅
+            │   │       │   ├── body: ∅
+            │   │       │   ├── opening_loc: (1,13)-(1,15) = "do"
+            │   │       │   └── closing_loc: (1,16)-(1,19) = "end"
+            │   │       ├── flags: ∅
+            │   │       └── name: :fun
+            │   └── flags: ∅
             └── keyword_loc: (1,0)-(1,4) = "next"

--- a/test/prism/snapshots/whitequark/non_lvar_injecting_match.txt
+++ b/test/prism/snapshots/whitequark/non_lvar_injecting_match.txt
@@ -29,13 +29,14 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,23)-(1,28))
-            │   └── arguments: (length: 1)
-            │       └── @ StringNode (location: (1,23)-(1,28))
-            │           ├── flags: ∅
-            │           ├── opening_loc: (1,23)-(1,24) = "'"
-            │           ├── content_loc: (1,24)-(1,27) = "bar"
-            │           ├── closing_loc: (1,27)-(1,28) = "'"
-            │           └── unescaped: "bar"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ StringNode (location: (1,23)-(1,28))
+            │   │       ├── flags: ∅
+            │   │       ├── opening_loc: (1,23)-(1,24) = "'"
+            │   │       ├── content_loc: (1,24)-(1,27) = "bar"
+            │   │       ├── closing_loc: (1,27)-(1,28) = "'"
+            │   │       └── unescaped: "bar"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/not_cmd.txt
+++ b/test/prism/snapshots/whitequark/not_cmd.txt
@@ -12,17 +12,18 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,6)-(1,9))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ CallNode (location: (1,6)-(1,9))
-            │   │           ├── receiver: ∅
-            │   │           ├── call_operator_loc: ∅
-            │   │           ├── message_loc: (1,6)-(1,9) = "foo"
-            │   │           ├── opening_loc: ∅
-            │   │           ├── arguments: ∅
-            │   │           ├── closing_loc: ∅
-            │   │           ├── block: ∅
-            │   │           ├── flags: variable_call
-            │   │           └── name: :foo
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ CallNode (location: (1,6)-(1,9))
+            │   │   │       ├── receiver: ∅
+            │   │   │       ├── call_operator_loc: ∅
+            │   │   │       ├── message_loc: (1,6)-(1,9) = "foo"
+            │   │   │       ├── opening_loc: ∅
+            │   │   │       ├── arguments: ∅
+            │   │   │       ├── closing_loc: ∅
+            │   │   │       ├── block: ∅
+            │   │   │       ├── flags: variable_call
+            │   │   │       └── name: :foo
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/numbered_args_after_27.txt
+++ b/test/prism/snapshots/whitequark/numbered_args_after_27.txt
@@ -22,10 +22,11 @@
         │               ├── opening_loc: ∅
         │               ├── arguments:
         │               │   @ ArgumentsNode (location: (1,11)-(1,13))
-        │               │   └── arguments: (length: 1)
-        │               │       └── @ LocalVariableReadNode (location: (1,11)-(1,13))
-        │               │           ├── name: :_9
-        │               │           └── depth: 0
+        │               │   ├── arguments: (length: 1)
+        │               │   │   └── @ LocalVariableReadNode (location: (1,11)-(1,13))
+        │               │   │       ├── name: :_9
+        │               │   │       └── depth: 0
+        │               │   └── flags: ∅
         │               ├── closing_loc: ∅
         │               ├── block: ∅
         │               ├── flags: ∅
@@ -49,10 +50,11 @@
         │               ├── opening_loc: ∅
         │               ├── arguments:
         │               │   @ ArgumentsNode (location: (3,10)-(3,12))
-        │               │   └── arguments: (length: 1)
-        │               │       └── @ LocalVariableReadNode (location: (3,10)-(3,12))
-        │               │           ├── name: :_9
-        │               │           └── depth: 0
+        │               │   ├── arguments: (length: 1)
+        │               │   │   └── @ LocalVariableReadNode (location: (3,10)-(3,12))
+        │               │   │       ├── name: :_9
+        │               │   │       └── depth: 0
+        │               │   └── flags: ∅
         │               ├── closing_loc: ∅
         │               ├── block: ∅
         │               ├── flags: ∅
@@ -81,10 +83,11 @@
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments:
         │   │   │           │   @ ArgumentsNode (location: (5,10)-(5,12))
-        │   │   │           │   └── arguments: (length: 1)
-        │   │   │           │       └── @ LocalVariableReadNode (location: (5,10)-(5,12))
-        │   │   │           │           ├── name: :_9
-        │   │   │           │           └── depth: 0
+        │   │   │           │   ├── arguments: (length: 1)
+        │   │   │           │   │   └── @ LocalVariableReadNode (location: (5,10)-(5,12))
+        │   │   │           │   │       ├── name: :_9
+        │   │   │           │   │       └── depth: 0
+        │   │   │           │   └── flags: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           ├── block: ∅
         │   │   │           ├── flags: ∅
@@ -117,10 +120,11 @@
             │   │           ├── opening_loc: ∅
             │   │           ├── arguments:
             │   │           │   @ ArgumentsNode (location: (7,9)-(7,11))
-            │   │           │   └── arguments: (length: 1)
-            │   │           │       └── @ LocalVariableReadNode (location: (7,9)-(7,11))
-            │   │           │           ├── name: :_9
-            │   │           │           └── depth: 0
+            │   │           │   ├── arguments: (length: 1)
+            │   │           │   │   └── @ LocalVariableReadNode (location: (7,9)-(7,11))
+            │   │           │   │       ├── name: :_9
+            │   │           │   │       └── depth: 0
+            │   │           │   └── flags: ∅
             │   │           ├── closing_loc: ∅
             │   │           ├── block: ∅
             │   │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/op_asgn_cmd.txt
+++ b/test/prism/snapshots/whitequark/op_asgn_cmd.txt
@@ -30,17 +30,18 @@
         │       ├── opening_loc: ∅
         │       ├── arguments:
         │       │   @ ArgumentsNode (location: (1,11)-(1,14))
-        │       │   └── arguments: (length: 1)
-        │       │       └── @ CallNode (location: (1,11)-(1,14))
-        │       │           ├── receiver: ∅
-        │       │           ├── call_operator_loc: ∅
-        │       │           ├── message_loc: (1,11)-(1,14) = "foo"
-        │       │           ├── opening_loc: ∅
-        │       │           ├── arguments: ∅
-        │       │           ├── closing_loc: ∅
-        │       │           ├── block: ∅
-        │       │           ├── flags: variable_call
-        │       │           └── name: :foo
+        │       │   ├── arguments: (length: 1)
+        │       │   │   └── @ CallNode (location: (1,11)-(1,14))
+        │       │   │       ├── receiver: ∅
+        │       │   │       ├── call_operator_loc: ∅
+        │       │   │       ├── message_loc: (1,11)-(1,14) = "foo"
+        │       │   │       ├── opening_loc: ∅
+        │       │   │       ├── arguments: ∅
+        │       │   │       ├── closing_loc: ∅
+        │       │   │       ├── block: ∅
+        │       │   │       ├── flags: variable_call
+        │       │   │       └── name: :foo
+        │       │   └── flags: ∅
         │       ├── closing_loc: ∅
         │       ├── block: ∅
         │       ├── flags: ∅
@@ -72,17 +73,18 @@
         │       ├── opening_loc: ∅
         │       ├── arguments:
         │       │   @ ArgumentsNode (location: (3,11)-(3,14))
-        │       │   └── arguments: (length: 1)
-        │       │       └── @ CallNode (location: (3,11)-(3,14))
-        │       │           ├── receiver: ∅
-        │       │           ├── call_operator_loc: ∅
-        │       │           ├── message_loc: (3,11)-(3,14) = "foo"
-        │       │           ├── opening_loc: ∅
-        │       │           ├── arguments: ∅
-        │       │           ├── closing_loc: ∅
-        │       │           ├── block: ∅
-        │       │           ├── flags: variable_call
-        │       │           └── name: :foo
+        │       │   ├── arguments: (length: 1)
+        │       │   │   └── @ CallNode (location: (3,11)-(3,14))
+        │       │   │       ├── receiver: ∅
+        │       │   │       ├── call_operator_loc: ∅
+        │       │   │       ├── message_loc: (3,11)-(3,14) = "foo"
+        │       │   │       ├── opening_loc: ∅
+        │       │   │       ├── arguments: ∅
+        │       │   │       ├── closing_loc: ∅
+        │       │   │       ├── block: ∅
+        │       │   │       ├── flags: variable_call
+        │       │   │       └── name: :foo
+        │       │   └── flags: ∅
         │       ├── closing_loc: ∅
         │       ├── block: ∅
         │       ├── flags: ∅
@@ -114,17 +116,18 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (5,12)-(5,15))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ CallNode (location: (5,12)-(5,15))
-        │   │   │           ├── receiver: ∅
-        │   │   │           ├── call_operator_loc: ∅
-        │   │   │           ├── message_loc: (5,12)-(5,15) = "foo"
-        │   │   │           ├── opening_loc: ∅
-        │   │   │           ├── arguments: ∅
-        │   │   │           ├── closing_loc: ∅
-        │   │   │           ├── block: ∅
-        │   │   │           ├── flags: variable_call
-        │   │   │           └── name: :foo
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ CallNode (location: (5,12)-(5,15))
+        │   │   │   │       ├── receiver: ∅
+        │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │       ├── message_loc: (5,12)-(5,15) = "foo"
+        │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │       ├── arguments: ∅
+        │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │       ├── block: ∅
+        │   │   │   │       ├── flags: variable_call
+        │   │   │   │       └── name: :foo
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block: ∅
         │   │   ├── flags: ∅
@@ -157,17 +160,18 @@
                 ├── opening_loc: ∅
                 ├── arguments:
                 │   @ ArgumentsNode (location: (7,12)-(7,15))
-                │   └── arguments: (length: 1)
-                │       └── @ CallNode (location: (7,12)-(7,15))
-                │           ├── receiver: ∅
-                │           ├── call_operator_loc: ∅
-                │           ├── message_loc: (7,12)-(7,15) = "foo"
-                │           ├── opening_loc: ∅
-                │           ├── arguments: ∅
-                │           ├── closing_loc: ∅
-                │           ├── block: ∅
-                │           ├── flags: variable_call
-                │           └── name: :foo
+                │   ├── arguments: (length: 1)
+                │   │   └── @ CallNode (location: (7,12)-(7,15))
+                │   │       ├── receiver: ∅
+                │   │       ├── call_operator_loc: ∅
+                │   │       ├── message_loc: (7,12)-(7,15) = "foo"
+                │   │       ├── opening_loc: ∅
+                │   │       ├── arguments: ∅
+                │   │       ├── closing_loc: ∅
+                │   │       ├── block: ∅
+                │   │       ├── flags: variable_call
+                │   │       └── name: :foo
+                │   └── flags: ∅
                 ├── closing_loc: ∅
                 ├── block: ∅
                 ├── flags: ∅

--- a/test/prism/snapshots/whitequark/op_asgn_index.txt
+++ b/test/prism/snapshots/whitequark/op_asgn_index.txt
@@ -19,11 +19,12 @@
             ├── opening_loc: (1,3)-(1,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,8))
-            │   └── arguments: (length: 2)
-            │       ├── @ IntegerNode (location: (1,4)-(1,5))
-            │       │   └── flags: decimal
-            │       └── @ IntegerNode (location: (1,7)-(1,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ IntegerNode (location: (1,4)-(1,5))
+            │   │   │   └── flags: decimal
+            │   │   └── @ IntegerNode (location: (1,7)-(1,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,8)-(1,9) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/op_asgn_index_cmd.txt
+++ b/test/prism/snapshots/whitequark/op_asgn_index_cmd.txt
@@ -19,11 +19,12 @@
             ├── opening_loc: (1,3)-(1,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,8))
-            │   └── arguments: (length: 2)
-            │       ├── @ IntegerNode (location: (1,4)-(1,5))
-            │       │   └── flags: decimal
-            │       └── @ IntegerNode (location: (1,7)-(1,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ IntegerNode (location: (1,4)-(1,5))
+            │   │   │   └── flags: decimal
+            │   │   └── @ IntegerNode (location: (1,7)-(1,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,8)-(1,9) = "]"
             ├── block: ∅
             ├── flags: ∅
@@ -37,17 +38,18 @@
                 ├── opening_loc: ∅
                 ├── arguments:
                 │   @ ArgumentsNode (location: (1,15)-(1,18))
-                │   └── arguments: (length: 1)
-                │       └── @ CallNode (location: (1,15)-(1,18))
-                │           ├── receiver: ∅
-                │           ├── call_operator_loc: ∅
-                │           ├── message_loc: (1,15)-(1,18) = "foo"
-                │           ├── opening_loc: ∅
-                │           ├── arguments: ∅
-                │           ├── closing_loc: ∅
-                │           ├── block: ∅
-                │           ├── flags: variable_call
-                │           └── name: :foo
+                │   ├── arguments: (length: 1)
+                │   │   └── @ CallNode (location: (1,15)-(1,18))
+                │   │       ├── receiver: ∅
+                │   │       ├── call_operator_loc: ∅
+                │   │       ├── message_loc: (1,15)-(1,18) = "foo"
+                │   │       ├── opening_loc: ∅
+                │   │       ├── arguments: ∅
+                │   │       ├── closing_loc: ∅
+                │   │       ├── block: ∅
+                │   │       ├── flags: variable_call
+                │   │       └── name: :foo
+                │   └── flags: ∅
                 ├── closing_loc: ∅
                 ├── block: ∅
                 ├── flags: ∅

--- a/test/prism/snapshots/whitequark/or_asgn.txt
+++ b/test/prism/snapshots/whitequark/or_asgn.txt
@@ -40,11 +40,12 @@
             ├── opening_loc: (3,3)-(3,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (3,4)-(3,8))
-            │   └── arguments: (length: 2)
-            │       ├── @ IntegerNode (location: (3,4)-(3,5))
-            │       │   └── flags: decimal
-            │       └── @ IntegerNode (location: (3,7)-(3,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ IntegerNode (location: (3,4)-(3,5))
+            │   │   │   └── flags: decimal
+            │   │   └── @ IntegerNode (location: (3,7)-(3,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (3,8)-(3,9) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/parser_bug_272.txt
+++ b/test/prism/snapshots/whitequark/parser_bug_272.txt
@@ -10,9 +10,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,4))
-            │   └── arguments: (length: 1)
-            │       └── @ InstanceVariableReadNode (location: (1,2)-(1,4))
-            │           └── name: :@b
+            │   ├── arguments: (length: 1)
+            │   │   └── @ InstanceVariableReadNode (location: (1,2)-(1,4))
+            │   │       └── name: :@b
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,5)-(1,15))

--- a/test/prism/snapshots/whitequark/parser_bug_525.txt
+++ b/test/prism/snapshots/whitequark/parser_bug_525.txt
@@ -10,28 +10,29 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,3)-(1,11))
-            │   └── arguments: (length: 1)
-            │       └── @ KeywordHashNode (location: (1,3)-(1,11))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,3)-(1,11))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (1,3)-(1,5))
-            │                   │   ├── opening_loc: (1,3)-(1,4) = ":"
-            │                   │   ├── value_loc: (1,4)-(1,5) = "k"
-            │                   │   ├── closing_loc: ∅
-            │                   │   └── unescaped: "k"
-            │                   ├── value:
-            │                   │   @ CallNode (location: (1,9)-(1,11))
-            │                   │   ├── receiver: ∅
-            │                   │   ├── call_operator_loc: ∅
-            │                   │   ├── message_loc: (1,9)-(1,11) = "m2"
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── arguments: ∅
-            │                   │   ├── closing_loc: ∅
-            │                   │   ├── block: ∅
-            │                   │   ├── flags: variable_call
-            │                   │   └── name: :m2
-            │                   └── operator_loc: (1,6)-(1,8) = "=>"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ KeywordHashNode (location: (1,3)-(1,11))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,3)-(1,11))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (1,3)-(1,5))
+            │   │               │   ├── opening_loc: (1,3)-(1,4) = ":"
+            │   │               │   ├── value_loc: (1,4)-(1,5) = "k"
+            │   │               │   ├── closing_loc: ∅
+            │   │               │   └── unescaped: "k"
+            │   │               ├── value:
+            │   │               │   @ CallNode (location: (1,9)-(1,11))
+            │   │               │   ├── receiver: ∅
+            │   │               │   ├── call_operator_loc: ∅
+            │   │               │   ├── message_loc: (1,9)-(1,11) = "m2"
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── arguments: ∅
+            │   │               │   ├── closing_loc: ∅
+            │   │               │   ├── block: ∅
+            │   │               │   ├── flags: variable_call
+            │   │               │   └── name: :m2
+            │   │               └── operator_loc: (1,6)-(1,8) = "=>"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,12)-(1,32))

--- a/test/prism/snapshots/whitequark/parser_bug_604.txt
+++ b/test/prism/snapshots/whitequark/parser_bug_604.txt
@@ -10,39 +10,41 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,7))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,2)-(1,7))
-            │           ├── receiver:
-            │           │   @ CallNode (location: (1,2)-(1,3))
-            │           │   ├── receiver: ∅
-            │           │   ├── call_operator_loc: ∅
-            │           │   ├── message_loc: (1,2)-(1,3) = "a"
-            │           │   ├── opening_loc: ∅
-            │           │   ├── arguments: ∅
-            │           │   ├── closing_loc: ∅
-            │           │   ├── block: ∅
-            │           │   ├── flags: variable_call
-            │           │   └── name: :a
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,4)-(1,5) = "+"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (1,6)-(1,7))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ CallNode (location: (1,6)-(1,7))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (1,6)-(1,7) = "b"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: variable_call
-            │           │           └── name: :b
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :+
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,2)-(1,7))
+            │   │       ├── receiver:
+            │   │       │   @ CallNode (location: (1,2)-(1,3))
+            │   │       │   ├── receiver: ∅
+            │   │       │   ├── call_operator_loc: ∅
+            │   │       │   ├── message_loc: (1,2)-(1,3) = "a"
+            │   │       │   ├── opening_loc: ∅
+            │   │       │   ├── arguments: ∅
+            │   │       │   ├── closing_loc: ∅
+            │   │       │   ├── block: ∅
+            │   │       │   ├── flags: variable_call
+            │   │       │   └── name: :a
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,4)-(1,5) = "+"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (1,6)-(1,7))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ CallNode (location: (1,6)-(1,7))
+            │   │       │   │       ├── receiver: ∅
+            │   │       │   │       ├── call_operator_loc: ∅
+            │   │       │   │       ├── message_loc: (1,6)-(1,7) = "b"
+            │   │       │   │       ├── opening_loc: ∅
+            │   │       │   │       ├── arguments: ∅
+            │   │       │   │       ├── closing_loc: ∅
+            │   │       │   │       ├── block: ∅
+            │   │       │   │       ├── flags: variable_call
+            │   │       │   │       └── name: :b
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: ∅
+            │   │       └── name: :+
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,8)-(1,14))

--- a/test/prism/snapshots/whitequark/pattern_matching__FILE__LINE_literals.txt
+++ b/test/prism/snapshots/whitequark/pattern_matching__FILE__LINE_literals.txt
@@ -17,9 +17,10 @@
             │   │   │   ├── opening_loc: ∅
             │   │   │   ├── arguments:
             │   │   │   │   @ ArgumentsNode (location: (1,35)-(1,36))
-            │   │   │   │   └── arguments: (length: 1)
-            │   │   │   │       └── @ IntegerNode (location: (1,35)-(1,36))
-            │   │   │   │           └── flags: decimal
+            │   │   │   │   ├── arguments: (length: 1)
+            │   │   │   │   │   └── @ IntegerNode (location: (1,35)-(1,36))
+            │   │   │   │   │       └── flags: decimal
+            │   │   │   │   └── flags: ∅
             │   │   │   ├── closing_loc: ∅
             │   │   │   ├── block: ∅
             │   │   │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/return.txt
+++ b/test/prism/snapshots/whitequark/return.txt
@@ -10,44 +10,47 @@
         │   ├── keyword_loc: (3,0)-(3,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (3,7)-(3,10))
-        │       └── arguments: (length: 1)
-        │           └── @ CallNode (location: (3,7)-(3,10))
-        │               ├── receiver: ∅
-        │               ├── call_operator_loc: ∅
-        │               ├── message_loc: (3,7)-(3,10) = "foo"
-        │               ├── opening_loc: ∅
-        │               ├── arguments: ∅
-        │               ├── closing_loc: ∅
-        │               ├── block: ∅
-        │               ├── flags: variable_call
-        │               └── name: :foo
+        │       ├── arguments: (length: 1)
+        │       │   └── @ CallNode (location: (3,7)-(3,10))
+        │       │       ├── receiver: ∅
+        │       │       ├── call_operator_loc: ∅
+        │       │       ├── message_loc: (3,7)-(3,10) = "foo"
+        │       │       ├── opening_loc: ∅
+        │       │       ├── arguments: ∅
+        │       │       ├── closing_loc: ∅
+        │       │       ├── block: ∅
+        │       │       ├── flags: variable_call
+        │       │       └── name: :foo
+        │       └── flags: ∅
         ├── @ ReturnNode (location: (5,0)-(5,8))
         │   ├── keyword_loc: (5,0)-(5,6) = "return"
         │   └── arguments:
         │       @ ArgumentsNode (location: (5,6)-(5,8))
-        │       └── arguments: (length: 1)
-        │           └── @ ParenthesesNode (location: (5,6)-(5,8))
-        │               ├── body: ∅
-        │               ├── opening_loc: (5,6)-(5,7) = "("
-        │               └── closing_loc: (5,7)-(5,8) = ")"
+        │       ├── arguments: (length: 1)
+        │       │   └── @ ParenthesesNode (location: (5,6)-(5,8))
+        │       │       ├── body: ∅
+        │       │       ├── opening_loc: (5,6)-(5,7) = "("
+        │       │       └── closing_loc: (5,7)-(5,8) = ")"
+        │       └── flags: ∅
         └── @ ReturnNode (location: (7,0)-(7,11))
             ├── keyword_loc: (7,0)-(7,6) = "return"
             └── arguments:
                 @ ArgumentsNode (location: (7,6)-(7,11))
-                └── arguments: (length: 1)
-                    └── @ ParenthesesNode (location: (7,6)-(7,11))
-                        ├── body:
-                        │   @ StatementsNode (location: (7,7)-(7,10))
-                        │   └── body: (length: 1)
-                        │       └── @ CallNode (location: (7,7)-(7,10))
-                        │           ├── receiver: ∅
-                        │           ├── call_operator_loc: ∅
-                        │           ├── message_loc: (7,7)-(7,10) = "foo"
-                        │           ├── opening_loc: ∅
-                        │           ├── arguments: ∅
-                        │           ├── closing_loc: ∅
-                        │           ├── block: ∅
-                        │           ├── flags: variable_call
-                        │           └── name: :foo
-                        ├── opening_loc: (7,6)-(7,7) = "("
-                        └── closing_loc: (7,10)-(7,11) = ")"
+                ├── arguments: (length: 1)
+                │   └── @ ParenthesesNode (location: (7,6)-(7,11))
+                │       ├── body:
+                │       │   @ StatementsNode (location: (7,7)-(7,10))
+                │       │   └── body: (length: 1)
+                │       │       └── @ CallNode (location: (7,7)-(7,10))
+                │       │           ├── receiver: ∅
+                │       │           ├── call_operator_loc: ∅
+                │       │           ├── message_loc: (7,7)-(7,10) = "foo"
+                │       │           ├── opening_loc: ∅
+                │       │           ├── arguments: ∅
+                │       │           ├── closing_loc: ∅
+                │       │           ├── block: ∅
+                │       │           ├── flags: variable_call
+                │       │           └── name: :foo
+                │       ├── opening_loc: (7,6)-(7,7) = "("
+                │       └── closing_loc: (7,10)-(7,11) = ")"
+                └── flags: ∅

--- a/test/prism/snapshots/whitequark/return_block.txt
+++ b/test/prism/snapshots/whitequark/return_block.txt
@@ -7,32 +7,34 @@
             ├── keyword_loc: (1,0)-(1,6) = "return"
             └── arguments:
                 @ ArgumentsNode (location: (1,7)-(1,21))
-                └── arguments: (length: 1)
-                    └── @ CallNode (location: (1,7)-(1,21))
-                        ├── receiver: ∅
-                        ├── call_operator_loc: ∅
-                        ├── message_loc: (1,7)-(1,10) = "fun"
-                        ├── opening_loc: ∅
-                        ├── arguments:
-                        │   @ ArgumentsNode (location: (1,11)-(1,14))
-                        │   └── arguments: (length: 1)
-                        │       └── @ CallNode (location: (1,11)-(1,14))
-                        │           ├── receiver: ∅
-                        │           ├── call_operator_loc: ∅
-                        │           ├── message_loc: (1,11)-(1,14) = "foo"
-                        │           ├── opening_loc: ∅
-                        │           ├── arguments: ∅
-                        │           ├── closing_loc: ∅
-                        │           ├── block: ∅
-                        │           ├── flags: variable_call
-                        │           └── name: :foo
-                        ├── closing_loc: ∅
-                        ├── block:
-                        │   @ BlockNode (location: (1,15)-(1,21))
-                        │   ├── locals: []
-                        │   ├── parameters: ∅
-                        │   ├── body: ∅
-                        │   ├── opening_loc: (1,15)-(1,17) = "do"
-                        │   └── closing_loc: (1,18)-(1,21) = "end"
-                        ├── flags: ∅
-                        └── name: :fun
+                ├── arguments: (length: 1)
+                │   └── @ CallNode (location: (1,7)-(1,21))
+                │       ├── receiver: ∅
+                │       ├── call_operator_loc: ∅
+                │       ├── message_loc: (1,7)-(1,10) = "fun"
+                │       ├── opening_loc: ∅
+                │       ├── arguments:
+                │       │   @ ArgumentsNode (location: (1,11)-(1,14))
+                │       │   ├── arguments: (length: 1)
+                │       │   │   └── @ CallNode (location: (1,11)-(1,14))
+                │       │   │       ├── receiver: ∅
+                │       │   │       ├── call_operator_loc: ∅
+                │       │   │       ├── message_loc: (1,11)-(1,14) = "foo"
+                │       │   │       ├── opening_loc: ∅
+                │       │   │       ├── arguments: ∅
+                │       │   │       ├── closing_loc: ∅
+                │       │   │       ├── block: ∅
+                │       │   │       ├── flags: variable_call
+                │       │   │       └── name: :foo
+                │       │   └── flags: ∅
+                │       ├── closing_loc: ∅
+                │       ├── block:
+                │       │   @ BlockNode (location: (1,15)-(1,21))
+                │       │   ├── locals: []
+                │       │   ├── parameters: ∅
+                │       │   ├── body: ∅
+                │       │   ├── opening_loc: (1,15)-(1,17) = "do"
+                │       │   └── closing_loc: (1,18)-(1,21) = "end"
+                │       ├── flags: ∅
+                │       └── name: :fun
+                └── flags: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_10653.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_10653.txt
@@ -142,10 +142,11 @@
             │           │   │           ├── opening_loc: ∅
             │           │   │           ├── arguments:
             │           │   │           │   @ ArgumentsNode (location: (5,22)-(5,23))
-            │           │   │           │   └── arguments: (length: 1)
-            │           │   │           │       └── @ LocalVariableReadNode (location: (5,22)-(5,23))
-            │           │   │           │           ├── name: :n
-            │           │   │           │           └── depth: 0
+            │           │   │           │   ├── arguments: (length: 1)
+            │           │   │           │   │   └── @ LocalVariableReadNode (location: (5,22)-(5,23))
+            │           │   │           │   │       ├── name: :n
+            │           │   │           │   │       └── depth: 0
+            │           │   │           │   └── flags: ∅
             │           │   │           ├── closing_loc: ∅
             │           │   │           ├── block: ∅
             │           │   │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_11107.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_11107.txt
@@ -10,37 +10,38 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,24))
-            │   └── arguments: (length: 1)
-            │       └── @ LambdaNode (location: (1,2)-(1,24))
-            │           ├── locals: []
-            │           ├── operator_loc: (1,2)-(1,4) = "->"
-            │           ├── opening_loc: (1,7)-(1,9) = "do"
-            │           ├── closing_loc: (1,21)-(1,24) = "end"
-            │           ├── parameters:
-            │           │   @ BlockParametersNode (location: (1,4)-(1,6))
-            │           │   ├── parameters: ∅
-            │           │   ├── locals: (length: 0)
-            │           │   ├── opening_loc: (1,4)-(1,5) = "("
-            │           │   └── closing_loc: (1,5)-(1,6) = ")"
-            │           └── body:
-            │               @ StatementsNode (location: (1,10)-(1,20))
-            │               └── body: (length: 1)
-            │                   └── @ CallNode (location: (1,10)-(1,20))
-            │                       ├── receiver: ∅
-            │                       ├── call_operator_loc: ∅
-            │                       ├── message_loc: (1,10)-(1,11) = "a"
-            │                       ├── opening_loc: (1,11)-(1,12) = "("
-            │                       ├── arguments: ∅
-            │                       ├── closing_loc: (1,12)-(1,13) = ")"
-            │                       ├── block:
-            │                       │   @ BlockNode (location: (1,14)-(1,20))
-            │                       │   ├── locals: []
-            │                       │   ├── parameters: ∅
-            │                       │   ├── body: ∅
-            │                       │   ├── opening_loc: (1,14)-(1,16) = "do"
-            │                       │   └── closing_loc: (1,17)-(1,20) = "end"
-            │                       ├── flags: ∅
-            │                       └── name: :a
+            │   ├── arguments: (length: 1)
+            │   │   └── @ LambdaNode (location: (1,2)-(1,24))
+            │   │       ├── locals: []
+            │   │       ├── operator_loc: (1,2)-(1,4) = "->"
+            │   │       ├── opening_loc: (1,7)-(1,9) = "do"
+            │   │       ├── closing_loc: (1,21)-(1,24) = "end"
+            │   │       ├── parameters:
+            │   │       │   @ BlockParametersNode (location: (1,4)-(1,6))
+            │   │       │   ├── parameters: ∅
+            │   │       │   ├── locals: (length: 0)
+            │   │       │   ├── opening_loc: (1,4)-(1,5) = "("
+            │   │       │   └── closing_loc: (1,5)-(1,6) = ")"
+            │   │       └── body:
+            │   │           @ StatementsNode (location: (1,10)-(1,20))
+            │   │           └── body: (length: 1)
+            │   │               └── @ CallNode (location: (1,10)-(1,20))
+            │   │                   ├── receiver: ∅
+            │   │                   ├── call_operator_loc: ∅
+            │   │                   ├── message_loc: (1,10)-(1,11) = "a"
+            │   │                   ├── opening_loc: (1,11)-(1,12) = "("
+            │   │                   ├── arguments: ∅
+            │   │                   ├── closing_loc: (1,12)-(1,13) = ")"
+            │   │                   ├── block:
+            │   │                   │   @ BlockNode (location: (1,14)-(1,20))
+            │   │                   │   ├── locals: []
+            │   │                   │   ├── parameters: ∅
+            │   │                   │   ├── body: ∅
+            │   │                   │   ├── opening_loc: (1,14)-(1,16) = "do"
+            │   │                   │   └── closing_loc: (1,17)-(1,20) = "end"
+            │   │                   ├── flags: ∅
+            │   │                   └── name: :a
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_11380.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_11380.txt
@@ -10,34 +10,35 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,21))
-            │   └── arguments: (length: 2)
-            │       ├── @ LambdaNode (location: (1,2)-(1,15))
-            │       │   ├── locals: []
-            │       │   ├── operator_loc: (1,2)-(1,4) = "->"
-            │       │   ├── opening_loc: (1,5)-(1,6) = "{"
-            │       │   ├── closing_loc: (1,14)-(1,15) = "}"
-            │       │   ├── parameters: ∅
-            │       │   └── body:
-            │       │       @ StatementsNode (location: (1,7)-(1,13))
-            │       │       └── body: (length: 1)
-            │       │           └── @ SymbolNode (location: (1,7)-(1,13))
-            │       │               ├── opening_loc: (1,7)-(1,8) = ":"
-            │       │               ├── value_loc: (1,8)-(1,13) = "hello"
-            │       │               ├── closing_loc: ∅
-            │       │               └── unescaped: "hello"
-            │       └── @ KeywordHashNode (location: (1,17)-(1,21))
-            │           └── elements: (length: 1)
-            │               └── @ AssocNode (location: (1,17)-(1,21))
-            │                   ├── key:
-            │                   │   @ SymbolNode (location: (1,17)-(1,19))
-            │                   │   ├── opening_loc: ∅
-            │                   │   ├── value_loc: (1,17)-(1,18) = "a"
-            │                   │   ├── closing_loc: (1,18)-(1,19) = ":"
-            │                   │   └── unescaped: "a"
-            │                   ├── value:
-            │                   │   @ IntegerNode (location: (1,20)-(1,21))
-            │                   │   └── flags: decimal
-            │                   └── operator_loc: ∅
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ LambdaNode (location: (1,2)-(1,15))
+            │   │   │   ├── locals: []
+            │   │   │   ├── operator_loc: (1,2)-(1,4) = "->"
+            │   │   │   ├── opening_loc: (1,5)-(1,6) = "{"
+            │   │   │   ├── closing_loc: (1,14)-(1,15) = "}"
+            │   │   │   ├── parameters: ∅
+            │   │   │   └── body:
+            │   │   │       @ StatementsNode (location: (1,7)-(1,13))
+            │   │   │       └── body: (length: 1)
+            │   │   │           └── @ SymbolNode (location: (1,7)-(1,13))
+            │   │   │               ├── opening_loc: (1,7)-(1,8) = ":"
+            │   │   │               ├── value_loc: (1,8)-(1,13) = "hello"
+            │   │   │               ├── closing_loc: ∅
+            │   │   │               └── unescaped: "hello"
+            │   │   └── @ KeywordHashNode (location: (1,17)-(1,21))
+            │   │       └── elements: (length: 1)
+            │   │           └── @ AssocNode (location: (1,17)-(1,21))
+            │   │               ├── key:
+            │   │               │   @ SymbolNode (location: (1,17)-(1,19))
+            │   │               │   ├── opening_loc: ∅
+            │   │               │   ├── value_loc: (1,17)-(1,18) = "a"
+            │   │               │   ├── closing_loc: (1,18)-(1,19) = ":"
+            │   │               │   └── unescaped: "a"
+            │   │               ├── value:
+            │   │               │   @ IntegerNode (location: (1,20)-(1,21))
+            │   │               │   └── flags: decimal
+            │   │               └── operator_loc: ∅
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,22)-(1,28))

--- a/test/prism/snapshots/whitequark/ruby_bug_11873.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_11873.txt
@@ -10,47 +10,50 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,13))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (1,2)-(1,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (1,2)-(1,3) = "b"
-        │   │       │   ├── opening_loc: (1,3)-(1,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (1,4)-(1,7))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (1,4)-(1,7))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (1,4)-(1,5) = "c"
-        │   │       │   │           ├── opening_loc: ∅
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (1,6)-(1,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (1,6)-(1,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (1,6)-(1,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: ∅
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (1,7)-(1,8) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ StringNode (location: (1,10)-(1,13))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (1,10)-(1,11) = "\""
-        │   │           ├── content_loc: (1,11)-(1,12) = "x"
-        │   │           ├── closing_loc: (1,12)-(1,13) = "\""
-        │   │           └── unescaped: "x"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (1,2)-(1,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (1,2)-(1,3) = "b"
+        │   │   │   │   ├── opening_loc: (1,3)-(1,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (1,4)-(1,7))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (1,4)-(1,7))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (1,4)-(1,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (1,6)-(1,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (1,6)-(1,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (1,6)-(1,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (1,7)-(1,8) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ StringNode (location: (1,10)-(1,13))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (1,10)-(1,11) = "\""
+        │   │   │       ├── content_loc: (1,11)-(1,12) = "x"
+        │   │   │       ├── closing_loc: (1,12)-(1,13) = "\""
+        │   │   │       └── unescaped: "x"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (1,14)-(1,20))
@@ -68,47 +71,50 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,2)-(3,13))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (3,2)-(3,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (3,2)-(3,3) = "b"
-        │   │       │   ├── opening_loc: (3,3)-(3,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (3,4)-(3,7))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (3,4)-(3,7))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (3,4)-(3,5) = "c"
-        │   │       │   │           ├── opening_loc: ∅
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (3,6)-(3,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (3,6)-(3,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (3,6)-(3,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: ∅
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (3,7)-(3,8) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ RegularExpressionNode (location: (3,10)-(3,13))
-        │   │           ├── opening_loc: (3,10)-(3,11) = "/"
-        │   │           ├── content_loc: (3,11)-(3,12) = "x"
-        │   │           ├── closing_loc: (3,12)-(3,13) = "/"
-        │   │           ├── unescaped: "x"
-        │   │           └── flags: ∅
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (3,2)-(3,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (3,2)-(3,3) = "b"
+        │   │   │   │   ├── opening_loc: (3,3)-(3,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (3,4)-(3,7))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (3,4)-(3,7))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (3,4)-(3,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (3,6)-(3,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (3,6)-(3,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (3,6)-(3,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (3,7)-(3,8) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ RegularExpressionNode (location: (3,10)-(3,13))
+        │   │   │       ├── opening_loc: (3,10)-(3,11) = "/"
+        │   │   │       ├── content_loc: (3,11)-(3,12) = "x"
+        │   │   │       ├── closing_loc: (3,12)-(3,13) = "/"
+        │   │   │       ├── unescaped: "x"
+        │   │   │       └── flags: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (3,14)-(3,20))
@@ -126,47 +132,50 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,2)-(5,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (5,2)-(5,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (5,2)-(5,3) = "b"
-        │   │       │   ├── opening_loc: (5,3)-(5,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (5,4)-(5,7))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (5,4)-(5,7))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (5,4)-(5,5) = "c"
-        │   │       │   │           ├── opening_loc: ∅
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (5,6)-(5,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (5,6)-(5,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (5,6)-(5,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: ∅
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (5,7)-(5,8) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ RegularExpressionNode (location: (5,10)-(5,14))
-        │   │           ├── opening_loc: (5,10)-(5,11) = "/"
-        │   │           ├── content_loc: (5,11)-(5,12) = "x"
-        │   │           ├── closing_loc: (5,12)-(5,14) = "/m"
-        │   │           ├── unescaped: "x"
-        │   │           └── flags: multi_line
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (5,2)-(5,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (5,2)-(5,3) = "b"
+        │   │   │   │   ├── opening_loc: (5,3)-(5,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (5,4)-(5,7))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (5,4)-(5,7))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (5,4)-(5,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (5,6)-(5,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (5,6)-(5,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (5,6)-(5,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (5,7)-(5,8) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ RegularExpressionNode (location: (5,10)-(5,14))
+        │   │   │       ├── opening_loc: (5,10)-(5,11) = "/"
+        │   │   │       ├── content_loc: (5,11)-(5,12) = "x"
+        │   │   │       ├── closing_loc: (5,12)-(5,14) = "/m"
+        │   │   │       ├── unescaped: "x"
+        │   │   │       └── flags: multi_line
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (5,15)-(5,21))
@@ -184,47 +193,50 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,2)-(7,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (7,2)-(7,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (7,2)-(7,3) = "b"
-        │   │       │   ├── opening_loc: (7,3)-(7,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (7,4)-(7,8))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (7,4)-(7,8))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (7,4)-(7,5) = "c"
-        │   │       │   │           ├── opening_loc: (7,5)-(7,6) = "("
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (7,6)-(7,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (7,6)-(7,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (7,6)-(7,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: (7,7)-(7,8) = ")"
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (7,8)-(7,9) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ StringNode (location: (7,11)-(7,14))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (7,11)-(7,12) = "\""
-        │   │           ├── content_loc: (7,12)-(7,13) = "x"
-        │   │           ├── closing_loc: (7,13)-(7,14) = "\""
-        │   │           └── unescaped: "x"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (7,2)-(7,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (7,2)-(7,3) = "b"
+        │   │   │   │   ├── opening_loc: (7,3)-(7,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (7,4)-(7,8))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (7,4)-(7,8))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (7,4)-(7,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: (7,5)-(7,6) = "("
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (7,6)-(7,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (7,6)-(7,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (7,6)-(7,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: (7,7)-(7,8) = ")"
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (7,8)-(7,9) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ StringNode (location: (7,11)-(7,14))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (7,11)-(7,12) = "\""
+        │   │   │       ├── content_loc: (7,12)-(7,13) = "x"
+        │   │   │       ├── closing_loc: (7,13)-(7,14) = "\""
+        │   │   │       └── unescaped: "x"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (7,15)-(7,21))
@@ -242,47 +254,50 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (9,2)-(9,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (9,2)-(9,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (9,2)-(9,3) = "b"
-        │   │       │   ├── opening_loc: (9,3)-(9,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (9,4)-(9,8))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (9,4)-(9,8))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (9,4)-(9,5) = "c"
-        │   │       │   │           ├── opening_loc: (9,5)-(9,6) = "("
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (9,6)-(9,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (9,6)-(9,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (9,6)-(9,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: (9,7)-(9,8) = ")"
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (9,8)-(9,9) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ RegularExpressionNode (location: (9,11)-(9,14))
-        │   │           ├── opening_loc: (9,11)-(9,12) = "/"
-        │   │           ├── content_loc: (9,12)-(9,13) = "x"
-        │   │           ├── closing_loc: (9,13)-(9,14) = "/"
-        │   │           ├── unescaped: "x"
-        │   │           └── flags: ∅
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (9,2)-(9,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (9,2)-(9,3) = "b"
+        │   │   │   │   ├── opening_loc: (9,3)-(9,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (9,4)-(9,8))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (9,4)-(9,8))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (9,4)-(9,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: (9,5)-(9,6) = "("
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (9,6)-(9,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (9,6)-(9,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (9,6)-(9,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: (9,7)-(9,8) = ")"
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (9,8)-(9,9) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ RegularExpressionNode (location: (9,11)-(9,14))
+        │   │   │       ├── opening_loc: (9,11)-(9,12) = "/"
+        │   │   │       ├── content_loc: (9,12)-(9,13) = "x"
+        │   │   │       ├── closing_loc: (9,13)-(9,14) = "/"
+        │   │   │       ├── unescaped: "x"
+        │   │   │       └── flags: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (9,15)-(9,21))
@@ -300,47 +315,50 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (11,2)-(11,15))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (11,2)-(11,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (11,2)-(11,3) = "b"
-        │   │       │   ├── opening_loc: (11,3)-(11,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (11,4)-(11,8))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (11,4)-(11,8))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (11,4)-(11,5) = "c"
-        │   │       │   │           ├── opening_loc: (11,5)-(11,6) = "("
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (11,6)-(11,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (11,6)-(11,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (11,6)-(11,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: (11,7)-(11,8) = ")"
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (11,8)-(11,9) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ RegularExpressionNode (location: (11,11)-(11,15))
-        │   │           ├── opening_loc: (11,11)-(11,12) = "/"
-        │   │           ├── content_loc: (11,12)-(11,13) = "x"
-        │   │           ├── closing_loc: (11,13)-(11,15) = "/m"
-        │   │           ├── unescaped: "x"
-        │   │           └── flags: multi_line
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (11,2)-(11,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (11,2)-(11,3) = "b"
+        │   │   │   │   ├── opening_loc: (11,3)-(11,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (11,4)-(11,8))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (11,4)-(11,8))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (11,4)-(11,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: (11,5)-(11,6) = "("
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (11,6)-(11,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (11,6)-(11,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (11,6)-(11,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: (11,7)-(11,8) = ")"
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (11,8)-(11,9) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ RegularExpressionNode (location: (11,11)-(11,15))
+        │   │   │       ├── opening_loc: (11,11)-(11,12) = "/"
+        │   │   │       ├── content_loc: (11,12)-(11,13) = "x"
+        │   │   │       ├── closing_loc: (11,13)-(11,15) = "/m"
+        │   │   │       ├── unescaped: "x"
+        │   │   │       └── flags: multi_line
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (11,16)-(11,22))
@@ -358,53 +376,55 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (13,2)-(13,13))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (13,2)-(13,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (13,2)-(13,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (13,3)-(13,8))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (13,4)-(13,7))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (13,4)-(13,7))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (13,4)-(13,5) = "c"
-        │   │       │   │   │           ├── opening_loc: ∅
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (13,6)-(13,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (13,6)-(13,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (13,6)-(13,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: ∅
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (13,3)-(13,4) = "{"
-        │   │       │   │   └── closing_loc: (13,7)-(13,8) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ StringNode (location: (13,10)-(13,13))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (13,10)-(13,11) = "\""
-        │   │           ├── content_loc: (13,11)-(13,12) = "x"
-        │   │           ├── closing_loc: (13,12)-(13,13) = "\""
-        │   │           └── unescaped: "x"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (13,2)-(13,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (13,2)-(13,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (13,3)-(13,8))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (13,4)-(13,7))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (13,4)-(13,7))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (13,4)-(13,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: ∅
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (13,6)-(13,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (13,6)-(13,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (13,6)-(13,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: ∅
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (13,3)-(13,4) = "{"
+        │   │   │   │   │   └── closing_loc: (13,7)-(13,8) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ StringNode (location: (13,10)-(13,13))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (13,10)-(13,11) = "\""
+        │   │   │       ├── content_loc: (13,11)-(13,12) = "x"
+        │   │   │       ├── closing_loc: (13,12)-(13,13) = "\""
+        │   │   │       └── unescaped: "x"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (13,14)-(13,20))
@@ -422,53 +442,55 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (15,2)-(15,13))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (15,2)-(15,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (15,2)-(15,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (15,3)-(15,8))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (15,4)-(15,7))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (15,4)-(15,7))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (15,4)-(15,5) = "c"
-        │   │       │   │   │           ├── opening_loc: ∅
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (15,6)-(15,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (15,6)-(15,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (15,6)-(15,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: ∅
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (15,3)-(15,4) = "{"
-        │   │       │   │   └── closing_loc: (15,7)-(15,8) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ RegularExpressionNode (location: (15,10)-(15,13))
-        │   │           ├── opening_loc: (15,10)-(15,11) = "/"
-        │   │           ├── content_loc: (15,11)-(15,12) = "x"
-        │   │           ├── closing_loc: (15,12)-(15,13) = "/"
-        │   │           ├── unescaped: "x"
-        │   │           └── flags: ∅
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (15,2)-(15,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (15,2)-(15,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (15,3)-(15,8))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (15,4)-(15,7))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (15,4)-(15,7))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (15,4)-(15,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: ∅
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (15,6)-(15,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (15,6)-(15,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (15,6)-(15,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: ∅
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (15,3)-(15,4) = "{"
+        │   │   │   │   │   └── closing_loc: (15,7)-(15,8) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ RegularExpressionNode (location: (15,10)-(15,13))
+        │   │   │       ├── opening_loc: (15,10)-(15,11) = "/"
+        │   │   │       ├── content_loc: (15,11)-(15,12) = "x"
+        │   │   │       ├── closing_loc: (15,12)-(15,13) = "/"
+        │   │   │       ├── unescaped: "x"
+        │   │   │       └── flags: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (15,14)-(15,20))
@@ -486,53 +508,55 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (17,2)-(17,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (17,2)-(17,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (17,2)-(17,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (17,3)-(17,8))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (17,4)-(17,7))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (17,4)-(17,7))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (17,4)-(17,5) = "c"
-        │   │       │   │   │           ├── opening_loc: ∅
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (17,6)-(17,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (17,6)-(17,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (17,6)-(17,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: ∅
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (17,3)-(17,4) = "{"
-        │   │       │   │   └── closing_loc: (17,7)-(17,8) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ RegularExpressionNode (location: (17,10)-(17,14))
-        │   │           ├── opening_loc: (17,10)-(17,11) = "/"
-        │   │           ├── content_loc: (17,11)-(17,12) = "x"
-        │   │           ├── closing_loc: (17,12)-(17,14) = "/m"
-        │   │           ├── unescaped: "x"
-        │   │           └── flags: multi_line
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (17,2)-(17,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (17,2)-(17,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (17,3)-(17,8))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (17,4)-(17,7))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (17,4)-(17,7))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (17,4)-(17,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: ∅
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (17,6)-(17,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (17,6)-(17,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (17,6)-(17,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: ∅
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (17,3)-(17,4) = "{"
+        │   │   │   │   │   └── closing_loc: (17,7)-(17,8) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ RegularExpressionNode (location: (17,10)-(17,14))
+        │   │   │       ├── opening_loc: (17,10)-(17,11) = "/"
+        │   │   │       ├── content_loc: (17,11)-(17,12) = "x"
+        │   │   │       ├── closing_loc: (17,12)-(17,14) = "/m"
+        │   │   │       ├── unescaped: "x"
+        │   │   │       └── flags: multi_line
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (17,15)-(17,21))
@@ -550,53 +574,55 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (19,2)-(19,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (19,2)-(19,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (19,2)-(19,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (19,3)-(19,9))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (19,4)-(19,8))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (19,4)-(19,8))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (19,4)-(19,5) = "c"
-        │   │       │   │   │           ├── opening_loc: (19,5)-(19,6) = "("
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (19,6)-(19,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (19,6)-(19,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (19,6)-(19,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: (19,7)-(19,8) = ")"
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (19,3)-(19,4) = "{"
-        │   │       │   │   └── closing_loc: (19,8)-(19,9) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ StringNode (location: (19,11)-(19,14))
-        │   │           ├── flags: ∅
-        │   │           ├── opening_loc: (19,11)-(19,12) = "\""
-        │   │           ├── content_loc: (19,12)-(19,13) = "x"
-        │   │           ├── closing_loc: (19,13)-(19,14) = "\""
-        │   │           └── unescaped: "x"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (19,2)-(19,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (19,2)-(19,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (19,3)-(19,9))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (19,4)-(19,8))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (19,4)-(19,8))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (19,4)-(19,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: (19,5)-(19,6) = "("
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (19,6)-(19,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (19,6)-(19,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (19,6)-(19,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: (19,7)-(19,8) = ")"
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (19,3)-(19,4) = "{"
+        │   │   │   │   │   └── closing_loc: (19,8)-(19,9) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ StringNode (location: (19,11)-(19,14))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: (19,11)-(19,12) = "\""
+        │   │   │       ├── content_loc: (19,12)-(19,13) = "x"
+        │   │   │       ├── closing_loc: (19,13)-(19,14) = "\""
+        │   │   │       └── unescaped: "x"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (19,15)-(19,21))
@@ -614,53 +640,55 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (21,2)-(21,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (21,2)-(21,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (21,2)-(21,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (21,3)-(21,9))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (21,4)-(21,8))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (21,4)-(21,8))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (21,4)-(21,5) = "c"
-        │   │       │   │   │           ├── opening_loc: (21,5)-(21,6) = "("
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (21,6)-(21,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (21,6)-(21,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (21,6)-(21,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: (21,7)-(21,8) = ")"
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (21,3)-(21,4) = "{"
-        │   │       │   │   └── closing_loc: (21,8)-(21,9) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ RegularExpressionNode (location: (21,11)-(21,14))
-        │   │           ├── opening_loc: (21,11)-(21,12) = "/"
-        │   │           ├── content_loc: (21,12)-(21,13) = "x"
-        │   │           ├── closing_loc: (21,13)-(21,14) = "/"
-        │   │           ├── unescaped: "x"
-        │   │           └── flags: ∅
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (21,2)-(21,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (21,2)-(21,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (21,3)-(21,9))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (21,4)-(21,8))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (21,4)-(21,8))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (21,4)-(21,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: (21,5)-(21,6) = "("
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (21,6)-(21,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (21,6)-(21,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (21,6)-(21,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: (21,7)-(21,8) = ")"
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (21,3)-(21,4) = "{"
+        │   │   │   │   │   └── closing_loc: (21,8)-(21,9) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ RegularExpressionNode (location: (21,11)-(21,14))
+        │   │   │       ├── opening_loc: (21,11)-(21,12) = "/"
+        │   │   │       ├── content_loc: (21,12)-(21,13) = "x"
+        │   │   │       ├── closing_loc: (21,13)-(21,14) = "/"
+        │   │   │       ├── unescaped: "x"
+        │   │   │       └── flags: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (21,15)-(21,21))
@@ -678,53 +706,55 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (23,2)-(23,15))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (23,2)-(23,9))
-            │       │   ├── receiver: ∅
-            │       │   ├── call_operator_loc: ∅
-            │       │   ├── message_loc: (23,2)-(23,3) = "b"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block:
-            │       │   │   @ BlockNode (location: (23,3)-(23,9))
-            │       │   │   ├── locals: []
-            │       │   │   ├── parameters: ∅
-            │       │   │   ├── body:
-            │       │   │   │   @ StatementsNode (location: (23,4)-(23,8))
-            │       │   │   │   └── body: (length: 1)
-            │       │   │   │       └── @ CallNode (location: (23,4)-(23,8))
-            │       │   │   │           ├── receiver: ∅
-            │       │   │   │           ├── call_operator_loc: ∅
-            │       │   │   │           ├── message_loc: (23,4)-(23,5) = "c"
-            │       │   │   │           ├── opening_loc: (23,5)-(23,6) = "("
-            │       │   │   │           ├── arguments:
-            │       │   │   │           │   @ ArgumentsNode (location: (23,6)-(23,7))
-            │       │   │   │           │   └── arguments: (length: 1)
-            │       │   │   │           │       └── @ CallNode (location: (23,6)-(23,7))
-            │       │   │   │           │           ├── receiver: ∅
-            │       │   │   │           │           ├── call_operator_loc: ∅
-            │       │   │   │           │           ├── message_loc: (23,6)-(23,7) = "d"
-            │       │   │   │           │           ├── opening_loc: ∅
-            │       │   │   │           │           ├── arguments: ∅
-            │       │   │   │           │           ├── closing_loc: ∅
-            │       │   │   │           │           ├── block: ∅
-            │       │   │   │           │           ├── flags: variable_call
-            │       │   │   │           │           └── name: :d
-            │       │   │   │           ├── closing_loc: (23,7)-(23,8) = ")"
-            │       │   │   │           ├── block: ∅
-            │       │   │   │           ├── flags: ∅
-            │       │   │   │           └── name: :c
-            │       │   │   ├── opening_loc: (23,3)-(23,4) = "{"
-            │       │   │   └── closing_loc: (23,8)-(23,9) = "}"
-            │       │   ├── flags: ∅
-            │       │   └── name: :b
-            │       └── @ RegularExpressionNode (location: (23,11)-(23,15))
-            │           ├── opening_loc: (23,11)-(23,12) = "/"
-            │           ├── content_loc: (23,12)-(23,13) = "x"
-            │           ├── closing_loc: (23,13)-(23,15) = "/m"
-            │           ├── unescaped: "x"
-            │           └── flags: multi_line
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (23,2)-(23,9))
+            │   │   │   ├── receiver: ∅
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── message_loc: (23,2)-(23,3) = "b"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block:
+            │   │   │   │   @ BlockNode (location: (23,3)-(23,9))
+            │   │   │   │   ├── locals: []
+            │   │   │   │   ├── parameters: ∅
+            │   │   │   │   ├── body:
+            │   │   │   │   │   @ StatementsNode (location: (23,4)-(23,8))
+            │   │   │   │   │   └── body: (length: 1)
+            │   │   │   │   │       └── @ CallNode (location: (23,4)-(23,8))
+            │   │   │   │   │           ├── receiver: ∅
+            │   │   │   │   │           ├── call_operator_loc: ∅
+            │   │   │   │   │           ├── message_loc: (23,4)-(23,5) = "c"
+            │   │   │   │   │           ├── opening_loc: (23,5)-(23,6) = "("
+            │   │   │   │   │           ├── arguments:
+            │   │   │   │   │           │   @ ArgumentsNode (location: (23,6)-(23,7))
+            │   │   │   │   │           │   ├── arguments: (length: 1)
+            │   │   │   │   │           │   │   └── @ CallNode (location: (23,6)-(23,7))
+            │   │   │   │   │           │   │       ├── receiver: ∅
+            │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+            │   │   │   │   │           │   │       ├── message_loc: (23,6)-(23,7) = "d"
+            │   │   │   │   │           │   │       ├── opening_loc: ∅
+            │   │   │   │   │           │   │       ├── arguments: ∅
+            │   │   │   │   │           │   │       ├── closing_loc: ∅
+            │   │   │   │   │           │   │       ├── block: ∅
+            │   │   │   │   │           │   │       ├── flags: variable_call
+            │   │   │   │   │           │   │       └── name: :d
+            │   │   │   │   │           │   └── flags: ∅
+            │   │   │   │   │           ├── closing_loc: (23,7)-(23,8) = ")"
+            │   │   │   │   │           ├── block: ∅
+            │   │   │   │   │           ├── flags: ∅
+            │   │   │   │   │           └── name: :c
+            │   │   │   │   ├── opening_loc: (23,3)-(23,4) = "{"
+            │   │   │   │   └── closing_loc: (23,8)-(23,9) = "}"
+            │   │   │   ├── flags: ∅
+            │   │   │   └── name: :b
+            │   │   └── @ RegularExpressionNode (location: (23,11)-(23,15))
+            │   │       ├── opening_loc: (23,11)-(23,12) = "/"
+            │   │       ├── content_loc: (23,12)-(23,13) = "x"
+            │   │       ├── closing_loc: (23,13)-(23,15) = "/m"
+            │   │       ├── unescaped: "x"
+            │   │       └── flags: multi_line
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (23,16)-(23,22))

--- a/test/prism/snapshots/whitequark/ruby_bug_11873_a.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_11873_a.txt
@@ -10,43 +10,46 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,11))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (1,2)-(1,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (1,2)-(1,3) = "b"
-        │   │       │   ├── opening_loc: (1,3)-(1,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (1,4)-(1,7))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (1,4)-(1,7))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (1,4)-(1,5) = "c"
-        │   │       │   │           ├── opening_loc: ∅
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (1,6)-(1,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (1,6)-(1,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (1,6)-(1,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: ∅
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (1,7)-(1,8) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ IntegerNode (location: (1,10)-(1,11))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (1,2)-(1,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (1,2)-(1,3) = "b"
+        │   │   │   │   ├── opening_loc: (1,3)-(1,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (1,4)-(1,7))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (1,4)-(1,7))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (1,4)-(1,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (1,6)-(1,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (1,6)-(1,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (1,6)-(1,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (1,7)-(1,8) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ IntegerNode (location: (1,10)-(1,11))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (1,12)-(1,18))
@@ -64,42 +67,45 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,2)-(3,13))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (3,2)-(3,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (3,2)-(3,3) = "b"
-        │   │       │   ├── opening_loc: (3,3)-(3,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (3,4)-(3,7))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (3,4)-(3,7))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (3,4)-(3,5) = "c"
-        │   │       │   │           ├── opening_loc: ∅
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (3,6)-(3,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (3,6)-(3,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (3,6)-(3,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: ∅
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (3,7)-(3,8) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ FloatNode (location: (3,10)-(3,13))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (3,2)-(3,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (3,2)-(3,3) = "b"
+        │   │   │   │   ├── opening_loc: (3,3)-(3,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (3,4)-(3,7))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (3,4)-(3,7))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (3,4)-(3,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (3,6)-(3,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (3,6)-(3,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (3,6)-(3,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (3,7)-(3,8) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ FloatNode (location: (3,10)-(3,13))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (3,14)-(3,20))
@@ -117,44 +123,47 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,2)-(5,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (5,2)-(5,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (5,2)-(5,3) = "b"
-        │   │       │   ├── opening_loc: (5,3)-(5,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (5,4)-(5,7))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (5,4)-(5,7))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (5,4)-(5,5) = "c"
-        │   │       │   │           ├── opening_loc: ∅
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (5,6)-(5,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (5,6)-(5,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (5,6)-(5,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: ∅
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (5,7)-(5,8) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ ImaginaryNode (location: (5,10)-(5,14))
-        │   │           └── numeric:
-        │   │               @ FloatNode (location: (5,10)-(5,13))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (5,2)-(5,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (5,2)-(5,3) = "b"
+        │   │   │   │   ├── opening_loc: (5,3)-(5,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (5,4)-(5,7))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (5,4)-(5,7))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (5,4)-(5,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (5,6)-(5,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (5,6)-(5,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (5,6)-(5,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (5,7)-(5,8) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ ImaginaryNode (location: (5,10)-(5,14))
+        │   │   │       └── numeric:
+        │   │   │           @ FloatNode (location: (5,10)-(5,13))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (5,15)-(5,21))
@@ -172,44 +181,47 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,2)-(7,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (7,2)-(7,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (7,2)-(7,3) = "b"
-        │   │       │   ├── opening_loc: (7,3)-(7,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (7,4)-(7,7))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (7,4)-(7,7))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (7,4)-(7,5) = "c"
-        │   │       │   │           ├── opening_loc: ∅
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (7,6)-(7,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (7,6)-(7,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (7,6)-(7,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: ∅
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (7,7)-(7,8) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ RationalNode (location: (7,10)-(7,14))
-        │   │           └── numeric:
-        │   │               @ FloatNode (location: (7,10)-(7,13))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (7,2)-(7,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (7,2)-(7,3) = "b"
+        │   │   │   │   ├── opening_loc: (7,3)-(7,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (7,4)-(7,7))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (7,4)-(7,7))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (7,4)-(7,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (7,6)-(7,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (7,6)-(7,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (7,6)-(7,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (7,7)-(7,8) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ RationalNode (location: (7,10)-(7,14))
+        │   │   │       └── numeric:
+        │   │   │           @ FloatNode (location: (7,10)-(7,13))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (7,15)-(7,21))
@@ -227,46 +239,49 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (9,2)-(9,12))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (9,2)-(9,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (9,2)-(9,3) = "b"
-        │   │       │   ├── opening_loc: (9,3)-(9,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (9,4)-(9,7))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (9,4)-(9,7))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (9,4)-(9,5) = "c"
-        │   │       │   │           ├── opening_loc: ∅
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (9,6)-(9,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (9,6)-(9,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (9,6)-(9,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: ∅
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (9,7)-(9,8) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ SymbolNode (location: (9,10)-(9,12))
-        │   │           ├── opening_loc: (9,10)-(9,11) = ":"
-        │   │           ├── value_loc: (9,11)-(9,12) = "e"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "e"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (9,2)-(9,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (9,2)-(9,3) = "b"
+        │   │   │   │   ├── opening_loc: (9,3)-(9,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (9,4)-(9,7))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (9,4)-(9,7))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (9,4)-(9,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (9,6)-(9,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (9,6)-(9,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (9,6)-(9,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (9,7)-(9,8) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ SymbolNode (location: (9,10)-(9,12))
+        │   │   │       ├── opening_loc: (9,10)-(9,11) = ":"
+        │   │   │       ├── value_loc: (9,11)-(9,12) = "e"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "e"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (9,13)-(9,19))
@@ -284,43 +299,46 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (11,2)-(11,12))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (11,2)-(11,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (11,2)-(11,3) = "b"
-        │   │       │   ├── opening_loc: (11,3)-(11,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (11,4)-(11,8))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (11,4)-(11,8))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (11,4)-(11,5) = "c"
-        │   │       │   │           ├── opening_loc: (11,5)-(11,6) = "("
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (11,6)-(11,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (11,6)-(11,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (11,6)-(11,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: (11,7)-(11,8) = ")"
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (11,8)-(11,9) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ IntegerNode (location: (11,11)-(11,12))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (11,2)-(11,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (11,2)-(11,3) = "b"
+        │   │   │   │   ├── opening_loc: (11,3)-(11,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (11,4)-(11,8))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (11,4)-(11,8))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (11,4)-(11,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: (11,5)-(11,6) = "("
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (11,6)-(11,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (11,6)-(11,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (11,6)-(11,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: (11,7)-(11,8) = ")"
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (11,8)-(11,9) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ IntegerNode (location: (11,11)-(11,12))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (11,13)-(11,19))
@@ -338,42 +356,45 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (13,2)-(13,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (13,2)-(13,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (13,2)-(13,3) = "b"
-        │   │       │   ├── opening_loc: (13,3)-(13,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (13,4)-(13,8))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (13,4)-(13,8))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (13,4)-(13,5) = "c"
-        │   │       │   │           ├── opening_loc: (13,5)-(13,6) = "("
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (13,6)-(13,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (13,6)-(13,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (13,6)-(13,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: (13,7)-(13,8) = ")"
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (13,8)-(13,9) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ FloatNode (location: (13,11)-(13,14))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (13,2)-(13,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (13,2)-(13,3) = "b"
+        │   │   │   │   ├── opening_loc: (13,3)-(13,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (13,4)-(13,8))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (13,4)-(13,8))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (13,4)-(13,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: (13,5)-(13,6) = "("
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (13,6)-(13,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (13,6)-(13,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (13,6)-(13,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: (13,7)-(13,8) = ")"
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (13,8)-(13,9) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ FloatNode (location: (13,11)-(13,14))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (13,15)-(13,21))
@@ -391,44 +412,47 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (15,2)-(15,15))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (15,2)-(15,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (15,2)-(15,3) = "b"
-        │   │       │   ├── opening_loc: (15,3)-(15,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (15,4)-(15,8))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (15,4)-(15,8))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (15,4)-(15,5) = "c"
-        │   │       │   │           ├── opening_loc: (15,5)-(15,6) = "("
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (15,6)-(15,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (15,6)-(15,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (15,6)-(15,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: (15,7)-(15,8) = ")"
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (15,8)-(15,9) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ ImaginaryNode (location: (15,11)-(15,15))
-        │   │           └── numeric:
-        │   │               @ FloatNode (location: (15,11)-(15,14))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (15,2)-(15,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (15,2)-(15,3) = "b"
+        │   │   │   │   ├── opening_loc: (15,3)-(15,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (15,4)-(15,8))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (15,4)-(15,8))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (15,4)-(15,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: (15,5)-(15,6) = "("
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (15,6)-(15,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (15,6)-(15,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (15,6)-(15,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: (15,7)-(15,8) = ")"
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (15,8)-(15,9) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ ImaginaryNode (location: (15,11)-(15,15))
+        │   │   │       └── numeric:
+        │   │   │           @ FloatNode (location: (15,11)-(15,14))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (15,16)-(15,22))
@@ -446,44 +470,47 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (17,2)-(17,15))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (17,2)-(17,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (17,2)-(17,3) = "b"
-        │   │       │   ├── opening_loc: (17,3)-(17,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (17,4)-(17,8))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (17,4)-(17,8))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (17,4)-(17,5) = "c"
-        │   │       │   │           ├── opening_loc: (17,5)-(17,6) = "("
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (17,6)-(17,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (17,6)-(17,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (17,6)-(17,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: (17,7)-(17,8) = ")"
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (17,8)-(17,9) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ RationalNode (location: (17,11)-(17,15))
-        │   │           └── numeric:
-        │   │               @ FloatNode (location: (17,11)-(17,14))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (17,2)-(17,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (17,2)-(17,3) = "b"
+        │   │   │   │   ├── opening_loc: (17,3)-(17,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (17,4)-(17,8))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (17,4)-(17,8))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (17,4)-(17,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: (17,5)-(17,6) = "("
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (17,6)-(17,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (17,6)-(17,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (17,6)-(17,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: (17,7)-(17,8) = ")"
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (17,8)-(17,9) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ RationalNode (location: (17,11)-(17,15))
+        │   │   │       └── numeric:
+        │   │   │           @ FloatNode (location: (17,11)-(17,14))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (17,16)-(17,22))
@@ -501,46 +528,49 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (19,2)-(19,13))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (19,2)-(19,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (19,2)-(19,3) = "b"
-        │   │       │   ├── opening_loc: (19,3)-(19,4) = "("
-        │   │       │   ├── arguments:
-        │   │       │   │   @ ArgumentsNode (location: (19,4)-(19,8))
-        │   │       │   │   └── arguments: (length: 1)
-        │   │       │   │       └── @ CallNode (location: (19,4)-(19,8))
-        │   │       │   │           ├── receiver: ∅
-        │   │       │   │           ├── call_operator_loc: ∅
-        │   │       │   │           ├── message_loc: (19,4)-(19,5) = "c"
-        │   │       │   │           ├── opening_loc: (19,5)-(19,6) = "("
-        │   │       │   │           ├── arguments:
-        │   │       │   │           │   @ ArgumentsNode (location: (19,6)-(19,7))
-        │   │       │   │           │   └── arguments: (length: 1)
-        │   │       │   │           │       └── @ CallNode (location: (19,6)-(19,7))
-        │   │       │   │           │           ├── receiver: ∅
-        │   │       │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │           │           ├── message_loc: (19,6)-(19,7) = "d"
-        │   │       │   │           │           ├── opening_loc: ∅
-        │   │       │   │           │           ├── arguments: ∅
-        │   │       │   │           │           ├── closing_loc: ∅
-        │   │       │   │           │           ├── block: ∅
-        │   │       │   │           │           ├── flags: variable_call
-        │   │       │   │           │           └── name: :d
-        │   │       │   │           ├── closing_loc: (19,7)-(19,8) = ")"
-        │   │       │   │           ├── block: ∅
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           └── name: :c
-        │   │       │   ├── closing_loc: (19,8)-(19,9) = ")"
-        │   │       │   ├── block: ∅
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ SymbolNode (location: (19,11)-(19,13))
-        │   │           ├── opening_loc: (19,11)-(19,12) = ":"
-        │   │           ├── value_loc: (19,12)-(19,13) = "e"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "e"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (19,2)-(19,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (19,2)-(19,3) = "b"
+        │   │   │   │   ├── opening_loc: (19,3)-(19,4) = "("
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (19,4)-(19,8))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ CallNode (location: (19,4)-(19,8))
+        │   │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       ├── message_loc: (19,4)-(19,5) = "c"
+        │   │   │   │   │   │       ├── opening_loc: (19,5)-(19,6) = "("
+        │   │   │   │   │   │       ├── arguments:
+        │   │   │   │   │   │       │   @ ArgumentsNode (location: (19,6)-(19,7))
+        │   │   │   │   │   │       │   ├── arguments: (length: 1)
+        │   │   │   │   │   │       │   │   └── @ CallNode (location: (19,6)-(19,7))
+        │   │   │   │   │   │       │   │       ├── receiver: ∅
+        │   │   │   │   │   │       │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │       │   │       ├── message_loc: (19,6)-(19,7) = "d"
+        │   │   │   │   │   │       │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │       │   │       ├── arguments: ∅
+        │   │   │   │   │   │       │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │       │   │       ├── block: ∅
+        │   │   │   │   │   │       │   │       ├── flags: variable_call
+        │   │   │   │   │   │       │   │       └── name: :d
+        │   │   │   │   │   │       │   └── flags: ∅
+        │   │   │   │   │   │       ├── closing_loc: (19,7)-(19,8) = ")"
+        │   │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │   │       ├── flags: ∅
+        │   │   │   │   │   │       └── name: :c
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (19,8)-(19,9) = ")"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ SymbolNode (location: (19,11)-(19,13))
+        │   │   │       ├── opening_loc: (19,11)-(19,12) = ":"
+        │   │   │       ├── value_loc: (19,12)-(19,13) = "e"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "e"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (19,14)-(19,20))
@@ -558,49 +588,51 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (21,2)-(21,11))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (21,2)-(21,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (21,2)-(21,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (21,3)-(21,8))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (21,4)-(21,7))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (21,4)-(21,7))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (21,4)-(21,5) = "c"
-        │   │       │   │   │           ├── opening_loc: ∅
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (21,6)-(21,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (21,6)-(21,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (21,6)-(21,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: ∅
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (21,3)-(21,4) = "{"
-        │   │       │   │   └── closing_loc: (21,7)-(21,8) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ IntegerNode (location: (21,10)-(21,11))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (21,2)-(21,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (21,2)-(21,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (21,3)-(21,8))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (21,4)-(21,7))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (21,4)-(21,7))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (21,4)-(21,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: ∅
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (21,6)-(21,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (21,6)-(21,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (21,6)-(21,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: ∅
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (21,3)-(21,4) = "{"
+        │   │   │   │   │   └── closing_loc: (21,7)-(21,8) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ IntegerNode (location: (21,10)-(21,11))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (21,12)-(21,18))
@@ -618,48 +650,50 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (23,2)-(23,13))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (23,2)-(23,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (23,2)-(23,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (23,3)-(23,8))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (23,4)-(23,7))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (23,4)-(23,7))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (23,4)-(23,5) = "c"
-        │   │       │   │   │           ├── opening_loc: ∅
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (23,6)-(23,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (23,6)-(23,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (23,6)-(23,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: ∅
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (23,3)-(23,4) = "{"
-        │   │       │   │   └── closing_loc: (23,7)-(23,8) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ FloatNode (location: (23,10)-(23,13))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (23,2)-(23,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (23,2)-(23,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (23,3)-(23,8))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (23,4)-(23,7))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (23,4)-(23,7))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (23,4)-(23,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: ∅
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (23,6)-(23,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (23,6)-(23,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (23,6)-(23,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: ∅
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (23,3)-(23,4) = "{"
+        │   │   │   │   │   └── closing_loc: (23,7)-(23,8) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ FloatNode (location: (23,10)-(23,13))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (23,14)-(23,20))
@@ -677,50 +711,52 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (25,2)-(25,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (25,2)-(25,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (25,2)-(25,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (25,3)-(25,8))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (25,4)-(25,7))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (25,4)-(25,7))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (25,4)-(25,5) = "c"
-        │   │       │   │   │           ├── opening_loc: ∅
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (25,6)-(25,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (25,6)-(25,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (25,6)-(25,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: ∅
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (25,3)-(25,4) = "{"
-        │   │       │   │   └── closing_loc: (25,7)-(25,8) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ ImaginaryNode (location: (25,10)-(25,14))
-        │   │           └── numeric:
-        │   │               @ FloatNode (location: (25,10)-(25,13))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (25,2)-(25,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (25,2)-(25,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (25,3)-(25,8))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (25,4)-(25,7))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (25,4)-(25,7))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (25,4)-(25,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: ∅
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (25,6)-(25,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (25,6)-(25,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (25,6)-(25,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: ∅
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (25,3)-(25,4) = "{"
+        │   │   │   │   │   └── closing_loc: (25,7)-(25,8) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ ImaginaryNode (location: (25,10)-(25,14))
+        │   │   │       └── numeric:
+        │   │   │           @ FloatNode (location: (25,10)-(25,13))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (25,15)-(25,21))
@@ -738,50 +774,52 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (27,2)-(27,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (27,2)-(27,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (27,2)-(27,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (27,3)-(27,8))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (27,4)-(27,7))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (27,4)-(27,7))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (27,4)-(27,5) = "c"
-        │   │       │   │   │           ├── opening_loc: ∅
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (27,6)-(27,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (27,6)-(27,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (27,6)-(27,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: ∅
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (27,3)-(27,4) = "{"
-        │   │       │   │   └── closing_loc: (27,7)-(27,8) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ RationalNode (location: (27,10)-(27,14))
-        │   │           └── numeric:
-        │   │               @ FloatNode (location: (27,10)-(27,13))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (27,2)-(27,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (27,2)-(27,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (27,3)-(27,8))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (27,4)-(27,7))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (27,4)-(27,7))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (27,4)-(27,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: ∅
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (27,6)-(27,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (27,6)-(27,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (27,6)-(27,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: ∅
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (27,3)-(27,4) = "{"
+        │   │   │   │   │   └── closing_loc: (27,7)-(27,8) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ RationalNode (location: (27,10)-(27,14))
+        │   │   │       └── numeric:
+        │   │   │           @ FloatNode (location: (27,10)-(27,13))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (27,15)-(27,21))
@@ -799,52 +837,54 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (29,2)-(29,12))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (29,2)-(29,8))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (29,2)-(29,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (29,3)-(29,8))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (29,4)-(29,7))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (29,4)-(29,7))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (29,4)-(29,5) = "c"
-        │   │       │   │   │           ├── opening_loc: ∅
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (29,6)-(29,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (29,6)-(29,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (29,6)-(29,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: ∅
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (29,3)-(29,4) = "{"
-        │   │       │   │   └── closing_loc: (29,7)-(29,8) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ SymbolNode (location: (29,10)-(29,12))
-        │   │           ├── opening_loc: (29,10)-(29,11) = ":"
-        │   │           ├── value_loc: (29,11)-(29,12) = "e"
-        │   │           ├── closing_loc: ∅
-        │   │           └── unescaped: "e"
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (29,2)-(29,8))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (29,2)-(29,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (29,3)-(29,8))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (29,4)-(29,7))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (29,4)-(29,7))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (29,4)-(29,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: ∅
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (29,6)-(29,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (29,6)-(29,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (29,6)-(29,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: ∅
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (29,3)-(29,4) = "{"
+        │   │   │   │   │   └── closing_loc: (29,7)-(29,8) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ SymbolNode (location: (29,10)-(29,12))
+        │   │   │       ├── opening_loc: (29,10)-(29,11) = ":"
+        │   │   │       ├── value_loc: (29,11)-(29,12) = "e"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "e"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (29,13)-(29,19))
@@ -862,49 +902,51 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (31,2)-(31,12))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (31,2)-(31,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (31,2)-(31,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (31,3)-(31,9))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (31,4)-(31,8))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (31,4)-(31,8))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (31,4)-(31,5) = "c"
-        │   │       │   │   │           ├── opening_loc: (31,5)-(31,6) = "("
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (31,6)-(31,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (31,6)-(31,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (31,6)-(31,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: (31,7)-(31,8) = ")"
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (31,3)-(31,4) = "{"
-        │   │       │   │   └── closing_loc: (31,8)-(31,9) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ IntegerNode (location: (31,11)-(31,12))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (31,2)-(31,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (31,2)-(31,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (31,3)-(31,9))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (31,4)-(31,8))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (31,4)-(31,8))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (31,4)-(31,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: (31,5)-(31,6) = "("
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (31,6)-(31,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (31,6)-(31,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (31,6)-(31,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: (31,7)-(31,8) = ")"
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (31,3)-(31,4) = "{"
+        │   │   │   │   │   └── closing_loc: (31,8)-(31,9) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ IntegerNode (location: (31,11)-(31,12))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (31,13)-(31,19))
@@ -922,48 +964,50 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (33,2)-(33,14))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (33,2)-(33,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (33,2)-(33,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (33,3)-(33,9))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (33,4)-(33,8))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (33,4)-(33,8))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (33,4)-(33,5) = "c"
-        │   │       │   │   │           ├── opening_loc: (33,5)-(33,6) = "("
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (33,6)-(33,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (33,6)-(33,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (33,6)-(33,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: (33,7)-(33,8) = ")"
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (33,3)-(33,4) = "{"
-        │   │       │   │   └── closing_loc: (33,8)-(33,9) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ FloatNode (location: (33,11)-(33,14))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (33,2)-(33,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (33,2)-(33,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (33,3)-(33,9))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (33,4)-(33,8))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (33,4)-(33,8))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (33,4)-(33,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: (33,5)-(33,6) = "("
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (33,6)-(33,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (33,6)-(33,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (33,6)-(33,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: (33,7)-(33,8) = ")"
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (33,3)-(33,4) = "{"
+        │   │   │   │   │   └── closing_loc: (33,8)-(33,9) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ FloatNode (location: (33,11)-(33,14))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (33,15)-(33,21))
@@ -981,50 +1025,52 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (35,2)-(35,15))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (35,2)-(35,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (35,2)-(35,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (35,3)-(35,9))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (35,4)-(35,8))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (35,4)-(35,8))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (35,4)-(35,5) = "c"
-        │   │       │   │   │           ├── opening_loc: (35,5)-(35,6) = "("
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (35,6)-(35,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (35,6)-(35,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (35,6)-(35,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: (35,7)-(35,8) = ")"
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (35,3)-(35,4) = "{"
-        │   │       │   │   └── closing_loc: (35,8)-(35,9) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ ImaginaryNode (location: (35,11)-(35,15))
-        │   │           └── numeric:
-        │   │               @ FloatNode (location: (35,11)-(35,14))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (35,2)-(35,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (35,2)-(35,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (35,3)-(35,9))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (35,4)-(35,8))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (35,4)-(35,8))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (35,4)-(35,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: (35,5)-(35,6) = "("
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (35,6)-(35,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (35,6)-(35,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (35,6)-(35,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: (35,7)-(35,8) = ")"
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (35,3)-(35,4) = "{"
+        │   │   │   │   │   └── closing_loc: (35,8)-(35,9) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ ImaginaryNode (location: (35,11)-(35,15))
+        │   │   │       └── numeric:
+        │   │   │           @ FloatNode (location: (35,11)-(35,14))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (35,16)-(35,22))
@@ -1042,50 +1088,52 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (37,2)-(37,15))
-        │   │   └── arguments: (length: 2)
-        │   │       ├── @ CallNode (location: (37,2)-(37,9))
-        │   │       │   ├── receiver: ∅
-        │   │       │   ├── call_operator_loc: ∅
-        │   │       │   ├── message_loc: (37,2)-(37,3) = "b"
-        │   │       │   ├── opening_loc: ∅
-        │   │       │   ├── arguments: ∅
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   ├── block:
-        │   │       │   │   @ BlockNode (location: (37,3)-(37,9))
-        │   │       │   │   ├── locals: []
-        │   │       │   │   ├── parameters: ∅
-        │   │       │   │   ├── body:
-        │   │       │   │   │   @ StatementsNode (location: (37,4)-(37,8))
-        │   │       │   │   │   └── body: (length: 1)
-        │   │       │   │   │       └── @ CallNode (location: (37,4)-(37,8))
-        │   │       │   │   │           ├── receiver: ∅
-        │   │       │   │   │           ├── call_operator_loc: ∅
-        │   │       │   │   │           ├── message_loc: (37,4)-(37,5) = "c"
-        │   │       │   │   │           ├── opening_loc: (37,5)-(37,6) = "("
-        │   │       │   │   │           ├── arguments:
-        │   │       │   │   │           │   @ ArgumentsNode (location: (37,6)-(37,7))
-        │   │       │   │   │           │   └── arguments: (length: 1)
-        │   │       │   │   │           │       └── @ CallNode (location: (37,6)-(37,7))
-        │   │       │   │   │           │           ├── receiver: ∅
-        │   │       │   │   │           │           ├── call_operator_loc: ∅
-        │   │       │   │   │           │           ├── message_loc: (37,6)-(37,7) = "d"
-        │   │       │   │   │           │           ├── opening_loc: ∅
-        │   │       │   │   │           │           ├── arguments: ∅
-        │   │       │   │   │           │           ├── closing_loc: ∅
-        │   │       │   │   │           │           ├── block: ∅
-        │   │       │   │   │           │           ├── flags: variable_call
-        │   │       │   │   │           │           └── name: :d
-        │   │       │   │   │           ├── closing_loc: (37,7)-(37,8) = ")"
-        │   │       │   │   │           ├── block: ∅
-        │   │       │   │   │           ├── flags: ∅
-        │   │       │   │   │           └── name: :c
-        │   │       │   │   ├── opening_loc: (37,3)-(37,4) = "{"
-        │   │       │   │   └── closing_loc: (37,8)-(37,9) = "}"
-        │   │       │   ├── flags: ∅
-        │   │       │   └── name: :b
-        │   │       └── @ RationalNode (location: (37,11)-(37,15))
-        │   │           └── numeric:
-        │   │               @ FloatNode (location: (37,11)-(37,14))
+        │   │   ├── arguments: (length: 2)
+        │   │   │   ├── @ CallNode (location: (37,2)-(37,9))
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── message_loc: (37,2)-(37,3) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   ├── block:
+        │   │   │   │   │   @ BlockNode (location: (37,3)-(37,9))
+        │   │   │   │   │   ├── locals: []
+        │   │   │   │   │   ├── parameters: ∅
+        │   │   │   │   │   ├── body:
+        │   │   │   │   │   │   @ StatementsNode (location: (37,4)-(37,8))
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (37,4)-(37,8))
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── message_loc: (37,4)-(37,5) = "c"
+        │   │   │   │   │   │           ├── opening_loc: (37,5)-(37,6) = "("
+        │   │   │   │   │   │           ├── arguments:
+        │   │   │   │   │   │           │   @ ArgumentsNode (location: (37,6)-(37,7))
+        │   │   │   │   │   │           │   ├── arguments: (length: 1)
+        │   │   │   │   │   │           │   │   └── @ CallNode (location: (37,6)-(37,7))
+        │   │   │   │   │   │           │   │       ├── receiver: ∅
+        │   │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │   │           │   │       ├── message_loc: (37,6)-(37,7) = "d"
+        │   │   │   │   │   │           │   │       ├── opening_loc: ∅
+        │   │   │   │   │   │           │   │       ├── arguments: ∅
+        │   │   │   │   │   │           │   │       ├── closing_loc: ∅
+        │   │   │   │   │   │           │   │       ├── block: ∅
+        │   │   │   │   │   │           │   │       ├── flags: variable_call
+        │   │   │   │   │   │           │   │       └── name: :d
+        │   │   │   │   │   │           │   └── flags: ∅
+        │   │   │   │   │   │           ├── closing_loc: (37,7)-(37,8) = ")"
+        │   │   │   │   │   │           ├── block: ∅
+        │   │   │   │   │   │           ├── flags: ∅
+        │   │   │   │   │   │           └── name: :c
+        │   │   │   │   │   ├── opening_loc: (37,3)-(37,4) = "{"
+        │   │   │   │   │   └── closing_loc: (37,8)-(37,9) = "}"
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── name: :b
+        │   │   │   └── @ RationalNode (location: (37,11)-(37,15))
+        │   │   │       └── numeric:
+        │   │   │           @ FloatNode (location: (37,11)-(37,14))
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (37,16)-(37,22))
@@ -1103,52 +1151,54 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (39,2)-(39,13))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (39,2)-(39,9))
-            │       │   ├── receiver: ∅
-            │       │   ├── call_operator_loc: ∅
-            │       │   ├── message_loc: (39,2)-(39,3) = "b"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block:
-            │       │   │   @ BlockNode (location: (39,3)-(39,9))
-            │       │   │   ├── locals: []
-            │       │   │   ├── parameters: ∅
-            │       │   │   ├── body:
-            │       │   │   │   @ StatementsNode (location: (39,4)-(39,8))
-            │       │   │   │   └── body: (length: 1)
-            │       │   │   │       └── @ CallNode (location: (39,4)-(39,8))
-            │       │   │   │           ├── receiver: ∅
-            │       │   │   │           ├── call_operator_loc: ∅
-            │       │   │   │           ├── message_loc: (39,4)-(39,5) = "c"
-            │       │   │   │           ├── opening_loc: (39,5)-(39,6) = "("
-            │       │   │   │           ├── arguments:
-            │       │   │   │           │   @ ArgumentsNode (location: (39,6)-(39,7))
-            │       │   │   │           │   └── arguments: (length: 1)
-            │       │   │   │           │       └── @ CallNode (location: (39,6)-(39,7))
-            │       │   │   │           │           ├── receiver: ∅
-            │       │   │   │           │           ├── call_operator_loc: ∅
-            │       │   │   │           │           ├── message_loc: (39,6)-(39,7) = "d"
-            │       │   │   │           │           ├── opening_loc: ∅
-            │       │   │   │           │           ├── arguments: ∅
-            │       │   │   │           │           ├── closing_loc: ∅
-            │       │   │   │           │           ├── block: ∅
-            │       │   │   │           │           ├── flags: variable_call
-            │       │   │   │           │           └── name: :d
-            │       │   │   │           ├── closing_loc: (39,7)-(39,8) = ")"
-            │       │   │   │           ├── block: ∅
-            │       │   │   │           ├── flags: ∅
-            │       │   │   │           └── name: :c
-            │       │   │   ├── opening_loc: (39,3)-(39,4) = "{"
-            │       │   │   └── closing_loc: (39,8)-(39,9) = "}"
-            │       │   ├── flags: ∅
-            │       │   └── name: :b
-            │       └── @ SymbolNode (location: (39,11)-(39,13))
-            │           ├── opening_loc: (39,11)-(39,12) = ":"
-            │           ├── value_loc: (39,12)-(39,13) = "e"
-            │           ├── closing_loc: ∅
-            │           └── unescaped: "e"
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (39,2)-(39,9))
+            │   │   │   ├── receiver: ∅
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── message_loc: (39,2)-(39,3) = "b"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block:
+            │   │   │   │   @ BlockNode (location: (39,3)-(39,9))
+            │   │   │   │   ├── locals: []
+            │   │   │   │   ├── parameters: ∅
+            │   │   │   │   ├── body:
+            │   │   │   │   │   @ StatementsNode (location: (39,4)-(39,8))
+            │   │   │   │   │   └── body: (length: 1)
+            │   │   │   │   │       └── @ CallNode (location: (39,4)-(39,8))
+            │   │   │   │   │           ├── receiver: ∅
+            │   │   │   │   │           ├── call_operator_loc: ∅
+            │   │   │   │   │           ├── message_loc: (39,4)-(39,5) = "c"
+            │   │   │   │   │           ├── opening_loc: (39,5)-(39,6) = "("
+            │   │   │   │   │           ├── arguments:
+            │   │   │   │   │           │   @ ArgumentsNode (location: (39,6)-(39,7))
+            │   │   │   │   │           │   ├── arguments: (length: 1)
+            │   │   │   │   │           │   │   └── @ CallNode (location: (39,6)-(39,7))
+            │   │   │   │   │           │   │       ├── receiver: ∅
+            │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+            │   │   │   │   │           │   │       ├── message_loc: (39,6)-(39,7) = "d"
+            │   │   │   │   │           │   │       ├── opening_loc: ∅
+            │   │   │   │   │           │   │       ├── arguments: ∅
+            │   │   │   │   │           │   │       ├── closing_loc: ∅
+            │   │   │   │   │           │   │       ├── block: ∅
+            │   │   │   │   │           │   │       ├── flags: variable_call
+            │   │   │   │   │           │   │       └── name: :d
+            │   │   │   │   │           │   └── flags: ∅
+            │   │   │   │   │           ├── closing_loc: (39,7)-(39,8) = ")"
+            │   │   │   │   │           ├── block: ∅
+            │   │   │   │   │           ├── flags: ∅
+            │   │   │   │   │           └── name: :c
+            │   │   │   │   ├── opening_loc: (39,3)-(39,4) = "{"
+            │   │   │   │   └── closing_loc: (39,8)-(39,9) = "}"
+            │   │   │   ├── flags: ∅
+            │   │   │   └── name: :b
+            │   │   └── @ SymbolNode (location: (39,11)-(39,13))
+            │   │       ├── opening_loc: (39,11)-(39,12) = ":"
+            │   │       ├── value_loc: (39,12)-(39,13) = "e"
+            │   │       ├── closing_loc: ∅
+            │   │       └── unescaped: "e"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (39,14)-(39,20))

--- a/test/prism/snapshots/whitequark/ruby_bug_11873_b.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_11873_b.txt
@@ -10,79 +10,82 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,18))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (1,2)-(1,13))
-            │       │   ├── receiver: ∅
-            │       │   ├── call_operator_loc: ∅
-            │       │   ├── message_loc: (1,2)-(1,3) = "p"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block:
-            │       │   │   @ BlockNode (location: (1,3)-(1,13))
-            │       │   │   ├── locals: []
-            │       │   │   ├── parameters: ∅
-            │       │   │   ├── body:
-            │       │   │   │   @ StatementsNode (location: (1,4)-(1,12))
-            │       │   │   │   └── body: (length: 2)
-            │       │   │   │       ├── @ CallNode (location: (1,4)-(1,8))
-            │       │   │   │       │   ├── receiver: ∅
-            │       │   │   │       │   ├── call_operator_loc: ∅
-            │       │   │   │       │   ├── message_loc: (1,4)-(1,5) = "p"
-            │       │   │   │       │   ├── opening_loc: (1,5)-(1,6) = "("
-            │       │   │   │       │   ├── arguments:
-            │       │   │   │       │   │   @ ArgumentsNode (location: (1,6)-(1,7))
-            │       │   │   │       │   │   └── arguments: (length: 1)
-            │       │   │   │       │   │       └── @ CallNode (location: (1,6)-(1,7))
-            │       │   │   │       │   │           ├── receiver: ∅
-            │       │   │   │       │   │           ├── call_operator_loc: ∅
-            │       │   │   │       │   │           ├── message_loc: (1,6)-(1,7) = "p"
-            │       │   │   │       │   │           ├── opening_loc: ∅
-            │       │   │   │       │   │           ├── arguments: ∅
-            │       │   │   │       │   │           ├── closing_loc: ∅
-            │       │   │   │       │   │           ├── block: ∅
-            │       │   │   │       │   │           ├── flags: variable_call
-            │       │   │   │       │   │           └── name: :p
-            │       │   │   │       │   ├── closing_loc: (1,7)-(1,8) = ")"
-            │       │   │   │       │   ├── block: ∅
-            │       │   │   │       │   ├── flags: ∅
-            │       │   │   │       │   └── name: :p
-            │       │   │   │       └── @ CallNode (location: (1,9)-(1,12))
-            │       │   │   │           ├── receiver: ∅
-            │       │   │   │           ├── call_operator_loc: ∅
-            │       │   │   │           ├── message_loc: (1,9)-(1,10) = "p"
-            │       │   │   │           ├── opening_loc: ∅
-            │       │   │   │           ├── arguments:
-            │       │   │   │           │   @ ArgumentsNode (location: (1,11)-(1,12))
-            │       │   │   │           │   └── arguments: (length: 1)
-            │       │   │   │           │       └── @ CallNode (location: (1,11)-(1,12))
-            │       │   │   │           │           ├── receiver: ∅
-            │       │   │   │           │           ├── call_operator_loc: ∅
-            │       │   │   │           │           ├── message_loc: (1,11)-(1,12) = "p"
-            │       │   │   │           │           ├── opening_loc: ∅
-            │       │   │   │           │           ├── arguments: ∅
-            │       │   │   │           │           ├── closing_loc: ∅
-            │       │   │   │           │           ├── block: ∅
-            │       │   │   │           │           ├── flags: variable_call
-            │       │   │   │           │           └── name: :p
-            │       │   │   │           ├── closing_loc: ∅
-            │       │   │   │           ├── block: ∅
-            │       │   │   │           ├── flags: ∅
-            │       │   │   │           └── name: :p
-            │       │   │   ├── opening_loc: (1,3)-(1,4) = "{"
-            │       │   │   └── closing_loc: (1,12)-(1,13) = "}"
-            │       │   ├── flags: ∅
-            │       │   └── name: :p
-            │       └── @ CallNode (location: (1,15)-(1,18))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,15)-(1,18) = "tap"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :tap
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (1,2)-(1,13))
+            │   │   │   ├── receiver: ∅
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── message_loc: (1,2)-(1,3) = "p"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block:
+            │   │   │   │   @ BlockNode (location: (1,3)-(1,13))
+            │   │   │   │   ├── locals: []
+            │   │   │   │   ├── parameters: ∅
+            │   │   │   │   ├── body:
+            │   │   │   │   │   @ StatementsNode (location: (1,4)-(1,12))
+            │   │   │   │   │   └── body: (length: 2)
+            │   │   │   │   │       ├── @ CallNode (location: (1,4)-(1,8))
+            │   │   │   │   │       │   ├── receiver: ∅
+            │   │   │   │   │       │   ├── call_operator_loc: ∅
+            │   │   │   │   │       │   ├── message_loc: (1,4)-(1,5) = "p"
+            │   │   │   │   │       │   ├── opening_loc: (1,5)-(1,6) = "("
+            │   │   │   │   │       │   ├── arguments:
+            │   │   │   │   │       │   │   @ ArgumentsNode (location: (1,6)-(1,7))
+            │   │   │   │   │       │   │   ├── arguments: (length: 1)
+            │   │   │   │   │       │   │   │   └── @ CallNode (location: (1,6)-(1,7))
+            │   │   │   │   │       │   │   │       ├── receiver: ∅
+            │   │   │   │   │       │   │   │       ├── call_operator_loc: ∅
+            │   │   │   │   │       │   │   │       ├── message_loc: (1,6)-(1,7) = "p"
+            │   │   │   │   │       │   │   │       ├── opening_loc: ∅
+            │   │   │   │   │       │   │   │       ├── arguments: ∅
+            │   │   │   │   │       │   │   │       ├── closing_loc: ∅
+            │   │   │   │   │       │   │   │       ├── block: ∅
+            │   │   │   │   │       │   │   │       ├── flags: variable_call
+            │   │   │   │   │       │   │   │       └── name: :p
+            │   │   │   │   │       │   │   └── flags: ∅
+            │   │   │   │   │       │   ├── closing_loc: (1,7)-(1,8) = ")"
+            │   │   │   │   │       │   ├── block: ∅
+            │   │   │   │   │       │   ├── flags: ∅
+            │   │   │   │   │       │   └── name: :p
+            │   │   │   │   │       └── @ CallNode (location: (1,9)-(1,12))
+            │   │   │   │   │           ├── receiver: ∅
+            │   │   │   │   │           ├── call_operator_loc: ∅
+            │   │   │   │   │           ├── message_loc: (1,9)-(1,10) = "p"
+            │   │   │   │   │           ├── opening_loc: ∅
+            │   │   │   │   │           ├── arguments:
+            │   │   │   │   │           │   @ ArgumentsNode (location: (1,11)-(1,12))
+            │   │   │   │   │           │   ├── arguments: (length: 1)
+            │   │   │   │   │           │   │   └── @ CallNode (location: (1,11)-(1,12))
+            │   │   │   │   │           │   │       ├── receiver: ∅
+            │   │   │   │   │           │   │       ├── call_operator_loc: ∅
+            │   │   │   │   │           │   │       ├── message_loc: (1,11)-(1,12) = "p"
+            │   │   │   │   │           │   │       ├── opening_loc: ∅
+            │   │   │   │   │           │   │       ├── arguments: ∅
+            │   │   │   │   │           │   │       ├── closing_loc: ∅
+            │   │   │   │   │           │   │       ├── block: ∅
+            │   │   │   │   │           │   │       ├── flags: variable_call
+            │   │   │   │   │           │   │       └── name: :p
+            │   │   │   │   │           │   └── flags: ∅
+            │   │   │   │   │           ├── closing_loc: ∅
+            │   │   │   │   │           ├── block: ∅
+            │   │   │   │   │           ├── flags: ∅
+            │   │   │   │   │           └── name: :p
+            │   │   │   │   ├── opening_loc: (1,3)-(1,4) = "{"
+            │   │   │   │   └── closing_loc: (1,12)-(1,13) = "}"
+            │   │   │   ├── flags: ∅
+            │   │   │   └── name: :p
+            │   │   └── @ CallNode (location: (1,15)-(1,18))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,15)-(1,18) = "tap"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :tap
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,19)-(1,25))

--- a/test/prism/snapshots/whitequark/ruby_bug_11989.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_11989.txt
@@ -10,13 +10,14 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,8))
-            │   └── arguments: (length: 1)
-            │       └── @ StringNode (location: (1,2)-(1,8))
-            │           ├── flags: ∅
-            │           ├── opening_loc: (1,2)-(1,8) = "<<~\"E\""
-            │           ├── content_loc: (2,0)-(2,0) = "  x\\n   y\n"
-            │           ├── closing_loc: (3,0)-(3,0) = "E\n"
-            │           └── unescaped: "x\n   y\n"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ StringNode (location: (1,2)-(1,8))
+            │   │       ├── flags: ∅
+            │   │       ├── opening_loc: (1,2)-(1,8) = "<<~\"E\""
+            │   │       ├── content_loc: (2,0)-(2,0) = "  x\\n   y\n"
+            │   │       ├── closing_loc: (3,0)-(3,0) = "E\n"
+            │   │       └── unescaped: "x\n   y\n"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_11990.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_11990.txt
@@ -10,22 +10,23 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,12))
-            │   └── arguments: (length: 1)
-            │       └── @ StringConcatNode (location: (1,2)-(1,12))
-            │           ├── left:
-            │           │   @ StringNode (location: (1,2)-(1,6))
-            │           │   ├── flags: ∅
-            │           │   ├── opening_loc: (1,2)-(1,6) = "<<~E"
-            │           │   ├── content_loc: (2,0)-(2,0) = "  x\n"
-            │           │   ├── closing_loc: (3,0)-(3,0) = "E\n"
-            │           │   └── unescaped: "x\n"
-            │           └── right:
-            │               @ StringNode (location: (1,7)-(1,12))
-            │               ├── flags: ∅
-            │               ├── opening_loc: (1,7)-(1,8) = "\""
-            │               ├── content_loc: (1,8)-(1,11) = "  y"
-            │               ├── closing_loc: (1,11)-(1,12) = "\""
-            │               └── unescaped: "  y"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ StringConcatNode (location: (1,2)-(1,12))
+            │   │       ├── left:
+            │   │       │   @ StringNode (location: (1,2)-(1,6))
+            │   │       │   ├── flags: ∅
+            │   │       │   ├── opening_loc: (1,2)-(1,6) = "<<~E"
+            │   │       │   ├── content_loc: (2,0)-(2,0) = "  x\n"
+            │   │       │   ├── closing_loc: (3,0)-(3,0) = "E\n"
+            │   │       │   └── unescaped: "x\n"
+            │   │       └── right:
+            │   │           @ StringNode (location: (1,7)-(1,12))
+            │   │           ├── flags: ∅
+            │   │           ├── opening_loc: (1,7)-(1,8) = "\""
+            │   │           ├── content_loc: (1,8)-(1,11) = "  y"
+            │   │           ├── closing_loc: (1,11)-(1,12) = "\""
+            │   │           └── unescaped: "  y"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_12073.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_12073.txt
@@ -18,20 +18,21 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,9)-(1,13))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ KeywordHashNode (location: (1,9)-(1,13))
-        │   │           └── elements: (length: 1)
-        │   │               └── @ AssocNode (location: (1,9)-(1,13))
-        │   │                   ├── key:
-        │   │                   │   @ SymbolNode (location: (1,9)-(1,11))
-        │   │                   │   ├── opening_loc: ∅
-        │   │                   │   ├── value_loc: (1,9)-(1,10) = "b"
-        │   │                   │   ├── closing_loc: (1,10)-(1,11) = ":"
-        │   │                   │   └── unescaped: "b"
-        │   │                   ├── value:
-        │   │                   │   @ IntegerNode (location: (1,12)-(1,13))
-        │   │                   │   └── flags: decimal
-        │   │                   └── operator_loc: ∅
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ KeywordHashNode (location: (1,9)-(1,13))
+        │   │   │       └── elements: (length: 1)
+        │   │   │           └── @ AssocNode (location: (1,9)-(1,13))
+        │   │   │               ├── key:
+        │   │   │               │   @ SymbolNode (location: (1,9)-(1,11))
+        │   │   │               │   ├── opening_loc: ∅
+        │   │   │               │   ├── value_loc: (1,9)-(1,10) = "b"
+        │   │   │               │   ├── closing_loc: (1,10)-(1,11) = ":"
+        │   │   │               │   └── unescaped: "b"
+        │   │   │               ├── value:
+        │   │   │               │   @ IntegerNode (location: (1,12)-(1,13))
+        │   │   │               │   └── flags: decimal
+        │   │   │               └── operator_loc: ∅
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -61,21 +62,22 @@
             │           ├── opening_loc: ∅
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (3,21)-(3,29))
-            │           │   └── arguments: (length: 2)
-            │           │       ├── @ ConstantPathNode (location: (3,21)-(3,25))
-            │           │       │   ├── parent:
-            │           │       │   │   @ ConstantReadNode (location: (3,21)-(3,22))
-            │           │       │   │   └── name: :A
-            │           │       │   ├── child:
-            │           │       │   │   @ ConstantReadNode (location: (3,24)-(3,25))
-            │           │       │   │   └── name: :B
-            │           │       │   └── delimiter_loc: (3,22)-(3,24) = "::"
-            │           │       └── @ StringNode (location: (3,27)-(3,29))
-            │           │           ├── flags: ∅
-            │           │           ├── opening_loc: (3,27)-(3,28) = "'"
-            │           │           ├── content_loc: (3,28)-(3,28) = ""
-            │           │           ├── closing_loc: (3,28)-(3,29) = "'"
-            │           │           └── unescaped: ""
+            │           │   ├── arguments: (length: 2)
+            │           │   │   ├── @ ConstantPathNode (location: (3,21)-(3,25))
+            │           │   │   │   ├── parent:
+            │           │   │   │   │   @ ConstantReadNode (location: (3,21)-(3,22))
+            │           │   │   │   │   └── name: :A
+            │           │   │   │   ├── child:
+            │           │   │   │   │   @ ConstantReadNode (location: (3,24)-(3,25))
+            │           │   │   │   │   └── name: :B
+            │           │   │   │   └── delimiter_loc: (3,22)-(3,24) = "::"
+            │           │   │   └── @ StringNode (location: (3,27)-(3,29))
+            │           │   │       ├── flags: ∅
+            │           │   │       ├── opening_loc: (3,27)-(3,28) = "'"
+            │           │   │       ├── content_loc: (3,28)-(3,28) = ""
+            │           │   │       ├── closing_loc: (3,28)-(3,29) = "'"
+            │           │   │       └── unescaped: ""
+            │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_12402.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_12402.txt
@@ -14,22 +14,23 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (1,13)-(1,27))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ RescueModifierNode (location: (1,13)-(1,27))
-        │   │   │           ├── expression:
-        │   │   │           │   @ CallNode (location: (1,13)-(1,16))
-        │   │   │           │   ├── receiver: ∅
-        │   │   │           │   ├── call_operator_loc: ∅
-        │   │   │           │   ├── message_loc: (1,13)-(1,16) = "bar"
-        │   │   │           │   ├── opening_loc: ∅
-        │   │   │           │   ├── arguments: ∅
-        │   │   │           │   ├── closing_loc: ∅
-        │   │   │           │   ├── block: ∅
-        │   │   │           │   ├── flags: variable_call
-        │   │   │           │   └── name: :bar
-        │   │   │           ├── keyword_loc: (1,17)-(1,23) = "rescue"
-        │   │   │           └── rescue_expression:
-        │   │   │               @ NilNode (location: (1,24)-(1,27))
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ RescueModifierNode (location: (1,13)-(1,27))
+        │   │   │   │       ├── expression:
+        │   │   │   │       │   @ CallNode (location: (1,13)-(1,16))
+        │   │   │   │       │   ├── receiver: ∅
+        │   │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │   │       │   ├── message_loc: (1,13)-(1,16) = "bar"
+        │   │   │   │       │   ├── opening_loc: ∅
+        │   │   │   │       │   ├── arguments: ∅
+        │   │   │   │       │   ├── closing_loc: ∅
+        │   │   │   │       │   ├── block: ∅
+        │   │   │   │       │   ├── flags: variable_call
+        │   │   │   │       │   └── name: :bar
+        │   │   │   │       ├── keyword_loc: (1,17)-(1,23) = "rescue"
+        │   │   │   │       └── rescue_expression:
+        │   │   │   │           @ NilNode (location: (1,24)-(1,27))
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block: ∅
         │   │   ├── flags: ∅
@@ -50,17 +51,18 @@
         │   │   │   ├── opening_loc: (3,12)-(3,13) = "("
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (3,13)-(3,16))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ CallNode (location: (3,13)-(3,16))
-        │   │   │   │           ├── receiver: ∅
-        │   │   │   │           ├── call_operator_loc: ∅
-        │   │   │   │           ├── message_loc: (3,13)-(3,16) = "bar"
-        │   │   │   │           ├── opening_loc: ∅
-        │   │   │   │           ├── arguments: ∅
-        │   │   │   │           ├── closing_loc: ∅
-        │   │   │   │           ├── block: ∅
-        │   │   │   │           ├── flags: variable_call
-        │   │   │   │           └── name: :bar
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ CallNode (location: (3,13)-(3,16))
+        │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │       ├── message_loc: (3,13)-(3,16) = "bar"
+        │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │       ├── arguments: ∅
+        │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │       ├── flags: variable_call
+        │   │   │   │   │       └── name: :bar
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: (3,16)-(3,17) = ")"
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅
@@ -83,22 +85,23 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (5,12)-(5,26))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ RescueModifierNode (location: (5,12)-(5,26))
-        │   │   │           ├── expression:
-        │   │   │           │   @ CallNode (location: (5,12)-(5,15))
-        │   │   │           │   ├── receiver: ∅
-        │   │   │           │   ├── call_operator_loc: ∅
-        │   │   │           │   ├── message_loc: (5,12)-(5,15) = "bar"
-        │   │   │           │   ├── opening_loc: ∅
-        │   │   │           │   ├── arguments: ∅
-        │   │   │           │   ├── closing_loc: ∅
-        │   │   │           │   ├── block: ∅
-        │   │   │           │   ├── flags: variable_call
-        │   │   │           │   └── name: :bar
-        │   │   │           ├── keyword_loc: (5,16)-(5,22) = "rescue"
-        │   │   │           └── rescue_expression:
-        │   │   │               @ NilNode (location: (5,23)-(5,26))
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ RescueModifierNode (location: (5,12)-(5,26))
+        │   │   │   │       ├── expression:
+        │   │   │   │       │   @ CallNode (location: (5,12)-(5,15))
+        │   │   │   │       │   ├── receiver: ∅
+        │   │   │   │       │   ├── call_operator_loc: ∅
+        │   │   │   │       │   ├── message_loc: (5,12)-(5,15) = "bar"
+        │   │   │   │       │   ├── opening_loc: ∅
+        │   │   │   │       │   ├── arguments: ∅
+        │   │   │   │       │   ├── closing_loc: ∅
+        │   │   │   │       │   ├── block: ∅
+        │   │   │   │       │   ├── flags: variable_call
+        │   │   │   │       │   └── name: :bar
+        │   │   │   │       ├── keyword_loc: (5,16)-(5,22) = "rescue"
+        │   │   │   │       └── rescue_expression:
+        │   │   │   │           @ NilNode (location: (5,23)-(5,26))
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block: ∅
         │   │   ├── flags: ∅
@@ -118,17 +121,18 @@
         │   │   │   ├── opening_loc: (7,11)-(7,12) = "("
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (7,12)-(7,15))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ CallNode (location: (7,12)-(7,15))
-        │   │   │   │           ├── receiver: ∅
-        │   │   │   │           ├── call_operator_loc: ∅
-        │   │   │   │           ├── message_loc: (7,12)-(7,15) = "bar"
-        │   │   │   │           ├── opening_loc: ∅
-        │   │   │   │           ├── arguments: ∅
-        │   │   │   │           ├── closing_loc: ∅
-        │   │   │   │           ├── block: ∅
-        │   │   │   │           ├── flags: variable_call
-        │   │   │   │           └── name: :bar
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ CallNode (location: (7,12)-(7,15))
+        │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │       ├── message_loc: (7,12)-(7,15) = "bar"
+        │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │       ├── arguments: ∅
+        │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │       ├── flags: variable_call
+        │   │   │   │   │       └── name: :bar
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: (7,15)-(7,16) = ")"
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅
@@ -157,22 +161,23 @@
         │       ├── opening_loc: ∅
         │       ├── arguments:
         │       │   @ ArgumentsNode (location: (9,15)-(9,29))
-        │       │   └── arguments: (length: 1)
-        │       │       └── @ RescueModifierNode (location: (9,15)-(9,29))
-        │       │           ├── expression:
-        │       │           │   @ CallNode (location: (9,15)-(9,18))
-        │       │           │   ├── receiver: ∅
-        │       │           │   ├── call_operator_loc: ∅
-        │       │           │   ├── message_loc: (9,15)-(9,18) = "bar"
-        │       │           │   ├── opening_loc: ∅
-        │       │           │   ├── arguments: ∅
-        │       │           │   ├── closing_loc: ∅
-        │       │           │   ├── block: ∅
-        │       │           │   ├── flags: variable_call
-        │       │           │   └── name: :bar
-        │       │           ├── keyword_loc: (9,19)-(9,25) = "rescue"
-        │       │           └── rescue_expression:
-        │       │               @ NilNode (location: (9,26)-(9,29))
+        │       │   ├── arguments: (length: 1)
+        │       │   │   └── @ RescueModifierNode (location: (9,15)-(9,29))
+        │       │   │       ├── expression:
+        │       │   │       │   @ CallNode (location: (9,15)-(9,18))
+        │       │   │       │   ├── receiver: ∅
+        │       │   │       │   ├── call_operator_loc: ∅
+        │       │   │       │   ├── message_loc: (9,15)-(9,18) = "bar"
+        │       │   │       │   ├── opening_loc: ∅
+        │       │   │       │   ├── arguments: ∅
+        │       │   │       │   ├── closing_loc: ∅
+        │       │   │       │   ├── block: ∅
+        │       │   │       │   ├── flags: variable_call
+        │       │   │       │   └── name: :bar
+        │       │   │       ├── keyword_loc: (9,19)-(9,25) = "rescue"
+        │       │   │       └── rescue_expression:
+        │       │   │           @ NilNode (location: (9,26)-(9,29))
+        │       │   └── flags: ∅
         │       ├── closing_loc: ∅
         │       ├── block: ∅
         │       ├── flags: ∅
@@ -199,17 +204,18 @@
         │       │   ├── opening_loc: (11,14)-(11,15) = "("
         │       │   ├── arguments:
         │       │   │   @ ArgumentsNode (location: (11,15)-(11,18))
-        │       │   │   └── arguments: (length: 1)
-        │       │   │       └── @ CallNode (location: (11,15)-(11,18))
-        │       │   │           ├── receiver: ∅
-        │       │   │           ├── call_operator_loc: ∅
-        │       │   │           ├── message_loc: (11,15)-(11,18) = "bar"
-        │       │   │           ├── opening_loc: ∅
-        │       │   │           ├── arguments: ∅
-        │       │   │           ├── closing_loc: ∅
-        │       │   │           ├── block: ∅
-        │       │   │           ├── flags: variable_call
-        │       │   │           └── name: :bar
+        │       │   │   ├── arguments: (length: 1)
+        │       │   │   │   └── @ CallNode (location: (11,15)-(11,18))
+        │       │   │   │       ├── receiver: ∅
+        │       │   │   │       ├── call_operator_loc: ∅
+        │       │   │   │       ├── message_loc: (11,15)-(11,18) = "bar"
+        │       │   │   │       ├── opening_loc: ∅
+        │       │   │   │       ├── arguments: ∅
+        │       │   │   │       ├── closing_loc: ∅
+        │       │   │   │       ├── block: ∅
+        │       │   │   │       ├── flags: variable_call
+        │       │   │   │       └── name: :bar
+        │       │   │   └── flags: ∅
         │       │   ├── closing_loc: (11,18)-(11,19) = ")"
         │       │   ├── block: ∅
         │       │   ├── flags: ∅
@@ -237,22 +243,23 @@
         │       ├── opening_loc: ∅
         │       ├── arguments:
         │       │   @ ArgumentsNode (location: (13,15)-(13,29))
-        │       │   └── arguments: (length: 1)
-        │       │       └── @ RescueModifierNode (location: (13,15)-(13,29))
-        │       │           ├── expression:
-        │       │           │   @ CallNode (location: (13,15)-(13,18))
-        │       │           │   ├── receiver: ∅
-        │       │           │   ├── call_operator_loc: ∅
-        │       │           │   ├── message_loc: (13,15)-(13,18) = "bar"
-        │       │           │   ├── opening_loc: ∅
-        │       │           │   ├── arguments: ∅
-        │       │           │   ├── closing_loc: ∅
-        │       │           │   ├── block: ∅
-        │       │           │   ├── flags: variable_call
-        │       │           │   └── name: :bar
-        │       │           ├── keyword_loc: (13,19)-(13,25) = "rescue"
-        │       │           └── rescue_expression:
-        │       │               @ NilNode (location: (13,26)-(13,29))
+        │       │   ├── arguments: (length: 1)
+        │       │   │   └── @ RescueModifierNode (location: (13,15)-(13,29))
+        │       │   │       ├── expression:
+        │       │   │       │   @ CallNode (location: (13,15)-(13,18))
+        │       │   │       │   ├── receiver: ∅
+        │       │   │       │   ├── call_operator_loc: ∅
+        │       │   │       │   ├── message_loc: (13,15)-(13,18) = "bar"
+        │       │   │       │   ├── opening_loc: ∅
+        │       │   │       │   ├── arguments: ∅
+        │       │   │       │   ├── closing_loc: ∅
+        │       │   │       │   ├── block: ∅
+        │       │   │       │   ├── flags: variable_call
+        │       │   │       │   └── name: :bar
+        │       │   │       ├── keyword_loc: (13,19)-(13,25) = "rescue"
+        │       │   │       └── rescue_expression:
+        │       │   │           @ NilNode (location: (13,26)-(13,29))
+        │       │   └── flags: ∅
         │       ├── closing_loc: ∅
         │       ├── block: ∅
         │       ├── flags: ∅
@@ -279,17 +286,18 @@
         │       │   ├── opening_loc: (15,14)-(15,15) = "("
         │       │   ├── arguments:
         │       │   │   @ ArgumentsNode (location: (15,15)-(15,18))
-        │       │   │   └── arguments: (length: 1)
-        │       │   │       └── @ CallNode (location: (15,15)-(15,18))
-        │       │   │           ├── receiver: ∅
-        │       │   │           ├── call_operator_loc: ∅
-        │       │   │           ├── message_loc: (15,15)-(15,18) = "bar"
-        │       │   │           ├── opening_loc: ∅
-        │       │   │           ├── arguments: ∅
-        │       │   │           ├── closing_loc: ∅
-        │       │   │           ├── block: ∅
-        │       │   │           ├── flags: variable_call
-        │       │   │           └── name: :bar
+        │       │   │   ├── arguments: (length: 1)
+        │       │   │   │   └── @ CallNode (location: (15,15)-(15,18))
+        │       │   │   │       ├── receiver: ∅
+        │       │   │   │       ├── call_operator_loc: ∅
+        │       │   │   │       ├── message_loc: (15,15)-(15,18) = "bar"
+        │       │   │   │       ├── opening_loc: ∅
+        │       │   │   │       ├── arguments: ∅
+        │       │   │   │       ├── closing_loc: ∅
+        │       │   │   │       ├── block: ∅
+        │       │   │   │       ├── flags: variable_call
+        │       │   │   │       └── name: :bar
+        │       │   │   └── flags: ∅
         │       │   ├── closing_loc: (15,18)-(15,19) = ")"
         │       │   ├── block: ∅
         │       │   ├── flags: ∅
@@ -317,22 +325,23 @@
         │       ├── opening_loc: ∅
         │       ├── arguments:
         │       │   @ ArgumentsNode (location: (17,17)-(17,31))
-        │       │   └── arguments: (length: 1)
-        │       │       └── @ RescueModifierNode (location: (17,17)-(17,31))
-        │       │           ├── expression:
-        │       │           │   @ CallNode (location: (17,17)-(17,20))
-        │       │           │   ├── receiver: ∅
-        │       │           │   ├── call_operator_loc: ∅
-        │       │           │   ├── message_loc: (17,17)-(17,20) = "bar"
-        │       │           │   ├── opening_loc: ∅
-        │       │           │   ├── arguments: ∅
-        │       │           │   ├── closing_loc: ∅
-        │       │           │   ├── block: ∅
-        │       │           │   ├── flags: variable_call
-        │       │           │   └── name: :bar
-        │       │           ├── keyword_loc: (17,21)-(17,27) = "rescue"
-        │       │           └── rescue_expression:
-        │       │               @ NilNode (location: (17,28)-(17,31))
+        │       │   ├── arguments: (length: 1)
+        │       │   │   └── @ RescueModifierNode (location: (17,17)-(17,31))
+        │       │   │       ├── expression:
+        │       │   │       │   @ CallNode (location: (17,17)-(17,20))
+        │       │   │       │   ├── receiver: ∅
+        │       │   │       │   ├── call_operator_loc: ∅
+        │       │   │       │   ├── message_loc: (17,17)-(17,20) = "bar"
+        │       │   │       │   ├── opening_loc: ∅
+        │       │   │       │   ├── arguments: ∅
+        │       │   │       │   ├── closing_loc: ∅
+        │       │   │       │   ├── block: ∅
+        │       │   │       │   ├── flags: variable_call
+        │       │   │       │   └── name: :bar
+        │       │   │       ├── keyword_loc: (17,21)-(17,27) = "rescue"
+        │       │   │       └── rescue_expression:
+        │       │   │           @ NilNode (location: (17,28)-(17,31))
+        │       │   └── flags: ∅
         │       ├── closing_loc: ∅
         │       ├── block: ∅
         │       ├── flags: ∅
@@ -359,17 +368,18 @@
         │       │   ├── opening_loc: (19,16)-(19,17) = "("
         │       │   ├── arguments:
         │       │   │   @ ArgumentsNode (location: (19,17)-(19,20))
-        │       │   │   └── arguments: (length: 1)
-        │       │   │       └── @ CallNode (location: (19,17)-(19,20))
-        │       │   │           ├── receiver: ∅
-        │       │   │           ├── call_operator_loc: ∅
-        │       │   │           ├── message_loc: (19,17)-(19,20) = "bar"
-        │       │   │           ├── opening_loc: ∅
-        │       │   │           ├── arguments: ∅
-        │       │   │           ├── closing_loc: ∅
-        │       │   │           ├── block: ∅
-        │       │   │           ├── flags: variable_call
-        │       │   │           └── name: :bar
+        │       │   │   ├── arguments: (length: 1)
+        │       │   │   │   └── @ CallNode (location: (19,17)-(19,20))
+        │       │   │   │       ├── receiver: ∅
+        │       │   │   │       ├── call_operator_loc: ∅
+        │       │   │   │       ├── message_loc: (19,17)-(19,20) = "bar"
+        │       │   │   │       ├── opening_loc: ∅
+        │       │   │   │       ├── arguments: ∅
+        │       │   │   │       ├── closing_loc: ∅
+        │       │   │   │       ├── block: ∅
+        │       │   │   │       ├── flags: variable_call
+        │       │   │   │       └── name: :bar
+        │       │   │   └── flags: ∅
         │       │   ├── closing_loc: (19,20)-(19,21) = ")"
         │       │   ├── block: ∅
         │       │   ├── flags: ∅
@@ -397,22 +407,23 @@
         │       ├── opening_loc: ∅
         │       ├── arguments:
         │       │   @ ArgumentsNode (location: (21,16)-(21,30))
-        │       │   └── arguments: (length: 1)
-        │       │       └── @ RescueModifierNode (location: (21,16)-(21,30))
-        │       │           ├── expression:
-        │       │           │   @ CallNode (location: (21,16)-(21,19))
-        │       │           │   ├── receiver: ∅
-        │       │           │   ├── call_operator_loc: ∅
-        │       │           │   ├── message_loc: (21,16)-(21,19) = "bar"
-        │       │           │   ├── opening_loc: ∅
-        │       │           │   ├── arguments: ∅
-        │       │           │   ├── closing_loc: ∅
-        │       │           │   ├── block: ∅
-        │       │           │   ├── flags: variable_call
-        │       │           │   └── name: :bar
-        │       │           ├── keyword_loc: (21,20)-(21,26) = "rescue"
-        │       │           └── rescue_expression:
-        │       │               @ NilNode (location: (21,27)-(21,30))
+        │       │   ├── arguments: (length: 1)
+        │       │   │   └── @ RescueModifierNode (location: (21,16)-(21,30))
+        │       │   │       ├── expression:
+        │       │   │       │   @ CallNode (location: (21,16)-(21,19))
+        │       │   │       │   ├── receiver: ∅
+        │       │   │       │   ├── call_operator_loc: ∅
+        │       │   │       │   ├── message_loc: (21,16)-(21,19) = "bar"
+        │       │   │       │   ├── opening_loc: ∅
+        │       │   │       │   ├── arguments: ∅
+        │       │   │       │   ├── closing_loc: ∅
+        │       │   │       │   ├── block: ∅
+        │       │   │       │   ├── flags: variable_call
+        │       │   │       │   └── name: :bar
+        │       │   │       ├── keyword_loc: (21,20)-(21,26) = "rescue"
+        │       │   │       └── rescue_expression:
+        │       │   │           @ NilNode (location: (21,27)-(21,30))
+        │       │   └── flags: ∅
         │       ├── closing_loc: ∅
         │       ├── block: ∅
         │       ├── flags: ∅
@@ -439,17 +450,18 @@
         │       │   ├── opening_loc: (23,15)-(23,16) = "("
         │       │   ├── arguments:
         │       │   │   @ ArgumentsNode (location: (23,16)-(23,19))
-        │       │   │   └── arguments: (length: 1)
-        │       │   │       └── @ CallNode (location: (23,16)-(23,19))
-        │       │   │           ├── receiver: ∅
-        │       │   │           ├── call_operator_loc: ∅
-        │       │   │           ├── message_loc: (23,16)-(23,19) = "bar"
-        │       │   │           ├── opening_loc: ∅
-        │       │   │           ├── arguments: ∅
-        │       │   │           ├── closing_loc: ∅
-        │       │   │           ├── block: ∅
-        │       │   │           ├── flags: variable_call
-        │       │   │           └── name: :bar
+        │       │   │   ├── arguments: (length: 1)
+        │       │   │   │   └── @ CallNode (location: (23,16)-(23,19))
+        │       │   │   │       ├── receiver: ∅
+        │       │   │   │       ├── call_operator_loc: ∅
+        │       │   │   │       ├── message_loc: (23,16)-(23,19) = "bar"
+        │       │   │   │       ├── opening_loc: ∅
+        │       │   │   │       ├── arguments: ∅
+        │       │   │   │       ├── closing_loc: ∅
+        │       │   │   │       ├── block: ∅
+        │       │   │   │       ├── flags: variable_call
+        │       │   │   │       └── name: :bar
+        │       │   │   └── flags: ∅
         │       │   ├── closing_loc: (23,19)-(23,20) = ")"
         │       │   ├── block: ∅
         │       │   ├── flags: ∅
@@ -466,9 +478,10 @@
         │   ├── opening_loc: (25,3)-(25,4) = "["
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (25,4)-(25,5))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (25,4)-(25,5))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (25,4)-(25,5))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (25,5)-(25,6) = "]"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -482,22 +495,23 @@
         │       ├── opening_loc: ∅
         │       ├── arguments:
         │       │   @ ArgumentsNode (location: (25,16)-(25,30))
-        │       │   └── arguments: (length: 1)
-        │       │       └── @ RescueModifierNode (location: (25,16)-(25,30))
-        │       │           ├── expression:
-        │       │           │   @ CallNode (location: (25,16)-(25,19))
-        │       │           │   ├── receiver: ∅
-        │       │           │   ├── call_operator_loc: ∅
-        │       │           │   ├── message_loc: (25,16)-(25,19) = "bar"
-        │       │           │   ├── opening_loc: ∅
-        │       │           │   ├── arguments: ∅
-        │       │           │   ├── closing_loc: ∅
-        │       │           │   ├── block: ∅
-        │       │           │   ├── flags: variable_call
-        │       │           │   └── name: :bar
-        │       │           ├── keyword_loc: (25,20)-(25,26) = "rescue"
-        │       │           └── rescue_expression:
-        │       │               @ NilNode (location: (25,27)-(25,30))
+        │       │   ├── arguments: (length: 1)
+        │       │   │   └── @ RescueModifierNode (location: (25,16)-(25,30))
+        │       │   │       ├── expression:
+        │       │   │       │   @ CallNode (location: (25,16)-(25,19))
+        │       │   │       │   ├── receiver: ∅
+        │       │   │       │   ├── call_operator_loc: ∅
+        │       │   │       │   ├── message_loc: (25,16)-(25,19) = "bar"
+        │       │   │       │   ├── opening_loc: ∅
+        │       │   │       │   ├── arguments: ∅
+        │       │   │       │   ├── closing_loc: ∅
+        │       │   │       │   ├── block: ∅
+        │       │   │       │   ├── flags: variable_call
+        │       │   │       │   └── name: :bar
+        │       │   │       ├── keyword_loc: (25,20)-(25,26) = "rescue"
+        │       │   │       └── rescue_expression:
+        │       │   │           @ NilNode (location: (25,27)-(25,30))
+        │       │   └── flags: ∅
         │       ├── closing_loc: ∅
         │       ├── block: ∅
         │       ├── flags: ∅
@@ -511,9 +525,10 @@
             ├── opening_loc: (27,3)-(27,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (27,4)-(27,5))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (27,4)-(27,5))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (27,4)-(27,5))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (27,5)-(27,6) = "]"
             ├── block: ∅
             ├── flags: ∅
@@ -529,17 +544,18 @@
                 │   ├── opening_loc: (27,15)-(27,16) = "("
                 │   ├── arguments:
                 │   │   @ ArgumentsNode (location: (27,16)-(27,19))
-                │   │   └── arguments: (length: 1)
-                │   │       └── @ CallNode (location: (27,16)-(27,19))
-                │   │           ├── receiver: ∅
-                │   │           ├── call_operator_loc: ∅
-                │   │           ├── message_loc: (27,16)-(27,19) = "bar"
-                │   │           ├── opening_loc: ∅
-                │   │           ├── arguments: ∅
-                │   │           ├── closing_loc: ∅
-                │   │           ├── block: ∅
-                │   │           ├── flags: variable_call
-                │   │           └── name: :bar
+                │   │   ├── arguments: (length: 1)
+                │   │   │   └── @ CallNode (location: (27,16)-(27,19))
+                │   │   │       ├── receiver: ∅
+                │   │   │       ├── call_operator_loc: ∅
+                │   │   │       ├── message_loc: (27,16)-(27,19) = "bar"
+                │   │   │       ├── opening_loc: ∅
+                │   │   │       ├── arguments: ∅
+                │   │   │       ├── closing_loc: ∅
+                │   │   │       ├── block: ∅
+                │   │   │       ├── flags: variable_call
+                │   │   │       └── name: :bar
+                │   │   └── flags: ∅
                 │   ├── closing_loc: (27,19)-(27,20) = ")"
                 │   ├── block: ∅
                 │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_12669.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_12669.txt
@@ -18,12 +18,13 @@
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (1,16)-(1,18))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ SymbolNode (location: (1,16)-(1,18))
-        │   │   │   │           ├── opening_loc: (1,16)-(1,17) = ":"
-        │   │   │   │           ├── value_loc: (1,17)-(1,18) = "x"
-        │   │   │   │           ├── closing_loc: ∅
-        │   │   │   │           └── unescaped: "x"
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ SymbolNode (location: (1,16)-(1,18))
+        │   │   │   │   │       ├── opening_loc: (1,16)-(1,17) = ":"
+        │   │   │   │   │       ├── value_loc: (1,17)-(1,18) = "x"
+        │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │       └── unescaped: "x"
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: ∅
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅
@@ -50,12 +51,13 @@
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (3,15)-(3,17))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ SymbolNode (location: (3,15)-(3,17))
-        │   │   │   │           ├── opening_loc: (3,15)-(3,16) = ":"
-        │   │   │   │           ├── value_loc: (3,16)-(3,17) = "x"
-        │   │   │   │           ├── closing_loc: ∅
-        │   │   │   │           └── unescaped: "x"
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ SymbolNode (location: (3,15)-(3,17))
+        │   │   │   │   │       ├── opening_loc: (3,15)-(3,16) = ":"
+        │   │   │   │   │       ├── value_loc: (3,16)-(3,17) = "x"
+        │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │       └── unescaped: "x"
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: ∅
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅
@@ -80,12 +82,13 @@
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── arguments:
         │   │   │   │   @ ArgumentsNode (location: (5,15)-(5,17))
-        │   │   │   │   └── arguments: (length: 1)
-        │   │   │   │       └── @ SymbolNode (location: (5,15)-(5,17))
-        │   │   │   │           ├── opening_loc: (5,15)-(5,16) = ":"
-        │   │   │   │           ├── value_loc: (5,16)-(5,17) = "x"
-        │   │   │   │           ├── closing_loc: ∅
-        │   │   │   │           └── unescaped: "x"
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ SymbolNode (location: (5,15)-(5,17))
+        │   │   │   │   │       ├── opening_loc: (5,15)-(5,16) = ":"
+        │   │   │   │   │       ├── value_loc: (5,16)-(5,17) = "x"
+        │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │       └── unescaped: "x"
+        │   │   │   │   └── flags: ∅
         │   │   │   ├── closing_loc: ∅
         │   │   │   ├── block: ∅
         │   │   │   ├── flags: ∅
@@ -111,12 +114,13 @@
             │   │   ├── opening_loc: ∅
             │   │   ├── arguments:
             │   │   │   @ ArgumentsNode (location: (7,14)-(7,16))
-            │   │   │   └── arguments: (length: 1)
-            │   │   │       └── @ SymbolNode (location: (7,14)-(7,16))
-            │   │   │           ├── opening_loc: (7,14)-(7,15) = ":"
-            │   │   │           ├── value_loc: (7,15)-(7,16) = "x"
-            │   │   │           ├── closing_loc: ∅
-            │   │   │           └── unescaped: "x"
+            │   │   │   ├── arguments: (length: 1)
+            │   │   │   │   └── @ SymbolNode (location: (7,14)-(7,16))
+            │   │   │   │       ├── opening_loc: (7,14)-(7,15) = ":"
+            │   │   │   │       ├── value_loc: (7,15)-(7,16) = "x"
+            │   │   │   │       ├── closing_loc: ∅
+            │   │   │   │       └── unescaped: "x"
+            │   │   │   └── flags: ∅
             │   │   ├── closing_loc: ∅
             │   │   ├── block: ∅
             │   │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_12686.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_12686.txt
@@ -10,28 +10,29 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,2)-(1,16))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,2)-(1,16))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,3)-(1,15))
-            │           │   └── body: (length: 1)
-            │           │       └── @ RescueModifierNode (location: (1,3)-(1,15))
-            │           │           ├── expression:
-            │           │           │   @ CallNode (location: (1,3)-(1,4))
-            │           │           │   ├── receiver: ∅
-            │           │           │   ├── call_operator_loc: ∅
-            │           │           │   ├── message_loc: (1,3)-(1,4) = "g"
-            │           │           │   ├── opening_loc: ∅
-            │           │           │   ├── arguments: ∅
-            │           │           │   ├── closing_loc: ∅
-            │           │           │   ├── block: ∅
-            │           │           │   ├── flags: variable_call
-            │           │           │   └── name: :g
-            │           │           ├── keyword_loc: (1,5)-(1,11) = "rescue"
-            │           │           └── rescue_expression:
-            │           │               @ NilNode (location: (1,12)-(1,15))
-            │           ├── opening_loc: (1,2)-(1,3) = "("
-            │           └── closing_loc: (1,15)-(1,16) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,2)-(1,16))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,3)-(1,15))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ RescueModifierNode (location: (1,3)-(1,15))
+            │   │       │           ├── expression:
+            │   │       │           │   @ CallNode (location: (1,3)-(1,4))
+            │   │       │           │   ├── receiver: ∅
+            │   │       │           │   ├── call_operator_loc: ∅
+            │   │       │           │   ├── message_loc: (1,3)-(1,4) = "g"
+            │   │       │           │   ├── opening_loc: ∅
+            │   │       │           │   ├── arguments: ∅
+            │   │       │           │   ├── closing_loc: ∅
+            │   │       │           │   ├── block: ∅
+            │   │       │           │   ├── flags: variable_call
+            │   │       │           │   └── name: :g
+            │   │       │           ├── keyword_loc: (1,5)-(1,11) = "rescue"
+            │   │       │           └── rescue_expression:
+            │   │       │               @ NilNode (location: (1,12)-(1,15))
+            │   │       ├── opening_loc: (1,2)-(1,3) = "("
+            │   │       └── closing_loc: (1,15)-(1,16) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_14690.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_14690.txt
@@ -10,11 +10,12 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,4)-(1,6))
-            │           ├── body: ∅
-            │           ├── opening_loc: (1,4)-(1,5) = "("
-            │           └── closing_loc: (1,5)-(1,6) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,4)-(1,6))
+            │   │       ├── body: ∅
+            │   │       ├── opening_loc: (1,4)-(1,5) = "("
+            │   │       └── closing_loc: (1,5)-(1,6) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,7)-(1,23))
@@ -30,17 +31,18 @@
             │   │           ├── opening_loc: (1,10)-(1,11) = "("
             │   │           ├── arguments:
             │   │           │   @ ArgumentsNode (location: (1,11)-(1,12))
-            │   │           │   └── arguments: (length: 1)
-            │   │           │       └── @ CallNode (location: (1,11)-(1,12))
-            │   │           │           ├── receiver: ∅
-            │   │           │           ├── call_operator_loc: ∅
-            │   │           │           ├── message_loc: (1,11)-(1,12) = "a"
-            │   │           │           ├── opening_loc: ∅
-            │   │           │           ├── arguments: ∅
-            │   │           │           ├── closing_loc: ∅
-            │   │           │           ├── block: ∅
-            │   │           │           ├── flags: variable_call
-            │   │           │           └── name: :a
+            │   │           │   ├── arguments: (length: 1)
+            │   │           │   │   └── @ CallNode (location: (1,11)-(1,12))
+            │   │           │   │       ├── receiver: ∅
+            │   │           │   │       ├── call_operator_loc: ∅
+            │   │           │   │       ├── message_loc: (1,11)-(1,12) = "a"
+            │   │           │   │       ├── opening_loc: ∅
+            │   │           │   │       ├── arguments: ∅
+            │   │           │   │       ├── closing_loc: ∅
+            │   │           │   │       ├── block: ∅
+            │   │           │   │       ├── flags: variable_call
+            │   │           │   │       └── name: :a
+            │   │           │   └── flags: ∅
             │   │           ├── closing_loc: (1,12)-(1,13) = ")"
             │   │           ├── block:
             │   │           │   @ BlockNode (location: (1,14)-(1,21))

--- a/test/prism/snapshots/whitequark/ruby_bug_15789.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_15789.txt
@@ -10,49 +10,50 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,2)-(1,20))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ LambdaNode (location: (1,2)-(1,20))
-        │   │           ├── locals: [:a]
-        │   │           ├── operator_loc: (1,2)-(1,4) = "->"
-        │   │           ├── opening_loc: (1,17)-(1,18) = "{"
-        │   │           ├── closing_loc: (1,19)-(1,20) = "}"
-        │   │           ├── parameters:
-        │   │           │   @ BlockParametersNode (location: (1,4)-(1,16))
-        │   │           │   ├── parameters:
-        │   │           │   │   @ ParametersNode (location: (1,5)-(1,15))
-        │   │           │   │   ├── requireds: (length: 0)
-        │   │           │   │   ├── optionals: (length: 1)
-        │   │           │   │   │   └── @ OptionalParameterNode (location: (1,5)-(1,15))
-        │   │           │   │   │       ├── name: :a
-        │   │           │   │   │       ├── name_loc: (1,5)-(1,6) = "a"
-        │   │           │   │   │       ├── operator_loc: (1,7)-(1,8) = "="
-        │   │           │   │   │       └── value:
-        │   │           │   │   │           @ LambdaNode (location: (1,9)-(1,15))
-        │   │           │   │   │           ├── locals: [:_1]
-        │   │           │   │   │           ├── operator_loc: (1,9)-(1,11) = "->"
-        │   │           │   │   │           ├── opening_loc: (1,11)-(1,12) = "{"
-        │   │           │   │   │           ├── closing_loc: (1,14)-(1,15) = "}"
-        │   │           │   │   │           ├── parameters: ∅
-        │   │           │   │   │           └── body:
-        │   │           │   │   │               @ StatementsNode (location: (1,12)-(1,14))
-        │   │           │   │   │               └── body: (length: 1)
-        │   │           │   │   │                   └── @ LocalVariableReadNode (location: (1,12)-(1,14))
-        │   │           │   │   │                       ├── name: :_1
-        │   │           │   │   │                       └── depth: 0
-        │   │           │   │   ├── rest: ∅
-        │   │           │   │   ├── posts: (length: 0)
-        │   │           │   │   ├── keywords: (length: 0)
-        │   │           │   │   ├── keyword_rest: ∅
-        │   │           │   │   └── block: ∅
-        │   │           │   ├── locals: (length: 0)
-        │   │           │   ├── opening_loc: (1,4)-(1,5) = "("
-        │   │           │   └── closing_loc: (1,15)-(1,16) = ")"
-        │   │           └── body:
-        │   │               @ StatementsNode (location: (1,18)-(1,19))
-        │   │               └── body: (length: 1)
-        │   │                   └── @ LocalVariableReadNode (location: (1,18)-(1,19))
-        │   │                       ├── name: :a
-        │   │                       └── depth: 0
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ LambdaNode (location: (1,2)-(1,20))
+        │   │   │       ├── locals: [:a]
+        │   │   │       ├── operator_loc: (1,2)-(1,4) = "->"
+        │   │   │       ├── opening_loc: (1,17)-(1,18) = "{"
+        │   │   │       ├── closing_loc: (1,19)-(1,20) = "}"
+        │   │   │       ├── parameters:
+        │   │   │       │   @ BlockParametersNode (location: (1,4)-(1,16))
+        │   │   │       │   ├── parameters:
+        │   │   │       │   │   @ ParametersNode (location: (1,5)-(1,15))
+        │   │   │       │   │   ├── requireds: (length: 0)
+        │   │   │       │   │   ├── optionals: (length: 1)
+        │   │   │       │   │   │   └── @ OptionalParameterNode (location: (1,5)-(1,15))
+        │   │   │       │   │   │       ├── name: :a
+        │   │   │       │   │   │       ├── name_loc: (1,5)-(1,6) = "a"
+        │   │   │       │   │   │       ├── operator_loc: (1,7)-(1,8) = "="
+        │   │   │       │   │   │       └── value:
+        │   │   │       │   │   │           @ LambdaNode (location: (1,9)-(1,15))
+        │   │   │       │   │   │           ├── locals: [:_1]
+        │   │   │       │   │   │           ├── operator_loc: (1,9)-(1,11) = "->"
+        │   │   │       │   │   │           ├── opening_loc: (1,11)-(1,12) = "{"
+        │   │   │       │   │   │           ├── closing_loc: (1,14)-(1,15) = "}"
+        │   │   │       │   │   │           ├── parameters: ∅
+        │   │   │       │   │   │           └── body:
+        │   │   │       │   │   │               @ StatementsNode (location: (1,12)-(1,14))
+        │   │   │       │   │   │               └── body: (length: 1)
+        │   │   │       │   │   │                   └── @ LocalVariableReadNode (location: (1,12)-(1,14))
+        │   │   │       │   │   │                       ├── name: :_1
+        │   │   │       │   │   │                       └── depth: 0
+        │   │   │       │   │   ├── rest: ∅
+        │   │   │       │   │   ├── posts: (length: 0)
+        │   │   │       │   │   ├── keywords: (length: 0)
+        │   │   │       │   │   ├── keyword_rest: ∅
+        │   │   │       │   │   └── block: ∅
+        │   │   │       │   ├── locals: (length: 0)
+        │   │   │       │   ├── opening_loc: (1,4)-(1,5) = "("
+        │   │   │       │   └── closing_loc: (1,15)-(1,16) = ")"
+        │   │   │       └── body:
+        │   │   │           @ StatementsNode (location: (1,18)-(1,19))
+        │   │   │           └── body: (length: 1)
+        │   │   │               └── @ LocalVariableReadNode (location: (1,18)-(1,19))
+        │   │   │                   ├── name: :a
+        │   │   │                   └── depth: 0
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -64,48 +65,49 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (3,2)-(3,19))
-            │   └── arguments: (length: 1)
-            │       └── @ LambdaNode (location: (3,2)-(3,19))
-            │           ├── locals: [:a]
-            │           ├── operator_loc: (3,2)-(3,4) = "->"
-            │           ├── opening_loc: (3,16)-(3,17) = "{"
-            │           ├── closing_loc: (3,18)-(3,19) = "}"
-            │           ├── parameters:
-            │           │   @ BlockParametersNode (location: (3,4)-(3,15))
-            │           │   ├── parameters:
-            │           │   │   @ ParametersNode (location: (3,5)-(3,14))
-            │           │   │   ├── requireds: (length: 0)
-            │           │   │   ├── optionals: (length: 0)
-            │           │   │   ├── rest: ∅
-            │           │   │   ├── posts: (length: 0)
-            │           │   │   ├── keywords: (length: 1)
-            │           │   │   │   └── @ KeywordParameterNode (location: (3,5)-(3,14))
-            │           │   │   │       ├── name: :a
-            │           │   │   │       ├── name_loc: (3,5)-(3,7) = "a:"
-            │           │   │   │       └── value:
-            │           │   │   │           @ LambdaNode (location: (3,8)-(3,14))
-            │           │   │   │           ├── locals: [:_1]
-            │           │   │   │           ├── operator_loc: (3,8)-(3,10) = "->"
-            │           │   │   │           ├── opening_loc: (3,10)-(3,11) = "{"
-            │           │   │   │           ├── closing_loc: (3,13)-(3,14) = "}"
-            │           │   │   │           ├── parameters: ∅
-            │           │   │   │           └── body:
-            │           │   │   │               @ StatementsNode (location: (3,11)-(3,13))
-            │           │   │   │               └── body: (length: 1)
-            │           │   │   │                   └── @ LocalVariableReadNode (location: (3,11)-(3,13))
-            │           │   │   │                       ├── name: :_1
-            │           │   │   │                       └── depth: 0
-            │           │   │   ├── keyword_rest: ∅
-            │           │   │   └── block: ∅
-            │           │   ├── locals: (length: 0)
-            │           │   ├── opening_loc: (3,4)-(3,5) = "("
-            │           │   └── closing_loc: (3,14)-(3,15) = ")"
-            │           └── body:
-            │               @ StatementsNode (location: (3,17)-(3,18))
-            │               └── body: (length: 1)
-            │                   └── @ LocalVariableReadNode (location: (3,17)-(3,18))
-            │                       ├── name: :a
-            │                       └── depth: 0
+            │   ├── arguments: (length: 1)
+            │   │   └── @ LambdaNode (location: (3,2)-(3,19))
+            │   │       ├── locals: [:a]
+            │   │       ├── operator_loc: (3,2)-(3,4) = "->"
+            │   │       ├── opening_loc: (3,16)-(3,17) = "{"
+            │   │       ├── closing_loc: (3,18)-(3,19) = "}"
+            │   │       ├── parameters:
+            │   │       │   @ BlockParametersNode (location: (3,4)-(3,15))
+            │   │       │   ├── parameters:
+            │   │       │   │   @ ParametersNode (location: (3,5)-(3,14))
+            │   │       │   │   ├── requireds: (length: 0)
+            │   │       │   │   ├── optionals: (length: 0)
+            │   │       │   │   ├── rest: ∅
+            │   │       │   │   ├── posts: (length: 0)
+            │   │       │   │   ├── keywords: (length: 1)
+            │   │       │   │   │   └── @ KeywordParameterNode (location: (3,5)-(3,14))
+            │   │       │   │   │       ├── name: :a
+            │   │       │   │   │       ├── name_loc: (3,5)-(3,7) = "a:"
+            │   │       │   │   │       └── value:
+            │   │       │   │   │           @ LambdaNode (location: (3,8)-(3,14))
+            │   │       │   │   │           ├── locals: [:_1]
+            │   │       │   │   │           ├── operator_loc: (3,8)-(3,10) = "->"
+            │   │       │   │   │           ├── opening_loc: (3,10)-(3,11) = "{"
+            │   │       │   │   │           ├── closing_loc: (3,13)-(3,14) = "}"
+            │   │       │   │   │           ├── parameters: ∅
+            │   │       │   │   │           └── body:
+            │   │       │   │   │               @ StatementsNode (location: (3,11)-(3,13))
+            │   │       │   │   │               └── body: (length: 1)
+            │   │       │   │   │                   └── @ LocalVariableReadNode (location: (3,11)-(3,13))
+            │   │       │   │   │                       ├── name: :_1
+            │   │       │   │   │                       └── depth: 0
+            │   │       │   │   ├── keyword_rest: ∅
+            │   │       │   │   └── block: ∅
+            │   │       │   ├── locals: (length: 0)
+            │   │       │   ├── opening_loc: (3,4)-(3,5) = "("
+            │   │       │   └── closing_loc: (3,14)-(3,15) = ")"
+            │   │       └── body:
+            │   │           @ StatementsNode (location: (3,17)-(3,18))
+            │   │           └── body: (length: 1)
+            │   │               └── @ LocalVariableReadNode (location: (3,17)-(3,18))
+            │   │                   ├── name: :a
+            │   │                   └── depth: 0
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_attr_asgn.txt
+++ b/test/prism/snapshots/whitequark/send_attr_asgn.txt
@@ -20,9 +20,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,8)-(1,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (1,8)-(1,9))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (1,8)-(1,9))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -44,9 +45,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,8)-(3,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (3,8)-(3,9))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (3,8)-(3,9))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -90,9 +92,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (7,9)-(7,10))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (7,9)-(7,10))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (7,9)-(7,10))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_attr_asgn_conditional.txt
+++ b/test/prism/snapshots/whitequark/send_attr_asgn_conditional.txt
@@ -20,9 +20,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,7)-(1,8))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (1,7)-(1,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (1,7)-(1,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: safe_navigation

--- a/test/prism/snapshots/whitequark/send_binary_op.txt
+++ b/test/prism/snapshots/whitequark/send_binary_op.txt
@@ -20,9 +20,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,7)-(1,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (1,7)-(1,8))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (1,7)-(1,8))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -44,9 +45,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,7)-(3,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (3,7)-(3,8))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (3,7)-(3,8))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -68,9 +70,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,6)-(5,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (5,6)-(5,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (5,6)-(5,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -92,9 +95,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,6)-(7,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (7,6)-(7,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (7,6)-(7,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -116,9 +120,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (9,6)-(9,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (9,6)-(9,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (9,6)-(9,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -140,9 +145,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (11,7)-(11,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (11,7)-(11,8))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (11,7)-(11,8))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -164,9 +170,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (13,6)-(13,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (13,6)-(13,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (13,6)-(13,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -188,9 +195,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (15,6)-(15,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (15,6)-(15,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (15,6)-(15,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -212,9 +220,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (17,6)-(17,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (17,6)-(17,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (17,6)-(17,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -236,9 +245,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (19,6)-(19,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (19,6)-(19,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (19,6)-(19,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -260,9 +270,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (21,7)-(21,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (21,7)-(21,8))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (21,7)-(21,8))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -284,9 +295,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (23,7)-(23,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (23,7)-(23,8))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (23,7)-(23,8))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -308,9 +320,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (25,8)-(25,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (25,8)-(25,9))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (25,8)-(25,9))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -332,9 +345,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (27,7)-(27,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (27,7)-(27,8))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (27,7)-(27,8))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -356,9 +370,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (29,8)-(29,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (29,8)-(29,9))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (29,8)-(29,9))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -380,9 +395,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (31,7)-(31,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (31,7)-(31,8))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (31,7)-(31,8))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -404,9 +420,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (33,6)-(33,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (33,6)-(33,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (33,6)-(33,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -428,9 +445,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (35,7)-(35,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (35,7)-(35,8))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (35,7)-(35,8))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -452,9 +470,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (37,7)-(37,8))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (37,7)-(37,8))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (37,7)-(37,8))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -476,9 +495,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (39,6)-(39,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (39,6)-(39,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (39,6)-(39,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -500,9 +520,10 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (41,6)-(41,7))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (41,6)-(41,7))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (41,6)-(41,7))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_block_chain_cmd.txt
+++ b/test/prism/snapshots/whitequark/send_block_chain_cmd.txt
@@ -12,9 +12,10 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (1,5)-(1,6))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ IntegerNode (location: (1,5)-(1,6))
-        │   │   │           └── flags: decimal
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ IntegerNode (location: (1,5)-(1,6))
+        │   │   │   │       └── flags: decimal
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block:
         │   │   │   @ BlockNode (location: (1,7)-(1,13))
@@ -30,17 +31,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,18)-(1,21))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (1,18)-(1,21))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (1,18)-(1,21) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (1,18)-(1,21))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (1,18)-(1,21) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -54,9 +56,10 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (3,5)-(3,6))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ IntegerNode (location: (3,5)-(3,6))
-        │   │   │           └── flags: decimal
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ IntegerNode (location: (3,5)-(3,6))
+        │   │   │   │       └── flags: decimal
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block:
         │   │   │   @ BlockNode (location: (3,7)-(3,13))
@@ -72,17 +75,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,18)-(3,21))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (3,18)-(3,21))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (3,18)-(3,21) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (3,18)-(3,21))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (3,18)-(3,21) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (3,22)-(3,28))
@@ -102,9 +106,10 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (5,5)-(5,6))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ IntegerNode (location: (5,5)-(5,6))
-        │   │   │           └── flags: decimal
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ IntegerNode (location: (5,5)-(5,6))
+        │   │   │   │       └── flags: decimal
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block:
         │   │   │   @ BlockNode (location: (5,7)-(5,13))
@@ -138,9 +143,10 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (7,5)-(7,6))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ IntegerNode (location: (7,5)-(7,6))
-        │   │   │           └── flags: decimal
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ IntegerNode (location: (7,5)-(7,6))
+        │   │   │   │       └── flags: decimal
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block:
         │   │   │   @ BlockNode (location: (7,7)-(7,13))
@@ -156,17 +162,18 @@
         │   ├── opening_loc: (7,17)-(7,18) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (7,18)-(7,21))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (7,18)-(7,21))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (7,18)-(7,21) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (7,18)-(7,21))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (7,18)-(7,21) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (7,21)-(7,22) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -180,9 +187,10 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (9,5)-(9,6))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ IntegerNode (location: (9,5)-(9,6))
-        │   │   │           └── flags: decimal
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ IntegerNode (location: (9,5)-(9,6))
+        │   │   │   │       └── flags: decimal
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block:
         │   │   │   @ BlockNode (location: (9,7)-(9,13))
@@ -198,17 +206,18 @@
         │   ├── opening_loc: (9,17)-(9,18) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (9,18)-(9,21))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (9,18)-(9,21))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (9,18)-(9,21) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (9,18)-(9,21))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (9,18)-(9,21) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: (9,21)-(9,22) = ")"
         │   ├── block:
         │   │   @ BlockNode (location: (9,23)-(9,25))
@@ -228,9 +237,10 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (11,5)-(11,6))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ IntegerNode (location: (11,5)-(11,6))
-        │   │   │           └── flags: decimal
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ IntegerNode (location: (11,5)-(11,6))
+        │   │   │   │       └── flags: decimal
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block:
         │   │   │   @ BlockNode (location: (11,7)-(11,13))
@@ -246,17 +256,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (11,19)-(11,22))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (11,19)-(11,22))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (11,19)-(11,22) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (11,19)-(11,22))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (11,19)-(11,22) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -270,9 +281,10 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (13,5)-(13,6))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ IntegerNode (location: (13,5)-(13,6))
-            │   │           └── flags: decimal
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ IntegerNode (location: (13,5)-(13,6))
+            │   │   │       └── flags: decimal
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block:
             │   │   @ BlockNode (location: (13,7)-(13,13))
@@ -288,17 +300,18 @@
             ├── opening_loc: (13,18)-(13,19) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (13,19)-(13,22))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (13,19)-(13,22))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (13,19)-(13,22) = "bar"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :bar
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (13,19)-(13,22))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (13,19)-(13,22) = "bar"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :bar
+            │   └── flags: ∅
             ├── closing_loc: (13,22)-(13,23) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_call.txt
+++ b/test/prism/snapshots/whitequark/send_call.txt
@@ -20,9 +20,10 @@
         │   ├── opening_loc: (1,4)-(1,5) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,5)-(1,6))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (1,5)-(1,6))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (1,5)-(1,6))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: (1,6)-(1,7) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -44,9 +45,10 @@
             ├── opening_loc: (3,5)-(3,6) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (3,6)-(3,7))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (3,6)-(3,7))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (3,6)-(3,7))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (3,7)-(3,8) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_index.txt
+++ b/test/prism/snapshots/whitequark/send_index.txt
@@ -20,11 +20,12 @@
             ├── opening_loc: (1,3)-(1,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,8))
-            │   └── arguments: (length: 2)
-            │       ├── @ IntegerNode (location: (1,4)-(1,5))
-            │       │   └── flags: decimal
-            │       └── @ IntegerNode (location: (1,7)-(1,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ IntegerNode (location: (1,4)-(1,5))
+            │   │   │   └── flags: decimal
+            │   │   └── @ IntegerNode (location: (1,7)-(1,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,8)-(1,9) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_index_asgn.txt
+++ b/test/prism/snapshots/whitequark/send_index_asgn.txt
@@ -20,13 +20,14 @@
             ├── opening_loc: (1,3)-(1,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,13))
-            │   └── arguments: (length: 3)
-            │       ├── @ IntegerNode (location: (1,4)-(1,5))
-            │       │   └── flags: decimal
-            │       ├── @ IntegerNode (location: (1,7)-(1,8))
-            │       │   └── flags: decimal
-            │       └── @ IntegerNode (location: (1,12)-(1,13))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 3)
+            │   │   ├── @ IntegerNode (location: (1,4)-(1,5))
+            │   │   │   └── flags: decimal
+            │   │   ├── @ IntegerNode (location: (1,7)-(1,8))
+            │   │   │   └── flags: decimal
+            │   │   └── @ IntegerNode (location: (1,12)-(1,13))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,8)-(1,9) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_index_asgn_legacy.txt
+++ b/test/prism/snapshots/whitequark/send_index_asgn_legacy.txt
@@ -20,13 +20,14 @@
             ├── opening_loc: (1,3)-(1,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,13))
-            │   └── arguments: (length: 3)
-            │       ├── @ IntegerNode (location: (1,4)-(1,5))
-            │       │   └── flags: decimal
-            │       ├── @ IntegerNode (location: (1,7)-(1,8))
-            │       │   └── flags: decimal
-            │       └── @ IntegerNode (location: (1,12)-(1,13))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 3)
+            │   │   ├── @ IntegerNode (location: (1,4)-(1,5))
+            │   │   │   └── flags: decimal
+            │   │   ├── @ IntegerNode (location: (1,7)-(1,8))
+            │   │   │   └── flags: decimal
+            │   │   └── @ IntegerNode (location: (1,12)-(1,13))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,8)-(1,9) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_index_cmd.txt
+++ b/test/prism/snapshots/whitequark/send_index_cmd.txt
@@ -20,29 +20,31 @@
             ├── opening_loc: (1,3)-(1,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,9))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,4)-(1,9))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,4)-(1,5) = "m"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (1,6)-(1,9))
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ CallNode (location: (1,6)-(1,9))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (1,6)-(1,9) = "bar"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments: ∅
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: variable_call
-            │           │           └── name: :bar
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :m
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,4)-(1,9))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (1,4)-(1,5) = "m"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments:
+            │   │       │   @ ArgumentsNode (location: (1,6)-(1,9))
+            │   │       │   ├── arguments: (length: 1)
+            │   │       │   │   └── @ CallNode (location: (1,6)-(1,9))
+            │   │       │   │       ├── receiver: ∅
+            │   │       │   │       ├── call_operator_loc: ∅
+            │   │       │   │       ├── message_loc: (1,6)-(1,9) = "bar"
+            │   │       │   │       ├── opening_loc: ∅
+            │   │       │   │       ├── arguments: ∅
+            │   │       │   │       ├── closing_loc: ∅
+            │   │       │   │       ├── block: ∅
+            │   │       │   │       ├── flags: variable_call
+            │   │       │   │       └── name: :bar
+            │   │       │   └── flags: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: ∅
+            │   │       └── name: :m
+            │   └── flags: ∅
             ├── closing_loc: (1,9)-(1,10) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_index_legacy.txt
+++ b/test/prism/snapshots/whitequark/send_index_legacy.txt
@@ -20,11 +20,12 @@
             ├── opening_loc: (1,3)-(1,4) = "["
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,8))
-            │   └── arguments: (length: 2)
-            │       ├── @ IntegerNode (location: (1,4)-(1,5))
-            │       │   └── flags: decimal
-            │       └── @ IntegerNode (location: (1,7)-(1,8))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ IntegerNode (location: (1,4)-(1,5))
+            │   │   │   └── flags: decimal
+            │   │   └── @ IntegerNode (location: (1,7)-(1,8))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (1,8)-(1,9) = "]"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_plain_cmd.txt
+++ b/test/prism/snapshots/whitequark/send_plain_cmd.txt
@@ -20,17 +20,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,8)-(1,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (1,8)-(1,11))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (1,8)-(1,11) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (1,8)-(1,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (1,8)-(1,11) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -52,17 +53,18 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,9)-(3,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (3,9)-(3,12))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (3,9)-(3,12) = "bar"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :bar
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (3,9)-(3,12))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (3,9)-(3,12) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :bar
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -84,17 +86,18 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (5,9)-(5,12))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (5,9)-(5,12))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (5,9)-(5,12) = "bar"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :bar
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (5,9)-(5,12))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (5,9)-(5,12) = "bar"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :bar
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_self.txt
+++ b/test/prism/snapshots/whitequark/send_self.txt
@@ -30,9 +30,10 @@
             ├── opening_loc: (5,3)-(5,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (5,4)-(5,5))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (5,4)-(5,5))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (5,4)-(5,5))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (5,5)-(5,6) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/send_self_block.txt
+++ b/test/prism/snapshots/whitequark/send_self_block.txt
@@ -58,9 +58,10 @@
             ├── opening_loc: (7,3)-(7,4) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (7,4)-(7,5))
-            │   └── arguments: (length: 1)
-            │       └── @ IntegerNode (location: (7,4)-(7,5))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 1)
+            │   │   └── @ IntegerNode (location: (7,4)-(7,5))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             ├── closing_loc: (7,5)-(7,6) = ")"
             ├── block:
             │   @ BlockNode (location: (7,7)-(7,10))

--- a/test/prism/snapshots/whitequark/space_args_arg.txt
+++ b/test/prism/snapshots/whitequark/space_args_arg.txt
@@ -10,15 +10,16 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,7))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,4)-(1,7))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,5)-(1,6))
-            │           │   └── body: (length: 1)
-            │           │       └── @ IntegerNode (location: (1,5)-(1,6))
-            │           │           └── flags: decimal
-            │           ├── opening_loc: (1,4)-(1,5) = "("
-            │           └── closing_loc: (1,6)-(1,7) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,4)-(1,7))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,5)-(1,6))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ IntegerNode (location: (1,5)-(1,6))
+            │   │       │           └── flags: decimal
+            │   │       ├── opening_loc: (1,4)-(1,5) = "("
+            │   │       └── closing_loc: (1,6)-(1,7) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/space_args_arg_block.txt
+++ b/test/prism/snapshots/whitequark/space_args_arg_block.txt
@@ -20,15 +20,16 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,8)-(1,11))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (1,8)-(1,11))
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (1,9)-(1,10))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (1,9)-(1,10))
-        │   │           │           └── flags: decimal
-        │   │           ├── opening_loc: (1,8)-(1,9) = "("
-        │   │           └── closing_loc: (1,10)-(1,11) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (1,8)-(1,11))
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (1,9)-(1,10))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ IntegerNode (location: (1,9)-(1,10))
+        │   │   │       │           └── flags: decimal
+        │   │   │       ├── opening_loc: (1,8)-(1,9) = "("
+        │   │   │       └── closing_loc: (1,10)-(1,11) = ")"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (1,12)-(1,14))
@@ -56,15 +57,16 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,9)-(3,12))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ ParenthesesNode (location: (3,9)-(3,12))
-        │   │           ├── body:
-        │   │           │   @ StatementsNode (location: (3,10)-(3,11))
-        │   │           │   └── body: (length: 1)
-        │   │           │       └── @ IntegerNode (location: (3,10)-(3,11))
-        │   │           │           └── flags: decimal
-        │   │           ├── opening_loc: (3,9)-(3,10) = "("
-        │   │           └── closing_loc: (3,11)-(3,12) = ")"
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ ParenthesesNode (location: (3,9)-(3,12))
+        │   │   │       ├── body:
+        │   │   │       │   @ StatementsNode (location: (3,10)-(3,11))
+        │   │   │       │   └── body: (length: 1)
+        │   │   │       │       └── @ IntegerNode (location: (3,10)-(3,11))
+        │   │   │       │           └── flags: decimal
+        │   │   │       ├── opening_loc: (3,9)-(3,10) = "("
+        │   │   │       └── closing_loc: (3,11)-(3,12) = ")"
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (3,13)-(3,15))
@@ -82,15 +84,16 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (5,4)-(5,7))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (5,4)-(5,7))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (5,5)-(5,6))
-            │           │   └── body: (length: 1)
-            │           │       └── @ IntegerNode (location: (5,5)-(5,6))
-            │           │           └── flags: decimal
-            │           ├── opening_loc: (5,4)-(5,5) = "("
-            │           └── closing_loc: (5,6)-(5,7) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (5,4)-(5,7))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (5,5)-(5,6))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ IntegerNode (location: (5,5)-(5,6))
+            │   │       │           └── flags: decimal
+            │   │       ├── opening_loc: (5,4)-(5,5) = "("
+            │   │       └── closing_loc: (5,6)-(5,7) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (5,8)-(5,10))

--- a/test/prism/snapshots/whitequark/space_args_arg_call.txt
+++ b/test/prism/snapshots/whitequark/space_args_arg_call.txt
@@ -10,25 +10,26 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,12))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (1,4)-(1,12))
-            │           ├── receiver:
-            │           │   @ ParenthesesNode (location: (1,4)-(1,7))
-            │           │   ├── body:
-            │           │   │   @ StatementsNode (location: (1,5)-(1,6))
-            │           │   │   └── body: (length: 1)
-            │           │   │       └── @ IntegerNode (location: (1,5)-(1,6))
-            │           │   │           └── flags: decimal
-            │           │   ├── opening_loc: (1,4)-(1,5) = "("
-            │           │   └── closing_loc: (1,6)-(1,7) = ")"
-            │           ├── call_operator_loc: (1,7)-(1,8) = "."
-            │           ├── message_loc: (1,8)-(1,12) = "to_i"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :to_i
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (1,4)-(1,12))
+            │   │       ├── receiver:
+            │   │       │   @ ParenthesesNode (location: (1,4)-(1,7))
+            │   │       │   ├── body:
+            │   │       │   │   @ StatementsNode (location: (1,5)-(1,6))
+            │   │       │   │   └── body: (length: 1)
+            │   │       │   │       └── @ IntegerNode (location: (1,5)-(1,6))
+            │   │       │   │           └── flags: decimal
+            │   │       │   ├── opening_loc: (1,4)-(1,5) = "("
+            │   │       │   └── closing_loc: (1,6)-(1,7) = ")"
+            │   │       ├── call_operator_loc: (1,7)-(1,8) = "."
+            │   │       ├── message_loc: (1,8)-(1,12) = "to_i"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: ∅
+            │   │       └── name: :to_i
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/space_args_arg_newline.txt
+++ b/test/prism/snapshots/whitequark/space_args_arg_newline.txt
@@ -10,15 +10,16 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(2,1))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,4)-(2,1))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,5)-(1,6))
-            │           │   └── body: (length: 1)
-            │           │       └── @ IntegerNode (location: (1,5)-(1,6))
-            │           │           └── flags: decimal
-            │           ├── opening_loc: (1,4)-(1,5) = "("
-            │           └── closing_loc: (2,0)-(2,1) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,4)-(2,1))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,5)-(1,6))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ IntegerNode (location: (1,5)-(1,6))
+            │   │       │           └── flags: decimal
+            │   │       ├── opening_loc: (1,4)-(1,5) = "("
+            │   │       └── closing_loc: (2,0)-(2,1) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/space_args_block.txt
+++ b/test/prism/snapshots/whitequark/space_args_block.txt
@@ -10,11 +10,12 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,6))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,4)-(1,6))
-            │           ├── body: ∅
-            │           ├── opening_loc: (1,4)-(1,5) = "("
-            │           └── closing_loc: (1,5)-(1,6) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,4)-(1,6))
+            │   │       ├── body: ∅
+            │   │       ├── opening_loc: (1,4)-(1,5) = "("
+            │   │       └── closing_loc: (1,5)-(1,6) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block:
             │   @ BlockNode (location: (1,7)-(1,9))

--- a/test/prism/snapshots/whitequark/space_args_cmd.txt
+++ b/test/prism/snapshots/whitequark/space_args_cmd.txt
@@ -10,35 +10,37 @@
             ├── opening_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (1,4)-(1,11))
-            │   └── arguments: (length: 1)
-            │       └── @ ParenthesesNode (location: (1,4)-(1,11))
-            │           ├── body:
-            │           │   @ StatementsNode (location: (1,5)-(1,10))
-            │           │   └── body: (length: 1)
-            │           │       └── @ CallNode (location: (1,5)-(1,10))
-            │           │           ├── receiver: ∅
-            │           │           ├── call_operator_loc: ∅
-            │           │           ├── message_loc: (1,5)-(1,6) = "f"
-            │           │           ├── opening_loc: ∅
-            │           │           ├── arguments:
-            │           │           │   @ ArgumentsNode (location: (1,7)-(1,10))
-            │           │           │   └── arguments: (length: 1)
-            │           │           │       └── @ CallNode (location: (1,7)-(1,10))
-            │           │           │           ├── receiver: ∅
-            │           │           │           ├── call_operator_loc: ∅
-            │           │           │           ├── message_loc: (1,7)-(1,10) = "bar"
-            │           │           │           ├── opening_loc: ∅
-            │           │           │           ├── arguments: ∅
-            │           │           │           ├── closing_loc: ∅
-            │           │           │           ├── block: ∅
-            │           │           │           ├── flags: variable_call
-            │           │           │           └── name: :bar
-            │           │           ├── closing_loc: ∅
-            │           │           ├── block: ∅
-            │           │           ├── flags: ∅
-            │           │           └── name: :f
-            │           ├── opening_loc: (1,4)-(1,5) = "("
-            │           └── closing_loc: (1,10)-(1,11) = ")"
+            │   ├── arguments: (length: 1)
+            │   │   └── @ ParenthesesNode (location: (1,4)-(1,11))
+            │   │       ├── body:
+            │   │       │   @ StatementsNode (location: (1,5)-(1,10))
+            │   │       │   └── body: (length: 1)
+            │   │       │       └── @ CallNode (location: (1,5)-(1,10))
+            │   │       │           ├── receiver: ∅
+            │   │       │           ├── call_operator_loc: ∅
+            │   │       │           ├── message_loc: (1,5)-(1,6) = "f"
+            │   │       │           ├── opening_loc: ∅
+            │   │       │           ├── arguments:
+            │   │       │           │   @ ArgumentsNode (location: (1,7)-(1,10))
+            │   │       │           │   ├── arguments: (length: 1)
+            │   │       │           │   │   └── @ CallNode (location: (1,7)-(1,10))
+            │   │       │           │   │       ├── receiver: ∅
+            │   │       │           │   │       ├── call_operator_loc: ∅
+            │   │       │           │   │       ├── message_loc: (1,7)-(1,10) = "bar"
+            │   │       │           │   │       ├── opening_loc: ∅
+            │   │       │           │   │       ├── arguments: ∅
+            │   │       │           │   │       ├── closing_loc: ∅
+            │   │       │           │   │       ├── block: ∅
+            │   │       │           │   │       ├── flags: variable_call
+            │   │       │           │   │       └── name: :bar
+            │   │       │           │   └── flags: ∅
+            │   │       │           ├── closing_loc: ∅
+            │   │       │           ├── block: ∅
+            │   │       │           ├── flags: ∅
+            │   │       │           └── name: :f
+            │   │       ├── opening_loc: (1,4)-(1,5) = "("
+            │   │       └── closing_loc: (1,10)-(1,11) = ")"
+            │   └── flags: ∅
             ├── closing_loc: ∅
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/whitequark/super.txt
+++ b/test/prism/snapshots/whitequark/super.txt
@@ -8,17 +8,18 @@
         │   ├── lparen_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,6)-(1,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (1,6)-(1,9))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (1,6)-(1,9) = "foo"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :foo
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (1,6)-(1,9))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (1,6)-(1,9) = "foo"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :foo
+        │   │   └── flags: ∅
         │   ├── rparen_loc: ∅
         │   └── block: ∅
         ├── @ SuperNode (location: (3,0)-(3,7))
@@ -32,16 +33,17 @@
             ├── lparen_loc: (5,5)-(5,6) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (5,6)-(5,9))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (5,6)-(5,9))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (5,6)-(5,9) = "foo"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :foo
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (5,6)-(5,9))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (5,6)-(5,9) = "foo"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :foo
+            │   └── flags: ∅
             ├── rparen_loc: (5,9)-(5,10) = ")"
             └── block: ∅

--- a/test/prism/snapshots/whitequark/super_block.txt
+++ b/test/prism/snapshots/whitequark/super_block.txt
@@ -16,27 +16,28 @@
             ├── lparen_loc: ∅
             ├── arguments:
             │   @ ArgumentsNode (location: (3,6)-(3,14))
-            │   └── arguments: (length: 2)
-            │       ├── @ CallNode (location: (3,6)-(3,9))
-            │       │   ├── receiver: ∅
-            │       │   ├── call_operator_loc: ∅
-            │       │   ├── message_loc: (3,6)-(3,9) = "foo"
-            │       │   ├── opening_loc: ∅
-            │       │   ├── arguments: ∅
-            │       │   ├── closing_loc: ∅
-            │       │   ├── block: ∅
-            │       │   ├── flags: variable_call
-            │       │   └── name: :foo
-            │       └── @ CallNode (location: (3,11)-(3,14))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (3,11)-(3,14) = "bar"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :bar
+            │   ├── arguments: (length: 2)
+            │   │   ├── @ CallNode (location: (3,6)-(3,9))
+            │   │   │   ├── receiver: ∅
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── message_loc: (3,6)-(3,9) = "foo"
+            │   │   │   ├── opening_loc: ∅
+            │   │   │   ├── arguments: ∅
+            │   │   │   ├── closing_loc: ∅
+            │   │   │   ├── block: ∅
+            │   │   │   ├── flags: variable_call
+            │   │   │   └── name: :foo
+            │   │   └── @ CallNode (location: (3,11)-(3,14))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (3,11)-(3,14) = "bar"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :bar
+            │   └── flags: ∅
             ├── rparen_loc: ∅
             └── block:
                 @ BlockNode (location: (3,15)-(3,21))

--- a/test/prism/snapshots/whitequark/trailing_forward_arg.txt
+++ b/test/prism/snapshots/whitequark/trailing_forward_arg.txt
@@ -31,13 +31,14 @@
             │           ├── opening_loc: (1,23)-(1,24) = "("
             │           ├── arguments:
             │           │   @ ArgumentsNode (location: (1,24)-(1,34))
-            │           │   └── arguments: (length: 3)
-            │           │       ├── @ LocalVariableReadNode (location: (1,24)-(1,25))
-            │           │       │   ├── name: :a
-            │           │       │   └── depth: 0
-            │           │       ├── @ IntegerNode (location: (1,27)-(1,29))
-            │           │       │   └── flags: decimal
-            │           │       └── @ ForwardingArgumentsNode (location: (1,31)-(1,34))
+            │           │   ├── arguments: (length: 3)
+            │           │   │   ├── @ LocalVariableReadNode (location: (1,24)-(1,25))
+            │           │   │   │   ├── name: :a
+            │           │   │   │   └── depth: 0
+            │           │   │   ├── @ IntegerNode (location: (1,27)-(1,29))
+            │           │   │   │   └── flags: decimal
+            │           │   │   └── @ ForwardingArgumentsNode (location: (1,31)-(1,34))
+            │           │   └── flags: ∅
             │           ├── closing_loc: (1,34)-(1,35) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/unary_num_pow_precedence.txt
+++ b/test/prism/snapshots/whitequark/unary_num_pow_precedence.txt
@@ -11,9 +11,10 @@
         │   ├── opening_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (1,8)-(1,10))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (1,8)-(1,10))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (1,8)-(1,10))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -29,9 +30,10 @@
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments:
         │   │   │   @ ArgumentsNode (location: (3,6)-(3,8))
-        │   │   │   └── arguments: (length: 1)
-        │   │   │       └── @ IntegerNode (location: (3,6)-(3,8))
-        │   │   │           └── flags: decimal
+        │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   └── @ IntegerNode (location: (3,6)-(3,8))
+        │   │   │   │       └── flags: decimal
+        │   │   │   └── flags: ∅
         │   │   ├── closing_loc: ∅
         │   │   ├── block: ∅
         │   │   ├── flags: ∅
@@ -54,9 +56,10 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (5,8)-(5,10))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ IntegerNode (location: (5,8)-(5,10))
-            │   │           └── flags: decimal
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ IntegerNode (location: (5,8)-(5,10))
+            │   │   │       └── flags: decimal
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/var_op_asgn_cmd.txt
+++ b/test/prism/snapshots/whitequark/var_op_asgn_cmd.txt
@@ -14,10 +14,11 @@
             │   ├── opening_loc: ∅
             │   ├── arguments:
             │   │   @ ArgumentsNode (location: (1,9)-(1,12))
-            │   │   └── arguments: (length: 1)
-            │   │       └── @ LocalVariableReadNode (location: (1,9)-(1,12))
-            │   │           ├── name: :foo
-            │   │           └── depth: 0
+            │   │   ├── arguments: (length: 1)
+            │   │   │   └── @ LocalVariableReadNode (location: (1,9)-(1,12))
+            │   │   │       ├── name: :foo
+            │   │   │       └── depth: 0
+            │   │   └── flags: ∅
             │   ├── closing_loc: ∅
             │   ├── block: ∅
             │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/yield.txt
+++ b/test/prism/snapshots/whitequark/yield.txt
@@ -13,17 +13,18 @@
         │   ├── lparen_loc: ∅
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (3,6)-(3,9))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ CallNode (location: (3,6)-(3,9))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (3,6)-(3,9) = "foo"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: variable_call
-        │   │           └── name: :foo
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (3,6)-(3,9))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── message_loc: (3,6)-(3,9) = "foo"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       ├── flags: variable_call
+        │   │   │       └── name: :foo
+        │   │   └── flags: ∅
         │   └── rparen_loc: ∅
         ├── @ YieldNode (location: (5,0)-(5,7))
         │   ├── keyword_loc: (5,0)-(5,5) = "yield"
@@ -35,15 +36,16 @@
             ├── lparen_loc: (7,5)-(7,6) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (7,6)-(7,9))
-            │   └── arguments: (length: 1)
-            │       └── @ CallNode (location: (7,6)-(7,9))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (7,6)-(7,9) = "foo"
-            │           ├── opening_loc: ∅
-            │           ├── arguments: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: variable_call
-            │           └── name: :foo
+            │   ├── arguments: (length: 1)
+            │   │   └── @ CallNode (location: (7,6)-(7,9))
+            │   │       ├── receiver: ∅
+            │   │       ├── call_operator_loc: ∅
+            │   │       ├── message_loc: (7,6)-(7,9) = "foo"
+            │   │       ├── opening_loc: ∅
+            │   │       ├── arguments: ∅
+            │   │       ├── closing_loc: ∅
+            │   │       ├── block: ∅
+            │   │       ├── flags: variable_call
+            │   │       └── name: :foo
+            │   └── flags: ∅
             └── rparen_loc: (7,9)-(7,10) = ")"

--- a/test/prism/snapshots/yield.txt
+++ b/test/prism/snapshots/yield.txt
@@ -18,20 +18,22 @@
         │   ├── lparen_loc: (5,5)-(5,6) = "("
         │   ├── arguments:
         │   │   @ ArgumentsNode (location: (5,6)-(5,7))
-        │   │   └── arguments: (length: 1)
-        │   │       └── @ IntegerNode (location: (5,6)-(5,7))
-        │   │           └── flags: decimal
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ IntegerNode (location: (5,6)-(5,7))
+        │   │   │       └── flags: decimal
+        │   │   └── flags: ∅
         │   └── rparen_loc: (5,7)-(5,8) = ")"
         └── @ YieldNode (location: (7,0)-(7,14))
             ├── keyword_loc: (7,0)-(7,5) = "yield"
             ├── lparen_loc: (7,5)-(7,6) = "("
             ├── arguments:
             │   @ ArgumentsNode (location: (7,6)-(7,13))
-            │   └── arguments: (length: 3)
-            │       ├── @ IntegerNode (location: (7,6)-(7,7))
-            │       │   └── flags: decimal
-            │       ├── @ IntegerNode (location: (7,9)-(7,10))
-            │       │   └── flags: decimal
-            │       └── @ IntegerNode (location: (7,12)-(7,13))
-            │           └── flags: decimal
+            │   ├── arguments: (length: 3)
+            │   │   ├── @ IntegerNode (location: (7,6)-(7,7))
+            │   │   │   └── flags: decimal
+            │   │   ├── @ IntegerNode (location: (7,9)-(7,10))
+            │   │   │   └── flags: decimal
+            │   │   └── @ IntegerNode (location: (7,12)-(7,13))
+            │   │       └── flags: decimal
+            │   └── flags: ∅
             └── rparen_loc: (7,13)-(7,14) = ")"


### PR DESCRIPTION
Method calls with keyword splat args compile differently than without since they merge the keyword arg hash with the keyword splat hash. We know this information at parse time, so can set a flag which the compiler can use.