### PR TITLE
Fix line calculations in Java Loading

### DIFF
--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -69,20 +69,22 @@ public abstract class Nodes {
             return Arrays.copyOf(lineOffsets, lineOffsetsSize);
         }
 
+        // 1-based
         public int line(int byteOffset) {
             return startLine + findLine(byteOffset);
         }
 
+        // 0-based
         public int findLine(int byteOffset) {
             assert byteOffset >= 0 && byteOffset < bytes.length : byteOffset;
             int index = Arrays.binarySearch(lineOffsets, byteOffset);
             int line;
             if (index < 0) {
-                line = -index - 1;
+                line = -index - 2;
             } else {
-                line = index + 1;
+                line = index;
             }
-            assert line >= 1 && line <= getLineCount() : line;
+            assert line >= 0 && line <= getLineCount() : line;
             return line;
         }
 


### PR DESCRIPTION
Current code was using startLine which was 1-based and adding it to findLine() which was returning a 1-based value.  This PR changes findLine() to be 0-based.