### PR TITLE
Correctly parse the `resuce` modifier in the rhs of the assignments

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -10021,7 +10021,7 @@ typedef enum {
     PM_BINDING_POWER_MODIFIER_RESCUE =  6, // rescue
     PM_BINDING_POWER_COMPOSITION =      8, // and or
     PM_BINDING_POWER_NOT =             10, // not
-    PM_BINDING_POWER_MATCH =           12, // =>
+    PM_BINDING_POWER_MATCH =           12, // => in
     PM_BINDING_POWER_DEFINED =         14, // defined?
     PM_BINDING_POWER_ASSIGNMENT =      16, // = += -= *= /= %= &= |= ^= &&= ||= <<= >>= **=
     PM_BINDING_POWER_TERNARY =         18, // ?:
@@ -10080,12 +10080,7 @@ pm_binding_powers_t pm_binding_powers[PM_TOKEN_MAXIMUM] = {
     [PM_TOKEN_KEYWORD_WHILE_MODIFIER] = LEFT_ASSOCIATIVE(PM_BINDING_POWER_MODIFIER),
 
     // rescue
-    [PM_TOKEN_KEYWORD_RESCUE_MODIFIER] = {
-        PM_BINDING_POWER_ASSIGNMENT,
-        PM_BINDING_POWER_MODIFIER_RESCUE + 1,
-        true,
-        false
-    },
+    [PM_TOKEN_KEYWORD_RESCUE_MODIFIER] = LEFT_ASSOCIATIVE(PM_BINDING_POWER_MODIFIER_RESCUE),
 
     // and or
     [PM_TOKEN_KEYWORD_AND] = LEFT_ASSOCIATIVE(PM_BINDING_POWER_COMPOSITION),
@@ -15644,10 +15639,29 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power) {
 }
 
 static inline pm_node_t *
-parse_assignment_value(pm_parser_t *parser, pm_binding_power_t previous_binding_power, pm_binding_power_t binding_power, pm_diagnostic_id_t diag_id) {
+parse_assignment_value(pm_parser_t *parser, pm_binding_power_t binding_power, pm_diagnostic_id_t diag_id) {
+    pm_node_t *value = parse_value_expression(parser, binding_power, diag_id);
+
+    // Contradicting binding powers, the right-hand-side value of rthe assignment allows the `rescue` modifier.
+    if (match1(parser, PM_TOKEN_KEYWORD_RESCUE_MODIFIER)) {
+        pm_token_t rescue = parser->current;
+        parser_lex(parser);
+        pm_node_t *right = parse_expression(parser, binding_power, PM_ERR_RESCUE_MODIFIER_VALUE);
+
+        return (pm_node_t *) pm_rescue_modifier_node_create(parser, value, &rescue, right);
+    }
+
+    return value;
+}
+
+
+static inline pm_node_t *
+parse_assignment_values(pm_parser_t *parser, pm_binding_power_t previous_binding_power, pm_binding_power_t binding_power, pm_diagnostic_id_t diag_id) {
     pm_node_t *value = parse_starred_expression(parser, binding_power, diag_id);
 
+    bool is_single_value = true;
     if (previous_binding_power == PM_BINDING_POWER_STATEMENT && (PM_NODE_TYPE_P(value, PM_SPLAT_NODE) || match1(parser, PM_TOKEN_COMMA))) {
+        is_single_value = false;
         pm_token_t opening = not_provided(parser);
         pm_array_node_t *array = pm_array_node_create(parser, &opening);
 
@@ -15659,6 +15673,15 @@ parse_assignment_value(pm_parser_t *parser, pm_binding_power_t previous_binding_
             pm_array_node_elements_append(array, element);
             if (PM_NODE_TYPE_P(element, PM_MISSING_NODE)) break;
         }
+    }
+
+    // Contradicting binding powers, the right-hand-side value of the assignment allows the `rescue` modifier.
+    if (is_single_value && match1(parser, PM_TOKEN_KEYWORD_RESCUE_MODIFIER)) {
+        pm_token_t rescue = parser->current;
+        parser_lex(parser);
+        pm_node_t *right = parse_expression(parser, binding_power, PM_ERR_RESCUE_MODIFIER_VALUE);
+
+        return (pm_node_t *) pm_rescue_modifier_node_create(parser, value, &rescue, right);
     }
 
     return value;
@@ -15800,7 +15823,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 /* fallthrough */
                 case PM_CASE_WRITABLE: {
                     parser_lex(parser);
-                    pm_node_t *value = parse_assignment_value(parser, previous_binding_power, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_EQUAL);
+                    pm_node_t *value = parse_assignment_values(parser, previous_binding_power, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_EQUAL);
                     return parse_write(parser, node, &token, value);
                 }
                 case PM_SPLAT_NODE: {
@@ -15808,7 +15831,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                     pm_multi_target_node_targets_append(parser, multi_target, node);
 
                     parser_lex(parser);
-                    pm_node_t *value = parse_assignment_value(parser, previous_binding_power, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_EQUAL);
+                    pm_node_t *value = parse_assignment_values(parser, previous_binding_power, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_EQUAL);
                     return parse_write(parser, (pm_node_t *) multi_target, &token, value);
                 }
                 default:
@@ -15830,7 +15853,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_GLOBAL_VARIABLE_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
                     pm_node_t *result = (pm_node_t *) pm_global_variable_and_write_node_create(parser, node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -15839,7 +15862,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_CLASS_VARIABLE_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
                     pm_node_t *result = (pm_node_t *) pm_class_variable_and_write_node_create(parser, (pm_class_variable_read_node_t *) node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -15848,13 +15871,13 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_CONSTANT_PATH_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
                     return (pm_node_t *) pm_constant_path_and_write_node_create(parser, (pm_constant_path_node_t *) node, &token, value);
                 }
                 case PM_CONSTANT_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
                     pm_node_t *result = (pm_node_t *) pm_constant_and_write_node_create(parser, (pm_constant_read_node_t *) node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -15863,7 +15886,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_INSTANCE_VARIABLE_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
                     pm_node_t *result = (pm_node_t *) pm_instance_variable_and_write_node_create(parser, (pm_instance_variable_read_node_t *) node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -15873,7 +15896,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                     pm_local_variable_read_node_t *cast = (pm_local_variable_read_node_t *) node;
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
                     pm_node_t *result = (pm_node_t *) pm_local_variable_and_write_node_create(parser, node, &token, value, cast->name, cast->depth);
 
                     pm_node_destroy(parser, node);
@@ -15894,7 +15917,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                             pm_parser_err_location(parser, &message_loc, PM_ERR_PARAMETER_NUMBERED_RESERVED);
                         }
 
-                        pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
+                        pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
                         pm_node_t *result = (pm_node_t *) pm_local_variable_and_write_node_create(parser, (pm_node_t *) cast, &token, value, constant_id, 0);
 
                         pm_node_destroy(parser, (pm_node_t *) cast);
@@ -15905,7 +15928,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                     // this is an aref expression, and we can transform it into
                     // an aset expression.
                     if (pm_call_node_index_p(cast)) {
-                        pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
+                        pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
                         return (pm_node_t *) pm_index_and_write_node_create(parser, cast, &token, value);
                     }
 
@@ -15917,7 +15940,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                     }
 
                     parse_call_operator_write(parser, cast, &token);
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_AMPAMPEQ);
                     return (pm_node_t *) pm_call_and_write_node_create(parser, cast, &token, value);
                 }
                 case PM_MULTI_WRITE_NODE: {
@@ -15944,7 +15967,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_GLOBAL_VARIABLE_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
                     pm_node_t *result = (pm_node_t *) pm_global_variable_or_write_node_create(parser, node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -15953,7 +15976,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_CLASS_VARIABLE_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
                     pm_node_t *result = (pm_node_t *) pm_class_variable_or_write_node_create(parser, (pm_class_variable_read_node_t *) node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -15962,13 +15985,13 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_CONSTANT_PATH_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
                     return (pm_node_t *) pm_constant_path_or_write_node_create(parser, (pm_constant_path_node_t *) node, &token, value);
                 }
                 case PM_CONSTANT_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
                     pm_node_t *result = (pm_node_t *) pm_constant_or_write_node_create(parser, (pm_constant_read_node_t *) node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -15977,7 +16000,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_INSTANCE_VARIABLE_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
                     pm_node_t *result = (pm_node_t *) pm_instance_variable_or_write_node_create(parser, (pm_instance_variable_read_node_t *) node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -15987,7 +16010,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                     pm_local_variable_read_node_t *cast = (pm_local_variable_read_node_t *) node;
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
                     pm_node_t *result = (pm_node_t *) pm_local_variable_or_write_node_create(parser, node, &token, value, cast->name, cast->depth);
 
                     pm_node_destroy(parser, node);
@@ -16008,7 +16031,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                             pm_parser_err_location(parser, &message_loc, PM_ERR_PARAMETER_NUMBERED_RESERVED);
                         }
 
-                        pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
+                        pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
                         pm_node_t *result = (pm_node_t *) pm_local_variable_or_write_node_create(parser, (pm_node_t *) cast, &token, value, constant_id, 0);
 
                         pm_node_destroy(parser, (pm_node_t *) cast);
@@ -16019,7 +16042,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                     // this is an aref expression, and we can transform it into
                     // an aset expression.
                     if (pm_call_node_index_p(cast)) {
-                        pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
+                        pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
                         return (pm_node_t *) pm_index_or_write_node_create(parser, cast, &token, value);
                     }
 
@@ -16031,7 +16054,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                     }
 
                     parse_call_operator_write(parser, cast, &token);
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_PIPEPIPEEQ);
                     return (pm_node_t *) pm_call_or_write_node_create(parser, cast, &token, value);
                 }
                 case PM_MULTI_WRITE_NODE: {
@@ -16068,7 +16091,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_GLOBAL_VARIABLE_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
                     pm_node_t *result = (pm_node_t *) pm_global_variable_operator_write_node_create(parser, node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -16077,7 +16100,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_CLASS_VARIABLE_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
                     pm_node_t *result = (pm_node_t *) pm_class_variable_operator_write_node_create(parser, (pm_class_variable_read_node_t *) node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -16086,13 +16109,13 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_CONSTANT_PATH_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
                     return (pm_node_t *) pm_constant_path_operator_write_node_create(parser, (pm_constant_path_node_t *) node, &token, value);
                 }
                 case PM_CONSTANT_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
                     pm_node_t *result = (pm_node_t *) pm_constant_operator_write_node_create(parser, (pm_constant_read_node_t *) node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -16101,7 +16124,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 case PM_INSTANCE_VARIABLE_READ_NODE: {
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
                     pm_node_t *result = (pm_node_t *) pm_instance_variable_operator_write_node_create(parser, (pm_instance_variable_read_node_t *) node, &token, value);
 
                     pm_node_destroy(parser, node);
@@ -16111,7 +16134,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                     pm_local_variable_read_node_t *cast = (pm_local_variable_read_node_t *) node;
                     parser_lex(parser);
 
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
                     pm_node_t *result = (pm_node_t *) pm_local_variable_operator_write_node_create(parser, node, &token, value, cast->name, cast->depth);
 
                     pm_node_destroy(parser, node);
@@ -16132,7 +16155,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                             pm_parser_err_location(parser, &message_loc, PM_ERR_PARAMETER_NUMBERED_RESERVED);
                         }
 
-                        pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
+                        pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
                         pm_node_t *result = (pm_node_t *) pm_local_variable_operator_write_node_create(parser, (pm_node_t *) cast, &token, value, constant_id, 0);
 
                         pm_node_destroy(parser, (pm_node_t *) cast);
@@ -16143,7 +16166,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                     // this is an aref expression, and we can transform it into
                     // an aset expression.
                     if (pm_call_node_index_p(cast)) {
-                        pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
+                        pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
                         return (pm_node_t *) pm_index_operator_write_node_create(parser, cast, &token, value);
                     }
 
@@ -16155,7 +16178,7 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                     }
 
                     parse_call_operator_write(parser, cast, &token);
-                    pm_node_t *value = parse_expression(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
+                    pm_node_t *value = parse_assignment_value(parser, binding_power, PM_ERR_EXPECT_EXPRESSION_AFTER_OPERATOR);
                     return (pm_node_t *) pm_call_operator_write_node_create(parser, cast, &token, value);
                 }
                 case PM_MULTI_WRITE_NODE: {

--- a/test/prism/snapshots/rescue.txt
+++ b/test/prism/snapshots/rescue.txt
@@ -291,26 +291,26 @@
         │   ├── body:
         │   │   @ StatementsNode (location: (26,18)-(26,44))
         │   │   └── body: (length: 1)
-        │   │       └── @ CallNode (location: (26,18)-(26,44))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (26,18)-(26,30) = "other_method"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (26,31)-(26,44))
-        │   │           │   ├── arguments: (length: 1)
-        │   │           │   │   └── @ RescueModifierNode (location: (26,31)-(26,44))
-        │   │           │   │       ├── expression:
-        │   │           │   │       │   @ IntegerNode (location: (26,31)-(26,33))
-        │   │           │   │       │   └── flags: decimal
-        │   │           │   │       ├── keyword_loc: (26,34)-(26,40) = "rescue"
-        │   │           │   │       └── rescue_expression:
-        │   │           │   │           @ NilNode (location: (26,41)-(26,44))
-        │   │           │   └── flags: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :other_method
+        │   │       └── @ RescueModifierNode (location: (26,18)-(26,44))
+        │   │           ├── expression:
+        │   │           │   @ CallNode (location: (26,18)-(26,33))
+        │   │           │   ├── receiver: ∅
+        │   │           │   ├── call_operator_loc: ∅
+        │   │           │   ├── message_loc: (26,18)-(26,30) = "other_method"
+        │   │           │   ├── opening_loc: ∅
+        │   │           │   ├── arguments:
+        │   │           │   │   @ ArgumentsNode (location: (26,31)-(26,33))
+        │   │           │   │   ├── arguments: (length: 1)
+        │   │           │   │   │   └── @ IntegerNode (location: (26,31)-(26,33))
+        │   │           │   │   │       └── flags: decimal
+        │   │           │   │   └── flags: ∅
+        │   │           │   ├── closing_loc: ∅
+        │   │           │   ├── block: ∅
+        │   │           │   ├── flags: ∅
+        │   │           │   └── name: :other_method
+        │   │           ├── keyword_loc: (26,34)-(26,40) = "rescue"
+        │   │           └── rescue_expression:
+        │   │               @ NilNode (location: (26,41)-(26,44))
         │   ├── locals: []
         │   ├── def_keyword_loc: (26,0)-(26,3) = "def"
         │   ├── operator_loc: ∅

--- a/test/prism/snapshots/seattlerb/defn_endless_command_rescue.txt
+++ b/test/prism/snapshots/seattlerb/defn_endless_command_rescue.txt
@@ -11,27 +11,27 @@
             ├── body:
             │   @ StatementsNode (location: (1,18)-(1,43))
             │   └── body: (length: 1)
-            │       └── @ CallNode (location: (1,18)-(1,43))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,18)-(1,30) = "other_method"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (1,31)-(1,43))
-            │           │   ├── arguments: (length: 1)
-            │           │   │   └── @ RescueModifierNode (location: (1,31)-(1,43))
-            │           │   │       ├── expression:
-            │           │   │       │   @ IntegerNode (location: (1,31)-(1,33))
-            │           │   │       │   └── flags: decimal
-            │           │   │       ├── keyword_loc: (1,34)-(1,40) = "rescue"
-            │           │   │       └── rescue_expression:
-            │           │   │           @ IntegerNode (location: (1,41)-(1,43))
-            │           │   │           └── flags: decimal
-            │           │   └── flags: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :other_method
+            │       └── @ RescueModifierNode (location: (1,18)-(1,43))
+            │           ├── expression:
+            │           │   @ CallNode (location: (1,18)-(1,33))
+            │           │   ├── receiver: ∅
+            │           │   ├── call_operator_loc: ∅
+            │           │   ├── message_loc: (1,18)-(1,30) = "other_method"
+            │           │   ├── opening_loc: ∅
+            │           │   ├── arguments:
+            │           │   │   @ ArgumentsNode (location: (1,31)-(1,33))
+            │           │   │   ├── arguments: (length: 1)
+            │           │   │   │   └── @ IntegerNode (location: (1,31)-(1,33))
+            │           │   │   │       └── flags: decimal
+            │           │   │   └── flags: ∅
+            │           │   ├── closing_loc: ∅
+            │           │   ├── block: ∅
+            │           │   ├── flags: ∅
+            │           │   └── name: :other_method
+            │           ├── keyword_loc: (1,34)-(1,40) = "rescue"
+            │           └── rescue_expression:
+            │               @ IntegerNode (location: (1,41)-(1,43))
+            │               └── flags: decimal
             ├── locals: []
             ├── def_keyword_loc: (1,0)-(1,3) = "def"
             ├── operator_loc: ∅

--- a/test/prism/snapshots/seattlerb/defs_endless_command_rescue.txt
+++ b/test/prism/snapshots/seattlerb/defs_endless_command_rescue.txt
@@ -21,27 +21,27 @@
             ├── body:
             │   @ StatementsNode (location: (1,20)-(1,45))
             │   └── body: (length: 1)
-            │       └── @ CallNode (location: (1,20)-(1,45))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (1,20)-(1,32) = "other_method"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (1,33)-(1,45))
-            │           │   ├── arguments: (length: 1)
-            │           │   │   └── @ RescueModifierNode (location: (1,33)-(1,45))
-            │           │   │       ├── expression:
-            │           │   │       │   @ IntegerNode (location: (1,33)-(1,35))
-            │           │   │       │   └── flags: decimal
-            │           │   │       ├── keyword_loc: (1,36)-(1,42) = "rescue"
-            │           │   │       └── rescue_expression:
-            │           │   │           @ IntegerNode (location: (1,43)-(1,45))
-            │           │   │           └── flags: decimal
-            │           │   └── flags: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :other_method
+            │       └── @ RescueModifierNode (location: (1,20)-(1,45))
+            │           ├── expression:
+            │           │   @ CallNode (location: (1,20)-(1,35))
+            │           │   ├── receiver: ∅
+            │           │   ├── call_operator_loc: ∅
+            │           │   ├── message_loc: (1,20)-(1,32) = "other_method"
+            │           │   ├── opening_loc: ∅
+            │           │   ├── arguments:
+            │           │   │   @ ArgumentsNode (location: (1,33)-(1,35))
+            │           │   │   ├── arguments: (length: 1)
+            │           │   │   │   └── @ IntegerNode (location: (1,33)-(1,35))
+            │           │   │   │       └── flags: decimal
+            │           │   │   └── flags: ∅
+            │           │   ├── closing_loc: ∅
+            │           │   ├── block: ∅
+            │           │   ├── flags: ∅
+            │           │   └── name: :other_method
+            │           ├── keyword_loc: (1,36)-(1,42) = "rescue"
+            │           └── rescue_expression:
+            │               @ IntegerNode (location: (1,43)-(1,45))
+            │               └── flags: decimal
             ├── locals: []
             ├── def_keyword_loc: (1,0)-(1,3) = "def"
             ├── operator_loc: (1,5)-(1,6) = "."

--- a/test/prism/snapshots/seattlerb/lasgn_call_nobracket_rescue_arg.txt
+++ b/test/prism/snapshots/seattlerb/lasgn_call_nobracket_rescue_arg.txt
@@ -8,25 +8,25 @@
             ├── depth: 0
             ├── name_loc: (1,0)-(1,1) = "a"
             ├── value:
-            │   @ CallNode (location: (1,4)-(1,16))
-            │   ├── receiver: ∅
-            │   ├── call_operator_loc: ∅
-            │   ├── message_loc: (1,4)-(1,5) = "b"
-            │   ├── opening_loc: ∅
-            │   ├── arguments:
-            │   │   @ ArgumentsNode (location: (1,6)-(1,16))
-            │   │   ├── arguments: (length: 1)
-            │   │   │   └── @ RescueModifierNode (location: (1,6)-(1,16))
-            │   │   │       ├── expression:
-            │   │   │       │   @ IntegerNode (location: (1,6)-(1,7))
-            │   │   │       │   └── flags: decimal
-            │   │   │       ├── keyword_loc: (1,8)-(1,14) = "rescue"
-            │   │   │       └── rescue_expression:
-            │   │   │           @ IntegerNode (location: (1,15)-(1,16))
-            │   │   │           └── flags: decimal
-            │   │   └── flags: ∅
-            │   ├── closing_loc: ∅
-            │   ├── block: ∅
-            │   ├── flags: ∅
-            │   └── name: :b
+            │   @ RescueModifierNode (location: (1,4)-(1,16))
+            │   ├── expression:
+            │   │   @ CallNode (location: (1,4)-(1,7))
+            │   │   ├── receiver: ∅
+            │   │   ├── call_operator_loc: ∅
+            │   │   ├── message_loc: (1,4)-(1,5) = "b"
+            │   │   ├── opening_loc: ∅
+            │   │   ├── arguments:
+            │   │   │   @ ArgumentsNode (location: (1,6)-(1,7))
+            │   │   │   ├── arguments: (length: 1)
+            │   │   │   │   └── @ IntegerNode (location: (1,6)-(1,7))
+            │   │   │   │       └── flags: decimal
+            │   │   │   └── flags: ∅
+            │   │   ├── closing_loc: ∅
+            │   │   ├── block: ∅
+            │   │   ├── flags: ∅
+            │   │   └── name: :b
+            │   ├── keyword_loc: (1,8)-(1,14) = "rescue"
+            │   └── rescue_expression:
+            │       @ IntegerNode (location: (1,15)-(1,16))
+            │       └── flags: decimal
             └── operator_loc: (1,2)-(1,3) = "="

--- a/test/prism/snapshots/whitequark/endless_method_command_syntax.txt
+++ b/test/prism/snapshots/whitequark/endless_method_command_syntax.txt
@@ -269,48 +269,48 @@
         │   ├── body:
         │   │   @ StatementsNode (location: (13,17)-(13,60))
         │   │   └── body: (length: 1)
-        │   │       └── @ CallNode (location: (13,17)-(13,60))
-        │   │           ├── receiver: ∅
-        │   │           ├── call_operator_loc: ∅
-        │   │           ├── message_loc: (13,17)-(13,22) = "raise"
-        │   │           ├── opening_loc: ∅
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (13,23)-(13,60))
-        │   │           │   ├── arguments: (length: 1)
-        │   │           │   │   └── @ RescueModifierNode (location: (13,23)-(13,60))
-        │   │           │   │       ├── expression:
-        │   │           │   │       │   @ StringNode (location: (13,23)-(13,37))
-        │   │           │   │       │   ├── flags: ∅
-        │   │           │   │       │   ├── opening_loc: (13,23)-(13,24) = "\""
-        │   │           │   │       │   ├── content_loc: (13,24)-(13,36) = "to be caught"
-        │   │           │   │       │   ├── closing_loc: (13,36)-(13,37) = "\""
-        │   │           │   │       │   └── unescaped: "to be caught"
-        │   │           │   │       ├── keyword_loc: (13,38)-(13,44) = "rescue"
-        │   │           │   │       └── rescue_expression:
-        │   │           │   │           @ InterpolatedStringNode (location: (13,45)-(13,60))
-        │   │           │   │           ├── opening_loc: (13,45)-(13,46) = "\""
-        │   │           │   │           ├── parts: (length: 2)
-        │   │           │   │           │   ├── @ StringNode (location: (13,46)-(13,55))
-        │   │           │   │           │   │   ├── flags: ∅
-        │   │           │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │           │   │   ├── content_loc: (13,46)-(13,55) = "instance "
-        │   │           │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │           │   │   └── unescaped: "instance "
-        │   │           │   │           │   └── @ EmbeddedStatementsNode (location: (13,55)-(13,59))
-        │   │           │   │           │       ├── opening_loc: (13,55)-(13,57) = "\#{"
-        │   │           │   │           │       ├── statements:
-        │   │           │   │           │       │   @ StatementsNode (location: (13,57)-(13,58))
-        │   │           │   │           │       │   └── body: (length: 1)
-        │   │           │   │           │       │       └── @ LocalVariableReadNode (location: (13,57)-(13,58))
-        │   │           │   │           │       │           ├── name: :x
-        │   │           │   │           │       │           └── depth: 0
-        │   │           │   │           │       └── closing_loc: (13,58)-(13,59) = "}"
-        │   │           │   │           └── closing_loc: (13,59)-(13,60) = "\""
-        │   │           │   └── flags: ∅
-        │   │           ├── closing_loc: ∅
-        │   │           ├── block: ∅
-        │   │           ├── flags: ∅
-        │   │           └── name: :raise
+        │   │       └── @ RescueModifierNode (location: (13,17)-(13,60))
+        │   │           ├── expression:
+        │   │           │   @ CallNode (location: (13,17)-(13,37))
+        │   │           │   ├── receiver: ∅
+        │   │           │   ├── call_operator_loc: ∅
+        │   │           │   ├── message_loc: (13,17)-(13,22) = "raise"
+        │   │           │   ├── opening_loc: ∅
+        │   │           │   ├── arguments:
+        │   │           │   │   @ ArgumentsNode (location: (13,23)-(13,37))
+        │   │           │   │   ├── arguments: (length: 1)
+        │   │           │   │   │   └── @ StringNode (location: (13,23)-(13,37))
+        │   │           │   │   │       ├── flags: ∅
+        │   │           │   │   │       ├── opening_loc: (13,23)-(13,24) = "\""
+        │   │           │   │   │       ├── content_loc: (13,24)-(13,36) = "to be caught"
+        │   │           │   │   │       ├── closing_loc: (13,36)-(13,37) = "\""
+        │   │           │   │   │       └── unescaped: "to be caught"
+        │   │           │   │   └── flags: ∅
+        │   │           │   ├── closing_loc: ∅
+        │   │           │   ├── block: ∅
+        │   │           │   ├── flags: ∅
+        │   │           │   └── name: :raise
+        │   │           ├── keyword_loc: (13,38)-(13,44) = "rescue"
+        │   │           └── rescue_expression:
+        │   │               @ InterpolatedStringNode (location: (13,45)-(13,60))
+        │   │               ├── opening_loc: (13,45)-(13,46) = "\""
+        │   │               ├── parts: (length: 2)
+        │   │               │   ├── @ StringNode (location: (13,46)-(13,55))
+        │   │               │   │   ├── flags: ∅
+        │   │               │   │   ├── opening_loc: ∅
+        │   │               │   │   ├── content_loc: (13,46)-(13,55) = "instance "
+        │   │               │   │   ├── closing_loc: ∅
+        │   │               │   │   └── unescaped: "instance "
+        │   │               │   └── @ EmbeddedStatementsNode (location: (13,55)-(13,59))
+        │   │               │       ├── opening_loc: (13,55)-(13,57) = "\#{"
+        │   │               │       ├── statements:
+        │   │               │       │   @ StatementsNode (location: (13,57)-(13,58))
+        │   │               │       │   └── body: (length: 1)
+        │   │               │       │       └── @ LocalVariableReadNode (location: (13,57)-(13,58))
+        │   │               │       │           ├── name: :x
+        │   │               │       │           └── depth: 0
+        │   │               │       └── closing_loc: (13,58)-(13,59) = "}"
+        │   │               └── closing_loc: (13,59)-(13,60) = "\""
         │   ├── locals: [:x]
         │   ├── def_keyword_loc: (13,0)-(13,3) = "def"
         │   ├── operator_loc: ∅
