### PR TITLE
Fix lex_compat for `<<HEREDOC # comment` at EOF

### DIFF
--- a/test/prism/fixtures/heredoc_with_comment.txt
+++ b/test/prism/fixtures/heredoc_with_comment.txt
@@ -1,0 +1,2 @@
+<<-TARGET # comment
+TARGET

--- a/test/prism/snapshots/heredoc_with_comment_at_start.txt
+++ b/test/prism/snapshots/heredoc_with_comment_at_start.txt
@@ -1,0 +1,11 @@
+@ ProgramNode (location: (1,0)-(1,9))
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (1,0)-(1,9))
+    └── body: (length: 1)
+        └── @ StringNode (location: (1,0)-(1,9))
+            ├── flags: ∅
+            ├── opening_loc: (1,0)-(1,9) = "<<-TARGET"
+            ├── content_loc: (2,0)-(3,0) = "  data\r\n"
+            ├── closing_loc: (3,0)-(4,0) = "TARGET\r\n"
+            └── unescaped: "  data\r\n"


### PR DESCRIPTION
Fixes a special case of the `:on_nl` token after a comment. When the token immediately preceding the comment is a `:HEREDOC_END` then the `:on_nl` is _not_ added. 

~~I had posted this fix in the issue, but let's just try opening a PR and see if the solution works for everyone.~~

UPDATE: This is now a different fix. I found the underlying problem.

When a comment follows a heredoc end, the end_offset of the comment at the _start_ of the heredoc end token. We must use the heredoc_end token's `end_offset` for the offset to be in the correct location.

The bug is caused when `if start_offset < end_offset` returns true because start_offset is at the end of the comment. It always finds the end of the heredoc, `"HEREDOC"` and thinks it's trailing whitespace. With the correct offset, it is not confused and outputs the on_nl correctly.

Fixes #1874

