### PR TITLE
fix: Handle zero-length block parameters in invalid Ruby

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -5610,7 +5610,7 @@ pm_parser_parameter_name_check(pm_parser_t *parser, const pm_token_t *name) {
     }
 
     // We want to ignore any parameter name that starts with an underscore.
-    if ((*name->start == '_')) return;
+    if ((name->start < name->end) && (*name->start == '_')) return;
 
     // Otherwise we'll fetch the constant id for the parameter name and check
     // whether it's already in the current scope.

--- a/test/prism/fuzzer_test.rb
+++ b/test/prism/fuzzer_test.rb
@@ -57,5 +57,7 @@ module Prism
       a
       /{/, ''\\
     RUBY
+
+    snippet "parameter name that is zero length", "a { |b;"
   end
 end


### PR DESCRIPTION
Found by fuzzing.