@@ -337,48 +337,48 @@
             ├── body:
             │   @ StatementsNode (location: (15,22)-(15,62))
             │   └── body: (length: 1)
-            │       └── @ CallNode (location: (15,22)-(15,62))
-            │           ├── receiver: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── message_loc: (15,22)-(15,27) = "raise"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (15,28)-(15,62))
-            │           │   ├── arguments: (length: 1)
-            │           │   │   └── @ RescueModifierNode (location: (15,28)-(15,62))
-            │           │   │       ├── expression:
-            │           │   │       │   @ StringNode (location: (15,28)-(15,42))
-            │           │   │       │   ├── flags: ∅
-            │           │   │       │   ├── opening_loc: (15,28)-(15,29) = "\""
-            │           │   │       │   ├── content_loc: (15,29)-(15,41) = "to be caught"
-            │           │   │       │   ├── closing_loc: (15,41)-(15,42) = "\""
-            │           │   │       │   └── unescaped: "to be caught"
-            │           │   │       ├── keyword_loc: (15,43)-(15,49) = "rescue"
-            │           │   │       └── rescue_expression:
-            │           │   │           @ InterpolatedStringNode (location: (15,50)-(15,62))
-            │           │   │           ├── opening_loc: (15,50)-(15,51) = "\""
-            │           │   │           ├── parts: (length: 2)
-            │           │   │           │   ├── @ StringNode (location: (15,51)-(15,57))
-            │           │   │           │   │   ├── flags: ∅
-            │           │   │           │   │   ├── opening_loc: ∅
-            │           │   │           │   │   ├── content_loc: (15,51)-(15,57) = "class "
-            │           │   │           │   │   ├── closing_loc: ∅
-            │           │   │           │   │   └── unescaped: "class "
-            │           │   │           │   └── @ EmbeddedStatementsNode (location: (15,57)-(15,61))
-            │           │   │           │       ├── opening_loc: (15,57)-(15,59) = "\#{"
-            │           │   │           │       ├── statements:
-            │           │   │           │       │   @ StatementsNode (location: (15,59)-(15,60))
-            │           │   │           │       │   └── body: (length: 1)
-            │           │   │           │       │       └── @ LocalVariableReadNode (location: (15,59)-(15,60))
-            │           │   │           │       │           ├── name: :x
-            │           │   │           │       │           └── depth: 0
-            │           │   │           │       └── closing_loc: (15,60)-(15,61) = "}"
-            │           │   │           └── closing_loc: (15,61)-(15,62) = "\""
-            │           │   └── flags: ∅
-            │           ├── closing_loc: ∅
-            │           ├── block: ∅
-            │           ├── flags: ∅
-            │           └── name: :raise
+            │       └── @ RescueModifierNode (location: (15,22)-(15,62))
+            │           ├── expression:
+            │           │   @ CallNode (location: (15,22)-(15,42))
+            │           │   ├── receiver: ∅
+            │           │   ├── call_operator_loc: ∅
+            │           │   ├── message_loc: (15,22)-(15,27) = "raise"
+            │           │   ├── opening_loc: ∅
+            │           │   ├── arguments:
+            │           │   │   @ ArgumentsNode (location: (15,28)-(15,42))
+            │           │   │   ├── arguments: (length: 1)
+            │           │   │   │   └── @ StringNode (location: (15,28)-(15,42))
+            │           │   │   │       ├── flags: ∅
+            │           │   │   │       ├── opening_loc: (15,28)-(15,29) = "\""
+            │           │   │   │       ├── content_loc: (15,29)-(15,41) = "to be caught"
+            │           │   │   │       ├── closing_loc: (15,41)-(15,42) = "\""
+            │           │   │   │       └── unescaped: "to be caught"
+            │           │   │   └── flags: ∅
+            │           │   ├── closing_loc: ∅
+            │           │   ├── block: ∅
+            │           │   ├── flags: ∅
+            │           │   └── name: :raise
+            │           ├── keyword_loc: (15,43)-(15,49) = "rescue"
+            │           └── rescue_expression:
+            │               @ InterpolatedStringNode (location: (15,50)-(15,62))
+            │               ├── opening_loc: (15,50)-(15,51) = "\""
+            │               ├── parts: (length: 2)
+            │               │   ├── @ StringNode (location: (15,51)-(15,57))
+            │               │   │   ├── flags: ∅
+            │               │   │   ├── opening_loc: ∅
+            │               │   │   ├── content_loc: (15,51)-(15,57) = "class "
+            │               │   │   ├── closing_loc: ∅
+            │               │   │   └── unescaped: "class "
+            │               │   └── @ EmbeddedStatementsNode (location: (15,57)-(15,61))
+            │               │       ├── opening_loc: (15,57)-(15,59) = "\#{"
+            │               │       ├── statements:
+            │               │       │   @ StatementsNode (location: (15,59)-(15,60))
+            │               │       │   └── body: (length: 1)
+            │               │       │       └── @ LocalVariableReadNode (location: (15,59)-(15,60))
+            │               │       │           ├── name: :x
+            │               │       │           └── depth: 0
+            │               │       └── closing_loc: (15,60)-(15,61) = "}"
+            │               └── closing_loc: (15,61)-(15,62) = "\""
             ├── locals: [:x]
             ├── def_keyword_loc: (15,0)-(15,3) = "def"
             ├── operator_loc: (15,8)-(15,9) = "."

