### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tmp/
 /lib/prism.bundle
 /lib/prism.so
 /test.rb
+.DS_Store
 *.dSYM
 /*.iml
 *~


### PR DESCRIPTION
While I was poking around with prism locally, git was kind to point out that I had modified this (mac specific) file. It would be convenient if it was ignored by default.