### PR TITLE
Add setNewLineFlag(boolean) for Java nodes

### DIFF
--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -122,6 +122,10 @@ public abstract class Nodes {
             }
         }
 
+        public void setNewLineFlag(boolean newLineFlag) {
+            this.newLineFlag = newLineFlag;
+        }
+
         public abstract <T> T accept(AbstractNodeVisitor<T> visitor);
 
         public abstract <T> void visitChildNodes(AbstractNodeVisitor<T> visitor);


### PR DESCRIPTION
* This is useful when desugaring and creating new nodes to not lose the newLineFlag.

For example when desugaring InterpolatedStringNode(StringNode StringNode) into a single StringNode.

I was thinking
```java
        public void copyNewLineFlag(Nodes.Node to) {
            if (newLineFlag) {
                to.newLineFlag = true;
            }
        }
```
might be nice but it's actually pretty inconvenient for that example, so keep things simple.