### PR TITLE
Use inttypes for more accurate printf formatting

### DIFF
--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -17,6 +17,14 @@
 #include <string.h>
 
 /**
+ * We want to be able to use the PRI* macros for printing out integers, but on
+ * some platforms they aren't included unless this is already defined.
+ */
+#define __STDC_FORMAT_MACROS
+
+#include <inttypes.h>
+
+/**
  * By default, we compile with -fvisibility=hidden. When this is enabled, we
  * need to mark certain functions as being publically-visible. This macro does
  * that in a compiler-agnostic way.

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -152,8 +152,10 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
                     prettyprint_source(output_buffer, location->start, (size_t) (location->end - location->start));
                     pm_buffer_append_string(output_buffer, "\"\n", 2);
                 }
-            <%- when Prism::UInt8Field, Prism::UInt32Field -%>
-                pm_buffer_append_format(output_buffer, " %d\n", cast-><%= field.name %>);
+            <%- when Prism::UInt8Field -%>
+                pm_buffer_append_format(output_buffer, " %" PRIu8 "\n", cast-><%= field.name %>);
+            <%- when Prism::UInt32Field -%>
+                pm_buffer_append_format(output_buffer, " %" PRIu32 "\n", cast-><%= field.name %>);
             <%- when Prism::FlagsField -%>
                 bool found = false;
                 <%- found = flags.find { |flag| flag.name == field.kind }.tap { |found| raise "Expected to find #{field.kind}" unless found } -%>


### PR DESCRIPTION
A follow-up to https://github.com/ruby/prism/pull/2171