### PR TITLE
Unescape method name for unary methods.

### DIFF
--- a/test/prism/snapshots/seattlerb/defn_unary_not.txt
+++ b/test/prism/snapshots/seattlerb/defn_unary_not.txt
@@ -4,8 +4,8 @@
     @ StatementsNode (location: (1,0)-(1,17))
     └── body: (length: 1)
         └── @ DefNode (location: (1,0)-(1,17))
-            ├── name: :"!@"
-            ├── name_loc: (1,4)-(1,6) = "!@"
+            ├── name: :!
+            ├── name_loc: (1,4)-(1,5) = "!"
             ├── receiver: ∅
             ├── parameters: ∅
             ├── body:


### PR DESCRIPTION
This PR removes the trailing `@` from the Method name in the prism AST for `DefNode`s that define unary methods.

CRuby's parser removes the `@` from the `mid` of `def !@; true; end` as seen here

```
#             |   @ NODE_DEFN (id: 3, line: 2, location: (2,0)-(4,3))*
#             |   +- nd_mid: :!
#             |   +- nd_defn:
```

I've opted to handle it inside Prism so that method names in the AST match what CRubys parser generates, rather than handling it in the compiler.

Fixes #2226