### PR TITLE
Fix debug method names in truffleruby workflow

### DIFF
--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -67,12 +67,12 @@ jobs:
       working-directory: truffleruby-ws/truffleruby
 
     - name: Parse test/prism/fixtures/**/*.rb
-      run: jt ruby -e 'Dir.glob("test/prism/fixtures/**/*.rb") { |file| puts file; Truffle::Debug.prism_parse(File.read(file)) }'
+      run: jt ruby -e 'Dir.glob("test/prism/fixtures/**/*.rb") { |file| puts file; Truffle::Debug.yarp_parse(File.read(file)) }'
       working-directory: prism
 
     - name: Parse src/main/ruby/truffleruby/**/*.rb
-      run: jt ruby -e 'Dir.glob("src/main/ruby/truffleruby/**/*.rb") { |file| puts file; Truffle::Debug.prism_parse(File.read(file)) }'
+      run: jt ruby -e 'Dir.glob("src/main/ruby/truffleruby/**/*.rb") { |file| puts file; Truffle::Debug.yarp_parse(File.read(file)) }'
       working-directory: truffleruby-ws/truffleruby
 
     - name: Execute p 1+2
-      run: jt ruby -e 'Truffle::Debug.prism_execute "p 1+2"'
+      run: jt ruby -e 'Truffle::Debug.yarp_execute "p 1+2"'


### PR DESCRIPTION
TruffleRuby doesn't intend to rename those, they are debug methods, so let's use their current name.
This should let the truffleruby workflow be green.

FYI @andrykonchin 