--- a/test/prism/snapshots/whitequark/ruby_bug_12402.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_12402.txt
@@ -7,34 +7,34 @@
         │   ├── name_loc: (1,0)-(1,3) = "foo"
         │   ├── operator_loc: (1,4)-(1,6) = "+="
         │   ├── value:
-        │   │   @ CallNode (location: (1,7)-(1,27))
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── message_loc: (1,7)-(1,12) = "raise"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments:
-        │   │   │   @ ArgumentsNode (location: (1,13)-(1,27))
-        │   │   │   ├── arguments: (length: 1)
-        │   │   │   │   └── @ RescueModifierNode (location: (1,13)-(1,27))
-        │   │   │   │       ├── expression:
-        │   │   │   │       │   @ CallNode (location: (1,13)-(1,16))
-        │   │   │   │       │   ├── receiver: ∅
-        │   │   │   │       │   ├── call_operator_loc: ∅
-        │   │   │   │       │   ├── message_loc: (1,13)-(1,16) = "bar"
-        │   │   │   │       │   ├── opening_loc: ∅
-        │   │   │   │       │   ├── arguments: ∅
-        │   │   │   │       │   ├── closing_loc: ∅
-        │   │   │   │       │   ├── block: ∅
-        │   │   │   │       │   ├── flags: variable_call
-        │   │   │   │       │   └── name: :bar
-        │   │   │   │       ├── keyword_loc: (1,17)-(1,23) = "rescue"
-        │   │   │   │       └── rescue_expression:
-        │   │   │   │           @ NilNode (location: (1,24)-(1,27))
-        │   │   │   └── flags: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   ├── block: ∅
-        │   │   ├── flags: ∅
-        │   │   └── name: :raise
+        │   │   @ RescueModifierNode (location: (1,7)-(1,27))
+        │   │   ├── expression:
+        │   │   │   @ CallNode (location: (1,7)-(1,16))
+        │   │   │   ├── receiver: ∅
+        │   │   │   ├── call_operator_loc: ∅
+        │   │   │   ├── message_loc: (1,7)-(1,12) = "raise"
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── arguments:
+        │   │   │   │   @ ArgumentsNode (location: (1,13)-(1,16))
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ CallNode (location: (1,13)-(1,16))
+        │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │       ├── message_loc: (1,13)-(1,16) = "bar"
+        │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │       ├── arguments: ∅
+        │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │       ├── flags: variable_call
+        │   │   │   │   │       └── name: :bar
+        │   │   │   │   └── flags: ∅
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   ├── block: ∅
+        │   │   │   ├── flags: ∅
+        │   │   │   └── name: :raise
+        │   │   ├── keyword_loc: (1,17)-(1,23) = "rescue"
+        │   │   └── rescue_expression:
+        │   │       @ NilNode (location: (1,24)-(1,27))
         │   ├── name: :foo
         │   ├── operator: :+
         │   └── depth: 0
