### PR TITLE
Fix #1793.  offsets off of end of source should not assert.

### DIFF
--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -76,7 +76,8 @@ public abstract class Nodes {
 
         // 0-based
         public int findLine(int byteOffset) {
-            assert byteOffset >= 0 && byteOffset < bytes.length : byteOffset;
+            if (byteOffset >= bytes.length) byteOffset = bytes.length - 1;
+            assert byteOffset >= 0 : byteOffset;
             int index = Arrays.binarySearch(lineOffsets, byteOffset);
             int line;
             if (index < 0) {


### PR DESCRIPTION
There are cases where prism will run into a syntax error and advance to at least 1 byte past the end of source (beyond just regexps like as described in #1793).  There are many places this can happen so this PR fixes this issue by adjusting the offset we are trying to determine the line for to the last valid byteoffset in the source.