### PR TITLE
Improve comment generation in templates

### DIFF
--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -174,9 +174,11 @@ public abstract class Nodes {
 <%# NODES -%>
     <%- nodes.each do |node| -%>
 
+    /**
     <%- node.comment.each_line do |line| -%>
-    //<%= line.prepend(" ").rstrip %>
+     *<%= line.prepend(" ").rstrip %>
     <%- end -%>
+     */
     public static final class <%= node.name -%> extends Node {
         <%- if node.needs_serialized_length? -%>
         public final int serializedLength;

--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -174,7 +174,9 @@ public abstract class Nodes {
 <%# NODES -%>
     <%- nodes.each do |node| -%>
 
-    <%= "#{node.comment.split("\n").map { |line| "// #{line}" }.join("\n    ")}\n" if node.comment -%>
+    <%- node.comment.each_line do |line| -%>
+    //<%= line.prepend(" ").rstrip %>
+    <%- end -%>
     public static final class <%= node.name -%> extends Node {
         <%- if node.needs_serialized_length? -%>
         public final int serializedLength;

--- a/templates/javascript/src/nodes.js.erb
+++ b/templates/javascript/src/nodes.js.erb
@@ -42,7 +42,9 @@ const <%= flag.name %> = {
 <%- nodes.each do |node| -%>
 
 /**
-<%= "#{node.comment.split("\n").map { |line| line.empty? ? " *" : " * #{line}" }.join("\n")}" %>
+<%- node.comment.each_line do |line| -%>
+ *<%= line.prepend(" ").rstrip %>
+<%- end -%>
  */
 export class <%= node.name -%> {
   <%- node.fields.each do |field| -%>

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -32,7 +32,10 @@ module Prism
   end
   <%- nodes.each do |node| -%>
 
-  <%= "#{node.comment.split("\n").map { |line| line.empty? ? "#" : "# #{line}" }.join("\n  ")}\n  " if node.comment %>class <%= node.name -%> < Node
+  <%- node.comment.each_line do |line| -%>
+  #<%= line.prepend(" ").rstrip %>
+  <%- end -%>
+  class <%= node.name -%> < Node
     <%- node.fields.each do |field| -%>
     # attr_reader <%= field.name %>: <%= field.rbs_class %>
     <%= "private " if field.is_a?(Prism::FlagsField) %>attr_reader :<%= field.name %>

--- a/templates/rbi/prism.rbi.erb
+++ b/templates/rbi/prism.rbi.erb
@@ -1,7 +1,10 @@
 
 module Prism
   <%- nodes.each do |node| -%>
-  <%= "#{node.comment.split("\n").map { |line| line.empty? ? "#" : "# #{line}" }.join("\n  ")}\n  " if node.comment %>class <%= node.name -%> < Node
+  <%- node.comment.each_line do |line| -%>
+  #<%= line.prepend(" ").rstrip %>
+  <%- end -%>
+  class <%= node.name -%> < Node
     <%- node.fields.each do |field| -%>
     sig { returns(<%= field.rbi_class %>) }
     attr_reader :<%= field.name %>

--- a/templates/sig/prism.rbs.erb
+++ b/templates/sig/prism.rbs.erb
@@ -1,6 +1,9 @@
 module Prism
   <%- nodes.each do |node| -%>
-  <%= "#{node.comment.split("\n").map { |line| line.empty? ? "#" : "# #{line}" }.join("\n  ")}\n  " if node.comment %>class <%= node.name -%> < Node
+  <%- node.comment.each_line do |line| -%>
+  #<%= line.prepend(" ").rstrip %>
+  <%- end -%>
+  class <%= node.name -%> < Node
     <%- node.fields.each do |field| -%>
     attr_reader <%= field.name %>: <%= field.rbs_class %>
     <%- end -%>


### PR DESCRIPTION
The existing comment generation was hard to read and was making a lot of string manipulation. However, ERB files are already designed to do string manipulation, so we can use that instead.

So, instead of doing a split and a map, I opted to use the `#each_line` method to iterate over the lines of the file.

Also, in order to add an optional space padding at the beginning of the line, I opted to unconditionally pad it with a space and then right trim it. This makes sure that no space is left behind if the line is empty, but a space is added if the line is not empty. It also ensures that the line endings that are kept by `each_lines` are also removed.