### PR TITLE
Fix parsing calls with labels

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -424,6 +424,11 @@ lex_state_beg_p(pm_parser_t *parser) {
 }
 
 static inline bool
+lex_state_arg_labeled_p(pm_parser_t *parser) {
+    return (parser->lex_state & (PM_LEX_STATE_ARG | PM_LEX_STATE_LABELED)) == (PM_LEX_STATE_ARG | PM_LEX_STATE_LABELED);
+}
+
+static inline bool
 lex_state_arg_p(pm_parser_t *parser) {
     return lex_state_p(parser, PM_LEX_STATE_ARG_ANY);
 }
@@ -13909,7 +13914,7 @@ parse_strings(pm_parser_t *parser, pm_node_t *current) {
     assert(parser->current.type == PM_TOKEN_STRING_BEGIN);
 
     bool concating = false;
-    bool state_is_arg_labeled = lex_state_p(parser, PM_LEX_STATE_ARG | PM_LEX_STATE_LABELED);
+    bool state_is_arg_labeled = lex_state_arg_labeled_p(parser);
 
     while (match1(parser, PM_TOKEN_STRING_BEGIN)) {
         pm_node_t *node = NULL;

--- a/test/prism/fixtures/method_calls.txt
+++ b/test/prism/fixtures/method_calls.txt
@@ -152,3 +152,5 @@ foo 1, Bar { 1 }
 
 foo = 1
 foo {}
+
+@a.b "c#{name}": 42

--- a/test/prism/snapshots/method_calls.txt
+++ b/test/prism/snapshots/method_calls.txt
@@ -1,8 +1,8 @@
-@ ProgramNode (location: (1,0)-(154,6))
+@ ProgramNode (location: (1,0)-(156,19))
 ├── locals: [:foo]
 └── statements:
-    @ StatementsNode (location: (1,0)-(154,6))
-    └── body: (length: 66)
+    @ StatementsNode (location: (1,0)-(156,19))
+    └── body: (length: 67)
         ├── @ CallNode (location: (1,0)-(1,14))
         │   ├── flags: ∅
         │   ├── receiver:
@@ -2393,20 +2393,70 @@
         │   │   @ IntegerNode (location: (153,6)-(153,7))
         │   │   └── flags: decimal
         │   └── operator_loc: (153,4)-(153,5) = "="
-        └── @ CallNode (location: (154,0)-(154,6))
-            ├── flags: ignore_visibility
-            ├── receiver: ∅
-            ├── call_operator_loc: ∅
-            ├── name: :foo
-            ├── message_loc: (154,0)-(154,3) = "foo"
+        ├── @ CallNode (location: (154,0)-(154,6))
+        │   ├── flags: ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :foo
+        │   ├── message_loc: (154,0)-(154,3) = "foo"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   └── block:
+        │       @ BlockNode (location: (154,4)-(154,6))
+        │       ├── locals: []
+        │       ├── locals_body_index: 0
+        │       ├── parameters: ∅
+        │       ├── body: ∅
+        │       ├── opening_loc: (154,4)-(154,5) = "{"
+        │       └── closing_loc: (154,5)-(154,6) = "}"
+        └── @ CallNode (location: (156,0)-(156,19))
+            ├── flags: ∅
+            ├── receiver:
+            │   @ InstanceVariableReadNode (location: (156,0)-(156,2))
+            │   └── name: :@a
+            ├── call_operator_loc: (156,2)-(156,3) = "."
+            ├── name: :b
+            ├── message_loc: (156,3)-(156,4) = "b"
             ├── opening_loc: ∅
-            ├── arguments: ∅
+            ├── arguments:
+            │   @ ArgumentsNode (location: (156,5)-(156,19))
+            │   ├── flags: ∅
+            │   └── arguments: (length: 1)
+            │       └── @ KeywordHashNode (location: (156,5)-(156,19))
+            │           ├── flags: ∅
+            │           └── elements: (length: 1)
+            │               └── @ AssocNode (location: (156,5)-(156,19))
+            │                   ├── key:
+            │                   │   @ InterpolatedSymbolNode (location: (156,5)-(156,16))
+            │                   │   ├── opening_loc: (156,5)-(156,6) = "\""
+            │                   │   ├── parts: (length: 2)
+            │                   │   │   ├── @ StringNode (location: (156,6)-(156,7))
+            │                   │   │   │   ├── flags: ∅
+            │                   │   │   │   ├── opening_loc: ∅
+            │                   │   │   │   ├── content_loc: (156,6)-(156,7) = "c"
+            │                   │   │   │   ├── closing_loc: ∅
+            │                   │   │   │   └── unescaped: "c"
+            │                   │   │   └── @ EmbeddedStatementsNode (location: (156,7)-(156,14))
+            │                   │   │       ├── opening_loc: (156,7)-(156,9) = "\#{"
+            │                   │   │       ├── statements:
+            │                   │   │       │   @ StatementsNode (location: (156,9)-(156,13))
+            │                   │   │       │   └── body: (length: 1)
+            │                   │   │       │       └── @ CallNode (location: (156,9)-(156,13))
+            │                   │   │       │           ├── flags: variable_call, ignore_visibility
+            │                   │   │       │           ├── receiver: ∅
+            │                   │   │       │           ├── call_operator_loc: ∅
+            │                   │   │       │           ├── name: :name
+            │                   │   │       │           ├── message_loc: (156,9)-(156,13) = "name"
+            │                   │   │       │           ├── opening_loc: ∅
+            │                   │   │       │           ├── arguments: ∅
+            │                   │   │       │           ├── closing_loc: ∅
+            │                   │   │       │           └── block: ∅
+            │                   │   │       └── closing_loc: (156,13)-(156,14) = "}"
+            │                   │   └── closing_loc: (156,14)-(156,16) = "\":"
+            │                   ├── value:
+            │                   │   @ IntegerNode (location: (156,17)-(156,19))
+            │                   │   └── flags: decimal
+            │                   └── operator_loc: ∅
             ├── closing_loc: ∅
-            └── block:
-                @ BlockNode (location: (154,4)-(154,6))
-                ├── locals: []
-                ├── locals_body_index: 0
-                ├── parameters: ∅
-                ├── body: ∅
-                ├── opening_loc: (154,4)-(154,5) = "{"
-                └── closing_loc: (154,5)-(154,6) = "}"
+            └── block: ∅


### PR DESCRIPTION
Fixes code like:

```ruby
@a.b "c#{name}": 42
```

It looks like calls to `lex_state_p` with `or`ed parameters is not producing the expected results. I recall that that was also a problem with `lex_state_beg_p` before.