### PR TITLE
Document `*ReadNode` fields

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2287,6 +2287,16 @@ nodes:
     fields:
       - name: number
         type: uint32
+        comment: |
+          The (1-indexed, from the left) number of the capture group. Numbered
+          references that would overflow a `uint32`  result in a `number` of
+          exactly `2**32 - 1`.
+
+              $1          # number `1`
+
+              $5432       # number `5432`
+
+              $4294967296 # number `4294967295`
     comment: |
       Represents reading a numbered reference to a capture in the previous match.
 

--- a/config.yml
+++ b/config.yml
@@ -633,6 +633,12 @@ nodes:
     fields:
       - name: name
         type: constant
+        comment: |
+          The name of the back-reference variable, including the leading `$`.
+
+              $& # name `:$&`
+
+              $+ # name `:$+`
     comment: |
       Represents reading a reference to a field in the previous match.
 

--- a/config.yml
+++ b/config.yml
@@ -1507,6 +1507,22 @@ nodes:
     fields:
       - name: name
         type: constant
+        comment: |
+          The name of the global variable, including the leading `$`. Generally,
+          global variable names begin with an underscore, hyphen, alphabetical
+          or non-ASCII character, followed by arbitrarily many underscores,
+          alphanumeric or non-ASCII characters. The exact definitions of
+          "alphabetical" and "alphanumeric" are encoding-dependent.
+
+              $foo   # name `:$foo`
+
+              $_Test # name `:$_Test`
+
+              $🍟    # name `:$🍟`
+
+          In addition to the above, global variable names may be one of: `$~`,
+          `$*`, `$$`, `$?`, `$!`, `$@`, `$/`, `$\`, `$;`, `$,`, `$.`, `$=`,
+          `$:`, `$<`, `$>`, `$"`, or `$0`.
     comment: |
       Represents referencing a global variable.
 

--- a/config.yml
+++ b/config.yml
@@ -2085,8 +2085,33 @@ nodes:
     fields:
       - name: name
         type: constant
+        comment: |
+          The name of the local variable. Local variable names begin with an
+          underscore or a lower-case letter, followed by arbitrarily many
+          underscores, alphanumeric or non-ASCII characters. The exact
+          definitions of "lower-case", "alphabetical" and "alphanumeric" are
+          encoding-dependent.
+
+              x      # name `:x`
+
+              _Test  # name `:_Test`
+
+              🌯     # name `:🌯`
       - name: depth
         type: uint32
