### PR TITLE
Partial fix for #1783 for Java Loader

### DIFF
--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -49,7 +49,6 @@ public abstract class Nodes {
         }
 
         public void setStartLine(int startLine) {
-            assert startLine >= 1;
             this.startLine = startLine;
         }
 


### PR DESCRIPTION
`setStartLine(int line)` should not have an assert to only accept positive values.  start line can be negative.