### PR TITLE
Update args of Prism.dump on document

### DIFF
--- a/docs/ruby_api.md
+++ b/docs/ruby_api.md
@@ -14,7 +14,7 @@ The full API is documented below.
 
 ## API
 
-* `Prism.dump(source, filepath)` - parse the syntax tree corresponding to the given source string and filepath, and serialize it to a string. Filepath can be nil.
+* `Prism.dump(source)` - parse the syntax tree corresponding to the given source string, and serialize it to a string
 * `Prism.dump_file(filepath)` - parse the syntax tree corresponding to the given source file and serialize it to a string
 * `Prism.lex(source)` - parse the tokens corresponding to the given source string and return them as an array within a parse result
 * `Prism.lex_file(filepath)` - parse the tokens corresponding to the given source file and return them as an array within a parse result


### PR DESCRIPTION
Link: https://github.com/ruby/www.ruby-lang.org/pull/3156

function def: https://github.com/ruby/prism/blob/53ef1e8a193cc24d4ce3e0d2d2eade450125ce19/ext/prism/extension.c#L254-L258

From https://github.com/ruby/prism/pull/1763, filepath args of Prism.dump seems to moved in kwargs.


