### PR TITLE
Handle stovetop start in constant path full_name

### DIFF
--- a/lib/prism/node_ext.rb
+++ b/lib/prism/node_ext.rb
@@ -118,7 +118,7 @@ module Prism
         current = current.parent
       end
 
-      unless current.is_a?(ConstantReadNode)
+      unless current.is_a?(ConstantReadNode) || current == nil
         raise DynamicPartsInConstantPathError, "Constant path contains dynamic parts. Cannot compute full name"
       end
 

--- a/lib/prism/node_ext.rb
+++ b/lib/prism/node_ext.rb
@@ -118,7 +118,7 @@ module Prism
         current = current.parent
       end
 
-      unless current.is_a?(ConstantReadNode) || current == nil
+      if !current.is_a?(ConstantReadNode) && !current.nil?
         raise DynamicPartsInConstantPathError, "Constant path contains dynamic parts. Cannot compute full name"
       end
 

--- a/test/prism/constant_path_node_test.rb
+++ b/test/prism/constant_path_node_test.rb
@@ -52,5 +52,16 @@ module Prism
       node = Prism.parse(source).value.statements.body.first
       assert_equal("Foo::Bar::Baz::Qux", node.lefts.first.full_name)
     end
+
+    def test_full_name_for_constant_path_with_stovetop_start
+      source = <<~RUBY
+        ::Foo:: # comment
+          Bar::Baz::
+            Qux, Something = [1, 2]
+      RUBY
+
+      node = Prism.parse(source).value.statements.body.first
+      assert_equal("::Foo::Bar::Baz::Qux", node.lefts.first.full_name)
+    end
   end
 end


### PR DESCRIPTION
this prevents prism from raising `Constant path contains dynamic parts. Cannot compute full name` when a constant path starts with `::`.