### PR TITLE
Document `ClassVariableWriteNode` fields

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1032,10 +1032,7 @@ nodes:
       - name: name
         type: constant
         comment: |
-          The name of the class variable, including the leading `@@`.
-
-          For more information on permitted class variable names, see
-          [the Prism documentation](https://github.com/ruby/prism/main/docs/lexing.md).
+          The name of the class variable, which is a `@@` followed by an [identifier](https://github.com/ruby/prism/blob/main/docs/parsing_rules.md#identifiers).
 
               @@abc = 123     # name `@@abc`
 

--- a/config.yml
+++ b/config.yml
@@ -1036,7 +1036,7 @@ nodes:
       - name: value
         type: node
       - name: operator_loc
-        type: location?
+        type: location
     comment: |
       Represents writing to a class variable.
 

--- a/config.yml
+++ b/config.yml
@@ -1031,12 +1031,40 @@ nodes:
     fields:
       - name: name
         type: constant
+        comment: |
+          The name of the class variable, including the leading `@@`.
+
+          For more information on permitted class variable names, see
+          [the Prism documentation](https://github.com/ruby/prism/main/docs/lexing.md).
+
+              @@abc = 123     # name `@@abc`
+
+              @@_test = :test # name `@@_test`
       - name: name_loc
         type: location
+        comment: |
+          The location of the variable name.
+
+              @@foo = :bar
+              ^^^^^
       - name: value
         type: node
+        comment: |
+          The value to assign to the class variable. Can be any node that
+          represents a non-void expression.
+
+              @@foo = :bar
+                      ^^^^
+
+              @@_xyz = 123
+                       ^^^
       - name: operator_loc
         type: location
+        comment: |
+          The location of the `=` operator.
+
+              @@foo = :bar
+                    ^
     comment: |
       Represents writing to a class variable.
 

--- a/src/prism.c
+++ b/src/prism.c
@@ -2495,7 +2495,7 @@ pm_class_variable_write_node_create(pm_parser_t *parser, pm_class_variable_read_
         },
         .name = read_node->name,
         .name_loc = PM_LOCATION_NODE_VALUE((pm_node_t *) read_node),
-        .operator_loc = PM_OPTIONAL_LOCATION_TOKEN_VALUE(operator),
+        .operator_loc = PM_LOCATION_TOKEN_VALUE(operator),
         .value = value
     };
 


### PR DESCRIPTION
This PR adds documentation comments to `config.yml` for the fields of `ClassVariableWriteNode`.

While doing this, I noticed that `operator_loc` had type `location?`, but I was unable to find any situation where the `=` operator wouldn't be present. The tests & the `parse:topgems` task still pass when using `PM_LOCATION_TOKEN_VALUE` instead of `PM_OPTIONAL_LOCATION_TOKEN_VALUE`, so I added that change in a separate commit, on the assumption that the optionality was in error. If that's not correct let me know & I'll drop that commit & amend the documentation with an example that lacks the `=` location.