### PR TITLE
Document the `AliasGlobalVariableNode` fields

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -740,10 +740,25 @@ nodes:
     fields:
       - name: new_name
         type: node
+        comment: |
+          Represents the new name of the global variable that can be used after aliasing. This can be either a global variable, a back reference, or a numbered reference.
+
+              alias $foo $bar
+                    ^^^^
       - name: old_name
         type: node
+        comment: |
+          Represents the old name of the global variable that could be used before aliasing. This can be either a global variable, a back reference, or a numbered reference.
+
+              alias $foo $bar
+                         ^^^^
       - name: keyword_loc
         type: location
+        comment: |
+          The location of the `alias` keyword.
+
+              alias $foo $bar
+              ^^^^^
     comment: |
       Represents the use of the `alias` keyword to alias a global variable.
 


### PR DESCRIPTION
Add documentation for the `AliasGlobalVariableNode` fields.

```
irb(main):006> Prism.parse("alias $foo $bar")
=> 
#<Prism::ParseResult:0x0000000122cb6a60
 @comments=[],
 @data_loc=nil,
 @errors=[],
 @magic_comments=[],
 @source=#<Prism::Source:0x0000000122df93a0 @offsets=[0], @source="alias $foo $bar", @start_line=1>,
 @value=
  @ ProgramNode (location: (1,0)-(1,15))
  ├── locals: []
  └── statements:
      @ StatementsNode (location: (1,0)-(1,15))
      └── body: (length: 1)
          └── @ AliasGlobalVariableNode (location: (1,0)-(1,15))
              ├── new_name:
              │   @ GlobalVariableReadNode (location: (1,6)-(1,10))
              │   └── name: :$foo
              ├── old_name:
              │   @ GlobalVariableReadNode (location: (1,11)-(1,15))
              │   └── name: :$bar
              └── keyword_loc: (1,0)-(1,5) = "alias",
 @warnings=[]>
```