### PR TITLE
Fix defined with new line

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -14903,6 +14903,7 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power) {
                 if (parser->recovering) {
                     rparen = not_provided(parser);
                 } else {
+                    accept1(parser, PM_TOKEN_NEWLINE);
                     expect1(parser, PM_TOKEN_PARENTHESIS_RIGHT, PM_ERR_EXPECT_RPAREN);
                     rparen = parser->previous;
                 }

--- a/test/prism/fixtures/defined.txt
+++ b/test/prism/fixtures/defined.txt
@@ -5,3 +5,6 @@ defined?(x %= 2)
 defined?(foo and bar)
 
 defined? 1
+
+defined?("foo"
+)

--- a/test/prism/snapshots/defined.txt
+++ b/test/prism/snapshots/defined.txt
@@ -1,8 +1,8 @@
-@ ProgramNode (location: (1,0)-(7,10))
+@ ProgramNode (location: (1,0)-(10,1))
 ├── locals: [:x]
 └── statements:
-    @ StatementsNode (location: (1,0)-(7,10))
-    └── body: (length: 4)
+    @ StatementsNode (location: (1,0)-(10,1))
+    └── body: (length: 5)
         ├── @ AndNode (location: (1,0)-(1,25))
         │   ├── left:
         │   │   @ DefinedNode (location: (1,0)-(1,10))
@@ -64,10 +64,21 @@
         │   │   └── operator_loc: (5,13)-(5,16) = "and"
         │   ├── rparen_loc: (5,20)-(5,21) = ")"
         │   └── keyword_loc: (5,0)-(5,8) = "defined?"
-        └── @ DefinedNode (location: (7,0)-(7,10))
-            ├── lparen_loc: ∅
+        ├── @ DefinedNode (location: (7,0)-(7,10))
+        │   ├── lparen_loc: ∅
+        │   ├── value:
+        │   │   @ IntegerNode (location: (7,9)-(7,10))
+        │   │   └── flags: decimal
+        │   ├── rparen_loc: ∅
+        │   └── keyword_loc: (7,0)-(7,8) = "defined?"
+        └── @ DefinedNode (location: (9,0)-(10,1))
+            ├── lparen_loc: (9,8)-(9,9) = "("
             ├── value:
-            │   @ IntegerNode (location: (7,9)-(7,10))
-            │   └── flags: decimal
-            ├── rparen_loc: ∅
-            └── keyword_loc: (7,0)-(7,8) = "defined?"
+            │   @ StringNode (location: (9,9)-(9,14))
+            │   ├── flags: ∅
+            │   ├── opening_loc: (9,9)-(9,10) = "\""
+            │   ├── content_loc: (9,10)-(9,13) = "foo"
+            │   ├── closing_loc: (9,13)-(9,14) = "\""
+            │   └── unescaped: "foo"
+            ├── rparen_loc: (10,0)-(10,1) = ")"
+            └── keyword_loc: (9,0)-(9,8) = "defined?"


### PR DESCRIPTION
It's possible to write the following and have it be valid Ruby:

```
defined?("foo"
)
```

But Prism wasn't taking the new line into account. This adds an `accept1` for a `PM_TOKEN_NEWLINE` to account for this. I've also updated the fixtures and snapshots to test this.