### PR TITLE
Fix comments after HEREDOCs again.

### DIFF
--- a/test/prism/fixtures/heredoc_with_comment.txt
+++ b/test/prism/fixtures/heredoc_with_comment.txt
@@ -1,2 +1,3 @@
-<<-TARGET # comment
+<<-TARGET.chomp # the heredoc end token doesn't always precede the comment
+  content makes for an obvious error
 TARGET


### PR DESCRIPTION
The problem was deeper than just looking back a single token. You can push the heredoc_end token way back into the list. 

Unfortunately, we need to save the last location of a heredoc_end to see if it's the last token in the file. I feel like this is pretty inelegant, but it solve the problem more generally.

Fixes #1954 and all of the versions of this error that I brought up there.