### PR TITLE
Provide abstract methods in Prism::Node

### DIFF
--- a/rbi/prism_static.rbi
+++ b/rbi/prism_static.rbi
@@ -32,9 +32,6 @@ class Prism::ParseWarning
 end
 
 class Prism::Node
-  sig { returns(T::Array[T.nilable(Prism::Node)]) }
-  def child_nodes; end
-
   sig { returns(Prism::Location) }
   def location; end
 
@@ -43,6 +40,21 @@ class Prism::Node
 
   sig { returns(String) }
   def to_dot; end
+
+  sig { params(visitor: Prism::Visitor).void }
+  def accept(visitor); end
+
+  sig { returns(T::Array[T.nilable(Prism::Node)]) }
+  def child_nodes; end
+
+  sig { returns(T::Array[Prism::Node]) }
+  def compact_child_nodes; end
+
+  sig { returns(T::Array[T.nilable(Prism::Node)]) }
+  def deconstruct; end
+
+  sig { returns(Symbol) }
+  def type; end
 end
 
 class Prism::Comment

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -36,6 +36,44 @@ module Prism
     def to_dot
       DotVisitor.new.tap { |visitor| accept(visitor) }.to_dot
     end
+
+    # --------------------------------------------------------------------------
+    # :section: Node interface
+    # These methods are effectively abstract methods that must be implemented by
+    # the various subclasses of Node. They are here to make it easier to work
+    # with typecheckers.
+    # --------------------------------------------------------------------------
+
+    # Accepts a visitor and calls back into the specialized visit function.
+    def accept(visitor)
+      raise NoMethodError, "undefined method `accept' for #{inspect}"
+    end
+
+    # Returns an array of child nodes, including `nil`s in the place of optional
+    # nodes that were not present.
+    def child_nodes
+      raise NoMethodError, "undefined method `#{__method__}' for #{inspect}"
+    end
+
+    alias deconstruct child_nodes
+
+    # Returns an array of child nodes, excluding any `nil`s in the place of
+    # optional nodes that were not present.
+    def compact_child_nodes
+      raise NoMethodError, "undefined method `compact_child_nodes' for #{inspect}"
+    end
+
+    # Returns an array of child nodes and locations that could potentially have
+    # comments attached to them.
+    def comment_targets
+      raise NoMethodError, "undefined method `comment_targets' for #{inspect}"
+    end
+
+    # Returns a symbol symbolizing the type of node that this represents. This
+    # is particularly useful for case statements and array comparisons.
+    def type
+      raise NoMethodError, "undefined method `type' for #{inspect}"
+    end
   end
   <%- nodes.each do |node| -%>
 


### PR DESCRIPTION
@st0012 I agree with your assessment here, I don't think we should be adding signatures for methods that don't exist. That feels pretty wrong.

I assume this was added because people wanted to work with multiple nodes and treat them the same, but sorbet's typing system makes interfaces very difficult without including a module. For that reason this PR introduces `Prism::AnyNode`, a type alias for all of the existing node types. Hopefully that should solve the root of the issue, because people can use that signature instead.

@vinistock sorry I didn't catch this in the initial code review when you first introduced the RBI. Can this solution work for your needs? I would really prefer to not provide signatures for methods that don't exist.