### PR TITLE
Remove non-existent Node#child_nodes signature

### DIFF
--- a/rbi/prism_static.rbi
+++ b/rbi/prism_static.rbi
@@ -32,9 +32,6 @@ class Prism::ParseWarning
 end
 
 class Prism::Node
-  sig { returns(T::Array[T.nilable(Prism::Node)]) }
-  def child_nodes; end
-
   sig { returns(Prism::Location) }
   def location; end
 


### PR DESCRIPTION
While all nodes have a `#child_nodes` method, it's not inherited from the `Prism::Node` class. So the current type signature is not correct.

```
$ be ruby -e "require 'prism'; puts Prism::Node.instance_methods(false)"

location
newline?
pretty_print
set_newline_flag
to_dot
slice
```