### PR TITLE
Raise error from bin/parse for missing source code and file

### DIFF
--- a/bin/parse
+++ b/bin/parse
@@ -13,6 +13,8 @@ if ARGV[0] == "-e"
   result = Prism.parse(ARGV[1])
 else
   result = Prism.parse_file(ARGV[0] || "test.rb")
+
+  raise ArgumentError, "There was nothing to parse. You must pass source code with `-e` or a Ruby file." if result.nil?
 end
 
 result.mark_newlines! if ENV["MARK_NEWLINES"]


### PR DESCRIPTION
Previously, if you called `bin/parse` without `-e` or a file, you would get the following confusing error:

```
$ bin/parse
open: No such file or directory
bin/parse:20:in `<main>': undefined method `value' for nil:NilClass (NoMethodError)

value = result.value
              ^^^^^^
```

Now you get an `ArgumentError`:

```
$ bin/parse
open: No such file or directory
bin/parse:17:in `<main>': There was nothing to parse. You must pass source code with `-e` or a Ruby file. (ArgumentError)
```