### PR TITLE
Fix `bin/lex` when encountering mismatch at EOF.

### DIFF
--- a/bin/lex
+++ b/bin/lex
@@ -55,6 +55,7 @@ prism_new_value = prism_new.value
   color = left == right ? "38;5;102" : "1;31"
 
   if ENV["VERBOSE"] || (left != right)
-    puts "\033[#{color}m#{pattern}\033[0m" % [left.inspect, right.inspect, [new[0].type, [new[0].location.start_offset, new[0].location.length]]]
+    new_value = [new[0].type, [new[0].location.start_offset, new[0].location.length]] if new
+    puts "\033[#{color}m#{pattern}\033[0m" % [left.inspect, right.inspect, new_value.inspect]
   end
 end


### PR DESCRIPTION
When encountering a situation where there is a mismatch at the very end of a file, and when `Prism.lex` produces a shorter output than `.lex_compat` and/or `.lex_ripper`, `bin/lex` itself fails with NoMethodError when calling `[0]` on `new` which is `nil`. This prevents outputting the actual mismatch.

This fix allows `new` to be `nil`, outputing `nil` in the 3rd column of `bin/lex` in this situation. (I can update this output approach if needed.)