### PR TITLE
Fix `Cannot find name 'Node'` error in types/visitor.d.ts

### DIFF
--- a/templates/javascript/src/visitor.js.erb
+++ b/templates/javascript/src/visitor.js.erb
@@ -21,7 +21,7 @@ export class BasicVisitor {
   /**
    * Visits each node in `nodes` by calling `accept` on each one.
    *
-   * @param {nodes.Node[]} node
+   * @param {nodes.Node[]} nodes
    */
   visitAll(nodes) {
     nodes.forEach((node) => {

--- a/templates/javascript/src/visitor.js.erb
+++ b/templates/javascript/src/visitor.js.erb
@@ -12,7 +12,7 @@ export class BasicVisitor {
    * Calls `accept` on the given node if it is not `null`, which in turn should
    * call back into this visitor by calling the appropriate `visit*` method.
    *
-   * @param {Node} node
+   * @param {nodes.Node} node
    */
   visit(node) {
     node?.accept(this);
@@ -21,7 +21,7 @@ export class BasicVisitor {
   /**
    * Visits each node in `nodes` by calling `accept` on each one.
    *
-   * @param {Node[]} node
+   * @param {nodes.Node[]} node
    */
   visitAll(nodes) {
     nodes.forEach((node) => {
@@ -32,7 +32,7 @@ export class BasicVisitor {
   /**
    * Visits the child nodes of `node` by calling `accept` on each one.
    *
-   * @param {Node} node
+   * @param {nodes.Node} node
    */
   visitChildNodes(node) {
     node.compactChildNodes().forEach((childNode) => {


### PR DESCRIPTION
When I tried to use npm's `@ruby/prism` package in my TypeScript project, I encountered the following error in tsc:

```
$ npm run compile

> vscode-ruby-light@0.5.2 compile
> npm run compile:tsc


> vscode-ruby-light@0.5.2 compile:tsc
> tsc -b

server/node_modules/@ruby/prism/types/visitor.d.ts:15:17 - error TS2304: Cannot find name 'Node'.

15     visit(node: Node): void;
                   ~~~~

server/node_modules/@ruby/prism/types/visitor.d.ts:27:27 - error TS2304: Cannot find name 'Node'.

27     visitChildNodes(node: Node): void;
                             ~~~~


Found 2 errors.
```

After a little investigation, it appears that some type names described in jsdoc are incorrect. I changed this part locally from `Node` to `nodes.Node` and confirmed that this tsc compilation passes.