### PR TITLE
Document `InstanceVariableWriteNode` fields

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1808,12 +1808,41 @@ nodes:
     fields:
       - name: name
         type: constant
+        comment: |
+          The name of the instance variable, including the leading `@`. Variable
+          names begin with an underscore, alphabetical, or non-ASCII character,
+          followed by arbitrarily many underscones, alphanumeric or non-ASCII
+          characters. The exact definitions of "alphabetical" and "alphanumeric"
+          are encoding-dependent.
+
+              @x = :y       # name `:@x`
+
+              @_foo = "bar" # name `@_foo`
       - name: name_loc
         type: location
+        comment: |
+          The location of the variable name.
+
+              @_x = 1
+              ^^^
       - name: value
         type: node
+        comment: |
+          The value to assign to the instance variable. Can be any node that
+          represents a non-void expression.
+
+              @foo = :bar
+                     ^^^^
+
+              @_x = 1234
+                    ^^^^
       - name: operator_loc
         type: location
+        comment: |
+          The location of the `=` operator.
+
+              @x = y
+                 ^
     comment: |
       Represents writing to an instance variable.
 

--- a/config.yml
+++ b/config.yml
@@ -1809,11 +1809,10 @@ nodes:
       - name: name
         type: constant
         comment: |
-          The name of the instance variable, including the leading `@`. Variable
-          names begin with an underscore, alphabetical, or non-ASCII character,
-          followed by arbitrarily many underscones, alphanumeric or non-ASCII
-          characters. The exact definitions of "alphabetical" and "alphanumeric"
-          are encoding-dependent.
+          The name of the instance variable, including the leading `@`.
+
+          For more information on permitted instance variable names, see
+          [the Prism documentation](https://github.com/ruby/prism/main/docs/lexing.md).
 
               @x = :y       # name `:@x`
 

--- a/config.yml
+++ b/config.yml
@@ -1809,10 +1809,7 @@ nodes:
       - name: name
         type: constant
         comment: |
-          The name of the instance variable, including the leading `@`.
-
-          For more information on permitted instance variable names, see
-          [the Prism documentation](https://github.com/ruby/prism/main/docs/lexing.md).
+          The name of the instance variable, which is a `@` followed by an [identifier](https://github.com/ruby/prism/blob/main/docs/parsing_rules.md#identifiers).
 
               @x = :y       # name `:@x`
 


### PR DESCRIPTION
This PR adds documentation comments in `config.yml` to the fields of `InstanceVariableWriteNode`.