### PR TITLE
Add source code and changelog metadata to gemspec

### DIFF
--- a/prism.gemspec
+++ b/prism.gemspec
@@ -118,4 +118,6 @@ Gem::Specification.new do |spec|
 
   spec.extensions = ["ext/prism/extconf.rb"]
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
+  spec.metadata["source_code_uri"] = "https://github.com/ruby/prism"
+  spec.metadata["changelog_uri"] = "https://github.com/ruby/prism/blob/main/CHANGELOG.md"
 end


### PR DESCRIPTION
This should fix #1738

It simply specifies the uri for the source code in the gemspec and also adds the uri for the changelog, as per @kddnewton's suggestion.