### PR TITLE
Use let declaration in scanConstant

### DIFF
--- a/templates/javascript/src/deserialize.js.erb
+++ b/templates/javascript/src/deserialize.js.erb
@@ -86,7 +86,7 @@ class SerializationBuffer {
 
   scanConstant(constantPoolOffset, constantIndex) {
     const offset = constantPoolOffset + constantIndex * 8;
-    const startOffset = this.scanUint32(offset);
+    let startOffset = this.scanUint32(offset);
     const length = this.scanUint32(offset + 4);
 
     if (startOffset & (1 << 31)) {


### PR DESCRIPTION
The `startOffset` variable is reassigned on line 93 and should therefore be declared using `let` instead of `const`.