### PR TITLE
fix: nested heredoc use-after-free

### DIFF
--- a/include/prism/parser.h
+++ b/include/prism/parser.h
@@ -532,6 +532,12 @@ struct pm_parser {
         size_t index;
     } lex_modes;
 
+    /**
+     * The common_whitespace value from the most-recently-popped heredoc mode of the lexer, so we
+     * can dedent the heredoc after popping the lex mode.
+     */
+    size_t current_string_common_whitespace;
+
     /** The pointer to the start of the source. */
     const uint8_t *start;
 

--- a/src/prism.c
+++ b/src/prism.c
@@ -9505,6 +9505,7 @@ parser_lex(pm_parser_t *parser) {
                             parser->heredoc_end = parser->current.end;
                         }
 
+                        parser->current_string_common_whitespace = parser->lex_modes.current->as.heredoc.common_whitespace;
                         lex_mode_pop(parser);
                         if (!at_end) {
                             lex_state_set(parser, PM_LEX_STATE_END);
@@ -13672,7 +13673,7 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power) {
                     cast->base.type = PM_X_STRING_NODE;
                 }
 
-                size_t common_whitespace = lex_mode->as.heredoc.common_whitespace;
+                size_t common_whitespace = parser->current_string_common_whitespace;
                 if (indent == PM_HEREDOC_INDENT_TILDE && (common_whitespace != (size_t) -1) && (common_whitespace != 0)) {
                     parse_heredoc_dedent_string(&cast->unescaped, common_whitespace);
                 }
@@ -13718,7 +13719,7 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power) {
 
                 // If this is a heredoc that is indented with a ~, then we need
                 // to dedent each line by the common leading whitespace.
-                size_t common_whitespace = lex_mode->as.heredoc.common_whitespace;
+                size_t common_whitespace = parser->current_string_common_whitespace;
                 if (indent == PM_HEREDOC_INDENT_TILDE && (common_whitespace != (size_t) -1) && (common_whitespace != 0)) {
                     pm_node_list_t *nodes;
                     if (quote == PM_HEREDOC_QUOTE_BACKTICK) {

--- a/test/prism/fixtures/heredocs_nested.txt
+++ b/test/prism/fixtures/heredocs_nested.txt
@@ -7,3 +7,16 @@ RUBY
 }
 post
 RUBY
+
+# depth greater than PM_LEX_STACK_SIZE
+<<-A
+#{
+<<-B
+#{
+<<-C
+#{3}
+C
+}
+B
+}
+A

--- a/test/prism/snapshots/heredocs_nested.txt
+++ b/test/prism/snapshots/heredocs_nested.txt
@@ -1,39 +1,89 @@
-@ ProgramNode (location: (1,0)-(1,7))
+@ ProgramNode (location: (1,0)-(12,4))
 ├── locals: []
 └── statements:
-    @ StatementsNode (location: (1,0)-(1,7))
-    └── body: (length: 1)
-        └── @ InterpolatedStringNode (location: (1,0)-(1,7))
-            ├── opening_loc: (1,0)-(1,7) = "<<~RUBY"
-            ├── parts: (length: 4)
-            │   ├── @ StringNode (location: (2,0)-(3,0))
-            │   │   ├── flags: ∅
-            │   │   ├── opening_loc: ∅
-            │   │   ├── content_loc: (2,0)-(3,0) = "pre\n"
-            │   │   ├── closing_loc: ∅
-            │   │   └── unescaped: "pre\n"
-            │   ├── @ EmbeddedStatementsNode (location: (3,0)-(7,1))
-            │   │   ├── opening_loc: (3,0)-(3,2) = "\#{"
+    @ StatementsNode (location: (1,0)-(12,4))
+    └── body: (length: 2)
+        ├── @ InterpolatedStringNode (location: (1,0)-(1,7))
+        │   ├── opening_loc: (1,0)-(1,7) = "<<~RUBY"
+        │   ├── parts: (length: 4)
+        │   │   ├── @ StringNode (location: (2,0)-(3,0))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (2,0)-(3,0) = "pre\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "pre\n"
+        │   │   ├── @ EmbeddedStatementsNode (location: (3,0)-(7,1))
+        │   │   │   ├── opening_loc: (3,0)-(3,2) = "\#{"
+        │   │   │   ├── statements:
+        │   │   │   │   @ StatementsNode (location: (4,0)-(4,6))
+        │   │   │   │   └── body: (length: 1)
+        │   │   │   │       └── @ StringNode (location: (4,0)-(4,6))
+        │   │   │   │           ├── flags: ∅
+        │   │   │   │           ├── opening_loc: (4,0)-(4,6) = "<<RUBY"
+        │   │   │   │           ├── content_loc: (5,0)-(6,0) = "  hello\n"
+        │   │   │   │           ├── closing_loc: (6,0)-(7,0) = "RUBY\n"
+        │   │   │   │           └── unescaped: "  hello\n"
+        │   │   │   └── closing_loc: (7,0)-(7,1) = "}"
+        │   │   ├── @ StringNode (location: (7,1)-(8,0))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (7,1)-(8,0) = "\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\n"
+        │   │   └── @ StringNode (location: (8,0)-(9,0))
+        │   │       ├── flags: ∅
+        │   │       ├── opening_loc: ∅
+        │   │       ├── content_loc: (8,0)-(9,0) = "post\n"
+        │   │       ├── closing_loc: ∅
+        │   │       └── unescaped: "post\n"
+        │   └── closing_loc: (9,0)-(10,0) = "RUBY\n"
+        └── @ InterpolatedStringNode (location: (12,0)-(12,4))
+            ├── opening_loc: (12,0)-(12,4) = "<<-A"
+            ├── parts: (length: 2)
+            │   ├── @ EmbeddedStatementsNode (location: (13,0)-(21,1))
+            │   │   ├── opening_loc: (13,0)-(13,2) = "\#{"
             │   │   ├── statements:
