### PR TITLE
Accept extra C flags in Makefile via $EXTRA_CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ FUZZ_OUTPUT_DIR = $(shell pwd)/fuzz/output
 SOEXT := $(shell ruby -e 'puts RbConfig::CONFIG["SOEXT"]')
 
 CPPFLAGS := -Iinclude
-CFLAGS := -g -O2 -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion -fPIC -fvisibility=hidden
+CFLAGS := -g -O2 -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion -fPIC -fvisibility=hidden $(EXTRA_CFLAGS)
 CC := cc
 WASI_SDK_PATH := /opt/wasi-sdk
 


### PR DESCRIPTION
* This is notably useful to silence incorrect warnings (which become errors with -Werror) such as `-Wmissing-braces` on system clang on macOS Mojave for `{ 0 }` initialization.

We saw a bunch more initialization warnings like in #1706:
```
src/prism.c:13487:46: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
                pm_arguments_t arguments = { 0 };
                                             ^
                                             {}
src/prism.c:13579:46: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
                pm_arguments_t arguments = { 0 };
                                             ^
                                             {}
src/prism.c:13611:50: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
                    pm_arguments_t arguments = { 0 };
                                                 ^
                                                 {}
src/prism.c:14009:42: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
            pm_arguments_t arguments = { 0 };
                                         ^
                                         {}
src/prism.c:14045:42: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
            pm_arguments_t arguments = { 0 };
                                         ^
                                         {}
src/prism.c:14062:42: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
            pm_arguments_t arguments = { 0 };
                                         ^
                                         {}
src/prism.c:14545:42: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
            pm_arguments_t arguments = { 0 };
                                         ^
                                         {}
Building Java module org.graalvm.shadowed.antlr4 (truffle-antlr4.jar) from TRUFFLE_ANTLR4
src/prism.c:15930:42: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
            pm_arguments_t arguments = { 0 };
                                         ^
                                         {}
src/prism.c:16056:54: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
                        pm_arguments_t arguments = { 0 };
                                                     ^
                                                     {}
src/prism.c:16082:50: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
                    pm_arguments_t arguments = { 0 };
                                                 ^
                                                 {}
src/prism.c:16096:50: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
                    pm_arguments_t arguments = { 0 };
                                                 ^
                                                 {}
src/prism.c:16118:42: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
            pm_arguments_t arguments = { 0 };
                                         ^
                                         {}
src/prism.c:16516:30: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    pm_options_t options = { 0 };
                             ^
                             {}
src/prism.c:16538:30: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    pm_options_t options = { 0 };
                             ^
                             {}
14 errors generated.
```

So the main way to deal with them seem to suppress them for now, as newer compilers don't warn for this.
(We also plan to update TruffleRuby's macOS CI from Mojave to Big Sur but that will take time as updating macOS is not very automatable)