### PR TITLE
Mention about `MAKEFLAGS` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,15 @@ to fetch the Ruby dependencies. Finally, run:
 rake compile
 ```
 
-to compile the shared library. It will be built in the `build` directory. To test that everything is working, run:
+to compile the shared library.
+
+One way to speed up the build process is to utilize `MAKEFLAGS` to pass options into `make`. For example, to use 10 jobs, run:
+
+```
+MAKEFLAGS="-j10" rake compile
+```
+
+It will be built in the `build` directory. To test that everything is working, run:
 
 ```
 bin/parse -e "1 + 2"


### PR DESCRIPTION
Added an environment variable `PRISM_MAKE_FLAGS` so we can pass arguments to `make` while running `rake compile`. I find this useful to speed up the build process by passing the `-j` flag.