@@ -78,34 +78,34 @@
         │   ├── depth: 0
         │   ├── name_loc: (5,0)-(5,3) = "foo"
         │   ├── value:
-        │   │   @ CallNode (location: (5,6)-(5,26))
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── message_loc: (5,6)-(5,11) = "raise"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments:
-        │   │   │   @ ArgumentsNode (location: (5,12)-(5,26))
-        │   │   │   ├── arguments: (length: 1)
-        │   │   │   │   └── @ RescueModifierNode (location: (5,12)-(5,26))
-        │   │   │   │       ├── expression:
-        │   │   │   │       │   @ CallNode (location: (5,12)-(5,15))
-        │   │   │   │       │   ├── receiver: ∅
-        │   │   │   │       │   ├── call_operator_loc: ∅
-        │   │   │   │       │   ├── message_loc: (5,12)-(5,15) = "bar"
-        │   │   │   │       │   ├── opening_loc: ∅
-        │   │   │   │       │   ├── arguments: ∅
-        │   │   │   │       │   ├── closing_loc: ∅
-        │   │   │   │       │   ├── block: ∅
-        │   │   │   │       │   ├── flags: variable_call
-        │   │   │   │       │   └── name: :bar
-        │   │   │   │       ├── keyword_loc: (5,16)-(5,22) = "rescue"
-        │   │   │   │       └── rescue_expression:
-        │   │   │   │           @ NilNode (location: (5,23)-(5,26))
-        │   │   │   └── flags: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   ├── block: ∅
-        │   │   ├── flags: ∅
-        │   │   └── name: :raise
+        │   │   @ RescueModifierNode (location: (5,6)-(5,26))
+        │   │   ├── expression:
+        │   │   │   @ CallNode (location: (5,6)-(5,15))
+        │   │   │   ├── receiver: ∅
+        │   │   │   ├── call_operator_loc: ∅
+        │   │   │   ├── message_loc: (5,6)-(5,11) = "raise"
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── arguments:
+        │   │   │   │   @ ArgumentsNode (location: (5,12)-(5,15))
+        │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   └── @ CallNode (location: (5,12)-(5,15))
+        │   │   │   │   │       ├── receiver: ∅
+        │   │   │   │   │       ├── call_operator_loc: ∅
+        │   │   │   │   │       ├── message_loc: (5,12)-(5,15) = "bar"
+        │   │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │   │       ├── arguments: ∅
+        │   │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │   │       ├── block: ∅
+        │   │   │   │   │       ├── flags: variable_call
+        │   │   │   │   │       └── name: :bar
+        │   │   │   │   └── flags: ∅
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   ├── block: ∅
+        │   │   │   ├── flags: ∅
+        │   │   │   └── name: :raise
+        │   │   ├── keyword_loc: (5,16)-(5,22) = "rescue"
+        │   │   └── rescue_expression:
+        │   │       @ NilNode (location: (5,23)-(5,26))
         │   └── operator_loc: (5,4)-(5,5) = "="
         ├── @ LocalVariableWriteNode (location: (7,0)-(7,27))
         │   ├── name: :foo
