### PR TITLE
parse_inline_comments -> parse_comments

### DIFF
--- a/docs/ruby_api.md
+++ b/docs/ruby_api.md
@@ -23,5 +23,5 @@ The full API is documented below.
 * `Prism.parse_lex(source)` - parse the syntax tree corresponding to the given source string and return it within a parse result, along with the tokens
 * `Prism.parse_lex_file(filepath)` - parse the syntax tree corresponding to the given source file and return it within a parse result, along with the tokens
 * `Prism.load(source, serialized)` - load the serialized syntax tree using the source as a reference into a syntax tree
-* `Prism.parse_inline_comments(source)` - parse the inline comments corresponding to the given source string and return them
-* `Prism.parse_file_inline_comments(source)` - parse the inline comments corresponding to the given source file and return them
+* `Prism.parse_comments(source)` - parse the comments corresponding to the given source string and return them
+* `Prism.parse_file_comments(source)` - parse the comments corresponding to the given source file and return them

--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -398,7 +398,7 @@ parse_input(pm_string_t *input, const char *filepath) {
 
 // Parse the given input and return an array of Comment objects.
 static VALUE
-parse_input_inline_comments(pm_string_t *input, const char *filepath) {
+parse_input_comments(pm_string_t *input, const char *filepath) {
     pm_parser_t parser;
     pm_parser_init(&parser, pm_string_source(input), pm_string_length(input), filepath);
 
@@ -406,20 +406,7 @@ parse_input_inline_comments(pm_string_t *input, const char *filepath) {
     rb_encoding *encoding = rb_enc_find(parser.encoding.name);
 
     VALUE source = pm_source_new(&parser, encoding);
-    VALUE comments = rb_ary_new();
-
-    for (pm_comment_t *comment = (pm_comment_t *) parser.comment_list.head; comment != NULL; comment = (pm_comment_t *) comment->node.next) {
-        if (comment->type != PM_COMMENT_INLINE) continue;
-
-        VALUE location_argv[] = {
-            source,
-            LONG2FIX(comment->start - parser.start),
-            LONG2FIX(comment->end - comment->start)
-        };
-
-        VALUE comment_argv[] = { ID2SYM(rb_intern("inline")), rb_class_new_instance(3, location_argv, rb_cPrismLocation) };
-        rb_ary_push(comments, rb_class_new_instance(2, comment_argv, rb_cPrismComment));
-    }
+    VALUE comments = parser_comments(&parser, source);
 
     pm_node_destroy(&parser, node);
     pm_parser_free(&parser);
@@ -469,7 +456,7 @@ parse_file(VALUE self, VALUE filepath) {
 
 // Parse the given string and return an array of Comment objects.
 static VALUE
-parse_inline_comments(int argc, VALUE *argv, VALUE self) {
+parse_comments(int argc, VALUE *argv, VALUE self) {
     VALUE string;
     VALUE filepath;
     rb_scan_args(argc, argv, "11", &string, &filepath);
@@ -477,18 +464,18 @@ parse_inline_comments(int argc, VALUE *argv, VALUE self) {
     pm_string_t input;
     input_load_string(&input, string);
 
-    return parse_input_inline_comments(&input, check_string(filepath));
+    return parse_input_comments(&input, check_string(filepath));
 }
 
 // Parse the given file and return an array of Comment objects.
 static VALUE
-parse_file_inline_comments(VALUE self, VALUE filepath) {
+parse_file_comments(VALUE self, VALUE filepath) {
     pm_string_t input;
 
     const char *checked = check_string(filepath);
     if (!pm_string_mapped_init(&input, checked)) return Qnil;
 
-    VALUE value = parse_input_inline_comments(&input, checked);
+    VALUE value = parse_input_comments(&input, checked);
     pm_string_free(&input);
 
     return value;
@@ -679,8 +666,8 @@ Init_prism(void) {
     rb_define_singleton_method(rb_cPrism, "lex_file", lex_file, 1);
     rb_define_singleton_method(rb_cPrism, "parse", parse, -1);
     rb_define_singleton_method(rb_cPrism, "parse_file", parse_file, 1);
-    rb_define_singleton_method(rb_cPrism, "parse_inline_comments", parse_inline_comments, -1);
-    rb_define_singleton_method(rb_cPrism, "parse_file_inline_comments", parse_file_inline_comments, 1);
+    rb_define_singleton_method(rb_cPrism, "parse_comments", parse_comments, -1);
+    rb_define_singleton_method(rb_cPrism, "parse_file_comments", parse_file_comments, 1);
     rb_define_singleton_method(rb_cPrism, "parse_lex", parse_lex, -1);
     rb_define_singleton_method(rb_cPrism, "parse_lex_file", parse_lex_file, 1);
 

--- a/include/prism.h
+++ b/include/prism.h
@@ -65,9 +65,8 @@ PRISM_EXPORTED_FUNCTION void pm_serialize(pm_parser_t *parser, pm_node_t *node, 
 // Parse the given source to the AST and serialize the AST to the given buffer.
 PRISM_EXPORTED_FUNCTION void pm_parse_serialize(const uint8_t *source, size_t size, pm_buffer_t *buffer, const char *metadata);
 
-// Parse and serialize the inline comments in the given source to the given
-// buffer.
-PRISM_EXPORTED_FUNCTION void pm_parse_serialize_inline_comments(const uint8_t *source, size_t size, pm_buffer_t *buffer, const char *metadata);
+// Parse and serialize the comments in the given source to the given buffer.
+PRISM_EXPORTED_FUNCTION void pm_parse_serialize_comments(const uint8_t *source, size_t size, pm_buffer_t *buffer, const char *metadata);
 
 // Lex the given source and serialize to the given buffer.
 PRISM_EXPORTED_FUNCTION void pm_lex_serialize(const uint8_t *source, size_t size, const char *filepath, pm_buffer_t *buffer);

--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -70,7 +70,7 @@ module Prism
       "prism.h",
       "pm_version",
       "pm_parse_serialize",
-      "pm_parse_serialize_inline_comments",
+      "pm_parse_serialize_comments",
       "pm_lex_serialize",
       "pm_parse_lex_serialize"
     )
@@ -225,11 +225,11 @@ module Prism
     end
   end
 
-  # Mirror the Prism.parse_inline_comments API by using the serialization API.
-  def self.parse_inline_comments(code, filepath = nil)
+  # Mirror the Prism.parse_comments API by using the serialization API.
+  def self.parse_comments(code, filepath = nil)
     LibRubyParser::PrismBuffer.with do |buffer|
       metadata = [filepath.bytesize, filepath.b, 0].pack("LA*L") if filepath
-      LibRubyParser.pm_parse_serialize_inline_comments(code, code.bytesize, buffer.pointer, metadata)
+      LibRubyParser.pm_parse_serialize_comments(code, code.bytesize, buffer.pointer, metadata)
 
       source = Source.new(code)
       loader = Serialize::Loader.new(source, buffer.read)
@@ -240,12 +240,12 @@ module Prism
     end
   end
 
-  # Mirror the Prism.parse_file_inline_comments API by using the serialization
+  # Mirror the Prism.parse_file_comments API by using the serialization
   # API. This uses native strings instead of Ruby strings because it allows us
   # to use mmap when it is available.
-  def self.parse_file_inline_comments(filepath)
+  def self.parse_file_comments(filepath)
     LibRubyParser::PrismString.with(filepath) do |string|
-      parse_inline_comments(string.read, filepath)
+      parse_comments(string.read, filepath)
     end
   end
 

--- a/src/prism.c
+++ b/src/prism.c
@@ -15723,10 +15723,9 @@ pm_parse_serialize(const uint8_t *source, size_t size, pm_buffer_t *buffer, cons
     pm_parser_free(&parser);
 }
 
-// Parse and serialize the inline comments in the given source to the given
-// buffer.
+// Parse and serialize the comments in the given source to the given buffer.
 PRISM_EXPORTED_FUNCTION void
-pm_parse_serialize_inline_comments(const uint8_t *source, size_t size, pm_buffer_t *buffer, const char *metadata) {
+pm_parse_serialize_comments(const uint8_t *source, size_t size, pm_buffer_t *buffer, const char *metadata) {
     pm_parser_t parser;
     pm_parser_init(&parser, source, size, NULL);
     if (metadata) pm_parser_metadata(&parser, metadata);

--- a/test/prism/parse_comments_test.rb
+++ b/test/prism/parse_comments_test.rb
@@ -3,16 +3,16 @@
 require_relative "test_helper"
 
 module Prism
-  class ParseInlineCommentsTest < TestCase
-    def test_parse_inline_comments
-      comments = Prism.parse_inline_comments("# foo")
+  class ParseCommentsTest < TestCase
+    def test_parse_comments
+      comments = Prism.parse_comments("# foo")
 
       assert_kind_of Array, comments
       assert_equal 1, comments.length
     end
 
-    def test_parse_file_inline_comments
-      comments = Prism.parse_file_inline_comments(__FILE__)
+    def test_parse_file_comments
+      comments = Prism.parse_file_comments(__FILE__)
 
       assert_kind_of Array, comments
       assert_equal 1, comments.length


### PR DESCRIPTION
There was a bug where the serialization API didn't line up with the Ruby API because the serialization API would return all comments. To simplify, just return all comments in both cases, `__END__` and `=begin` are so rare anyway.