### PR TITLE
Document `AliasMethodNode` and `AliasGlobalVariableNode` fields

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -431,10 +431,25 @@ nodes:
     fields:
       - name: new_name
         type: node
+        comment: |
+          The value of the new global variable name
+
+            alias $foo $bar
+                  ^^^^
       - name: old_name
         type: node
+        comment: |
+          The value of the existing global variable name
+
+            alias $foo $bar
+                       ^^^^
       - name: keyword_loc
         type: location
+        comment: |
+          The location of the `alias` keyword
+
+            alias $foo $bar
+            ^^^^^
     comment: |
       Represents the use of the `alias` keyword to alias a global variable.
 
@@ -444,10 +459,25 @@ nodes:
     fields:
       - name: new_name
         type: node
+        comment: |
+          The value of the new method name
+
+            alias foo bar
+                  ^^^
       - name: old_name
         type: node
+        comment: |
+          The value of the existing method name
+
+            alias foo bar
+                      ^^^
       - name: keyword_loc
         type: location
+        comment: |
+          The location of the `alias` keyword
+
+            alias foo bar
+            ^^^^^
     comment: |
       Represents the use of the `alias` keyword to alias a method.
 


### PR DESCRIPTION
This pull request includes changes to the `config.yml` file. The changes primarily focus on adding comments to the `fields` in the `nodes` section of the file. These comments provide additional context and explanations for the `alias` keyword usage in the context of global variables and methods.