@@ -154,34 +154,34 @@
         │   ├── operator: :+
         │   ├── operator_loc: (9,6)-(9,8) = "+="
         │   └── value:
-        │       @ CallNode (location: (9,9)-(9,29))
-        │       ├── receiver: ∅
-        │       ├── call_operator_loc: ∅
-        │       ├── message_loc: (9,9)-(9,14) = "raise"
-        │       ├── opening_loc: ∅
-        │       ├── arguments:
-        │       │   @ ArgumentsNode (location: (9,15)-(9,29))
-        │       │   ├── arguments: (length: 1)
-        │       │   │   └── @ RescueModifierNode (location: (9,15)-(9,29))
-        │       │   │       ├── expression:
-        │       │   │       │   @ CallNode (location: (9,15)-(9,18))
-        │       │   │       │   ├── receiver: ∅
-        │       │   │       │   ├── call_operator_loc: ∅
-        │       │   │       │   ├── message_loc: (9,15)-(9,18) = "bar"
-        │       │   │       │   ├── opening_loc: ∅
-        │       │   │       │   ├── arguments: ∅
-        │       │   │       │   ├── closing_loc: ∅
-        │       │   │       │   ├── block: ∅
-        │       │   │       │   ├── flags: variable_call
-        │       │   │       │   └── name: :bar
-        │       │   │       ├── keyword_loc: (9,19)-(9,25) = "rescue"
-        │       │   │       └── rescue_expression:
-        │       │   │           @ NilNode (location: (9,26)-(9,29))
-        │       │   └── flags: ∅
-        │       ├── closing_loc: ∅
-        │       ├── block: ∅
-        │       ├── flags: ∅
-        │       └── name: :raise
+        │       @ RescueModifierNode (location: (9,9)-(9,29))
+        │       ├── expression:
+        │       │   @ CallNode (location: (9,9)-(9,18))
+        │       │   ├── receiver: ∅
+        │       │   ├── call_operator_loc: ∅
+        │       │   ├── message_loc: (9,9)-(9,14) = "raise"
+        │       │   ├── opening_loc: ∅
+        │       │   ├── arguments:
+        │       │   │   @ ArgumentsNode (location: (9,15)-(9,18))
+        │       │   │   ├── arguments: (length: 1)
+        │       │   │   │   └── @ CallNode (location: (9,15)-(9,18))
+        │       │   │   │       ├── receiver: ∅
+        │       │   │   │       ├── call_operator_loc: ∅
+        │       │   │   │       ├── message_loc: (9,15)-(9,18) = "bar"
+        │       │   │   │       ├── opening_loc: ∅
+        │       │   │   │       ├── arguments: ∅
+        │       │   │   │       ├── closing_loc: ∅
+        │       │   │   │       ├── block: ∅
+        │       │   │   │       ├── flags: variable_call
+        │       │   │   │       └── name: :bar
+        │       │   │   └── flags: ∅
+        │       │   ├── closing_loc: ∅
+        │       │   ├── block: ∅
+        │       │   ├── flags: ∅
+        │       │   └── name: :raise
+        │       ├── keyword_loc: (9,19)-(9,25) = "rescue"
+        │       └── rescue_expression:
+        │           @ NilNode (location: (9,26)-(9,29))
         ├── @ CallOperatorWriteNode (location: (11,0)-(11,30))
         │   ├── receiver:
         │   │   @ LocalVariableReadNode (location: (11,0)-(11,3))
