### PR TITLE
Fix constant path full name when parent is not a constant

### DIFF
--- a/lib/prism/node_ext.rb
+++ b/lib/prism/node_ext.rb
@@ -79,7 +79,7 @@ module Prism
     # Foo::Bar::Baz -> does not raise because all parts of the constant path are
     # simple constants
     # var::Bar::Baz -> raises because the first part of the constant path is a
-    # local variablV
+    # local variable
     class DynamicPartsInConstantPathError < StandardError; end
 
     # Returns the list of parts for the full name of this constant path.

--- a/lib/prism/node_ext.rb
+++ b/lib/prism/node_ext.rb
@@ -74,6 +74,14 @@ module Prism
   end
 
   class ConstantPathNode < Node
+    # An error class raised when dynamic parts are found while computing a
+    # constant path's full name. For example:
+    # Foo::Bar::Baz -> does not raise because all parts of the constant path are
+    # simple constants
+    # var::Bar::Baz -> raises because the first part of the constant path is a
+    # local variablV
+    class DynamicPartsInConstantPathError < StandardError; end
+
     # Returns the list of parts for the full name of this constant path.
     # For example: [:Foo, :Bar]
     def full_name_parts
@@ -83,6 +91,10 @@ module Prism
       while current.is_a?(ConstantPathNode)
         parts.unshift(current.child.name)
         current = current.parent
+      end
+
+      unless current.is_a?(ConstantReadNode)
+        raise DynamicPartsInConstantPathError, "Constant path contains dynamic parts. Cannot compute full name"
       end
 
       parts.unshift(current&.name || :"")

--- a/test/prism/constant_path_node_test.rb
+++ b/test/prism/constant_path_node_test.rb
@@ -15,6 +15,33 @@ module Prism
       assert_equal("Foo::Bar::Baz::Qux", constant_path.full_name)
     end
 
+    def test_full_name_for_constant_path_with_self
+      source = <<~RUBY
+        self:: # comment
+          Bar::Baz::
+            Qux
+      RUBY
+
+      constant_path = Prism.parse(source).value.statements.body.first
+      assert_raise(ConstantPathNode::DynamicPartsInConstantPathError) do
+        constant_path.full_name
+      end
+    end
+
+    def test_full_name_for_constant_path_with_variable
+      source = <<~RUBY
+        foo:: # comment
+          Bar::Baz::
+            Qux
+      RUBY
+
+      constant_path = Prism.parse(source).value.statements.body.first
+
+      assert_raise(ConstantPathNode::DynamicPartsInConstantPathError) do
+        constant_path.full_name
+      end
+    end
+
     def test_full_name_for_constant_path_target
       source = <<~RUBY
         Foo:: # comment


### PR DESCRIPTION
When we introduced `full_name`, we forgot that Ruby allows you to do `self::Foo::Bar` or even `var::Foo::Bar`. The code currently breaks in those scenarios when trying to invoke `name`, since the nodes that represent the beginning of the path don't implement it (like `SelfNode`).

There are a few options on how we might fix this. This PR is just using `node.slice` if the node is not a constant read. We can omit the first part when it's not a constant. Or we can add a `name` field to the nodes that don't have it, just returning the slice.

Let me know how you prefer to deal with this scenario.