### PR TITLE
Forwarding parameter fixes

### DIFF
--- a/lib/prism/debug.rb
+++ b/lib/prism/debug.rb
@@ -133,6 +133,10 @@ module Prism
               *params.keywords.grep(OptionalKeywordParameterNode).map(&:name),
             ]
 
+            if params.keyword_rest.is_a?(ForwardingParameterNode)
+              sorted.push(:*, :&, :"...")
+            end
+
             sorted << AnonymousLocal if params.keywords.any?
 
             # Recurse down the parameter tree to find any destructured

--- a/src/prism.c
+++ b/src/prism.c
@@ -11029,7 +11029,7 @@ parse_parameters(
     pm_binding_power_t binding_power,
     bool uses_parentheses,
     bool allows_trailing_comma,
-    bool allows_forwarding_parameter
+    bool allows_forwarding_parameters
 ) {
     pm_parameters_node_t *params = pm_parameters_node_create(parser);
     bool looping = true;
@@ -11064,7 +11064,10 @@ parse_parameters(
                     pm_parser_local_add_token(parser, &name);
                 } else {
                     name = not_provided(parser);
-                    pm_parser_local_add_token(parser, &operator);
+
+                    if (allows_forwarding_parameters) {
+                        pm_parser_local_add_token(parser, &operator);
+                    }
                 }
 
                 pm_block_parameter_node_t *param = pm_block_parameter_node_create(parser, &name, &operator);
@@ -11078,7 +11081,7 @@ parse_parameters(
                 break;
             }
             case PM_TOKEN_UDOT_DOT_DOT: {
-                if (!allows_forwarding_parameter) {
+                if (!allows_forwarding_parameters) {
                     pm_parser_err_current(parser, PM_ERR_ARGUMENT_NO_FORWARDING_ELLIPSES);
                 }
 
@@ -11086,7 +11089,7 @@ parse_parameters(
                     update_parameter_state(parser, &parser->current, &order);
                     parser_lex(parser);
 
-                    if (allows_forwarding_parameter) {
+                    if (allows_forwarding_parameters) {
                         pm_parser_local_add_constant(parser, "*", 1);
                         pm_parser_local_add_constant(parser, "&", 1);
                         pm_parser_local_add_token(parser, &parser->previous);
@@ -11244,7 +11247,10 @@ parse_parameters(
                     pm_parser_local_add_token(parser, &name);
                 } else {
                     name = not_provided(parser);
-                    pm_parser_local_add_token(parser, &operator);
+
+                    if (allows_forwarding_parameters) {
+                        pm_parser_local_add_token(parser, &operator);
+                    }
                 }
 
                 pm_rest_parameter_node_t *param = pm_rest_parameter_node_create(parser, &operator, &name);
@@ -11276,7 +11282,10 @@ parse_parameters(
                         pm_parser_local_add_token(parser, &name);
                     } else {
                         name = not_provided(parser);
-                        pm_parser_local_add_token(parser, &operator);
+
+                        if (allows_forwarding_parameters) {
+                            pm_parser_local_add_token(parser, &operator);
+                        }
                     }
 
                     param = (pm_node_t *) pm_keyword_rest_parameter_node_create(parser, &operator, &name);

--- a/src/prism.c
+++ b/src/prism.c
@@ -5570,15 +5570,6 @@ pm_parser_local_add(pm_parser_t *parser, pm_constant_id_t constant_id) {
 }
 
 /**
- * Add a local variable from a constant string to the current scope.
- */
-static inline void
-pm_parser_local_add_constant(pm_parser_t *parser, const char *start, size_t length) {
-    pm_constant_id_t constant_id = pm_parser_constant_id_constant(parser, start, length);
-    if (constant_id != 0) pm_parser_local_add(parser, constant_id);
-}
-
-/**
  * Add a local variable from a location to the current scope.
  */
 static pm_constant_id_t
@@ -11090,8 +11081,6 @@ parse_parameters(
                     parser_lex(parser);
 
                     if (allows_forwarding_parameters) {
-                        pm_parser_local_add_constant(parser, "*", 1);
-                        pm_parser_local_add_constant(parser, "&", 1);
                         pm_parser_local_add_token(parser, &parser->previous);
                     }
 

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -723,7 +723,7 @@ module Prism
           nil
         ),
         nil,
-        [:*, :&, :"...", :a],
+        [:"...", :a],
         Location(),
         nil,
         Location(),
@@ -800,7 +800,7 @@ module Prism
         nil,
         ParametersNode([], [], nil, [], [], ForwardingParameterNode(), nil),
         nil,
-        [:*, :&, :"..."],
+        [:"..."],
         Location(),
         nil,
         Location(),

--- a/test/prism/snapshots/methods.txt
+++ b/test/prism/snapshots/methods.txt
@@ -189,7 +189,7 @@
         │   │   │   @ ForwardingParameterNode (location: (19,6)-(19,9))
         │   │   └── block: ∅
         │   ├── body: ∅
-        │   ├── locals: [:*, :&, :"..."]
+        │   ├── locals: [:"..."]
         │   ├── def_keyword_loc: (19,0)-(19,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: (19,5)-(19,6) = "("
@@ -953,7 +953,7 @@
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
         │   │           └── name: :b
-        │   ├── locals: [:*, :&, :"..."]
+        │   ├── locals: [:"..."]
         │   ├── def_keyword_loc: (112,0)-(112,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: (112,5)-(112,6) = "("
@@ -995,7 +995,7 @@
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
         │   │           └── name: :b
-        │   ├── locals: [:*, :&, :"..."]
+        │   ├── locals: [:"..."]
         │   ├── def_keyword_loc: (114,0)-(114,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: (114,5)-(114,6) = "("
@@ -1216,7 +1216,7 @@
         │   │           │       │           └── name: :b
         │   │           │       └── closing_loc: (136,24)-(136,25) = "}"
         │   │           └── closing_loc: (136,25)-(136,26) = "\""
-        │   ├── locals: [:*, :&, :"..."]
+        │   ├── locals: [:"..."]
         │   ├── def_keyword_loc: (136,0)-(136,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: (136,5)-(136,6) = "("

--- a/test/prism/snapshots/seattlerb/defn_arg_forward_args.txt
+++ b/test/prism/snapshots/seattlerb/defn_arg_forward_args.txt
@@ -39,7 +39,7 @@
             │           ├── block: ∅
             │           ├── flags: ∅
             │           └── name: :b
-            ├── locals: [:x, :*, :&, :"..."]
+            ├── locals: [:x, :"..."]
             ├── def_keyword_loc: (1,0)-(1,3) = "def"
             ├── operator_loc: ∅
             ├── lparen_loc: (1,5)-(1,6) = "("

--- a/test/prism/snapshots/seattlerb/defn_args_forward_args.txt
+++ b/test/prism/snapshots/seattlerb/defn_args_forward_args.txt
@@ -48,7 +48,7 @@
             │           ├── block: ∅
             │           ├── flags: ∅
             │           └── name: :b
-            ├── locals: [:x, :y, :z, :*, :&, :"..."]
+            ├── locals: [:x, :y, :z, :"..."]
             ├── def_keyword_loc: (1,0)-(1,3) = "def"
             ├── operator_loc: ∅
             ├── lparen_loc: (1,5)-(1,6) = "("

--- a/test/prism/snapshots/seattlerb/defn_forward_args.txt
+++ b/test/prism/snapshots/seattlerb/defn_forward_args.txt
@@ -34,7 +34,7 @@
             │           ├── block: ∅
             │           ├── flags: ∅
             │           └── name: :b
-            ├── locals: [:*, :&, :"..."]
+            ├── locals: [:"..."]
             ├── def_keyword_loc: (1,0)-(1,3) = "def"
             ├── operator_loc: ∅
             ├── lparen_loc: (1,5)-(1,6) = "("

--- a/test/prism/snapshots/seattlerb/defn_forward_args__no_parens.txt
+++ b/test/prism/snapshots/seattlerb/defn_forward_args__no_parens.txt
@@ -34,7 +34,7 @@
             │           ├── block: ∅
             │           ├── flags: ∅
             │           └── name: :m
-            ├── locals: [:*, :&, :"..."]
+            ├── locals: [:"..."]
             ├── def_keyword_loc: (1,0)-(1,3) = "def"
             ├── operator_loc: ∅
             ├── lparen_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/block.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/block.txt
@@ -226,7 +226,7 @@
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (17,4)-(19,1))
-        │   │   ├── locals: [:a, :*]
+        │   │   ├── locals: [:a]
         │   │   ├── parameters:
         │   │   │   @ BlockParametersNode (location: (17,6)-(17,12))
         │   │   │   ├── parameters:
@@ -488,7 +488,7 @@
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (32,8)-(34,1))
-        │   │   ├── locals: [:*]
+        │   │   ├── locals: []
         │   │   ├── parameters:
         │   │   │   @ BlockParametersNode (location: (32,10)-(32,13))
         │   │   │   ├── parameters:

--- a/test/prism/snapshots/whitequark/blockargs.txt
+++ b/test/prism/snapshots/whitequark/blockargs.txt
@@ -119,7 +119,7 @@
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (9,1)-(9,12))
-        │   │   ├── locals: [:*, :b]
+        │   │   ├── locals: [:b]
         │   │   ├── parameters:
         │   │   │   @ BlockParametersNode (location: (9,3)-(9,10))
         │   │   │   ├── parameters:
@@ -265,7 +265,7 @@
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (17,1)-(17,8))
-        │   │   ├── locals: [:*]
+        │   │   ├── locals: []
         │   │   ├── parameters:
         │   │   │   @ BlockParametersNode (location: (17,3)-(17,6))
         │   │   │   ├── parameters:
@@ -379,7 +379,7 @@
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (27,1)-(27,15))
-        │   │   ├── locals: [:a, :*, :b]
+        │   │   ├── locals: [:a, :b]
         │   │   ├── parameters:
         │   │   │   @ BlockParametersNode (location: (27,3)-(27,13))
         │   │   │   ├── parameters:
@@ -533,7 +533,7 @@
         │   ├── closing_loc: ∅
         │   ├── block:
         │   │   @ BlockNode (location: (35,1)-(35,11))
-        │   │   ├── locals: [:a, :*]
+        │   │   ├── locals: [:a]
         │   │   ├── parameters:
         │   │   │   @ BlockParametersNode (location: (35,3)-(35,9))
         │   │   │   ├── parameters:

--- a/test/prism/snapshots/whitequark/endless_method_forwarded_args_legacy.txt
+++ b/test/prism/snapshots/whitequark/endless_method_forwarded_args_legacy.txt
@@ -34,7 +34,7 @@
             │           ├── block: ∅
             │           ├── flags: ∅
             │           └── name: :bar
-            ├── locals: [:*, :&, :"..."]
+            ├── locals: [:"..."]
             ├── def_keyword_loc: (1,0)-(1,3) = "def"
             ├── operator_loc: ∅
             ├── lparen_loc: (1,7)-(1,8) = "("

--- a/test/prism/snapshots/whitequark/forward_arg.txt
+++ b/test/prism/snapshots/whitequark/forward_arg.txt
@@ -34,7 +34,7 @@
             │           ├── block: ∅
             │           ├── flags: ∅
             │           └── name: :bar
-            ├── locals: [:*, :&, :"..."]
+            ├── locals: [:"..."]
             ├── def_keyword_loc: (1,0)-(1,3) = "def"
             ├── operator_loc: ∅
             ├── lparen_loc: (1,7)-(1,8) = "("

--- a/test/prism/snapshots/whitequark/forward_arg_with_open_args.txt
+++ b/test/prism/snapshots/whitequark/forward_arg_with_open_args.txt
@@ -38,7 +38,7 @@
         │   │           │           ├── block: ∅
         │   │           │           ├── flags: ∅
         │   │           │           └── name: :bar
-        │   │           ├── locals: [:*, :&, :"..."]
+        │   │           ├── locals: [:"..."]
         │   │           ├── def_keyword_loc: (1,1)-(1,4) = "def"
         │   │           ├── operator_loc: ∅
         │   │           ├── lparen_loc: ∅
@@ -82,7 +82,7 @@
         │   │           │           ├── block: ∅
         │   │           │           ├── flags: ∅
         │   │           │           └── name: :bar
-        │   │           ├── locals: [:*, :&, :"..."]
+        │   │           ├── locals: [:"..."]
         │   │           ├── def_keyword_loc: (5,1)-(5,4) = "def"
         │   │           ├── operator_loc: ∅
         │   │           ├── lparen_loc: ∅
@@ -106,7 +106,7 @@
         │   │   │   @ ForwardingParameterNode (location: (7,8)-(7,11))
         │   │   └── block: ∅
         │   ├── body: ∅
-        │   ├── locals: [:*, :&, :"..."]
+        │   ├── locals: [:"..."]
         │   ├── def_keyword_loc: (7,0)-(7,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: ∅
@@ -144,7 +144,7 @@
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
         │   │           └── name: :bar
-        │   ├── locals: [:*, :&, :"..."]
+        │   ├── locals: [:"..."]
         │   ├── def_keyword_loc: (10,0)-(10,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: ∅
@@ -184,7 +184,7 @@
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
         │   │           └── name: :bar
-        │   ├── locals: [:a, :*, :&, :"..."]
+        │   ├── locals: [:a, :"..."]
         │   ├── def_keyword_loc: (12,0)-(12,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: ∅
@@ -224,7 +224,7 @@
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
         │   │           └── name: :bar
-        │   ├── locals: [:a, :*, :&, :"..."]
+        │   ├── locals: [:a, :"..."]
         │   ├── def_keyword_loc: (16,0)-(16,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: ∅
@@ -255,7 +255,7 @@
         │   │   │   @ ForwardingParameterNode (location: (18,18)-(18,21))
         │   │   └── block: ∅
         │   ├── body: ∅
-        │   ├── locals: [:a, :b, :*, :&, :"..."]
+        │   ├── locals: [:a, :b, :"..."]
         │   ├── def_keyword_loc: (18,0)-(18,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: ∅
@@ -300,7 +300,7 @@
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
         │   │           └── name: :bar
-        │   ├── locals: [:b, :*, :&, :"..."]
+        │   ├── locals: [:b, :"..."]
         │   ├── def_keyword_loc: (21,0)-(21,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: ∅
@@ -345,7 +345,7 @@
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
         │   │           └── name: :bar
-        │   ├── locals: [:b, :*, :&, :"..."]
+        │   ├── locals: [:b, :"..."]
         │   ├── def_keyword_loc: (25,0)-(25,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: ∅
@@ -385,7 +385,7 @@
             │           ├── block: ∅
             │           ├── flags: ∅
             │           └── name: :bar
-            ├── locals: [:a, :*, :&, :"..."]
+            ├── locals: [:a, :"..."]
             ├── def_keyword_loc: (27,0)-(27,3) = "def"
             ├── operator_loc: ∅
             ├── lparen_loc: (27,7)-(27,8) = "("

--- a/test/prism/snapshots/whitequark/forward_args_legacy.txt
+++ b/test/prism/snapshots/whitequark/forward_args_legacy.txt
@@ -34,7 +34,7 @@
         │   │           ├── block: ∅
         │   │           ├── flags: ∅
         │   │           └── name: :bar
-        │   ├── locals: [:*, :&, :"..."]
+        │   ├── locals: [:"..."]
         │   ├── def_keyword_loc: (1,0)-(1,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: (1,7)-(1,8) = "("
@@ -56,7 +56,7 @@
         │   │   │   @ ForwardingParameterNode (location: (3,8)-(3,11))
         │   │   └── block: ∅
         │   ├── body: ∅
-        │   ├── locals: [:*, :&, :"..."]
+        │   ├── locals: [:"..."]
         │   ├── def_keyword_loc: (3,0)-(3,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: (3,7)-(3,8) = "("
@@ -90,7 +90,7 @@
             │           │   └── flags: ∅
             │           ├── rparen_loc: (5,23)-(5,24) = ")"
             │           └── block: ∅
-            ├── locals: [:*, :&, :"..."]
+            ├── locals: [:"..."]
             ├── def_keyword_loc: (5,0)-(5,3) = "def"
             ├── operator_loc: ∅
             ├── lparen_loc: (5,7)-(5,8) = "("

--- a/test/prism/snapshots/whitequark/send_lambda.txt
+++ b/test/prism/snapshots/whitequark/send_lambda.txt
@@ -4,7 +4,7 @@
     @ StatementsNode (location: (1,0)-(5,5))
     └── body: (length: 3)
         ├── @ LambdaNode (location: (1,0)-(1,8))
-        │   ├── locals: [:*]
+        │   ├── locals: []
         │   ├── operator_loc: (1,0)-(1,2) = "->"
         │   ├── opening_loc: (1,5)-(1,6) = "{"
         │   ├── closing_loc: (1,7)-(1,8) = "}"

--- a/test/prism/snapshots/whitequark/trailing_forward_arg.txt
+++ b/test/prism/snapshots/whitequark/trailing_forward_arg.txt
@@ -43,7 +43,7 @@
             │           ├── block: ∅
             │           ├── flags: ∅
             │           └── name: :bar
-            ├── locals: [:a, :b, :*, :&, :"..."]
+            ├── locals: [:a, :b, :"..."]
             ├── def_keyword_loc: (1,0)-(1,3) = "def"
             ├── operator_loc: ∅
             ├── lparen_loc: (1,7)-(1,8) = "("


### PR DESCRIPTION
Previously, we were adding `*` and `&` to locals when `...` was found in a block parameter list. This was my mistake, I didn't realize this didn't work. Fixes #1739. Fixes #1785.

Previously, because we were adding those values, it allowed forwarding when it shouldn't have. For example, `def foo(...); bar(*); end` was allowed by prism, but shouldn't have been. Fixes #1776.