### PR TITLE
RBS type fixes for positional parameters

### DIFF
--- a/sig/prism_static.rbs
+++ b/sig/prism_static.rbs
@@ -1,32 +1,79 @@
 module Prism
-  class ParseResult
-    def value: () -> ProgramNode
-    def comments: () -> Array[Comment]
-    def errors: () -> Array[ParseError]
-    def warnings: () -> Array[ParseWarning]
-    def source: () -> Source
+  BACKEND: :CEXT | :FFI
+  VERSION: String
+
+  def self.parse: (String source, ?filepath: String, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> ParseResult[ProgramNode]
+  def self.lex: (String source, ?filepath: String, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> ParseResult[Array[[Token, Integer]]]
+  def self.parse_lex: (String source, ?filepath: String, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> ParseResult[[ProgramNode, Array[[Token, Integer]]]]
+  def self.dump: (String source, ?filepath: String, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> String
+  def self.parse_comments: (String source, ?filepath: String, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> Array[Comment]
+  def self.parse_success?: (String source, ?filepath: String, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> bool
+  def self.parse_failure?: (String source, ?filepath: String, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> bool
+
+  def self.parse_file: (String filepath, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> ParseResult[ProgramNode]
+  def self.lex_file: (String filepath, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> ParseResult[Array[[Token, Integer]]]
+  def self.parse_lex_file: (String filepath, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> ParseResult[[ProgramNode, Array[[Token, Integer]]]]
+  def self.dump_file: (String filepath, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> String
+  def self.parse_file_comments: (String filepath, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> Array[Comment]
+  def self.parse_file_failure?: (String filepath, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> bool
+  def self.parse_file_success?: (String filepath, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> bool
+
+  def self.load: (String source, String serialized) -> ParseResult[ProgramNode]
+
+  type ripper_token = [[Integer, Integer], Symbol, String, untyped]
+  def self.lex_compat: (String source, ?filepath: String, ?line: Integer, ?encoding: Encoding, ?frozen_string_literal: bool, ?verbose: bool, ?scopes: Array[Array[Symbol]]) -> ParseResult[Array[ripper_token]]
+  def self.lex_ripper: (String source) -> Array[ripper_token]
+
+  class ParseResult[T]
+    attr_reader value: T
+    attr_reader comments: Array[Comment]
+    attr_reader magic_comments: Array[MagicComment]
+    attr_reader data_loc: Location?
+    attr_reader errors: Array[ParseError]
+    attr_reader warnings: Array[ParseWarning]
+    attr_reader source: Source
+
+    def initialize: (T value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, Source source) -> void
+    def deconstruct_keys: (Array[Symbol] keys) -> { value: T, comments: Array[Comment], magic_comments: Array[MagicComment], data_loc: Location?, errors: Array[ParseError], warnings: Array[ParseWarning] }
+    def success?: () -> bool
+    def failure?: () -> bool
   end
 
   class ParseError
-    def message: () -> String
-    def location: () -> Location
+    attr_reader message: String
+    attr_reader location: Location
+
+    def initialize: (String message, Location location) -> void
+    def deconstruct_keys: (Array[Symbol] keys) -> { message: String, location: Location }
   end
 
   class ParseWarning
-    def message: () -> String
-    def location: () -> Location
+    attr_reader message: String
+    attr_reader location: Location
+
+    def initialize: (String message, Location location) -> void
+    def deconstruct_keys: (Array[Symbol] keys) -> { message: String, location: Location }
   end
 
   class Node
+    @newline: bool
+
+    attr_reader location: Location
+
     def child_nodes: () -> Array[Node?]
-    def location: () -> Location
+    def newline?: () -> bool
+    def set_newline_flag: (Array[bool] newline_marked) -> void
     def slice: () -> String
+    def pretty_print: (untyped q) -> untyped
+    def inspect: (?NodeInspector inspector) -> String  # TODO: not right, only is defined on subclasses
     def to_dot: () -> String
   end
 
   class Comment
-    def location: () -> Location
-    def trailing?: () -> bool
+    attr_reader location: Location
+
+    def initialize: (Location location) -> void
+    def deconstruct_keys: (Array[Symbol] keys) -> { location: Location }
   end
 
   class InlineComment < Comment
@@ -34,22 +81,45 @@ module Prism
   end
 
   class EmbDocComment < Comment
+    def trailing?: () -> false
   end
 
-  class DATAComment < Comment
+  class MagicComment
+    attr_reader key_loc: Location
+    attr_reader value_loc: Location
+
+    def initialize: (Location key_loc, Location value_loc) -> void
+
+    def key: () -> String
+    def value: () -> String
+
+    def deconstruct_keys: (Array[Symbol] keys) -> { key_loc: Location, value_loc: Location }
   end
 
   class Location
-    def initialize: (source: Source, start_offset: Integer, length: Integer) -> void
+    attr_reader source: Source | nil
+    attr_reader start_offset: Integer
+    attr_reader length: Integer
+    attr_reader comments: Array[Comment]
+
+    def initialize: (Source? source, Integer start_offset, Integer length) -> void
+    def copy: (?source: Source, ?start_offset: Integer, ?length: Integer) -> Location
     def slice: () -> String
-    def comments: () -> Array[Comment]
-    def copy: (**untyped) -> Location
-    def start_offset: () -> Integer
+    def start_character_offset: () -> Integer
     def end_offset: () -> Integer
+    def end_character_offset: () -> Integer
     def start_line: () -> Integer
+    def start_line_slice: () -> String
     def end_line: () -> Integer
     def start_column: () -> Integer
+    def start_character_column: () -> Integer
     def end_column: () -> Integer
+    def end_character_column: () -> Integer
+    def deconstruct_keys: (Array[Symbol] keys) -> { start_offset: Integer, end_offset: Integer }
+    def pretty_print: (untyped q) -> untyped
+    def join: (Location other) -> Location
+
+    def self.null: () -> Location
   end
 
   class Source
@@ -57,30 +127,24 @@ module Prism
     attr_reader start_line: Integer
     attr_reader offsets: Array[Integer]
 
-    @source: String
-    @start_line: Integer
-    @offsets: Array[Integer]
-
-    def initialize: (source: String, start_line: Integer, offsets: Array[Integer]) -> void
-    def slice: (offset: Integer, length: Integer) -> String
-    def line: (value: Integer) -> Integer
-    def line_offset: (value: Integer) -> Integer
-    def column: (value: Integer) -> Integer
+    def initialize: (String source, ?Integer start_line, ?Array[Integer] offsets) -> void
+    def slice: (Integer byte_offset, Integer length) -> String
+    def line: (Integer byte_offset) -> Integer
+    def line_offset: (Integer byte_offset) -> Integer
+    def column: (Integer byte_offset) -> Integer
+    def character_offset: (Integer byte_offset) -> Integer
+    def character_column: (Integer byte_offset) -> Integer
   end
 
   class Token
-    attr_reader type: untyped
+    attr_reader type: Symbol
     attr_reader value: String
     attr_reader location: Location
 
-    @type: untyped
-    @value: String
-    @location: Location
-
-    def initialize: (type: untyped, value: String, location: Location) -> void
-    def deconstruct_keys: (keys: untyped) -> untyped
-    def pretty_print: (q: untyped) -> untyped
-    def ==: (other: untyped) -> bool
+    def initialize: (Symbol type, String value, Location location) -> void
+    def deconstruct_keys: (Array[Symbol] keys) -> { type: Symbol, value: String, location: Location }
+    def pretty_print: (untyped q) -> untyped
+    def ==: (untyped other) -> bool
   end
 
   class NodeInspector
@@ -90,35 +154,48 @@ module Prism
     @prefix: String
     @output: String
 
-    def initialize: (prefix: String) -> void
+    def initialize: (?String prefix) -> void
 
     # Appends a line to the output with the current prefix.
-    def <<: (line: String) -> void
+    def <<: (String line) -> void
 
     # This generates a string that is used as the header of the inspect output
     # for any given node.
-    def header: (node: Node) -> String
+    def header: (Node node) -> String
 
     # Generates a string that represents a list of nodes. It handles properly
     # using the box drawing characters to make the output look nice.
-    def list: (prefix: String, nodes: Array[Node]) -> String
+    def list: (String prefix, Array[Node] nodes) -> String
 
     # Generates a string that represents a location field on a node.
-    def location: (value: Location) -> String
+    def location: (Location? value) -> String
 
     # Generates a string that represents a child node.
-    def child_node: (node: Node, append: String) -> String
+    def child_node: (Node node, String append) -> String
 
     # Returns a new inspector that can be used to inspect a child node.
-    def child_inspector: (append: String) -> NodeInspector
+    def child_inspector: (String append) -> NodeInspector
 
     # Returns the output as a string.
     def to_str: () -> String
   end
 
   class BasicVisitor
-    def visit: (node: Node?) -> void
-    def visit_all: (nodes: Array[Node?]) -> void
-    def visit_child_nodes: (node: Node) -> void
+    def visit: (Node? node) -> void
+    def visit_all: (Array[Node?] nodes) -> void
+    def visit_child_nodes: (Node node) -> void
+  end
+
+  class Pattern
+    class CompilationError < StandardError
+    end
+
+    attr_reader query: String
+
+    @compiled: Proc
+
+    def initialize: (String query) -> void
+    def compile: () -> Proc
+    def scan: (Node root) -> void
   end
 end

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -44,11 +44,11 @@ module Prism
   <%- end -%>
   class <%= node.name -%> < Node
     <%- node.fields.each do |field| -%>
-    # attr_reader <%= field.name %>: <%= field.rbs_class %>
+    # <%= "private " if field.is_a?(Prism::FlagsField) %>attr_reader <%= field.name %>: <%= field.rbs_class %>
     <%= "private " if field.is_a?(Prism::FlagsField) %>attr_reader :<%= field.name %>
 
     <%- end -%>
-    # def initialize: (<%= (node.fields.map { |field| "#{field.name}: #{field.rbs_class}" } + ["location: Location"]).join(", ") %>) -> void
+    # def initialize: (<%= (node.fields.map { |field| "#{field.rbs_class} #{field.name}" } + ["Location location"]).join(", ") %>) -> void
     def initialize(<%= (node.fields.map(&:name) + ["location"]).join(", ") %>)
       <%- node.fields.each do |field| -%>
       @<%= field.name %> = <%= field.name %>
@@ -56,7 +56,7 @@ module Prism
       @location = location
     end
 
-    # def accept: (visitor: Visitor) -> void
+    # def accept: (Visitor visitor) -> void
     def accept(visitor)
       visitor.visit_<%= node.human %>(self)
     end
@@ -137,7 +137,7 @@ module Prism
     # def deconstruct: () -> Array[nil | Node]
     alias deconstruct child_nodes
 
-    # def deconstruct_keys: (keys: Array[Symbol]) -> Hash[Symbol, nil | Node | Array[Node] | String | Token | Array[Token] | Location]
+    # def deconstruct_keys: (Array[Symbol] keys) -> { <%= (node.fields.map { |field| "#{field.name}: #{field.rbs_class}" } + ["location: Location"]).join(", ") %> }
     def deconstruct_keys(keys)
       { <%= (node.fields.map { |field| "#{field.name}: #{field.name}" } + ["location: location"]).join(", ") %> }
     end
@@ -170,7 +170,7 @@ module Prism
     <%- end -%>
     <%- end -%>
 
-    # def inspect(inspector: NodeInspector) -> String
+    # def inspect(NodeInspector inspector) -> String
     def inspect(inspector = NodeInspector.new)
       inspector << inspector.header(self)
       <%- node.fields.each_with_index do |field, index| -%>

--- a/templates/sig/prism.rbs.erb
+++ b/templates/sig/prism.rbs.erb
@@ -5,18 +5,18 @@ module Prism
   <%- end -%>
   class <%= node.name -%> < Node
     <%- node.fields.each do |field| -%>
-    attr_reader <%= field.name %>: <%= field.rbs_class %>
+    <%= "private " if field.is_a?(Prism::FlagsField) %>attr_reader <%= field.name %>: <%= field.rbs_class %>
     <%- end -%>
 
-    def initialize: (<%= (node.fields.map { |field| "#{field.name}: #{field.rbs_class}" } + ["location: Location"]).join(", ") %>) -> void
-    def accept: (visitor: Visitor) -> void
-    def set_newline_flag: (newline_marked: Array[bool]) -> void
+    def initialize: (<%= (node.fields.map { |field| "#{field.rbs_class} #{field.name}" } + ["Location location"]).join(", ") %>) -> void
+    def accept: (Visitor visitor) -> void
+    def set_newline_flag: (Array[bool] newline_marked) -> void
     def child_nodes: () -> Array[Node?]
     def deconstruct: () -> Array[Node?]
 
     def copy: (**untyped) -> <%= node.name %>
 
-    def deconstruct_keys: (keys: Array[Symbol]) -> Hash[Symbol, (Node | Array[Node] | String | Token | Array[Token] | Location)?]
+    def deconstruct_keys: (Array[Symbol] keys) -> { <%= (node.fields.map { |field| "#{field.name}: #{field.rbs_class}" } + ["location: Location"]).join(", ") %> }
     <%- node.fields.each do |field| -%>
     <%- case field -%>
     <%- when Prism::LocationField -%>
@@ -37,7 +37,7 @@ module Prism
     <%- end -%>
     <%- end -%>
 
-    def inspect: (inspector: NodeInspector) -> String
+    def inspect: (?NodeInspector inspector) -> String
   end
   <%- end -%>
 
@@ -55,7 +55,7 @@ module Prism
   class Visitor < BasicVisitor
     <%- nodes.each do |node| -%>
     # Visit a <%= node.name %> node
-    def visit_<%= node.human %>: (node: <%= node.name %>) -> void
+    def visit_<%= node.human %>: (<%= node.name %> node) -> void
     <%= "\n" if node != nodes.last -%>
     <%- end -%>
   end
@@ -64,7 +64,7 @@ module Prism
     private
 
     # Create a new Location object
-    def Location: (source: Source?, start_offset: Integer, length: Integer) -> Location
+    def Location: (?Source? source, ?Integer start_offset, ?Integer length) -> Location
 
     <%- nodes.each do |node| -%>
     # Create a new <%= node.name %> node


### PR DESCRIPTION
Hello, I noticed there was mismatches between definitions of Node methods which used positional parameters and the RBS definitions which used keyword. This PR adjusts the templates to emit positional. I also updated prism_static.rbs based on the changes I saw in the other classes.

Question: I used steep to figure out what needed work. Do you want to add tests to prevent stuff from going out of sync, or is it too soon?