### PR TITLE
Provide the ability to format errors

### DIFF
--- a/include/prism.h
+++ b/include/prism.h
@@ -171,6 +171,15 @@ PRISM_EXPORTED_FUNCTION bool pm_parse_success_p(const uint8_t *source, size_t si
 PRISM_EXPORTED_FUNCTION const char * pm_token_type_to_str(pm_token_type_t token_type);
 
 /**
+ * Format the errors on the parser into the given buffer.
+ *
+ * @param parser The parser to format the errors for.
+ * @param buffer The buffer to format the errors into.
+ * @param colorize Whether or not to colorize the errors with ANSI escape sequences.
+ */
+PRISM_EXPORTED_FUNCTION void pm_parser_errors_format(const pm_parser_t *parser, pm_buffer_t *buffer, bool colorize);
+
+/**
  * @mainpage
  *
  * Prism is a parser for the Ruby programming language. It is designed to be

--- a/include/prism/util/pm_buffer.h
+++ b/include/prism/util/pm_buffer.h
@@ -129,6 +129,15 @@ void pm_buffer_append_varuint(pm_buffer_t *buffer, uint32_t value);
 void pm_buffer_append_varsint(pm_buffer_t *buffer, int32_t value);
 
 /**
+ * Prepend the given string to the buffer.
+ *
+ * @param buffer The buffer to prepend to.
+ * @param value The string to prepend.
+ * @param length The length of the string to prepend.
+ */
+void pm_buffer_prepend_string(pm_buffer_t *buffer, const char *value, size_t length);
+
+/**
  * Concatenate one buffer onto another.
  *
  * @param destination The buffer to concatenate onto.

--- a/src/util/pm_buffer.c
+++ b/src/util/pm_buffer.c
@@ -161,6 +161,17 @@ pm_buffer_append_varsint(pm_buffer_t *buffer, int32_t value) {
 }
 
 /**
+ * Prepend the given string to the buffer.
+ */
+void
+pm_buffer_prepend_string(pm_buffer_t *buffer, const char *value, size_t length) {
+    size_t cursor = buffer->length;
+    pm_buffer_append_length(buffer, length);
+    memmove(buffer->value + length, buffer->value, cursor);
+    memcpy(buffer->value, value, length);
+}
+
+/**
  * Concatenate one buffer onto another.
  */
 void


### PR DESCRIPTION
Adds `pm_parser_errors_format`, which can be used to format the list of errors on a parser into a given buffer.