### PR TITLE
Include field comments in Java source

### DIFF
--- a/templates/include/prism/ast.h.erb
+++ b/templates/include/prism/ast.h.erb
@@ -166,7 +166,13 @@ typedef struct pm_<%= node.human %> {
 <%- node.fields.grep_v(Prism::FlagsField).each do |field| -%>
 
     /**
-     * <%= node.name %>#<%= field.name %><%= "\n     *\n     * " + field.comment.split("\n").join("\n     * ") if field.comment %>
+     * <%= node.name %>#<%= field.name %>
+    <%- if field.comment -%>
+     *
+    <%- field.each_comment_line do |line| -%>
+     *<%= line %>
+    <%- end -%>
+    <%- end -%>
      */
     <%= case field
     when Prism::NodeField, Prism::OptionalNodeField then "struct #{field.c_type} *#{field.name}"

--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -16,7 +16,6 @@ import java.util.Arrays;
 // @formatter:off
 public abstract class Nodes {
 
-    public static final byte[][] EMPTY_BYTE_ARRAY_ARRAY = {};
     public static final <%= string_type %>[] EMPTY_STRING_ARRAY = {};
 
     @Target(ElementType.FIELD)

--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -4,6 +4,10 @@ package org.prism;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,6 +18,11 @@ public abstract class Nodes {
 
     public static final byte[][] EMPTY_BYTE_ARRAY_ARRAY = {};
     public static final <%= string_type %>[] EMPTY_STRING_ARRAY = {};
+
+    @Target(ElementType.FIELD)
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface Nullable {
+    }
 
     public static final class Location {
 
@@ -204,19 +213,17 @@ public abstract class Nodes {
         public final int serializedLength;
         <%- end -%>
         <%- node.semantic_fields.each do |field| -%>
-        <%- if field.class.name.include?('Optional') or field.comment -%>
-        /**
-        <%- if field.class.name.include?('Optional') -%>
-         * optional (can be null)
-        <%- end -%>
         <%- if field.comment -%>
+        /**
          * <pre>
         <%- field.each_comment_line do |line| -%>
          *<%= line %>
         <%- end -%>
          * </pre>
-        <%- end -%>
          */
+        <%- end -%>
+        <%- if field.class.name.include?('Optional') -%>
+        @Nullable
         <%- end -%>
         public final <%= field.java_type %> <%= field.name %>;
         <%- end -%>

--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -204,8 +204,19 @@ public abstract class Nodes {
         public final int serializedLength;
         <%- end -%>
         <%- node.semantic_fields.each do |field| -%>
+        <%- if field.class.name.include?('Optional') or field.comment -%>
+        /**
         <%- if field.class.name.include?('Optional') -%>
-        /** optional (can be null) */
+         * optional (can be null)
+        <%- end -%>
+        <%- if field.comment -%>
+         * <pre>
+        <%- field.each_comment_line do |line| -%>
+         *<%= line %>
+        <%- end -%>
+         * </pre>
+        <%- end -%>
+         */
         <%- end -%>
         public final <%= field.java_type %> <%= field.name %>;
         <%- end -%>

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -47,7 +47,9 @@ module Prism
     <%- if field.comment.nil? -%>
     # <%= "private " if field.is_a?(Prism::FlagsField) %>attr_reader <%= field.name %>: <%= field.rbs_class %>
     <%- else -%>
-    # <%= field.comment.split("\n").join("\n    # ") %>
+    <%- field.each_comment_line do |line| -%>
+    #<%= line %>
+    <%- end -%>
     <%- end -%>
     <%= "private " if field.is_a?(Prism::FlagsField) %>attr_reader :<%= field.name %>
 

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -21,6 +21,10 @@ module Prism
       @options = options
     end
 
+    def each_comment_line
+      comment.each_line { |line| yield line.prepend(" ").rstrip } if comment
+    end
+
     def semantic_field?
       true
     end


### PR DESCRIPTION
* Also use `field.each_comment_line` to simplify other usages of field comments.