### PR TITLE
Fix eval parsing depth

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -17185,9 +17185,14 @@ parse_expression(pm_parser_t *parser, pm_binding_power_t binding_power, bool acc
 
 static pm_node_t *
 parse_program(pm_parser_t *parser) {
-    pm_parser_scope_push(parser, !parser->current_scope);
-    parser_lex(parser);
+    // If the current scope is NULL, then we want to push a new top level scope.
+    // The current scope could exist in the event that we are parsing an eval
+    // and the user has passed into scopes that already exist.
+    if (parser->current_scope == NULL) {
+        pm_parser_scope_push(parser, true);
+    }
 
+    parser_lex(parser);
     pm_statements_node_t *statements = parse_statements(parser, PM_CONTEXT_MAIN);
     if (!statements) {
         statements = pm_statements_node_create(parser);

--- a/test/prism/ruby_api_test.rb
+++ b/test/prism/ruby_api_test.rb
@@ -42,7 +42,9 @@ module Prism
 
       assert_kind_of Prism::CallNode, Prism.parse("foo").value.statements.body[0]
       assert_kind_of Prism::LocalVariableReadNode, Prism.parse("foo", scopes: [[:foo]]).value.statements.body[0]
-      assert_equal 2, Prism.parse("foo", scopes: [[:foo], []]).value.statements.body[0].depth
+      assert_equal 1, Prism.parse("foo", scopes: [[:foo], []]).value.statements.body[0].depth
+
+      assert_equal [:foo], Prism.parse("foo", scopes: [[:foo]]).value.locals
     end
 
     def test_literal_value_method


### PR DESCRIPTION
Previously we would always push a new scope, which was inaccurate because eval can introduce locals in the caller's scope.