-            │   │   │   @ StatementsNode (location: (4,0)-(4,6))
+            │   │   │   @ StatementsNode (location: (14,0)-(14,4))
             │   │   │   └── body: (length: 1)
-            │   │   │       └── @ StringNode (location: (4,0)-(4,6))
-            │   │   │           ├── flags: ∅
-            │   │   │           ├── opening_loc: (4,0)-(4,6) = "<<RUBY"
-            │   │   │           ├── content_loc: (5,0)-(6,0) = "  hello\n"
-            │   │   │           ├── closing_loc: (6,0)-(7,0) = "RUBY\n"
-            │   │   │           └── unescaped: "  hello\n"
-            │   │   └── closing_loc: (7,0)-(7,1) = "}"
-            │   ├── @ StringNode (location: (7,1)-(8,0))
-            │   │   ├── flags: ∅
-            │   │   ├── opening_loc: ∅
-            │   │   ├── content_loc: (7,1)-(8,0) = "\n"
-            │   │   ├── closing_loc: ∅
-            │   │   └── unescaped: "\n"
-            │   └── @ StringNode (location: (8,0)-(9,0))
+            │   │   │       └── @ InterpolatedStringNode (location: (14,0)-(14,4))
+            │   │   │           ├── opening_loc: (14,0)-(14,4) = "<<-B"
+            │   │   │           ├── parts: (length: 2)
+            │   │   │           │   ├── @ EmbeddedStatementsNode (location: (15,0)-(19,1))
+            │   │   │           │   │   ├── opening_loc: (15,0)-(15,2) = "\#{"
+            │   │   │           │   │   ├── statements:
+            │   │   │           │   │   │   @ StatementsNode (location: (16,0)-(16,4))
+            │   │   │           │   │   │   └── body: (length: 1)
+            │   │   │           │   │   │       └── @ InterpolatedStringNode (location: (16,0)-(16,4))
+            │   │   │           │   │   │           ├── opening_loc: (16,0)-(16,4) = "<<-C"
+            │   │   │           │   │   │           ├── parts: (length: 2)
+            │   │   │           │   │   │           │   ├── @ EmbeddedStatementsNode (location: (17,0)-(17,4))
+            │   │   │           │   │   │           │   │   ├── opening_loc: (17,0)-(17,2) = "\#{"
+            │   │   │           │   │   │           │   │   ├── statements:
+            │   │   │           │   │   │           │   │   │   @ StatementsNode (location: (17,2)-(17,3))
+            │   │   │           │   │   │           │   │   │   └── body: (length: 1)
+            │   │   │           │   │   │           │   │   │       └── @ IntegerNode (location: (17,2)-(17,3))
+            │   │   │           │   │   │           │   │   │           └── flags: decimal
+            │   │   │           │   │   │           │   │   └── closing_loc: (17,3)-(17,4) = "}"
+            │   │   │           │   │   │           │   └── @ StringNode (location: (17,4)-(18,0))
+            │   │   │           │   │   │           │       ├── flags: ∅
+            │   │   │           │   │   │           │       ├── opening_loc: ∅
+            │   │   │           │   │   │           │       ├── content_loc: (17,4)-(18,0) = "\n"
+            │   │   │           │   │   │           │       ├── closing_loc: ∅
+            │   │   │           │   │   │           │       └── unescaped: "\n"
+            │   │   │           │   │   │           └── closing_loc: (18,0)-(19,0) = "C\n"
+            │   │   │           │   │   └── closing_loc: (19,0)-(19,1) = "}"
+            │   │   │           │   └── @ StringNode (location: (19,1)-(20,0))
+            │   │   │           │       ├── flags: ∅
+            │   │   │           │       ├── opening_loc: ∅
+            │   │   │           │       ├── content_loc: (19,1)-(20,0) = "\n"
+            │   │   │           │       ├── closing_loc: ∅
+            │   │   │           │       └── unescaped: "\n"
+            │   │   │           └── closing_loc: (20,0)-(21,0) = "B\n"
+            │   │   └── closing_loc: (21,0)-(21,1) = "}"
+            │   └── @ StringNode (location: (21,1)-(22,0))
             │       ├── flags: ∅
             │       ├── opening_loc: ∅
-            │       ├── content_loc: (8,0)-(9,0) = "post\n"
+            │       ├── content_loc: (21,1)-(22,0) = "\n"
             │       ├── closing_loc: ∅
-            │       └── unescaped: "post\n"
-            └── closing_loc: (9,0)-(10,0) = "RUBY\n"
+            │       └── unescaped: "\n"
+            └── closing_loc: (22,0)-(23,0) = "A\n"


### PR DESCRIPTION
Because the lex mode may be freed when popped, we need to store off this value for dedentation.

Co-authored-by: Kevin Newton <kddnewton@gmail.com>
