### PR TITLE
Regexp terminator escapes

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -9478,7 +9478,9 @@ parser_lex(pm_parser_t *parser) {
                         case '\r':
                             parser->current.end++;
                             if (peek(parser) != '\n') {
-                                pm_token_buffer_push(&token_buffer, '\\');
+                                if (lex_mode->as.regexp.terminator != '\r') {
+                                    pm_token_buffer_push(&token_buffer, '\\');
+                                }
                                 pm_token_buffer_push(&token_buffer, '\r');
                                 break;
                             }
@@ -9506,7 +9508,20 @@ parser_lex(pm_parser_t *parser) {
                             escape_read(parser, &token_buffer.buffer, PM_ESCAPE_FLAG_REGEXP);
                             break;
                         default:
-                            if (lex_mode->as.regexp.terminator == '/' && peeked == '/') {
+                            if (lex_mode->as.regexp.terminator == peeked) {
+                                // Some characters when they are used as the
+                                // terminator also receive an escape. They are
+                                // enumerated here.
+                                switch (peeked) {
+                                    case '$': case ')': case '*': case '+':
+                                    case '.': case '>': case '?': case ']':
+                                    case '^': case '|': case '}':
+                                        pm_token_buffer_push(&token_buffer, '\\');
+                                        break;
+                                    default:
+                                        break;
+                                }
+
                                 pm_token_buffer_push(&token_buffer, peeked);
                                 parser->current.end++;
                                 break;

--- a/test/prism/snapshots/seattlerb/bug190.txt
+++ b/test/prism/snapshots/seattlerb/bug190.txt
@@ -8,4 +8,4 @@
             ├── opening_loc: (1,0)-(1,3) = "%r'"
             ├── content_loc: (1,3)-(1,5) = "\\'"
             ├── closing_loc: (1,5)-(1,6) = "'"
-            └── unescaped: "\\'"
+            └── unescaped: "'"


### PR DESCRIPTION
I don't pretend to understand what is going on here, but basically if you use a regular expression opening/closing that is not `/` then sometimes you need an escape and sometimes you don't. I derived these rules by running every value in US-ASCII until it matched.

Fixes #2031.