@@ -236,34 +236,34 @@
         │   ├── operator: :+
         │   ├── operator_loc: (13,6)-(13,8) = "+="
         │   └── value:
-        │       @ CallNode (location: (13,9)-(13,29))
-        │       ├── receiver: ∅
-        │       ├── call_operator_loc: ∅
-        │       ├── message_loc: (13,9)-(13,14) = "raise"
-        │       ├── opening_loc: ∅
-        │       ├── arguments:
-        │       │   @ ArgumentsNode (location: (13,15)-(13,29))
-        │       │   ├── arguments: (length: 1)
-        │       │   │   └── @ RescueModifierNode (location: (13,15)-(13,29))
-        │       │   │       ├── expression:
-        │       │   │       │   @ CallNode (location: (13,15)-(13,18))
-        │       │   │       │   ├── receiver: ∅
-        │       │   │       │   ├── call_operator_loc: ∅
-        │       │   │       │   ├── message_loc: (13,15)-(13,18) = "bar"
-        │       │   │       │   ├── opening_loc: ∅
-        │       │   │       │   ├── arguments: ∅
-        │       │   │       │   ├── closing_loc: ∅
-        │       │   │       │   ├── block: ∅
-        │       │   │       │   ├── flags: variable_call
-        │       │   │       │   └── name: :bar
-        │       │   │       ├── keyword_loc: (13,19)-(13,25) = "rescue"
-        │       │   │       └── rescue_expression:
-        │       │   │           @ NilNode (location: (13,26)-(13,29))
-        │       │   └── flags: ∅
-        │       ├── closing_loc: ∅
-        │       ├── block: ∅
-        │       ├── flags: ∅
-        │       └── name: :raise
+        │       @ RescueModifierNode (location: (13,9)-(13,29))
+        │       ├── expression:
+        │       │   @ CallNode (location: (13,9)-(13,18))
+        │       │   ├── receiver: ∅
+        │       │   ├── call_operator_loc: ∅
+        │       │   ├── message_loc: (13,9)-(13,14) = "raise"
+        │       │   ├── opening_loc: ∅
+        │       │   ├── arguments:
+        │       │   │   @ ArgumentsNode (location: (13,15)-(13,18))
+        │       │   │   ├── arguments: (length: 1)
+        │       │   │   │   └── @ CallNode (location: (13,15)-(13,18))
+        │       │   │   │       ├── receiver: ∅
+        │       │   │   │       ├── call_operator_loc: ∅
+        │       │   │   │       ├── message_loc: (13,15)-(13,18) = "bar"
+        │       │   │   │       ├── opening_loc: ∅
+        │       │   │   │       ├── arguments: ∅
+        │       │   │   │       ├── closing_loc: ∅
+        │       │   │   │       ├── block: ∅
+        │       │   │   │       ├── flags: variable_call
+        │       │   │   │       └── name: :bar
+        │       │   │   └── flags: ∅
+        │       │   ├── closing_loc: ∅
+        │       │   ├── block: ∅
+        │       │   ├── flags: ∅
+        │       │   └── name: :raise
+        │       ├── keyword_loc: (13,19)-(13,25) = "rescue"
+        │       └── rescue_expression:
+        │           @ NilNode (location: (13,26)-(13,29))
         ├── @ CallOperatorWriteNode (location: (15,0)-(15,30))
         │   ├── receiver:
         │   │   @ LocalVariableReadNode (location: (15,0)-(15,3))