+        comment: |
+          The number of visible scopes searched up to find the declaration of
+          this local variable.
+
+              foo = 1; foo # depth 0
+
+              bar = 2; tap { bar } # depth 1
+
+          The specific rules for calculating the depth may differ from
+          individual Ruby implementations, as they are not specified by the
+          language.
+
+          For more information, see [the Prism documentation](https://github.com/ruby/prism/blob/main/docs/local_variable_depth.md).
     comment: |
       Represents reading a local variable. Note that this requires that a local
       variable of the same name has already been written to in the same scope,

--- a/config.yml
+++ b/config.yml
@@ -1037,6 +1037,18 @@ nodes:
     fields:
       - name: name
         type: constant
+        comment: |
+          The name of the class variable, including the leading `@@`. Variable
+          names begin with an underscore, alphabetical, or non-ASCII character,
+          followed by arbitrarily many underscores, alphanumeric or non-ASCII
+          characters. The exact definitions of "alphabetical" and "alphanumeric"
+          are encoding-dependent.
+
+              @@abc   # name `:@@abc`
+
+              @@_test # name `:@@_test`
+
+              @@🍔    # name `:@@🍔`
     comment: |
       Represents referencing a class variable.
 

--- a/config.yml
+++ b/config.yml
@@ -1225,6 +1225,17 @@ nodes:
     fields:
       - name: name
         type: constant
+        comment: |
+          The name of the constant. Constant names begin with an upper-case
+          letter, followed by arbitrarily many underscores, alphanumeric or
+          non-ASCII characters. The exact definitions of "upper-case",
+          and "alphanumeric" are encoding-dependent.
+
+              X              # name `:X`
+
+              SOME_CONSTANT  # name `:SOME_CONSTANT`
+
+              F🥨            # name `:F🥨`
     comment: |
       Represents referencing a constant.
 

--- a/config.yml
+++ b/config.yml
@@ -1053,8 +1053,6 @@ nodes:
               @@abc   # name `:@@abc`
 
               @@_test # name `:@@_test`
-
-              @@🍔    # name `:@@🍔`
     comment: |
       Represents referencing a class variable.
 
@@ -1234,8 +1232,6 @@ nodes:
               X              # name `:X`
 
               SOME_CONSTANT  # name `:SOME_CONSTANT`
-
-              F🥨            # name `:F🥨`
     comment: |
       Represents referencing a constant.
 
@@ -1534,8 +1530,6 @@ nodes:
               $foo   # name `:$foo`
 
               $_Test # name `:$_Test`
-
-              $🍟    # name `:$🍟`
 
           In addition to the above, global variable names may be one of: `$~`,
           `$*`, `$$`, `$?`, `$!`, `$@`, `$/`, `$\`, `$;`, `$,`, `$.`, `$=`,
@@ -1870,8 +1864,6 @@ nodes:
               @x     # name `:@x`
 
               @_test # name `:@_test`
-
-              @🌯    # name `:@🌯`
     comment: |
       Represents referencing an instance variable.
 
@@ -2106,8 +2098,6 @@ nodes:
               x      # name `:x`
 
               _Test  # name `:_Test`
-
-              🌯     # name `:🌯`
       - name: depth
         type: uint32
         comment: |

--- a/config.yml
+++ b/config.yml
@@ -1044,11 +1044,10 @@ nodes:
       - name: name
         type: constant
         comment: |
-          The name of the class variable, including the leading `@@`. Variable
-          names begin with an underscore, alphabetical, or non-ASCII character,
-          followed by arbitrarily many underscores, alphanumeric or non-ASCII
-          characters. The exact definitions of "alphabetical" and "alphanumeric"
-          are encoding-dependent.
+          The name of the class variable, including the leading `@@`.
+
+          For more information on permitted class variable names, see
+          [the Prism documentation](https://github.com/ruby/prism/blob/main/docs/lexing.md).
 
               @@abc   # name `:@@abc`
 
@@ -1224,10 +1223,10 @@ nodes:
       - name: name
         type: constant
         comment: |
-          The name of the constant. Constant names begin with an upper-case
-          letter, followed by arbitrarily many underscores, alphanumeric or
-          non-ASCII characters. The exact definitions of "upper-case",
-          and "alphanumeric" are encoding-dependent.
+          The name of the constant.
+
+          For more information on permitted constant names, see
+          [the Prism documentation](https://github.com/ruby/prism/blob/main/docs/lexing.md).
 
               X              # name `:X`
 
@@ -1521,19 +1520,14 @@ nodes:
       - name: name
         type: constant
         comment: |
-          The name of the global variable, including the leading `$`. Generally,
-          global variable names begin with an underscore, hyphen, alphabetical
-          or non-ASCII character, followed by arbitrarily many underscores,
-          alphanumeric or non-ASCII characters. The exact definitions of
-          "alphabetical" and "alphanumeric" are encoding-dependent.
+          The name of the global variable, including the leading `$`.
+
+          For more information on permitted global variable names, see
+          [the Prism documentation](https://github.com/ruby/prism/blob/main/docs/lexing.md).
 
               $foo   # name `:$foo`
 
               $_Test # name `:$_Test`
-
-          In addition to the above, global variable names may be one of: `$~`,
-          `$*`, `$$`, `$?`, `$!`, `$@`, `$/`, `$\`, `$;`, `$,`, `$.`, `$=`,
-          `$:`, `$<`, `$>`, `$"`, or `$0`.
     comment: |
       Represents referencing a global variable.
 
@@ -1855,11 +1849,10 @@ nodes:
       - name: name
         type: constant
         comment: |
-          The name of the instance variable, including the leading `@`. Variable
-          names begin with an underscore, alphabetical, or non-ASCII character,
-          followed by arbitrarily many underscores, alphanumeric or non-ASCII
-          characters. The exact definitions of "alphabetical" and "alphanumeric"
-          are encoding-dependent.
+          The name of the instance variable, including the leading `@`.
+
+          For more information on permitted instance variable names, see
+          [the Prism documentation](https://github.com/ruby/prism/blob/main/docs/lexing.md).
 
               @x     # name `:@x`
 
@@ -2089,11 +2082,10 @@ nodes:
       - name: name
         type: constant
         comment: |
-          The name of the local variable. Local variable names begin with an
-          underscore or a lower-case letter, followed by arbitrarily many
-          underscores, alphanumeric or non-ASCII characters. The exact
-          definitions of "lower-case", "alphabetical" and "alphanumeric" are
-          encoding-dependent.
+          The name of the local variable.
+
+          For more information on permitted local variable names, see
+          [the Prism documentation](https://github.com/ruby/prism/blob/main/docs/lexing.md).
 
               x      # name `:x`
 

--- a/config.yml
+++ b/config.yml
@@ -1815,6 +1815,18 @@ nodes:
     fields:
       - name: name
         type: constant
+        comment: |
+          The name of the instance variable, including the leading `@`. Variable
+          names begin with an underscore, alphabetical, or non-ASCII character,
+          followed by arbitrarily many underscores, alphanumeric or non-ASCII
+          characters. The exact definitions of "alphabetical" and "alphanumeric"
+          are encoding-dependent.
+
+              @x     # name `:@x`
+
+              @_test # name `:@_test`
+
+              @🌯    # name `:@🌯`
     comment: |
       Represents referencing an instance variable.
 

--- a/docs/lexing.md
+++ b/docs/lexing.md
@@ -1,0 +1,37 @@
+# Lexing
+
+## Identifiers
+
+This section documents the lexing rules for identifer tokens. In this section,
+the exact definition of terms like "lower-case", "upper-case", "alphabetical"
+and "alphanumeric" are encoding-dependent.
+
+### Local variables
+
+Local variable names begin with an underscore or lower-case letter, followed
+by arbitrarily many underscores, alphanumeric or non-ASCII characters. 
+
+### Instance & class variables
+
+Instance & class variable identifiers begin with an underscore, alphabetical, or 
+non-ASCII character, followed by arbitrarily many underscores, alphanumeric or
+non-ASCII characters.
+
+### Global variables
+
+Global variable identifiers begin with an underscore, hyphen, alphabetical or 
+non-ASCII character, followed by arbitrarily many underscores, alphanumeric or
+non-ASCII characters.
+
+The following are also valid global variable identiifers: `~`, `*`, `$`, `?`, 
+`!`, `@`, `/`, `\`, `;`, `,`, `.`, `=`, `:`, `<`, `>`, `"`, `0`.
+
+### Constants
+
+Constant names begin with an upper-case letter, followed by arbitrarily many
+underscores, alphanumeric or non-ASCII characters.
+
+### Back-referenced variables
+
+Back-referenced variable identifiers are one of `&`, `` ` ``, `'` or `+`.
+

--- a/prism.gemspec
+++ b/prism.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
     "docs/fuzzing.md",
     "docs/heredocs.md",
     "docs/javascript.md",
+    "docs/lexing.md",
     "docs/local_variable_depth.md",
     "docs/mapping.md",
     "docs/releasing.md",


### PR DESCRIPTION
This PR adds documentation comments in `config.yml` for:

- `InstanceVariableReadNode`
- `ClassVariableReadNode`
- `GlobalVariableReadNode`
- `BackReferencedReadNode`
- `NumberedReferenceReadNode`
- `LocalVariableReadNode`
- `ConstantReadNode`

