### PR TITLE
Fix to parse `*` as forwarding in `foo[*]` case

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -10333,6 +10333,14 @@ match3(const pm_parser_t *parser, pm_token_type_t type1, pm_token_type_t type2, 
 }
 
 /**
+ * Returns true if the current token is any of the four given types.
+ */
+static inline bool
+match4(const pm_parser_t *parser, pm_token_type_t type1, pm_token_type_t type2, pm_token_type_t type3, pm_token_type_t type4) {
+    return match1(parser, type1) || match1(parser, type2) || match1(parser, type3) || match1(parser, type4);
+}
+
+/**
  * Returns true if the current token is any of the five given types.
  */
 static inline bool
@@ -11216,7 +11224,7 @@ parse_arguments(pm_parser_t *parser, pm_arguments_t *arguments, bool accepts_for
                 parser_lex(parser);
                 pm_token_t operator = parser->previous;
 
-                if (match3(parser, PM_TOKEN_PARENTHESIS_RIGHT, PM_TOKEN_COMMA, PM_TOKEN_SEMICOLON)) {
+                if (match4(parser, PM_TOKEN_PARENTHESIS_RIGHT, PM_TOKEN_COMMA, PM_TOKEN_SEMICOLON, PM_TOKEN_BRACKET_RIGHT)) {
                     if (pm_parser_local_depth(parser, &parser->previous) == -1) {
                         pm_parser_err_token(parser, &operator, PM_ERR_ARGUMENT_NO_FORWARDING_STAR);
                     }

--- a/test/prism/fixtures/arrays.txt
+++ b/test/prism/fixtures/arrays.txt
@@ -124,3 +124,19 @@ foo.foo[bar, &baz] += 1
 foo.foo[bar, &baz] ||= 1
 
 foo.foo[bar, &baz] &&= 1
+
+def f(*); a[*]; end
+
+def f(*); a[1, *]; end
+
+def f(*); a[*] = 1; end
+
+def f(*); a[1, *] = 1; end
+
+def f(*); a[*] += 1; end
+
+def f(*); a[1, *] &&= 1; end
+
+def f(*); rescue => a[*]; end
+
+def f(*); rescue => a[1, *]; end

--- a/test/prism/snapshots/arrays.txt
+++ b/test/prism/snapshots/arrays.txt
@@ -1,8 +1,8 @@
-@ ProgramNode (location: (1,0)-(126,24))
+@ ProgramNode (location: (1,0)-(142,32))
 ├── locals: []
 └── statements:
-    @ StatementsNode (location: (1,0)-(126,24))
-    └── body: (length: 51)
+    @ StatementsNode (location: (1,0)-(142,32))
+    └── body: (length: 59)
         ├── @ ArrayNode (location: (1,0)-(1,4))
         │   ├── elements: (length: 1)
         │   │   └── @ SplatNode (location: (1,1)-(1,3))
@@ -1716,61 +1716,526 @@
         │   └── value:
         │       @ IntegerNode (location: (124,23)-(124,24))
         │       └── flags: decimal
-        └── @ IndexAndWriteNode (location: (126,0)-(126,24))
-            ├── receiver:
-            │   @ CallNode (location: (126,0)-(126,7))
-            │   ├── receiver:
-            │   │   @ CallNode (location: (126,0)-(126,3))
-            │   │   ├── receiver: ∅
-            │   │   ├── call_operator_loc: ∅
-            │   │   ├── name: :foo
-            │   │   ├── message_loc: (126,0)-(126,3) = "foo"
-            │   │   ├── opening_loc: ∅
-            │   │   ├── arguments: ∅
-            │   │   ├── closing_loc: ∅
-            │   │   ├── block: ∅
-            │   │   └── flags: variable_call
-            │   ├── call_operator_loc: (126,3)-(126,4) = "."
-            │   ├── name: :foo
-            │   ├── message_loc: (126,4)-(126,7) = "foo"
-            │   ├── opening_loc: ∅
-            │   ├── arguments: ∅
-            │   ├── closing_loc: ∅
-            │   ├── block: ∅
-            │   └── flags: ∅
-            ├── call_operator_loc: ∅
-            ├── opening_loc: (126,7)-(126,8) = "["
-            ├── arguments:
-            │   @ ArgumentsNode (location: (126,8)-(126,11))
-            │   ├── arguments: (length: 1)
-            │   │   └── @ CallNode (location: (126,8)-(126,11))
-            │   │       ├── receiver: ∅
-            │   │       ├── call_operator_loc: ∅
-            │   │       ├── name: :bar
-            │   │       ├── message_loc: (126,8)-(126,11) = "bar"
-            │   │       ├── opening_loc: ∅
-            │   │       ├── arguments: ∅
-            │   │       ├── closing_loc: ∅
-            │   │       ├── block: ∅
-            │   │       └── flags: variable_call
-            │   └── flags: ∅
-            ├── closing_loc: (126,17)-(126,18) = "]"
-            ├── block:
-            │   @ BlockArgumentNode (location: (126,13)-(126,17))
-            │   ├── expression:
-            │   │   @ CallNode (location: (126,14)-(126,17))
-            │   │   ├── receiver: ∅
-            │   │   ├── call_operator_loc: ∅
-            │   │   ├── name: :baz
-            │   │   ├── message_loc: (126,14)-(126,17) = "baz"
-            │   │   ├── opening_loc: ∅
-            │   │   ├── arguments: ∅
-            │   │   ├── closing_loc: ∅
-            │   │   ├── block: ∅
-            │   │   └── flags: variable_call
-            │   └── operator_loc: (126,13)-(126,14) = "&"
-            ├── flags: ∅
-            ├── operator_loc: (126,19)-(126,22) = "&&="
-            └── value:
-                @ IntegerNode (location: (126,23)-(126,24))
-                └── flags: decimal
+        ├── @ IndexAndWriteNode (location: (126,0)-(126,24))
+        │   ├── receiver:
+        │   │   @ CallNode (location: (126,0)-(126,7))
+        │   │   ├── receiver:
+        │   │   │   @ CallNode (location: (126,0)-(126,3))
+        │   │   │   ├── receiver: ∅
+        │   │   │   ├── call_operator_loc: ∅
+        │   │   │   ├── name: :foo
+        │   │   │   ├── message_loc: (126,0)-(126,3) = "foo"
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── arguments: ∅
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   ├── block: ∅
+        │   │   │   └── flags: variable_call
+        │   │   ├── call_operator_loc: (126,3)-(126,4) = "."
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (126,4)-(126,7) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   ├── block: ∅
+        │   │   └── flags: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── opening_loc: (126,7)-(126,8) = "["
+        │   ├── arguments:
+        │   │   @ ArgumentsNode (location: (126,8)-(126,11))
+        │   │   ├── arguments: (length: 1)
+        │   │   │   └── @ CallNode (location: (126,8)-(126,11))
+        │   │   │       ├── receiver: ∅
+        │   │   │       ├── call_operator_loc: ∅
+        │   │   │       ├── name: :bar
+        │   │   │       ├── message_loc: (126,8)-(126,11) = "bar"
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── arguments: ∅
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       ├── block: ∅
+        │   │   │       └── flags: variable_call
+        │   │   └── flags: ∅
+        │   ├── closing_loc: (126,17)-(126,18) = "]"
+        │   ├── block:
+        │   │   @ BlockArgumentNode (location: (126,13)-(126,17))
+        │   │   ├── expression:
+        │   │   │   @ CallNode (location: (126,14)-(126,17))
+        │   │   │   ├── receiver: ∅
+        │   │   │   ├── call_operator_loc: ∅
+        │   │   │   ├── name: :baz
+        │   │   │   ├── message_loc: (126,14)-(126,17) = "baz"
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── arguments: ∅
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   ├── block: ∅
+        │   │   │   └── flags: variable_call
+        │   │   └── operator_loc: (126,13)-(126,14) = "&"
+        │   ├── flags: ∅
+        │   ├── operator_loc: (126,19)-(126,22) = "&&="
+        │   └── value:
+        │       @ IntegerNode (location: (126,23)-(126,24))
+        │       └── flags: decimal
+        ├── @ DefNode (location: (128,0)-(128,19))
+        │   ├── name: :f
+        │   ├── name_loc: (128,4)-(128,5) = "f"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (128,6)-(128,7))
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest:
+        │   │   │   @ RestParameterNode (location: (128,6)-(128,7))
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (128,6)-(128,7) = "*"
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body:
+        │   │   @ StatementsNode (location: (128,10)-(128,14))
+        │   │   └── body: (length: 1)
+        │   │       └── @ CallNode (location: (128,10)-(128,14))
+        │   │           ├── receiver:
+        │   │           │   @ CallNode (location: (128,10)-(128,11))
+        │   │           │   ├── receiver: ∅
+        │   │           │   ├── call_operator_loc: ∅
+        │   │           │   ├── name: :a
+        │   │           │   ├── message_loc: (128,10)-(128,11) = "a"
+        │   │           │   ├── opening_loc: ∅
+        │   │           │   ├── arguments: ∅
+        │   │           │   ├── closing_loc: ∅
+        │   │           │   ├── block: ∅
+        │   │           │   └── flags: variable_call
+        │   │           ├── call_operator_loc: ∅
+        │   │           ├── name: :[]
+        │   │           ├── message_loc: (128,11)-(128,14) = "[*]"
+        │   │           ├── opening_loc: (128,11)-(128,12) = "["
+        │   │           ├── arguments:
+        │   │           │   @ ArgumentsNode (location: (128,12)-(128,13))
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ SplatNode (location: (128,12)-(128,13))
+        │   │           │   │       ├── operator_loc: (128,12)-(128,13) = "*"
+        │   │           │   │       └── expression: ∅
+        │   │           │   └── flags: ∅
+        │   │           ├── closing_loc: (128,13)-(128,14) = "]"
+        │   │           ├── block: ∅
+        │   │           └── flags: ∅
+        │   ├── locals: [:*]
+        │   ├── def_keyword_loc: (128,0)-(128,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (128,5)-(128,6) = "("
+        │   ├── rparen_loc: (128,7)-(128,8) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (128,16)-(128,19) = "end"
+        ├── @ DefNode (location: (130,0)-(130,22))
+        │   ├── name: :f
+        │   ├── name_loc: (130,4)-(130,5) = "f"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (130,6)-(130,7))
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest:
+        │   │   │   @ RestParameterNode (location: (130,6)-(130,7))
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (130,6)-(130,7) = "*"
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body:
+        │   │   @ StatementsNode (location: (130,10)-(130,17))
+        │   │   └── body: (length: 1)
+        │   │       └── @ CallNode (location: (130,10)-(130,17))
+        │   │           ├── receiver:
+        │   │           │   @ CallNode (location: (130,10)-(130,11))
+        │   │           │   ├── receiver: ∅
+        │   │           │   ├── call_operator_loc: ∅
+        │   │           │   ├── name: :a
+        │   │           │   ├── message_loc: (130,10)-(130,11) = "a"
+        │   │           │   ├── opening_loc: ∅
+        │   │           │   ├── arguments: ∅
+        │   │           │   ├── closing_loc: ∅
+        │   │           │   ├── block: ∅
+        │   │           │   └── flags: variable_call
+        │   │           ├── call_operator_loc: ∅
+        │   │           ├── name: :[]
+        │   │           ├── message_loc: (130,11)-(130,17) = "[1, *]"
+        │   │           ├── opening_loc: (130,11)-(130,12) = "["
+        │   │           ├── arguments:
+        │   │           │   @ ArgumentsNode (location: (130,12)-(130,16))
+        │   │           │   ├── arguments: (length: 2)
+        │   │           │   │   ├── @ IntegerNode (location: (130,12)-(130,13))
+        │   │           │   │   │   └── flags: decimal
+        │   │           │   │   └── @ SplatNode (location: (130,15)-(130,16))
+        │   │           │   │       ├── operator_loc: (130,15)-(130,16) = "*"
+        │   │           │   │       └── expression: ∅
+        │   │           │   └── flags: ∅
+        │   │           ├── closing_loc: (130,16)-(130,17) = "]"
+        │   │           ├── block: ∅
+        │   │           └── flags: ∅
+        │   ├── locals: [:*]
+        │   ├── def_keyword_loc: (130,0)-(130,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (130,5)-(130,6) = "("
+        │   ├── rparen_loc: (130,7)-(130,8) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (130,19)-(130,22) = "end"
+        ├── @ DefNode (location: (132,0)-(132,23))
+        │   ├── name: :f
+        │   ├── name_loc: (132,4)-(132,5) = "f"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (132,6)-(132,7))
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest:
+        │   │   │   @ RestParameterNode (location: (132,6)-(132,7))
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (132,6)-(132,7) = "*"
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body:
+        │   │   @ StatementsNode (location: (132,10)-(132,18))
+        │   │   └── body: (length: 1)
+        │   │       └── @ CallNode (location: (132,10)-(132,18))
+        │   │           ├── receiver:
+        │   │           │   @ CallNode (location: (132,10)-(132,11))
+        │   │           │   ├── receiver: ∅
+        │   │           │   ├── call_operator_loc: ∅
+        │   │           │   ├── name: :a
+        │   │           │   ├── message_loc: (132,10)-(132,11) = "a"
+        │   │           │   ├── opening_loc: ∅
+        │   │           │   ├── arguments: ∅
+        │   │           │   ├── closing_loc: ∅
+        │   │           │   ├── block: ∅
+        │   │           │   └── flags: variable_call
+        │   │           ├── call_operator_loc: ∅
+        │   │           ├── name: :[]=
+        │   │           ├── message_loc: (132,11)-(132,14) = "[*]"
+        │   │           ├── opening_loc: (132,11)-(132,12) = "["
+        │   │           ├── arguments:
+        │   │           │   @ ArgumentsNode (location: (132,12)-(132,18))
+        │   │           │   ├── arguments: (length: 2)
+        │   │           │   │   ├── @ SplatNode (location: (132,12)-(132,13))
+        │   │           │   │   │   ├── operator_loc: (132,12)-(132,13) = "*"
+        │   │           │   │   │   └── expression: ∅
+        │   │           │   │   └── @ IntegerNode (location: (132,17)-(132,18))
+        │   │           │   │       └── flags: decimal
+        │   │           │   └── flags: ∅
+        │   │           ├── closing_loc: (132,13)-(132,14) = "]"
+        │   │           ├── block: ∅
+        │   │           └── flags: ∅
+        │   ├── locals: [:*]
+        │   ├── def_keyword_loc: (132,0)-(132,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (132,5)-(132,6) = "("
+        │   ├── rparen_loc: (132,7)-(132,8) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (132,20)-(132,23) = "end"
+        ├── @ DefNode (location: (134,0)-(134,26))
+        │   ├── name: :f
+        │   ├── name_loc: (134,4)-(134,5) = "f"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (134,6)-(134,7))
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest:
+        │   │   │   @ RestParameterNode (location: (134,6)-(134,7))
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (134,6)-(134,7) = "*"
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body:
+        │   │   @ StatementsNode (location: (134,10)-(134,21))
+        │   │   └── body: (length: 1)
+        │   │       └── @ CallNode (location: (134,10)-(134,21))
+        │   │           ├── receiver:
+        │   │           │   @ CallNode (location: (134,10)-(134,11))
+        │   │           │   ├── receiver: ∅
+        │   │           │   ├── call_operator_loc: ∅
+        │   │           │   ├── name: :a
+        │   │           │   ├── message_loc: (134,10)-(134,11) = "a"
+        │   │           │   ├── opening_loc: ∅
+        │   │           │   ├── arguments: ∅
+        │   │           │   ├── closing_loc: ∅
+        │   │           │   ├── block: ∅
+        │   │           │   └── flags: variable_call
+        │   │           ├── call_operator_loc: ∅
+        │   │           ├── name: :[]=
+        │   │           ├── message_loc: (134,11)-(134,17) = "[1, *]"
+        │   │           ├── opening_loc: (134,11)-(134,12) = "["
+        │   │           ├── arguments:
+        │   │           │   @ ArgumentsNode (location: (134,12)-(134,21))
+        │   │           │   ├── arguments: (length: 3)
+        │   │           │   │   ├── @ IntegerNode (location: (134,12)-(134,13))
+        │   │           │   │   │   └── flags: decimal
+        │   │           │   │   ├── @ SplatNode (location: (134,15)-(134,16))
+        │   │           │   │   │   ├── operator_loc: (134,15)-(134,16) = "*"
+        │   │           │   │   │   └── expression: ∅
+        │   │           │   │   └── @ IntegerNode (location: (134,20)-(134,21))
+        │   │           │   │       └── flags: decimal
+        │   │           │   └── flags: ∅
+        │   │           ├── closing_loc: (134,16)-(134,17) = "]"
+        │   │           ├── block: ∅
+        │   │           └── flags: ∅
+        │   ├── locals: [:*]
+        │   ├── def_keyword_loc: (134,0)-(134,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (134,5)-(134,6) = "("
+        │   ├── rparen_loc: (134,7)-(134,8) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (134,23)-(134,26) = "end"
+        ├── @ DefNode (location: (136,0)-(136,24))
+        │   ├── name: :f
+        │   ├── name_loc: (136,4)-(136,5) = "f"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (136,6)-(136,7))
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest:
+        │   │   │   @ RestParameterNode (location: (136,6)-(136,7))
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (136,6)-(136,7) = "*"
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body:
+        │   │   @ StatementsNode (location: (136,10)-(136,19))
+        │   │   └── body: (length: 1)
+        │   │       └── @ IndexOperatorWriteNode (location: (136,10)-(136,19))
+        │   │           ├── receiver:
+        │   │           │   @ CallNode (location: (136,10)-(136,11))
+        │   │           │   ├── receiver: ∅
+        │   │           │   ├── call_operator_loc: ∅
+        │   │           │   ├── name: :a
+        │   │           │   ├── message_loc: (136,10)-(136,11) = "a"
+        │   │           │   ├── opening_loc: ∅
+        │   │           │   ├── arguments: ∅
+        │   │           │   ├── closing_loc: ∅
+        │   │           │   ├── block: ∅
+        │   │           │   └── flags: variable_call
+        │   │           ├── call_operator_loc: ∅
+        │   │           ├── opening_loc: (136,11)-(136,12) = "["
+        │   │           ├── arguments:
+        │   │           │   @ ArgumentsNode (location: (136,12)-(136,13))
+        │   │           │   ├── arguments: (length: 1)
+        │   │           │   │   └── @ SplatNode (location: (136,12)-(136,13))
+        │   │           │   │       ├── operator_loc: (136,12)-(136,13) = "*"
+        │   │           │   │       └── expression: ∅
+        │   │           │   └── flags: ∅
+        │   │           ├── closing_loc: (136,13)-(136,14) = "]"
+        │   │           ├── block: ∅
+        │   │           ├── flags: ∅
+        │   │           ├── operator: :+
+        │   │           ├── operator_loc: (136,15)-(136,17) = "+="
+        │   │           └── value:
+        │   │               @ IntegerNode (location: (136,18)-(136,19))
+        │   │               └── flags: decimal
+        │   ├── locals: [:*]
+        │   ├── def_keyword_loc: (136,0)-(136,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (136,5)-(136,6) = "("
+        │   ├── rparen_loc: (136,7)-(136,8) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (136,21)-(136,24) = "end"
+        ├── @ DefNode (location: (138,0)-(138,28))
+        │   ├── name: :f
+        │   ├── name_loc: (138,4)-(138,5) = "f"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (138,6)-(138,7))
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest:
+        │   │   │   @ RestParameterNode (location: (138,6)-(138,7))
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (138,6)-(138,7) = "*"
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body:
+        │   │   @ StatementsNode (location: (138,10)-(138,23))
+        │   │   └── body: (length: 1)
+        │   │       └── @ IndexAndWriteNode (location: (138,10)-(138,23))
+        │   │           ├── receiver:
+        │   │           │   @ CallNode (location: (138,10)-(138,11))
+        │   │           │   ├── receiver: ∅
+        │   │           │   ├── call_operator_loc: ∅
+        │   │           │   ├── name: :a
+        │   │           │   ├── message_loc: (138,10)-(138,11) = "a"
+        │   │           │   ├── opening_loc: ∅
+        │   │           │   ├── arguments: ∅
+        │   │           │   ├── closing_loc: ∅
+        │   │           │   ├── block: ∅
+        │   │           │   └── flags: variable_call
+        │   │           ├── call_operator_loc: ∅
+        │   │           ├── opening_loc: (138,11)-(138,12) = "["
+        │   │           ├── arguments:
+        │   │           │   @ ArgumentsNode (location: (138,12)-(138,16))
+        │   │           │   ├── arguments: (length: 2)
+        │   │           │   │   ├── @ IntegerNode (location: (138,12)-(138,13))
+        │   │           │   │   │   └── flags: decimal
+        │   │           │   │   └── @ SplatNode (location: (138,15)-(138,16))
+        │   │           │   │       ├── operator_loc: (138,15)-(138,16) = "*"
+        │   │           │   │       └── expression: ∅
+        │   │           │   └── flags: ∅
+        │   │           ├── closing_loc: (138,16)-(138,17) = "]"
+        │   │           ├── block: ∅
+        │   │           ├── flags: ∅
+        │   │           ├── operator_loc: (138,18)-(138,21) = "&&="
+        │   │           └── value:
+        │   │               @ IntegerNode (location: (138,22)-(138,23))
+        │   │               └── flags: decimal
+        │   ├── locals: [:*]
+        │   ├── def_keyword_loc: (138,0)-(138,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (138,5)-(138,6) = "("
+        │   ├── rparen_loc: (138,7)-(138,8) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (138,25)-(138,28) = "end"
+        ├── @ DefNode (location: (140,0)-(140,29))
+        │   ├── name: :f
+        │   ├── name_loc: (140,4)-(140,5) = "f"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (140,6)-(140,7))
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest:
+        │   │   │   @ RestParameterNode (location: (140,6)-(140,7))
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (140,6)-(140,7) = "*"
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body:
+        │   │   @ BeginNode (location: (140,10)-(140,29))
+        │   │   ├── begin_keyword_loc: ∅
+        │   │   ├── statements: ∅
+        │   │   ├── rescue_clause:
+        │   │   │   @ RescueNode (location: (140,10)-(140,24))
+        │   │   │   ├── keyword_loc: (140,10)-(140,16) = "rescue"
+        │   │   │   ├── exceptions: (length: 0)
+        │   │   │   ├── operator_loc: (140,17)-(140,19) = "=>"
+        │   │   │   ├── reference:
+        │   │   │   │   @ CallNode (location: (140,20)-(140,24))
+        │   │   │   │   ├── receiver:
+        │   │   │   │   │   @ CallNode (location: (140,20)-(140,21))
+        │   │   │   │   │   ├── receiver: ∅
+        │   │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   │   ├── name: :a
+        │   │   │   │   │   ├── message_loc: (140,20)-(140,21) = "a"
+        │   │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   │   ├── arguments: ∅
+        │   │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   │   ├── block: ∅
+        │   │   │   │   │   └── flags: variable_call
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── name: :[]=
+        │   │   │   │   ├── message_loc: (140,21)-(140,24) = "[*]"
+        │   │   │   │   ├── opening_loc: (140,21)-(140,22) = "["
+        │   │   │   │   ├── arguments:
+        │   │   │   │   │   @ ArgumentsNode (location: (140,22)-(140,23))
+        │   │   │   │   │   ├── arguments: (length: 1)
+        │   │   │   │   │   │   └── @ SplatNode (location: (140,22)-(140,23))
+        │   │   │   │   │   │       ├── operator_loc: (140,22)-(140,23) = "*"
+        │   │   │   │   │   │       └── expression: ∅
+        │   │   │   │   │   └── flags: ∅
+        │   │   │   │   ├── closing_loc: (140,23)-(140,24) = "]"
+        │   │   │   │   ├── block: ∅
+        │   │   │   │   └── flags: ∅
+        │   │   │   ├── statements: ∅
+        │   │   │   └── consequent: ∅
+        │   │   ├── else_clause: ∅
+        │   │   ├── ensure_clause: ∅
+        │   │   └── end_keyword_loc: (140,26)-(140,29) = "end"
+        │   ├── locals: [:*]
+        │   ├── def_keyword_loc: (140,0)-(140,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (140,5)-(140,6) = "("
+        │   ├── rparen_loc: (140,7)-(140,8) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (140,26)-(140,29) = "end"
+        └── @ DefNode (location: (142,0)-(142,32))
+            ├── name: :f
+            ├── name_loc: (142,4)-(142,5) = "f"
+            ├── receiver: ∅
+            ├── parameters:
+            │   @ ParametersNode (location: (142,6)-(142,7))
+            │   ├── requireds: (length: 0)
+            │   ├── optionals: (length: 0)
+            │   ├── rest:
+            │   │   @ RestParameterNode (location: (142,6)-(142,7))
+            │   │   ├── name: ∅
+            │   │   ├── name_loc: ∅
+            │   │   └── operator_loc: (142,6)-(142,7) = "*"
+            │   ├── posts: (length: 0)
+            │   ├── keywords: (length: 0)
+            │   ├── keyword_rest: ∅
+            │   └── block: ∅
+            ├── body:
+            │   @ BeginNode (location: (142,10)-(142,32))
+            │   ├── begin_keyword_loc: ∅
+            │   ├── statements: ∅
+            │   ├── rescue_clause:
+            │   │   @ RescueNode (location: (142,10)-(142,27))
+            │   │   ├── keyword_loc: (142,10)-(142,16) = "rescue"
+            │   │   ├── exceptions: (length: 0)
+            │   │   ├── operator_loc: (142,17)-(142,19) = "=>"
+            │   │   ├── reference:
+            │   │   │   @ CallNode (location: (142,20)-(142,27))
+            │   │   │   ├── receiver:
+            │   │   │   │   @ CallNode (location: (142,20)-(142,21))
+            │   │   │   │   ├── receiver: ∅
+            │   │   │   │   ├── call_operator_loc: ∅
+            │   │   │   │   ├── name: :a
+            │   │   │   │   ├── message_loc: (142,20)-(142,21) = "a"
+            │   │   │   │   ├── opening_loc: ∅
+            │   │   │   │   ├── arguments: ∅
+            │   │   │   │   ├── closing_loc: ∅
+            │   │   │   │   ├── block: ∅
+            │   │   │   │   └── flags: variable_call
+            │   │   │   ├── call_operator_loc: ∅
+            │   │   │   ├── name: :[]=
+            │   │   │   ├── message_loc: (142,21)-(142,27) = "[1, *]"
+            │   │   │   ├── opening_loc: (142,21)-(142,22) = "["
+            │   │   │   ├── arguments:
+            │   │   │   │   @ ArgumentsNode (location: (142,22)-(142,26))
+            │   │   │   │   ├── arguments: (length: 2)
+            │   │   │   │   │   ├── @ IntegerNode (location: (142,22)-(142,23))
+            │   │   │   │   │   │   └── flags: decimal
+            │   │   │   │   │   └── @ SplatNode (location: (142,25)-(142,26))
+            │   │   │   │   │       ├── operator_loc: (142,25)-(142,26) = "*"
+            │   │   │   │   │       └── expression: ∅
+            │   │   │   │   └── flags: ∅
+            │   │   │   ├── closing_loc: (142,26)-(142,27) = "]"
+            │   │   │   ├── block: ∅
+            │   │   │   └── flags: ∅
+            │   │   ├── statements: ∅
+            │   │   └── consequent: ∅
+            │   ├── else_clause: ∅
+            │   ├── ensure_clause: ∅
+            │   └── end_keyword_loc: (142,29)-(142,32) = "end"
+            ├── locals: [:*]
+            ├── def_keyword_loc: (142,0)-(142,3) = "def"
+            ├── operator_loc: ∅
+            ├── lparen_loc: (142,5)-(142,6) = "("
+            ├── rparen_loc: (142,7)-(142,8) = ")"
+            ├── equal_loc: ∅
+            └── end_keyword_loc: (142,29)-(142,32) = "end"


### PR DESCRIPTION
Fix #1924