@@ -318,34 +318,34 @@
         │   │   └── delimiter_loc: (17,3)-(17,5) = "::"
         │   ├── operator_loc: (17,7)-(17,10) = "||="
         │   └── value:
-        │       @ CallNode (location: (17,11)-(17,31))
-        │       ├── receiver: ∅
-        │       ├── call_operator_loc: ∅
-        │       ├── message_loc: (17,11)-(17,16) = "raise"
-        │       ├── opening_loc: ∅
-        │       ├── arguments:
-        │       │   @ ArgumentsNode (location: (17,17)-(17,31))
-        │       │   ├── arguments: (length: 1)
-        │       │   │   └── @ RescueModifierNode (location: (17,17)-(17,31))
-        │       │   │       ├── expression:
-        │       │   │       │   @ CallNode (location: (17,17)-(17,20))
-        │       │   │       │   ├── receiver: ∅
-        │       │   │       │   ├── call_operator_loc: ∅
-        │       │   │       │   ├── message_loc: (17,17)-(17,20) = "bar"
-        │       │   │       │   ├── opening_loc: ∅
-        │       │   │       │   ├── arguments: ∅
-        │       │   │       │   ├── closing_loc: ∅
-        │       │   │       │   ├── block: ∅
-        │       │   │       │   ├── flags: variable_call
-        │       │   │       │   └── name: :bar
-        │       │   │       ├── keyword_loc: (17,21)-(17,27) = "rescue"
-        │       │   │       └── rescue_expression:
-        │       │   │           @ NilNode (location: (17,28)-(17,31))
-        │       │   └── flags: ∅
-        │       ├── closing_loc: ∅
-        │       ├── block: ∅
-        │       ├── flags: ∅
-        │       └── name: :raise
+        │       @ RescueModifierNode (location: (17,11)-(17,31))
+        │       ├── expression:
+        │       │   @ CallNode (location: (17,11)-(17,20))
+        │       │   ├── receiver: ∅
+        │       │   ├── call_operator_loc: ∅
+        │       │   ├── message_loc: (17,11)-(17,16) = "raise"
+        │       │   ├── opening_loc: ∅
+        │       │   ├── arguments:
+        │       │   │   @ ArgumentsNode (location: (17,17)-(17,20))
+        │       │   │   ├── arguments: (length: 1)
+        │       │   │   │   └── @ CallNode (location: (17,17)-(17,20))
+        │       │   │   │       ├── receiver: ∅
+        │       │   │   │       ├── call_operator_loc: ∅
+        │       │   │   │       ├── message_loc: (17,17)-(17,20) = "bar"
+        │       │   │   │       ├── opening_loc: ∅
+        │       │   │   │       ├── arguments: ∅
+        │       │   │   │       ├── closing_loc: ∅
+        │       │   │   │       ├── block: ∅
+        │       │   │   │       ├── flags: variable_call
+        │       │   │   │       └── name: :bar
+        │       │   │   └── flags: ∅
+        │       │   ├── closing_loc: ∅
+        │       │   ├── block: ∅
+        │       │   ├── flags: ∅
+        │       │   └── name: :raise
+        │       ├── keyword_loc: (17,21)-(17,27) = "rescue"
+        │       └── rescue_expression:
+        │           @ NilNode (location: (17,28)-(17,31))
         ├── @ ConstantPathOrWriteNode (location: (19,0)-(19,32))
         │   ├── target:
         │   │   @ ConstantPathNode (location: (19,0)-(19,6))
@@ -400,34 +400,34 @@
         │   ├── operator: :+
         │   ├── operator_loc: (21,7)-(21,9) = "+="
         │   └── value:
