### PR TITLE
Revert "Ensure serialized file is little endian"

### DIFF
--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -74,14 +74,4 @@
 #   define snprintf _snprintf
 #endif
 
-/**
- * Defined PRISM_WORDS_BIGENDIAN so we can ensure our serialization happens in
- * little endian format regardless of platform.
- */
-#if defined(WORDS_BIGENDIAN)
-#   define PRISM_WORDS_BIGENDIAN
-#elif defined(AC_APPLE_UNIVERSAL_BUILD) && defined(__BIG_ENDIAN__)
-#   define PRISM_WORDS_BIGENDIAN
-#endif
-
 #endif

--- a/templates/java/org/prism/Loader.java.erb
+++ b/templates/java/org/prism/Loader.java.erb
@@ -54,7 +54,6 @@ public class Loader {
 
             if (constant == null) {
                 int offset = bufferOffset + index * 8;
-
                 int start = buffer.getInt(offset);
                 int length = buffer.getInt(offset + 4);
 
@@ -87,7 +86,7 @@ public class Loader {
     private ConstantPool constantPool;
 
     protected Loader(byte[] serialized, Nodes.Source source) {
-        this.buffer = ByteBuffer.wrap(serialized).order(ByteOrder.LITTLE_ENDIAN);
+        this.buffer = ByteBuffer.wrap(serialized).order(ByteOrder.nativeOrder());
         this.source = source;
     }
 

--- a/templates/lib/prism/serialize.rb.erb
+++ b/templates/lib/prism/serialize.rb.erb
@@ -137,7 +137,7 @@ module Prism
 
         comments, magic_comments, errors, warnings = load_metadata
 
-        @constant_pool_offset = io.read(4).unpack1("L<")
+        @constant_pool_offset = io.read(4).unpack1("L")
         @constant_pool = Array.new(load_varint, nil)
 
         [load_node, comments, magic_comments, errors, warnings]
@@ -167,7 +167,7 @@ module Prism
       end
 
       def load_serialized_length
-        io.read(4).unpack1("L<")
+        io.read(4).unpack1("L")
       end
 
       def load_optional_node
@@ -206,8 +206,8 @@ module Prism
 
         unless constant
           offset = constant_pool_offset + index * 8
-          start = serialized.unpack1("L<", offset: offset)
-          length = serialized.unpack1("L<", offset: offset + 4)
+          start = serialized.unpack1("L", offset: offset)
+          length = serialized.unpack1("L", offset: offset + 4)
 
           constant =
             if start.nobits?(1 << 31)

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -47,21 +47,6 @@ pm_serialize_string(pm_parser_t *parser, pm_string_t *string, pm_buffer_t *buffe
     }
 }
 
-/**
- * Serialize a 32-bit integer to the given address always in little-endian.
- */
-static void
-pm_serialize_32(char *address, uint32_t value) {
-#ifdef PRISM_WORDS_BIGENDIAN
-    address[0] = (char) ((value >> 24) & 0xFF);
-    address[1] = (char) ((value >> 16) & 0xFF);
-    address[2] = (char) ((value >> 8) & 0xFF);
-    address[3] = (char) (value & 0xFF);
-#else
-    memcpy(address, &value, sizeof(uint32_t));
-#endif
-}
-
 static void
 pm_serialize_node(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
     pm_buffer_append_byte(buffer, (uint8_t) PM_NODE_TYPE(node));
@@ -133,7 +118,7 @@ pm_serialize_node(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
             <%- if node.needs_serialized_length? -%>
             // serialize length
             uint32_t length = pm_sizet_to_u32(buffer->length - offset - sizeof(uint32_t));
-            pm_serialize_32(buffer->value + length_offset, length);
+            memcpy(buffer->value + length_offset, &length, sizeof(uint32_t));
             <%- end -%>
             break;
         }
@@ -246,7 +231,7 @@ pm_serialize_content(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) 
     // Now we're going to serialize the offset of the constant pool back where
     // we left space for it.
     uint32_t length = pm_sizet_to_u32(buffer->length);
-    pm_serialize_32(buffer->value + offset, length);
+    memcpy(buffer->value + offset, &length, sizeof(uint32_t));
 
     // Now we're going to serialize the constant pool.
     offset = buffer->length;
@@ -273,18 +258,18 @@ pm_serialize_content(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) 
                 assert(content_offset < owned_mask);
                 content_offset |= owned_mask;
 
-                pm_serialize_32(buffer->value + buffer_offset, content_offset);
+                memcpy(buffer->value + buffer_offset, &content_offset, 4);
                 pm_buffer_append_bytes(buffer, constant->start, constant->length);
             } else {
                 // Since this is a shared constant, we are going to write its
                 // source offset directly into the buffer.
                 uint32_t source_offset = pm_ptrdifft_to_u32(constant->start - parser->start);
-                pm_serialize_32(buffer->value + buffer_offset, source_offset);
+                memcpy(buffer->value + buffer_offset, &source_offset, 4);
             }
 
             // Now we can write the length of the constant into the buffer.
             uint32_t constant_length = pm_sizet_to_u32(constant->length);
-            pm_serialize_32(buffer->value + buffer_offset + 4, constant_length);
+            memcpy(buffer->value + buffer_offset + 4, &constant_length, 4);
         }
     }
 }


### PR DESCRIPTION
Reverts ruby/prism#1822

Apparently WORDS_BIGENDIAN is not being set automatically on s390x. We'll need a better feature detection to get this right, but in the meantime we'll revert to get CRuby CI back to green.