### PR TITLE
Improve portability of building libprism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ FUZZ_OUTPUT_DIR = $(shell pwd)/fuzz/output
 SOEXT := $(shell ruby -e 'puts RbConfig::CONFIG["SOEXT"]')
 
 CPPFLAGS := -Iinclude
-CFLAGS := -g -O2 -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion -Wno-missing-braces -fPIC -fvisibility=hidden
+CFLAGS := -g -O2 -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion -Wno-missing-braces -fPIC -fvisibility=hidden $(CFLAGS)
 CC := cc
 WASI_SDK_PATH := /opt/wasi-sdk
 

--- a/docs/build_system.md
+++ b/docs/build_system.md
@@ -72,3 +72,13 @@ and links to `libprism.a` (to avoid exporting symbols, so no conflict when insta
 ### Building prism as part of JRuby
 
 TODO, probably similar to TruffleRuby.
+
+### Building prism for cross-platform
+
+Prism is designed to be portable though, a simple build fails for a platform that doesn't support a memory map interface such as `mmap(2)`.
+Defining `PRISM_NO_MEMORY_MAP` constant macro excludes those functions from the build.
+
+For instance, the commands below demonstrate how to build `libprism.a` targeting the Arm Cortex-M0+ embedded system:
+
+* `templates/template.rb`
+* `CFLAGS="-mcpu=cortex-m0plus -DPRISM_NO_MEMORY_MAP" make static CC=arm-none-eabi-gcc`

--- a/include/prism/util/pm_string.h
+++ b/include/prism/util/pm_string.h
@@ -15,6 +15,7 @@
 #include <string.h>
 
 // The following headers are necessary to read files using demand paging.
+#ifndef PRISM_NO_MEMORY_MAP
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -22,6 +23,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#endif
 #endif
 
 /**
@@ -45,8 +47,10 @@ typedef struct {
         /** This string owns its memory, and should be freed using `pm_string_free`. */
         PM_STRING_OWNED,
 
+#ifndef PRISM_NO_MEMORY_MAP
         /** This string is a memory-mapped file, and should be freed using `pm_string_free`. */
         PM_STRING_MAPPED
+#endif
     } type;
 } pm_string_t;
 
@@ -106,7 +110,9 @@ void pm_string_constant_init(pm_string_t *string, const char *source, size_t len
  * @param filepath The filepath to read.
  * @return Whether or not the file was successfully mapped.
  */
+#ifndef PRISM_NO_MEMORY_MAP
 PRISM_EXPORTED_FUNCTION bool pm_string_mapped_init(pm_string_t *string, const char *filepath);
+#endif
 
 /**
  * Returns the memory size associated with the string.

--- a/src/util/pm_string.c
+++ b/src/util/pm_string.c
@@ -58,6 +58,7 @@ pm_string_constant_init(pm_string_t *string, const char *source, size_t length) 
  * `MapViewOfFile`, on POSIX systems that have access to `mmap` we'll use
  * `mmap`, and on other POSIX systems we'll use `read`.
  */
+#ifndef PRISM_NO_MEMORY_MAP
 bool
 pm_string_mapped_init(pm_string_t *string, const char *filepath) {
 #ifdef _WIN32
@@ -144,6 +145,7 @@ pm_string_mapped_init(pm_string_t *string, const char *filepath) {
     return true;
 #endif
 }
+#endif /* PRISM_NO_MEMORY_MAP */
 
 /**
  * Returns the memory size associated with the string.
@@ -200,11 +202,13 @@ pm_string_free(pm_string_t *string) {
 
     if (string->type == PM_STRING_OWNED) {
         free(memory);
+#ifndef PRISM_NO_MEMORY_MAP
     } else if (string->type == PM_STRING_MAPPED && string->length) {
 #if defined(_WIN32)
         UnmapViewOfFile(memory);
 #else
         munmap(memory, string->length);
+#endif
 #endif
     }
 }

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -1,6 +1,8 @@
 <%# encoding: ASCII -%>
 #include "prism/prettyprint.h"
 
+#include <inttypes.h>
+
 static void
 prettyprint_source(pm_buffer_t *output_buffer, const uint8_t *source, size_t length) {
     for (size_t index = 0; index < length; index++) {
@@ -152,8 +154,10 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
                     prettyprint_source(output_buffer, location->start, (size_t) (location->end - location->start));
                     pm_buffer_append_string(output_buffer, "\"\n", 2);
                 }
-            <%- when Prism::UInt8Field, Prism::UInt32Field -%>
-                pm_buffer_append_format(output_buffer, " %d\n", cast-><%= field.name %>);
+            <%- when Prism::UInt8Field -%>
+                pm_buffer_append_format(output_buffer, " %"PRId8"\n", cast-><%= field.name %>);
+            <%- when Prism::UInt32Field -%>
+                pm_buffer_append_format(output_buffer, " %"PRId32"\n", cast-><%= field.name %>);
             <%- when Prism::FlagsField -%>
                 bool found = false;
                 <%- found = flags.find { |flag| flag.name == field.kind }.tap { |found| raise "Expected to find #{field.kind}" unless found } -%>

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -1,6 +1,7 @@
 <%# encoding: ASCII -%>
 #include "prism/prettyprint.h"
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 static void
@@ -155,9 +156,9 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
                     pm_buffer_append_string(output_buffer, "\"\n", 2);
                 }
             <%- when Prism::UInt8Field -%>
-                pm_buffer_append_format(output_buffer, " %"PRId8"\n", cast-><%= field.name %>);
+                pm_buffer_append_format(output_buffer, " %"PRIu8"\n", cast-><%= field.name %>);
             <%- when Prism::UInt32Field -%>
-                pm_buffer_append_format(output_buffer, " %"PRId32"\n", cast-><%= field.name %>);
+                pm_buffer_append_format(output_buffer, " %"PRIu32"\n", cast-><%= field.name %>);
             <%- when Prism::FlagsField -%>
                 bool found = false;
                 <%- found = flags.find { |flag| flag.name == field.kind }.tap { |found| raise "Expected to find #{field.kind}" unless found } -%>

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -41,9 +41,11 @@ pm_serialize_string(pm_parser_t *parser, pm_string_t *string, pm_buffer_t *buffe
             pm_buffer_append_bytes(buffer, pm_string_source(string), length);
             break;
         }
+#ifndef PRISM_NO_MEMORY_MAP
         case PM_STRING_MAPPED:
             assert(false && "Cannot serialize mapped strings.");
             break;
+#endif
     }
 }
 


### PR DESCRIPTION
## Background

I'm investigating the possibility of making a compiler for mruby and PicoRuby using Prism.
To do that, I think some additional considerations in the build process of libprism will be helpful.

## Summary of the patch

- Define `PRISM_NO_MEMORY_MAP` constant macro to exclude the memory map interface such as `mmap(2)`. This makes libprism more portable, especially for a non-POSIX platform
- Include `<inttypes.h>` and use their macros to cover format specifiers of `printf()` among various platforms. Without this, building libprism against 32bit architecture raises errors that look like the following:
  ```
  src/prettyprint.c:6759:59: error: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
   6759 |                 pm_buffer_append_format(output_buffer, " %d\n", cast->number);
        |                                                          ~^     ~~~~~~~~~~~~
        |                                                           |         |
        |                                                           int       uint32_t {aka long unsigned int}
        |                                                          %ld
  ```
