### PR TITLE
Prism.parse_success?(source)

### DIFF
--- a/docs/ruby_api.md
+++ b/docs/ruby_api.md
@@ -25,6 +25,8 @@ The full API is documented below.
 * `Prism.load(source, serialized)` - load the serialized syntax tree using the source as a reference into a syntax tree
 * `Prism.parse_comments(source)` - parse the comments corresponding to the given source string and return them
 * `Prism.parse_file_comments(source)` - parse the comments corresponding to the given source file and return them
+* `Prism.parse_success?(source)` - parse the syntax tree corresponding to the given source string and return true if it was parsed without errors or warnings
+* `Prism.parse_file_success?(filepath)` - parse the syntax tree corresponding to the given source file and return true if it was parsed without errors or warnings
 
 ## Nodes
 

--- a/include/prism.h
+++ b/include/prism.h
@@ -153,6 +153,16 @@ PRISM_EXPORTED_FUNCTION void pm_serialize_lex(pm_buffer_t *buffer, const uint8_t
 PRISM_EXPORTED_FUNCTION void pm_serialize_parse_lex(pm_buffer_t *buffer, const uint8_t *source, size_t size, const char *data);
 
 /**
+ * Parse the source and return true if it parses without errors or warnings.
+ *
+ * @param source The source to parse.
+ * @param size The size of the source.
+ * @param data The optional data to pass to the parser.
+ * @return True if the source parses without errors or warnings.
+ */
+PRISM_EXPORTED_FUNCTION bool pm_parse_success_p(const uint8_t *source, size_t size, const char *data);
+
+/**
  * Returns a string representation of the given token type.
  *
  * @param token_type The token type to convert to a string.

--- a/lib/prism.rb
+++ b/lib/prism.rb
@@ -64,6 +64,22 @@ module Prism
   def self.load(source, serialized)
     Serialize.load(source, serialized)
   end
+
+  # :call-seq:
+  #   Prism::parse_failure?(source, **options) -> bool
+  #
+  # Returns true if the source is invalid Ruby code.
+  def self.parse_failure?(source, **options)
+    !parse_success?(source, **options)
+  end
+
+  # :call-seq:
+  #   Prism::parse_file_failure?(filepath, **options) -> bool
+  #
+  # Returns true if the file at filepath is invalid Ruby code.
+  def self.parse_file_failure?(filepath, **options)
+    !parse_file_success?(filepath, **options)
+  end
 end
 
 require_relative "prism/node"

--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -72,7 +72,8 @@ module Prism
       "pm_serialize_parse",
       "pm_serialize_parse_comments",
       "pm_serialize_lex",
-      "pm_serialize_parse_lex"
+      "pm_serialize_parse_lex",
+      "pm_parse_success_p"
     )
 
     load_exported_functions_from(
@@ -265,6 +266,18 @@ module Prism
     def parse_lex_file(filepath, **options)
       LibRubyParser::PrismString.with(filepath) do |string|
         parse_lex(string.read, **options, filepath: filepath)
+      end
+    end
+
+    # Mirror the Prism.parse_success? API by using the serialization API.
+    def parse_success?(code, **options)
+      LibRubyParser.pm_parse_success_p(code, code.bytesize, dump_options(options))
+    end
+
+    # Mirror the Prism.parse_file_success? API by using the serialization API.
+    def parse_file_success?(filepath, **options)
+      LibRubyParser::PrismString.with(filepath) do |string|
+        parse_success?(string.read, **options, filepath: filepath)
       end
     end
 

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -359,3 +359,24 @@ pm_serialize_parse_lex(pm_buffer_t *buffer, const uint8_t *source, size_t size, 
     pm_parser_free(&parser);
     pm_options_free(&options);
 }
+
+/**
+ * Parse the source and return true if it parses without errors or warnings.
+ */
+PRISM_EXPORTED_FUNCTION bool
+pm_parse_success_p(const uint8_t *source, size_t size, const char *data) {
+    pm_options_t options = { 0 };
+    pm_options_read(&options, data);
+
+    pm_parser_t parser;
+    pm_parser_init(&parser, source, size, &options);
+
+    pm_node_t *node = pm_parse(&parser);
+    pm_node_destroy(&parser, node);
+
+    bool result = parser.error_list.size == 0 && parser.warning_list.size == 0;
+    pm_parser_free(&parser);
+    pm_options_free(&options);
+
+    return result;
+}

--- a/test/prism/ruby_api_test.rb
+++ b/test/prism/ruby_api_test.rb
@@ -20,6 +20,18 @@ module Prism
       assert_equal_nodes ast2, ast3
     end
 
+    def test_parse_success?
+      assert Prism.parse_success?("1")
+      refute Prism.parse_success?("<>")
+
+      assert Prism.parse_success?("m //", verbose: false)
+      refute Prism.parse_success?("m //", verbose: true)
+    end
+
+    def test_parse_file_success?
+      assert Prism.parse_file_success?(__FILE__)
+    end
+
     def test_options
       assert_equal "", Prism.parse("__FILE__").value.statements.body[0].filepath
       assert_equal "foo.rb", Prism.parse("__FILE__", filepath: "foo.rb").value.statements.body[0].filepath


### PR DESCRIPTION
A lot of tools use Ripper/RubyVM::AbstractSyntaxTree to determine if a source is valid. These tools both create an AST instead of providing an API that will return a boolean only.

This new API only creates the C structs, but doesn't bother reifying them into Ruby/the serialization API. Instead it only returns true/false, which is significantly more efficient.