### PR TITLE
Fix a comment about NumberedParametersNode

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2126,7 +2126,7 @@ nodes:
       parameters within a block or lambda.
 
           -> { _1 + _2 }
-          ^^^^^^^^^^^^^^
+               ^^   ^^
   - name: NumberedReferenceReadNode
     fields:
       - name: number


### PR DESCRIPTION
I thought these arrows should point to `_1` or `_2` instead of the whole block.