### PR TITLE
Fix multiple assigns with newlines

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -11140,6 +11140,8 @@ static pm_node_t *
 parse_targets_validate(pm_parser_t *parser, pm_node_t *first_target, pm_binding_power_t binding_power) {
     pm_node_t *result = parse_targets(parser, first_target, binding_power);
 
+    while (accept1(parser, PM_TOKEN_NEWLINE));
+
     // Ensure that we have either an = or a ) after the targets.
     if (!match2(parser, PM_TOKEN_EQUAL, PM_TOKEN_PARENTHESIS_RIGHT)) {
         pm_parser_err_node(parser, result, PM_ERR_WRITE_TARGET_UNEXPECTED);

--- a/src/prism.c
+++ b/src/prism.c
@@ -11139,8 +11139,7 @@ parse_targets(pm_parser_t *parser, pm_node_t *first_target, pm_binding_power_t b
 static pm_node_t *
 parse_targets_validate(pm_parser_t *parser, pm_node_t *first_target, pm_binding_power_t binding_power) {
     pm_node_t *result = parse_targets(parser, first_target, binding_power);
-
-    while (accept1(parser, PM_TOKEN_NEWLINE));
+    accept1(parser, PM_TOKEN_NEWLINE);
 
     // Ensure that we have either an = or a ) after the targets.
     if (!match2(parser, PM_TOKEN_EQUAL, PM_TOKEN_PARENTHESIS_RIGHT)) {

--- a/test/prism/fixtures/patterns.txt
+++ b/test/prism/fixtures/patterns.txt
@@ -202,3 +202,8 @@ end
 foo => Object[{x:}]
 
 1.then { 1 in ^_1 }
+
+(
+  a,
+  b
+) = c

--- a/test/prism/snapshots/patterns.txt
+++ b/test/prism/snapshots/patterns.txt
@@ -1,8 +1,8 @@
-@ ProgramNode (location: (1,0)-(204,19))
+@ ProgramNode (location: (1,0)-(209,5))
 ├── locals: [:bar, :baz, :qux, :b, :a, :foo, :x]
 └── statements:
-    @ StatementsNode (location: (1,0)-(204,19))
-    └── body: (length: 177)
+    @ StatementsNode (location: (1,0)-(209,5))
+    └── body: (length: 178)
         ├── @ MatchRequiredNode (location: (1,0)-(1,10))
         │   ├── value:
         │   │   @ CallNode (location: (1,0)-(1,3))
@@ -4767,38 +4767,62 @@
         │   │   ├── opening_loc: (202,13)-(202,14) = "["
         │   │   └── closing_loc: (202,18)-(202,19) = "]"
         │   └── operator_loc: (202,4)-(202,6) = "=>"
-        └── @ CallNode (location: (204,0)-(204,19))
-            ├── flags: ∅
-            ├── receiver:
-            │   @ IntegerNode (location: (204,0)-(204,1))
-            │   └── flags: decimal
-            ├── call_operator_loc: (204,1)-(204,2) = "."
-            ├── name: :then
-            ├── message_loc: (204,2)-(204,6) = "then"
-            ├── opening_loc: ∅
-            ├── arguments: ∅
-            ├── closing_loc: ∅
-            └── block:
-                @ BlockNode (location: (204,7)-(204,19))
-                ├── locals: [:_1]
-                ├── locals_body_index: 1
-                ├── parameters:
-                │   @ NumberedParametersNode (location: (204,7)-(204,19))
-                │   └── maximum: 1
-                ├── body:
-                │   @ StatementsNode (location: (204,9)-(204,17))
-                │   └── body: (length: 1)
-                │       └── @ MatchPredicateNode (location: (204,9)-(204,17))
-                │           ├── value:
-                │           │   @ IntegerNode (location: (204,9)-(204,10))
-                │           │   └── flags: decimal
-                │           ├── pattern:
-                │           │   @ PinnedVariableNode (location: (204,14)-(204,17))
-                │           │   ├── variable:
-                │           │   │   @ LocalVariableReadNode (location: (204,15)-(204,17))
-                │           │   │   ├── name: :_1
-                │           │   │   └── depth: 0
-                │           │   └── operator_loc: (204,14)-(204,15) = "^"
-                │           └── operator_loc: (204,11)-(204,13) = "in"
-                ├── opening_loc: (204,7)-(204,8) = "{"
-                └── closing_loc: (204,18)-(204,19) = "}"
+        ├── @ CallNode (location: (204,0)-(204,19))
+        │   ├── flags: ∅
+        │   ├── receiver:
+        │   │   @ IntegerNode (location: (204,0)-(204,1))
+        │   │   └── flags: decimal
+        │   ├── call_operator_loc: (204,1)-(204,2) = "."
+        │   ├── name: :then
+        │   ├── message_loc: (204,2)-(204,6) = "then"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   └── block:
+        │       @ BlockNode (location: (204,7)-(204,19))
+        │       ├── locals: [:_1]
+        │       ├── locals_body_index: 1
+        │       ├── parameters:
+        │       │   @ NumberedParametersNode (location: (204,7)-(204,19))
+        │       │   └── maximum: 1
+        │       ├── body:
+        │       │   @ StatementsNode (location: (204,9)-(204,17))
+        │       │   └── body: (length: 1)
+        │       │       └── @ MatchPredicateNode (location: (204,9)-(204,17))
+        │       │           ├── value:
+        │       │           │   @ IntegerNode (location: (204,9)-(204,10))
+        │       │           │   └── flags: decimal
+        │       │           ├── pattern:
+        │       │           │   @ PinnedVariableNode (location: (204,14)-(204,17))
+        │       │           │   ├── variable:
+        │       │           │   │   @ LocalVariableReadNode (location: (204,15)-(204,17))
+        │       │           │   │   ├── name: :_1
+        │       │           │   │   └── depth: 0
+        │       │           │   └── operator_loc: (204,14)-(204,15) = "^"
+        │       │           └── operator_loc: (204,11)-(204,13) = "in"
+        │       ├── opening_loc: (204,7)-(204,8) = "{"
+        │       └── closing_loc: (204,18)-(204,19) = "}"
+        └── @ MultiWriteNode (location: (206,0)-(209,5))
+            ├── lefts: (length: 2)
+            │   ├── @ LocalVariableTargetNode (location: (207,2)-(207,3))
+            │   │   ├── name: :a
+            │   │   └── depth: 0
+            │   └── @ LocalVariableTargetNode (location: (208,2)-(208,3))
+            │       ├── name: :b
+            │       └── depth: 0
+            ├── rest: ∅
+            ├── rights: (length: 0)
+            ├── lparen_loc: (206,0)-(206,1) = "("
+            ├── rparen_loc: (209,0)-(209,1) = ")"
+            ├── operator_loc: (209,2)-(209,3) = "="
+            └── value:
+                @ CallNode (location: (209,4)-(209,5))
+                ├── flags: variable_call, ignore_visibility
+                ├── receiver: ∅
+                ├── call_operator_loc: ∅
+                ├── name: :c
+                ├── message_loc: (209,4)-(209,5) = "c"
+                ├── opening_loc: ∅
+                ├── arguments: ∅
+                ├── closing_loc: ∅
+                └── block: ∅


### PR DESCRIPTION
Fixes parsing code like:

```ruby
(
  a,
  b
) = c
```
