### PR TITLE
Implement JavaScript visitors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ a.out
 /javascript/package-lock.json
 /javascript/src/deserialize.js
 /javascript/src/nodes.js
+/javascript/src/visitor.js
 /javascript/src/prism.wasm
 /javascript/types/
 /java/org/prism/AbstractNodeVisitor.java

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -74,6 +74,34 @@ A ParseResult object is very similar to the Prism::ParseResult object from Ruby.
 console.log(JSON.stringify(parseResult.value, null, 2));
 ```
 
+## Visitors
+
+Prism allows you to traverse the AST of parsed Ruby code using visitors.
+
+Here's an example of a custom `FooCalls` visitor:
+
+```js
+import { loadPrism, Visitor } from "@ruby/prism"
+
+const parse = await loadPrism();
+const parseResult = parse("foo()");
+
+class FooCalls extends Visitor {
+  visitCallNode(node) {
+    if (node.name === "foo") {
+      // Do something with the node
+    }
+
+    // Call super so that the visitor continues walking the tree
+    super.visitCallNode(node);
+  }
+}
+
+const fooVisitor = new FooCalls();
+
+parseResult.value.accept(fooVisitor);
+```
+
 ## Building
 
 To build the WASM package yourself, first obtain a copy of `wasi-sdk`. You can retrieve this here: <https://github.com/WebAssembly/wasi-sdk>. Next, run:

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,3 +1,5 @@
 # @ruby/prism
 
 JavaScript bindings for Ruby's [prism](https://github.com/ruby/prism) parser.
+
+See the [JavaScript documentation](https://github.com/ruby/prism/blob/main/docs/javascript.md) for Prism.

--- a/javascript/src/index.js
+++ b/javascript/src/index.js
@@ -5,6 +5,9 @@ import { fileURLToPath } from "node:url";
 import { ParseResult } from "./deserialize.js";
 import { parsePrism } from "./parsePrism.js";
 
+export * from "./visitor.js";
+export * from "./nodes.js";
+
 /**
  * Load the prism wasm module and return a parse function.
  *

--- a/templates/javascript/src/nodes.js.erb
+++ b/templates/javascript/src/nodes.js.erb
@@ -1,6 +1,11 @@
 <%-
+
+def camelize(string)
+  string.gsub(/_([a-z])/) { $1.upcase }
+end
+
 def prop(field)
-  field.name == "arguments" ? "arguments_" : field.name.gsub(/_([a-z])/) { $1.upcase }
+  field.name == "arguments" ? "arguments_" : camelize(field.name)
 end
 
 def jstype(field)
@@ -19,6 +24,8 @@ def jstype(field)
   end
 end
 -%>
+import * as visitors from "./visitor.js"
+
 <%- flags.each do |flag| -%>
 
 /**
@@ -95,6 +102,68 @@ export class <%= node.name -%> {
   <%- end -%>
   <%- end -%>
 
+  /**
+   * Accept a visitor for this node.
+   *
+   * @param {visitors.Visitor} visitor
+   */
+  accept(visitor) {
+    visitor.visit<%= camelize(node.name) %>(this)
+  }
+
+  /**
+   * Returns all child nodes of the current node.
+   *
+   * @returns {(Node | null)[]} An array of child nodes.
+   */
+  childNodes() {
+    return [<%= node.fields.map { |field|
+    case field
+    when Prism::NodeField, Prism::OptionalNodeField then "this.#{prop(field)}"
+    when Prism::NodeListField then "...this.#{prop(field)}"
+    end
+    }.compact.join(", ") %>]
+  }
+
+  /**
+   * Compact and return an array of child nodes.
+   *
+   * @returns {Node[]} An array of compacted child nodes.
+   */
+  compactChildNodes() {
+    <%- if node.fields.any? { |field| field.is_a?(Prism::OptionalNodeField) } -%>
+    const compact = [];
+
+    <%- node.fields.each do |field| -%>
+    <%- case field -%>
+    <%- when Prism::NodeField -%>
+    compact.push(this.<%= prop(field) %>);
+
+    <%- when Prism::OptionalNodeField -%>
+    if (this.<%= prop(field) %>) {
+      compact.push(this.<%= prop(field) %>);
+    }
+    <%- when Prism::NodeListField -%>
+    compact.concat(this.<%= prop(field) %>);
+    <%- end -%>
+    <%- end -%>
+
+    return compact;
+    <%- else -%>
+    return [<%= node.fields.map { |field|
+    case field
+    when Prism::NodeField then "this.#{prop(field)}"
+    when Prism::NodeListField then "...this.#{prop(field)}"
+    end
+    }.compact.join(", ") %>];
+    <%- end -%>
+  }
+
+  /**
+   * Transforms the Node to a JavaScript object.
+   *
+   * @returns {Object}
+   */
   toJSON() {
     return {
       type: "<%= node.name %>",

--- a/templates/javascript/src/visitor.js.erb
+++ b/templates/javascript/src/visitor.js.erb
@@ -1,0 +1,78 @@
+import * as nodes from "./nodes.js";
+
+/**
+ * A class that knows how to walk down the tree. None of the individual visit
+ * methods are implemented on this visitor, so it forces the consumer to
+ * implement each one that they need. For a default implementation that
+ * continues walking the tree, see the `Visitor` class.
+ *
+ */
+export class BasicVisitor {
+  /**
+   * Calls `accept` on the given node if it is not `null`, which in turn should
+   * call back into this visitor by calling the appropriate `visit*` method.
+   *
+   * @param {Node} node
+   */
+  visit(node) {
+    node?.accept(this);
+  }
+
+  /**
+   * Visits each node in `nodes` by calling `accept` on each one.
+   *
+   * @param {Node[]} node
+   */
+  visitAll(nodes) {
+    nodes.forEach((node) => {
+      node?.accept(this);
+    });
+  }
+
+  /**
+   * Visits the child nodes of `node` by calling `accept` on each one.
+   *
+   * @param {Node} node
+   */
+  visitChildNodes(node) {
+    node.compactChildNodes().forEach((childNode) => {
+      childNode.accept(this);
+    });
+  }
+}
+
+/**
+ * A visitor is a class that provides a default implementation for every accept
+ * method defined on the nodes. This means it can walk a tree without the
+ * caller needing to define any special handling. This allows you to handle a
+ * subset of the tree, while still walking the whole tree.
+ *
+ * For example, to find all of the method calls that call the `foo` method, you
+ * could write:
+ *
+ * @example
+ * class FooCalls extends Visitor {
+ *   visitCallNode(node) {
+ *     if (node.name === "foo") {
+ *       // Do something with the node
+ *     }
+ *
+ *     // Call super so that the visitor continues walking the tree
+ *     super.visitCallNode(node);
+ *   }
+ * }
+ *
+ */
+export class Visitor extends BasicVisitor {
+<%- nodes.each_with_index do |node, index| -%>
+<%= "\n" if index != 0 -%>
+  /**
+   * Visit a <%= node.name %> node.
+   *
+   * @param {nodes.<%= node.name %>} node
+   */
+  <%= "visit#{node.name.gsub(/_([a-z])/) { $1.upcase }}" %>(node) {
+    this.visitChildNodes(node);
+  }
+<%- end -%>
+}

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -416,6 +416,7 @@ module Prism
     "include/prism/ast.h",
     "javascript/src/deserialize.js",
     "javascript/src/nodes.js",
+    "javascript/src/visitor.js",
     "java/org/prism/Loader.java",
     "java/org/prism/Nodes.java",
     "java/org/prism/AbstractNodeVisitor.java",


### PR DESCRIPTION
This pull request adds a new template for a `visitor.js` file in `javascript/src/`. This file implements a `BasicVisitor` and a `Visitor` class, very similar to the Ruby visitors which allow to traverse the Ruby AST in JavaScript.

An example of a custom `FooCalls` visitor in JavaScript would look like:

```js
import { loadPrism, Visitor } from "@ruby/prism"

class FooCalls extends Visitor {
  visitCallNode(node) {
    if (node.name === "foo") {
      // Do something with the node
    }

    // Call super so that the visitor continues walking the tree
    super.visitCallNode(node);
  }
}

const fooVisitor = new FooCalls()
const parse = await loadPrism()
const parseResult = parse("foo()")

parseResult.value.accept(fooVisitor)
```