### PR TITLE
Document `HashNode`, `AssocNode` and `AssocSplatNode` fields.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1455,10 +1455,28 @@ nodes:
     fields:
       - name: opening_loc
         type: location
+        comment: |
+          The location of the opening brace.
+
+              { a => b }
+              ^
       - name: elements
         type: node[]
+        comment: |
+          The elements of the hash. These can be either `AssocNode`s or `AssocSplatNode`s.
+
+              { a: b }
+                ^^^^
+
+              { **foo }
+                ^^^^^
       - name: closing_loc
         type: location
+        comment: |
+          The location of the closing brace.
+
+              { a => b }
+                       ^
     comment: |
       Represents a hash literal.
 

--- a/config.yml
+++ b/config.yml
@@ -543,10 +543,35 @@ nodes:
     fields:
       - name: key
         type: node
+        comment: |
+          The key of the association. This can be any node.
+
+              { a: b }
+                ^
+
+              { foo => bar }
+                ^^^
+
+              { def a; end => 1 }
+                ^^^^^^^^^^
       - name: value
         type: node?
+        comment: |
+          The value of the association, if present. This can be any node. Will
+          not be present if, e.g., this node is an element of a `HashPatternNode`.
+
+              { foo => bar }
+                       ^^^
+
+              { x: 1 }
+                   ^
       - name: operator_loc
         type: location?
+        comment: |
+          The location of the `=>` operator, if present.
+
+              { foo => bar }
+                    ^^
     comment: |
       Represents a hash key/value pair.
 

--- a/config.yml
+++ b/config.yml
@@ -544,7 +544,7 @@ nodes:
       - name: key
         type: node
         comment: |
-          The key of the association. This can be any node.
+          The key of the association. This can be any node that represents a non-void expression.
 
               { a: b }
                 ^
@@ -557,8 +557,9 @@ nodes:
       - name: value
         type: node?
         comment: |
-          The value of the association, if present. This can be any node. Will
-          not be present if, e.g., this node is an element of a `HashPatternNode`.
+          The value of the association, if present. This can be any node that
+          represents a non-void expression. It can be optionally omitted if this
+          node is an element in a `HashPatternNode`.
 
               { foo => bar }
                        ^^^

--- a/config.yml
+++ b/config.yml
@@ -581,8 +581,19 @@ nodes:
     fields:
       - name: value
         type: node?
+        comment: |
+          The value to be splatted, if present. Will be missing when keyword
+          rest argument forwarding is used.
+
+              { **foo }
+                  ^^^
       - name: operator_loc
         type: location
+        comment: |
+          The location of the `**` operator.
+
+              { **x }
+                ^^
     comment: |
       Represents a splat in a hash literal.
 


### PR DESCRIPTION
This PR adds documentation comments in `config.yml` for `HashNode`, `AssocNode` and `AssocSplatNode`.