-        │       @ CallNode (location: (21,10)-(21,30))
-        │       ├── receiver: ∅
-        │       ├── call_operator_loc: ∅
-        │       ├── message_loc: (21,10)-(21,15) = "raise"
-        │       ├── opening_loc: ∅
-        │       ├── arguments:
-        │       │   @ ArgumentsNode (location: (21,16)-(21,30))
-        │       │   ├── arguments: (length: 1)
-        │       │   │   └── @ RescueModifierNode (location: (21,16)-(21,30))
-        │       │   │       ├── expression:
-        │       │   │       │   @ CallNode (location: (21,16)-(21,19))
-        │       │   │       │   ├── receiver: ∅
-        │       │   │       │   ├── call_operator_loc: ∅
-        │       │   │       │   ├── message_loc: (21,16)-(21,19) = "bar"
-        │       │   │       │   ├── opening_loc: ∅
-        │       │   │       │   ├── arguments: ∅
-        │       │   │       │   ├── closing_loc: ∅
-        │       │   │       │   ├── block: ∅
-        │       │   │       │   ├── flags: variable_call
-        │       │   │       │   └── name: :bar
-        │       │   │       ├── keyword_loc: (21,20)-(21,26) = "rescue"
-        │       │   │       └── rescue_expression:
-        │       │   │           @ NilNode (location: (21,27)-(21,30))
-        │       │   └── flags: ∅
-        │       ├── closing_loc: ∅
-        │       ├── block: ∅
-        │       ├── flags: ∅
-        │       └── name: :raise
+        │       @ RescueModifierNode (location: (21,10)-(21,30))
+        │       ├── expression:
+        │       │   @ CallNode (location: (21,10)-(21,19))
+        │       │   ├── receiver: ∅
+        │       │   ├── call_operator_loc: ∅
+        │       │   ├── message_loc: (21,10)-(21,15) = "raise"
+        │       │   ├── opening_loc: ∅
+        │       │   ├── arguments:
+        │       │   │   @ ArgumentsNode (location: (21,16)-(21,19))
+        │       │   │   ├── arguments: (length: 1)
+        │       │   │   │   └── @ CallNode (location: (21,16)-(21,19))
+        │       │   │   │       ├── receiver: ∅
+        │       │   │   │       ├── call_operator_loc: ∅
+        │       │   │   │       ├── message_loc: (21,16)-(21,19) = "bar"
+        │       │   │   │       ├── opening_loc: ∅
+        │       │   │   │       ├── arguments: ∅
+        │       │   │   │       ├── closing_loc: ∅
+        │       │   │   │       ├── block: ∅
+        │       │   │   │       ├── flags: variable_call
+        │       │   │   │       └── name: :bar
+        │       │   │   └── flags: ∅
+        │       │   ├── closing_loc: ∅
+        │       │   ├── block: ∅
+        │       │   ├── flags: ∅
+        │       │   └── name: :raise
+        │       ├── keyword_loc: (21,20)-(21,26) = "rescue"
+        │       └── rescue_expression:
+        │           @ NilNode (location: (21,27)-(21,30))
         ├── @ CallOperatorWriteNode (location: (23,0)-(23,31))
         │   ├── receiver:
         │   │   @ LocalVariableReadNode (location: (23,0)-(23,3))
@@ -488,34 +488,34 @@
         │   ├── operator: :+
         │   ├── operator_loc: (25,7)-(25,9) = "+="
         │   └── value:
-        │       @ CallNode (location: (25,10)-(25,30))
-        │       ├── receiver: ∅
-        │       ├── call_operator_loc: ∅
-        │       ├── message_loc: (25,10)-(25,15) = "raise"
-        │       ├── opening_loc: ∅
-        │       ├── arguments:
-        │       │   @ ArgumentsNode (location: (25,16)-(25,30))
-        │       │   ├── arguments: (length: 1)
-        │       │   │   └── @ RescueModifierNode (location: (25,16)-(25,30))
-        │       │   │       ├── expression:
-        │       │   │       │   @ CallNode (location: (25,16)-(25,19))
-        │       │   │       │   ├── receiver: ∅
-        │       │   │       │   ├── call_operator_loc: ∅
-        │       │   │       │   ├── message_loc: (25,16)-(25,19) = "bar"
-        │       │   │       │   ├── opening_loc: ∅
-        │       │   │       │   ├── arguments: ∅
-        │       │   │       │   ├── closing_loc: ∅
-        │       │   │       │   ├── block: ∅
-        │       │   │       │   ├── flags: variable_call
-        │       │   │       │   └── name: :bar
-        │       │   │       ├── keyword_loc: (25,20)-(25,26) = "rescue"
-        │       │   │       └── rescue_expression:
-        │       │   │           @ NilNode (location: (25,27)-(25,30))
-        │       │   └── flags: ∅
-        │       ├── closing_loc: ∅
-        │       ├── block: ∅
-        │       ├── flags: ∅
-        │       └── name: :raise
+        │       @ RescueModifierNode (location: (25,10)-(25,30))
+        │       ├── expression:
+        │       │   @ CallNode (location: (25,10)-(25,19))
+        │       │   ├── receiver: ∅
+        │       │   ├── call_operator_loc: ∅
+        │       │   ├── message_loc: (25,10)-(25,15) = "raise"
+        │       │   ├── opening_loc: ∅
+        │       │   ├── arguments:
+        │       │   │   @ ArgumentsNode (location: (25,16)-(25,19))
+        │       │   │   ├── arguments: (length: 1)
+        │       │   │   │   └── @ CallNode (location: (25,16)-(25,19))
+        │       │   │   │       ├── receiver: ∅
+        │       │   │   │       ├── call_operator_loc: ∅
+        │       │   │   │       ├── message_loc: (25,16)-(25,19) = "bar"
+        │       │   │   │       ├── opening_loc: ∅
+        │       │   │   │       ├── arguments: ∅
+        │       │   │   │       ├── closing_loc: ∅
+        │       │   │   │       ├── block: ∅
+        │       │   │   │       ├── flags: variable_call
+        │       │   │   │       └── name: :bar
+        │       │   │   └── flags: ∅
+        │       │   ├── closing_loc: ∅
+        │       │   ├── block: ∅
+        │       │   ├── flags: ∅
+        │       │   └── name: :raise
+        │       ├── keyword_loc: (25,20)-(25,26) = "rescue"
+        │       └── rescue_expression:
+        │           @ NilNode (location: (25,27)-(25,30))
         └── @ IndexOperatorWriteNode (location: (27,0)-(27,31))
             ├── receiver:
             │   @ LocalVariableReadNode (location: (27,0)-(27,3))


### PR DESCRIPTION
Fix #1541

This PR reverts the trick of the binding power of the `rescue` modifier, and fixes to handle it in `parse_assignment_value`. This specific treatment of the `rescue` modifier only appears in the right-hand-side value of the assignments, so my implementation is right.

The right-hand-side values of the compound assignments have the same issue. This PR introduces a new function `parse_assignment_value` to parse this and rename the previous same name one to <code>parse_assignment_value<i>s</i></code> (Actually, it can parse multiple values, so that sounds good.)

Some snapshots are updated, but they seem the right results.