### PR TITLE
Document order of scopes in parsing options

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -179,6 +179,8 @@ The final argument to `pm_serialize_parse` is an optional string that controls t
 | `4`     | the number of scopes       |
 | ...     | the scopes                 |
 
+Scopes are ordered from the outermost scope to the innermost one.
+
 Each scope is layed out as follows:
 
 | # bytes | field                      |

--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -651,7 +651,8 @@ parse_input(pm_string_t *input, const pm_options_t *options) {
  *       prism (which you can trigger with `nil` or `"latest"`). If you want to
  *       parse exactly as CRuby 3.3.0 would, then you can pass `"3.3.0"`.
  * * `scopes` - the locals that are in scope surrounding the code that is being
- *       parsed. This should be an array of arrays of symbols or nil.
+ *       parsed. This should be an array of arrays of symbols or nil. Scopes are
+ *       ordered from the outermost scope to the innermost one.
  */
 static VALUE
 parse(int argc, VALUE *argv, VALUE self) {

--- a/include/prism/options.h
+++ b/include/prism/options.h
@@ -64,7 +64,8 @@ typedef struct {
     /**
      * The scopes surrounding the code that is being parsed. For most parses
      * this will be NULL, but for evals it will be the locals that are in scope
-     * surrounding the eval.
+     * surrounding the eval. Scopes are ordered from the outermost scope to the
+     * innermost one.
      */
     pm_options_scope_t *scopes;
 


### PR DESCRIPTION
`pm_serialize_parse` and similar functions/methods accept options as a Hash or char array and order of scopes (local variable) isn't specified explicitly.