### PR TITLE
Fix parsing unterminated empty string `"`

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -13520,7 +13520,8 @@ parse_strings(pm_parser_t *parser, pm_node_t *current) {
         pm_token_t opening = parser->current;
         parser_lex(parser);
 
-        if (accept1(parser, PM_TOKEN_STRING_END)) {
+        if (match2(parser, PM_TOKEN_STRING_END, PM_TOKEN_EOF)) {
+            expect1(parser, PM_TOKEN_STRING_END, PM_ERR_STRING_LITERAL_TERM);
             // If we get here, then we have an end immediately after a
             // start. In that case we'll create an empty content token and
             // return an uninterpolated string.

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -164,6 +164,15 @@ module Prism
       assert_equal expr.closing, ""
     end
 
+    def test_unterminated_empty_string
+      expr = expression('"')
+      assert_errors expr, '"', [
+        ["expected a closing delimiter for the string literal", 1..1]
+      ]
+      assert_equal expr.unescaped, ""
+      assert_equal expr.closing, ""
+    end
+
     def test_incomplete_instance_var_string
       assert_errors expression('%@#@@#'), '%@#@@#', [
         ["incomplete instance variable", 4..5],


### PR DESCRIPTION
Fix #2034