### PR TITLE
Remove unnecessary match in `parse_arguments`

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -11079,11 +11079,7 @@ parse_arguments(pm_parser_t *parser, pm_arguments_t *arguments, bool accepts_for
                 pm_keyword_hash_node_t *hash = pm_keyword_hash_node_create(parser);
                 argument = (pm_node_t *) hash;
 
-                bool contains_keyword_splat = false;
-                if (!match7(parser, terminator, PM_TOKEN_NEWLINE, PM_TOKEN_SEMICOLON, PM_TOKEN_EOF, PM_TOKEN_BRACE_RIGHT, PM_TOKEN_KEYWORD_DO, PM_TOKEN_PARENTHESIS_RIGHT)) {
-                    contains_keyword_splat = parse_assocs(parser, (pm_node_t *) hash);
-                }
-
+                bool contains_keyword_splat = parse_assocs(parser, (pm_node_t *) hash);
                 parsed_bare_hash = true;
                 parse_arguments_append(parser, arguments, argument);
                 if (contains_keyword_splat) {


### PR DESCRIPTION
We are testing the type of the current token but there is no way the current token can be changed before the test.

