### PR TITLE
Remove handling OptionalNodeField in set_newline_flag template

### DIFF
--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -242,7 +242,7 @@ public abstract class Nodes {
         public void setNewLineFlag(Source source, boolean[] newlineMarked) {
           <%- field = node.semantic_fields.find { |f| f.name == node.newline } or raise node.newline -%>
           <%- case field -%>
-          <%- when Prism::NodeField, Prism::OptionalNodeField -%>
+          <%- when Prism::NodeField -%>
             this.<%= field.name %>.setNewLineFlag(source, newlineMarked);
           <%- when Prism::NodeListField -%>
             Node first = this.<%= field.name %>.length > 0 ? this.<%= field.name %>[0] : null;

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -72,8 +72,6 @@ module Prism
       <%- case field -%>
       <%- when Prism::NodeField -%>
       <%= field.name %>.set_newline_flag(newline_marked)
-      <%- when Prism::OptionalNodeField -%>
-      <%= field.name %>.set_newline_flag(newline_marked) if <%= field.name %>
       <%- when Prism::NodeListField -%>
       first = <%= field.name %>.first
       first.set_newline_flag(newline_marked) if first

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -70,8 +70,10 @@ module Prism
     def set_newline_flag(newline_marked) # :nodoc:
       <%- field = node.fields.find { |f| f.name == node.newline } or raise node.newline -%>
       <%- case field -%>
-      <%- when Prism::NodeField, Prism::OptionalNodeField -%>
+      <%- when Prism::NodeField -%>
       <%= field.name %>.set_newline_flag(newline_marked)
+      <%- when Prism::OptionalNodeField -%>
+      <%= field.name %>.set_newline_flag(newline_marked) if <%= field.name %>
       <%- when Prism::NodeListField -%>
       first = <%= field.name %>.first
       first.set_newline_flag(newline_marked) if first


### PR DESCRIPTION
~A `Node#set_newline_flag` template for `OptionalNodeField` seems buggy.
If an `OptionalNodeField` is marked as a newline field, `NoMethodError` is raised at runtime.
Since there is no such field so far, it is not a problem.
This PR is for preventing the potential of bugs in the future.~

Because they are buggy, and actually they are dead code.