### PR TITLE
Silence clang analyzer warnings for the memory leaks

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -10327,6 +10327,8 @@ parse_write_name(pm_parser_t *parser, pm_constant_id_t *name_field) {
     name[length] = '=';
 
     // Now switch the name to the new string.
+    // This silences clang analyzer warning about leak of memory pointed by `name`.
+    // NOLINTNEXTLINE(clang-analyzer-*)
     *name_field = pm_constant_pool_insert_owned(&parser->constant_pool, name, length + 1);
 }
 
@@ -15582,6 +15584,9 @@ parse_regular_expression_named_captures(pm_parser_t *parser, const pm_string_t *
                 if (memory == NULL) abort();
 
                 memcpy(memory, source, length);
+
+                // This silences clang analyzer warning about leak of memory pointed by `memory`.
+                // NOLINTNEXTLINE(clang-analyzer-*)
                 local = pm_parser_local_add_owned(parser, (const uint8_t *) memory, length);
 
                 if (token_is_numbered_parameter(source, source + length)) {


### PR DESCRIPTION
clang analyzer reports two false positives about leaking memory. This PR silences these since we know that these are not actual memory leaks.