### PR TITLE
Move DATA parsing into its own parse result field

### DIFF
--- a/bin/parse
+++ b/bin/parse
@@ -25,6 +25,7 @@ parts["Comments"] = result.comments if result.comments.any?
 parts["Magic comments"] = result.magic_comments if result.magic_comments.any?
 parts["Warnings"] = result.warnings if result.warnings.any?
 parts["Errors"] = result.errors if result.errors.any?
+parts["DATA"] = result.data_loc if result.data_loc
 
 if parts.empty?
   puts value.inspect

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -34,7 +34,6 @@ The comment type is one of:
 
 * 0=`INLINE` (`# comment`)
 * 1=`EMBEDDED_DOCUMENT` (`=begin`/`=end`)
-* 2=`__END__` (after `__END__`)
 
 | # bytes | field |
 | --- | --- |
@@ -77,6 +76,7 @@ The header is structured like the following table:
 | comment* | comments |
 | varint | number of magic comments |
 | magic comment* | magic comments |
+| location? | the optional location of the `__END__` keyword and its contents |
 | varint | number of errors |
 | diagnostic* | errors |
 | varint | number of warnings |

--- a/include/prism/parser.h
+++ b/include/prism/parser.h
@@ -361,8 +361,7 @@ typedef struct pm_context_node {
 /** This is the type of a comment that we've found while parsing. */
 typedef enum {
     PM_COMMENT_INLINE,
-    PM_COMMENT_EMBDOC,
-    PM_COMMENT___END__
+    PM_COMMENT_EMBDOC
 } pm_comment_type_t;
 
 /**
@@ -570,6 +569,9 @@ struct pm_parser {
 
     /** The list of magic comments that have been found while parsing. */
     pm_list_t magic_comment_list;
+
+    /** The optional location of the __END__ keyword and its contents. */
+    pm_location_t data_loc;
 
     /** The list of warnings that have been found while parsing. */
     pm_list_t warning_list;

--- a/java/org/prism/ParseResult.java
+++ b/java/org/prism/ParseResult.java
@@ -35,12 +35,14 @@ public final class ParseResult {
 
     public final Nodes.Node value;
     public final MagicComment[] magicComments;
+    public final Nodes.Location dataLocation;
     public final Error[] errors;
     public final Warning[] warnings;
 
-    public ParseResult(Nodes.Node value, MagicComment[] magicComments, Error[] errors, Warning[] warnings) {
+    public ParseResult(Nodes.Node value, MagicComment[] magicComments, Nodes.Location dataLocation, Error[] errors, Warning[] warnings) {
         this.value = value;
         this.magicComments = magicComments;
+        this.dataLocation = dataLocation;
         this.errors = errors;
         this.warnings = warnings;
     }

--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -254,10 +254,10 @@ module Prism
         loader = Serialize::Loader.new(source, buffer.read)
 
         tokens = loader.load_tokens
-        node, comments, magic_comments, errors, warnings = loader.load_nodes
+        node, comments, magic_comments, data_loc, errors, warnings = loader.load_nodes
         tokens.each { |token,| token.value.force_encoding(loader.encoding) }
 
-        ParseResult.new([node, tokens], comments, magic_comments, errors, warnings, source)
+        ParseResult.new([node, tokens], comments, magic_comments, data_loc, errors, warnings, source)
       end
     end
 

--- a/lib/prism/lex_compat.rb
+++ b/lib/prism/lex_compat.rb
@@ -831,7 +831,7 @@ module Prism
       # We sort by location to compare against Ripper's output
       tokens.sort_by!(&:location)
 
-      ParseResult.new(tokens, result.comments, result.magic_comments, result.errors, result.warnings, [])
+      ParseResult.new(tokens, result.comments, result.magic_comments, result.data_loc, result.errors, result.warnings, [])
     end
   end
 

--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -238,11 +238,6 @@ module Prism
     def deconstruct_keys(keys)
       { location: location }
     end
-
-    # This can only be true for inline comments.
-    def trailing?
-      false
-    end
   end
 
   # InlineComment objects are the most common. They correspond to comments in
@@ -263,18 +258,14 @@ module Prism
   # EmbDocComment objects correspond to comments that are surrounded by =begin
   # and =end.
   class EmbDocComment < Comment
+    # This can only be true for inline comments.
+    def trailing?
+      false
+    end
+
     # Returns a string representation of this comment.
     def inspect
       "#<Prism::EmbDocComment @location=#{location.inspect}>"
-    end
-  end
-
-  # DATAComment objects correspond to comments that are after the __END__
-  # keyword in a source file.
-  class DATAComment < Comment
-    # Returns a string representation of this comment.
-    def inspect
-      "#<Prism::DATAComment @location=#{location.inspect}>"
     end
   end
 
@@ -378,6 +369,11 @@ module Prism
     # The list of magic comments that were encountered during parsing.
     attr_reader :magic_comments
 
+    # An optional location that represents the location of the content after the
+    # __END__ marker. This content is loaded into the DATA constant when the
+    # file being parsed is the main file being executed.
+    attr_reader :data_loc
+
     # The list of errors that were generated during parsing.
     attr_reader :errors
 
@@ -388,10 +384,11 @@ module Prism
     attr_reader :source
 
     # Create a new parse result object with the given values.
-    def initialize(value, comments, magic_comments, errors, warnings, source)
+    def initialize(value, comments, magic_comments, data_loc, errors, warnings, source)
       @value = value
       @comments = comments
       @magic_comments = magic_comments
+      @data_loc = data_loc
       @errors = errors
       @warnings = warnings
       @source = source
@@ -399,7 +396,7 @@ module Prism
 
     # Implement the hash pattern matching interface for ParseResult.
     def deconstruct_keys(keys)
-      { value: value, comments: comments, magic_comments: magic_comments, errors: errors, warnings: warnings }
+      { value: value, comments: comments, magic_comments: magic_comments, data_loc: data_loc, errors: errors, warnings: warnings }
     end
 
     # Returns true if there were no errors during parsing and false if there

--- a/src/prism.c
+++ b/src/prism.c
@@ -9231,8 +9231,8 @@ parser_lex(pm_parser_t *parser) {
                         parser->current.type = PM_TOKEN___END__;
                         parser_lex_callback(parser);
 
-                        pm_comment_t *comment = parser_comment(parser, PM_COMMENT___END__);
-                        pm_list_append(&parser->comment_list, (pm_list_node_t *) comment);
+                        parser->data_loc.start = parser->current.start;
+                        parser->data_loc.end = parser->current.end;
 
                         LEX(PM_TOKEN_EOF);
                     }

--- a/templates/java/org/prism/Loader.java.erb
+++ b/templates/java/org/prism/Loader.java.erb
@@ -115,6 +115,7 @@ public class Loader {
         source.setStartLine(loadVarInt());
 
         ParseResult.MagicComment[] magicComments = loadMagicComments();
+        Nodes.Location dataLocation = loadOptionalLocation();
         ParseResult.Error[] errors = loadSyntaxErrors();
         ParseResult.Warning[] warnings = loadWarnings();
 
@@ -133,7 +134,7 @@ public class Loader {
         MarkNewlinesVisitor visitor = new MarkNewlinesVisitor(source, newlineMarked);
         node.accept(visitor);
 
-        return new ParseResult(node, magicComments, errors, warnings);
+        return new ParseResult(node, magicComments, dataLocation, errors, warnings);
     }
 
     private byte[] loadEmbeddedString() {

--- a/templates/javascript/src/deserialize.js.erb
+++ b/templates/javascript/src/deserialize.js.erb
@@ -60,7 +60,7 @@ class SerializationBuffer {
     return { startOffset: this.readVarInt(), length: this.readVarInt() };
   }
 
-  readOptionalLocationField() {
+  readOptionalLocation() {
     if (this.readByte() != 0) {
       return this.readLocation();
     } else {
@@ -154,6 +154,10 @@ export class ParseResult {
   magicComments;
 
   /**
+   * @type {Location | null}
+   */
+
+  /**
    * @type {ParseError[]}
    */
   errors;
@@ -170,10 +174,11 @@ export class ParseResult {
    * @param {ParseError[]} errors
    * @param {ParseWarning[]} warnings
    */
-  constructor(value, comments, magicComments, errors, warnings) {
+  constructor(value, comments, magicComments, dataLoc, errors, warnings) {
     this.value = value;
     this.comments = comments;
     this.magicComments = magicComments;
+    this.dataLoc = dataLoc;
     this.errors = errors;
     this.warnings = warnings;
   }
@@ -220,6 +225,8 @@ export function deserialize(source, array) {
     endLocation: buffer.readLocation()
   }));
 
+  const dataLoc = buffer.readOptionalLocation();
+
   const errors = Array.from({ length: buffer.readVarInt() }, () => ({
     message: buffer.readString(buffer.readVarInt()),
     location: buffer.readLocation()
@@ -233,7 +240,7 @@ export function deserialize(source, array) {
   const constantPoolOffset = buffer.readUint32();
   const constants = Array.from({ length: buffer.readVarInt() }, () => null);
 
-  return new ParseResult(readRequiredNode(), comments, magicComments, errors, warnings);
+  return new ParseResult(readRequiredNode(), comments, magicComments, dataLoc, errors, warnings);
 
   function readRequiredNode() {
     const type = buffer.readByte();
@@ -255,7 +262,7 @@ export function deserialize(source, array) {
           when Prism::OptionalConstantField then "readOptionalConstant()"
           when Prism::ConstantListField then "Array.from({ length: buffer.readVarInt() }, readRequiredConstant)"
           when Prism::LocationField then "buffer.readLocation()"
-          when Prism::OptionalLocationField then "buffer.readOptionalLocationField()"
+          when Prism::OptionalLocationField then "buffer.readOptionalLocation()"
           when Prism::UInt32Field, Prism::FlagsField then "buffer.readVarInt()"
           else raise
           end

--- a/templates/lib/prism/serialize.rb.erb
+++ b/templates/lib/prism/serialize.rb.erb
@@ -95,9 +95,10 @@ module Prism
       def load_metadata
         comments = load_comments
         magic_comments = load_varint.times.map { MagicComment.new(load_location, load_location) }
+        data_loc = load_optional_location
         errors = load_varint.times.map { ParseError.new(load_embedded_string, load_location) }
         warnings = load_varint.times.map { ParseWarning.new(load_embedded_string, load_location) }
-        [comments, magic_comments, errors, warnings]
+        [comments, magic_comments, data_loc, errors, warnings]
       end
 
       def load_tokens
@@ -117,11 +118,11 @@ module Prism
         tokens = load_tokens
         encoding = load_encoding
         load_start_line
-        comments, magic_comments, errors, warnings = load_metadata
+        comments, magic_comments, data_loc, errors, warnings = load_metadata
         tokens.each { |token,| token.value.force_encoding(encoding) }
 
         raise "Expected to consume all bytes while deserializing" unless @io.eof?
-        Prism::ParseResult.new(tokens, comments, magic_comments, errors, warnings, @source)
+        Prism::ParseResult.new(tokens, comments, magic_comments, data_loc, errors, warnings, @source)
       end
 
       def load_nodes
@@ -129,17 +130,17 @@ module Prism
         load_encoding
         load_start_line
 
-        comments, magic_comments, errors, warnings = load_metadata
+        comments, magic_comments, data_loc, errors, warnings = load_metadata
 
         @constant_pool_offset = io.read(4).unpack1("L")
         @constant_pool = Array.new(load_varint, nil)
 
-        [load_node, comments, magic_comments, errors, warnings]
+        [load_node, comments, magic_comments, data_loc, errors, warnings]
       end
 
       def load_result
-        node, comments, magic_comments, errors, warnings = load_nodes
-        Prism::ParseResult.new(node, comments, magic_comments, errors, warnings, @source)
+        node, comments, magic_comments, data_loc, errors, warnings = load_nodes
+        Prism::ParseResult.new(node, comments, magic_comments, data_loc, errors, warnings, @source)
       end
 
       private

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -15,7 +15,7 @@ pm_sizet_to_u32(size_t value) {
 }
 
 static void
-pm_serialize_location(pm_parser_t *parser, pm_location_t *location, pm_buffer_t *buffer) {
+pm_serialize_location(const pm_parser_t *parser, const pm_location_t *location, pm_buffer_t *buffer) {
     assert(location->start);
     assert(location->end);
     assert(location->start <= location->end);
@@ -171,6 +171,16 @@ pm_serialize_magic_comment_list(pm_parser_t *parser, pm_list_t *list, pm_buffer_
 }
 
 static void
+pm_serialize_data_loc(const pm_parser_t *parser, pm_buffer_t *buffer) {
+    if (parser->data_loc.end == NULL) {
+        pm_buffer_append_byte(buffer, 0);
+    } else {
+        pm_buffer_append_byte(buffer, 1);
+        pm_serialize_location(parser, &parser->data_loc, buffer);
+    }
+}
+
+static void
 pm_serialize_diagnostic(pm_parser_t *parser, pm_diagnostic_t *diagnostic, pm_buffer_t *buffer) {
     // serialize message
     size_t message_length = strlen(diagnostic->message);
@@ -214,6 +224,7 @@ pm_serialize_content(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) 
     pm_serialize_comment_list(parser, &parser->comment_list, buffer);
 <%- end -%>
     pm_serialize_magic_comment_list(parser, &parser->magic_comment_list, buffer);
+    pm_serialize_data_loc(parser, buffer);
     pm_serialize_diagnostic_list(parser, &parser->error_list, buffer);
     pm_serialize_diagnostic_list(parser, &parser->warning_list, buffer);
 
@@ -310,6 +321,7 @@ pm_serialize_lex(pm_buffer_t *buffer, const uint8_t *source, size_t size, const 
     pm_buffer_append_varint(buffer, parser.start_line);
     pm_serialize_comment_list(&parser, &parser.comment_list, buffer);
     pm_serialize_magic_comment_list(&parser, &parser.magic_comment_list, buffer);
+    pm_serialize_data_loc(&parser, buffer);
     pm_serialize_diagnostic_list(&parser, &parser.error_list, buffer);
     pm_serialize_diagnostic_list(&parser, &parser.warning_list, buffer);
 

--- a/test/prism/comments_test.rb
+++ b/test/prism/comments_test.rb
@@ -39,37 +39,23 @@ module Prism
       )
     end
 
-    def test_comment___END__
-      source = <<~RUBY
+    def test___END__
+      result = Prism.parse(<<~RUBY)
         __END__
         comment
       RUBY
 
-      assert_comment(
-        source,
-        DATAComment,
-        start_offset: 0,
-        end_offset: 16,
-        start_line: 1,
-        end_line: 3,
-        start_column: 0,
-        end_column: 0
-      )
+      data_loc = result.data_loc
+      assert_equal 0, data_loc.start_offset
+      assert_equal 16, data_loc.end_offset
     end
 
-    def test_comment___END__crlf
-      source = "__END__\r\ncomment\r\n"
+    def test___END__crlf
+      result = Prism.parse("__END__\r\ncomment\r\n")
 
-      assert_comment(
-        source,
-        DATAComment,
-        start_offset: 0,
-        end_offset: 18,
-        start_line: 1,
-        end_line: 3,
-        start_column: 0,
-        end_column: 0
-      )
+      data_loc = result.data_loc
+      assert_equal 0, data_loc.start_offset
+      assert_equal 18, data_loc.end_offset
     end
 
     def test_comment_embedded_document


### PR DESCRIPTION
It's not really a comment anyway. This removes it from the types of comments and instead makes it its own field on parse result and serialization as an optional location.

Fixes #1824.