### PR TITLE
Add an implicit node for the target of a hash pattern

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    abbrev (0.1.2)
     ffi (1.15.5)
     mini_portile2 (2.8.5)
     nokogiri (1.15.4)
@@ -16,7 +17,8 @@ GEM
     rake (13.0.6)
     rake-compiler (1.2.5)
       rake
-    rbs (3.2.2)
+    rbs (3.4.2)
+      abbrev
     ruby_memcheck (2.2.1)
       nokogiri
     test-unit (3.6.1)

--- a/config.yml
+++ b/config.yml
@@ -580,9 +580,9 @@ nodes:
               { def a; end => 1 }
                 ^^^^^^^^^^
       - name: value
-        type: node?
+        type: node
         comment: |
-          The value of the association, if present. This can be any [non-void expression](https://github.com/ruby/prism/blob/main/docs/parsing_rules.md#non-void-expression). It can be optionally omitted if this node is an element in a `HashPatternNode`.
+          The value of the association, if present. This can be any [non-void expression](https://github.com/ruby/prism/blob/main/docs/parsing_rules.md#non-void-expression).
 
               { foo => bar }
                        ^^^
@@ -1634,6 +1634,9 @@ nodes:
 
           { Foo: }
             ^^^^
+
+          foo in { bar: }
+                   ^^^^
   - name: ImplicitRestNode
     comment: |
       Represents using a trailing comma to indicate an implicit rest parameter.

--- a/test/prism/snapshots/patterns.txt
+++ b/test/prism/snapshots/patterns.txt
@@ -4757,7 +4757,12 @@
         │   │   │       │       │   ├── value_loc: (202,15)-(202,16) = "x"
         │   │   │       │       │   ├── closing_loc: (202,16)-(202,17) = ":"
         │   │   │       │       │   └── unescaped: "x"
-        │   │   │       │       ├── value: ∅
+        │   │   │       │       ├── value:
+        │   │   │       │       │   @ ImplicitNode (location: (202,15)-(202,16))
+        │   │   │       │       │   └── value:
+        │   │   │       │       │       @ LocalVariableTargetNode (location: (202,15)-(202,16))
+        │   │   │       │       │       ├── name: :x
+        │   │   │       │       │       └── depth: 0
         │   │   │       │       └── operator_loc: ∅
         │   │   │       ├── rest: ∅
         │   │   │       ├── opening_loc: (202,14)-(202,15) = "{"

--- a/test/prism/snapshots/seattlerb/case_in.txt
+++ b/test/prism/snapshots/seattlerb/case_in.txt
@@ -25,7 +25,12 @@
         │   │       │   │       │   ├── value_loc: (2,5)-(2,6) = "b"
         │   │       │   │       │   ├── closing_loc: (2,6)-(2,8) = "\":"
         │   │       │   │       │   └── unescaped: "b"
-        │   │       │   │       ├── value: ∅
+        │   │       │   │       ├── value:
+        │   │       │   │       │   @ ImplicitNode (location: (2,5)-(2,6))
+        │   │       │   │       │   └── value:
+        │   │       │   │       │       @ LocalVariableTargetNode (location: (2,5)-(2,6))
+        │   │       │   │       │       ├── name: :b
+        │   │       │   │       │       └── depth: 0
         │   │       │   │       └── operator_loc: ∅
         │   │       │   ├── rest: ∅
         │   │       │   ├── opening_loc: ∅
@@ -905,7 +910,12 @@
         │   │       │   │       │   ├── value_loc: (106,6)-(106,7) = "b"
         │   │       │   │       │   ├── closing_loc: (106,7)-(106,9) = "\":"
         │   │       │   │       │   └── unescaped: "b"
-        │   │       │   │       ├── value: ∅
+        │   │       │   │       ├── value:
+        │   │       │   │       │   @ ImplicitNode (location: (106,6)-(106,7))
+        │   │       │   │       │   └── value:
+        │   │       │   │       │       @ LocalVariableTargetNode (location: (106,6)-(106,7))
+        │   │       │   │       │       ├── name: :b
+        │   │       │   │       │       └── depth: 0
         │   │       │   │       └── operator_loc: ∅
         │   │       │   ├── rest: ∅
         │   │       │   ├── opening_loc: (106,3)-(106,4) = "{"

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_assign.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_assign.txt
@@ -60,7 +60,12 @@
             │       │   │       │   ├── value_loc: (2,30)-(2,31) = "f"
             │       │   │       │   ├── closing_loc: (2,31)-(2,32) = ":"
             │       │   │       │   └── unescaped: "f"
-            │       │   │       ├── value: ∅
+            │       │   │       ├── value:
+            │       │   │       │   @ ImplicitNode (location: (2,30)-(2,31))
+            │       │   │       │   └── value:
+            │       │   │       │       @ LocalVariableTargetNode (location: (2,30)-(2,31))
+            │       │   │       │       ├── name: :f
+            │       │   │       │       └── depth: 0
             │       │   │       └── operator_loc: ∅
             │       │   ├── rest: ∅
             │       │   ├── opening_loc: (2,3)-(2,4) = "{"

--- a/test/prism/snapshots/seattlerb/parse_pattern_058.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_058.txt
@@ -35,7 +35,12 @@
             │       │   │       │   ├── value_loc: (2,4)-(2,5) = "a"
             │       │   │       │   ├── closing_loc: (2,5)-(2,6) = ":"
             │       │   │       │   └── unescaped: "a"
-            │       │   │       ├── value: ∅
+            │       │   │       ├── value:
+            │       │   │       │   @ ImplicitNode (location: (2,4)-(2,5))
+            │       │   │       │   └── value:
+            │       │   │       │       @ LocalVariableTargetNode (location: (2,4)-(2,5))
+            │       │   │       │       ├── name: :a
+            │       │   │       │       └── depth: 0
             │       │   │       └── operator_loc: ∅
             │       │   ├── rest:
             │       │   │   @ AssocSplatNode (location: (2,8)-(2,14))

--- a/test/prism/snapshots/seattlerb/parse_pattern_058_2.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_058_2.txt
@@ -35,7 +35,12 @@
             │       │   │       │   ├── value_loc: (2,4)-(2,5) = "a"
             │       │   │       │   ├── closing_loc: (2,5)-(2,6) = ":"
             │       │   │       │   └── unescaped: "a"
-            │       │   │       ├── value: ∅
+            │       │   │       ├── value:
+            │       │   │       │   @ ImplicitNode (location: (2,4)-(2,5))
+            │       │   │       │   └── value:
+            │       │   │       │       @ LocalVariableTargetNode (location: (2,4)-(2,5))
+            │       │   │       │       ├── name: :a
+            │       │   │       │       └── depth: 0
             │       │   │       └── operator_loc: ∅
             │       │   ├── rest:
             │       │   │   @ AssocSplatNode (location: (2,8)-(2,10))

--- a/test/prism/snapshots/unparser/corpus/literal/pattern.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/pattern.txt
@@ -89,7 +89,12 @@
         │   │   │   │   │       │   ├── value_loc: (6,5)-(6,6) = "x"
         │   │   │   │   │       │   ├── closing_loc: (6,6)-(6,7) = ":"
         │   │   │   │   │       │   └── unescaped: "x"
-        │   │   │   │   │       ├── value: ∅
+        │   │   │   │   │       ├── value:
+        │   │   │   │   │       │   @ ImplicitNode (location: (6,5)-(6,6))
+        │   │   │   │   │       │   └── value:
+        │   │   │   │   │       │       @ LocalVariableTargetNode (location: (6,5)-(6,6))
+        │   │   │   │   │       │       ├── name: :x
+        │   │   │   │   │       │       └── depth: 0
         │   │   │   │   │       └── operator_loc: ∅
         │   │   │   │   ├── rest: ∅
         │   │   │   │   ├── opening_loc: (6,4)-(6,5) = "("

--- a/test/prism/snapshots/whitequark/multiple_pattern_matches.txt
+++ b/test/prism/snapshots/whitequark/multiple_pattern_matches.txt
@@ -33,7 +33,12 @@
         │   │   │       │   ├── value_loc: (1,10)-(1,11) = "a"
         │   │   │       │   ├── closing_loc: (1,11)-(1,12) = ":"
         │   │   │       │   └── unescaped: "a"
-        │   │   │       ├── value: ∅
+        │   │   │       ├── value:
+        │   │   │       │   @ ImplicitNode (location: (1,10)-(1,11))
+        │   │   │       │   └── value:
+        │   │   │       │       @ LocalVariableTargetNode (location: (1,10)-(1,11))
+        │   │   │       │       ├── name: :a
+        │   │   │       │       └── depth: 0
         │   │   │       └── operator_loc: ∅
         │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅
@@ -69,7 +74,12 @@
         │   │   │       │   ├── value_loc: (2,10)-(2,11) = "a"
         │   │   │       │   ├── closing_loc: (2,11)-(2,12) = ":"
         │   │   │       │   └── unescaped: "a"
-        │   │   │       ├── value: ∅
+        │   │   │       ├── value:
+        │   │   │       │   @ ImplicitNode (location: (2,10)-(2,11))
+        │   │   │       │   └── value:
+        │   │   │       │       @ LocalVariableTargetNode (location: (2,10)-(2,11))
+        │   │   │       │       ├── name: :a
+        │   │   │       │       └── depth: 0
         │   │   │       └── operator_loc: ∅
         │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅
@@ -105,7 +115,12 @@
         │   │   │       │   ├── value_loc: (4,10)-(4,11) = "a"
         │   │   │       │   ├── closing_loc: (4,11)-(4,12) = ":"
         │   │   │       │   └── unescaped: "a"
-        │   │   │       ├── value: ∅
+        │   │   │       ├── value:
+        │   │   │       │   @ ImplicitNode (location: (4,10)-(4,11))
+        │   │   │       │   └── value:
+        │   │   │       │       @ LocalVariableTargetNode (location: (4,10)-(4,11))
+        │   │   │       │       ├── name: :a
+        │   │   │       │       └── depth: 0
         │   │   │       └── operator_loc: ∅
         │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅
@@ -141,7 +156,12 @@
             │   │       │   ├── value_loc: (5,10)-(5,11) = "a"
             │   │       │   ├── closing_loc: (5,11)-(5,12) = ":"
             │   │       │   └── unescaped: "a"
-            │   │       ├── value: ∅
+            │   │       ├── value:
+            │   │       │   @ ImplicitNode (location: (5,10)-(5,11))
+            │   │       │   └── value:
+            │   │       │       @ LocalVariableTargetNode (location: (5,10)-(5,11))
+            │   │       │       ├── name: :a
+            │   │       │       └── depth: 0
             │   │       └── operator_loc: ∅
             │   ├── rest: ∅
             │   ├── opening_loc: ∅

--- a/test/prism/snapshots/whitequark/newline_in_hash_argument.txt
+++ b/test/prism/snapshots/whitequark/newline_in_hash_argument.txt
@@ -29,7 +29,12 @@
         │   │   │   │   │       │   ├── value_loc: (2,3)-(2,4) = "a"
         │   │   │   │   │       │   ├── closing_loc: (2,4)-(2,5) = ":"
         │   │   │   │   │       │   └── unescaped: "a"
-        │   │   │   │   │       ├── value: ∅
+        │   │   │   │   │       ├── value:
+        │   │   │   │   │       │   @ ImplicitNode (location: (2,3)-(2,4))
+        │   │   │   │   │       │   └── value:
+        │   │   │   │   │       │       @ LocalVariableTargetNode (location: (2,3)-(2,4))
+        │   │   │   │   │       │       ├── name: :a
+        │   │   │   │   │       │       └── depth: 0
         │   │   │   │   │       └── operator_loc: ∅
         │   │   │   │   ├── rest: ∅
         │   │   │   │   ├── opening_loc: ∅
@@ -55,7 +60,12 @@
         │   │       │   │       │   ├── value_loc: (5,4)-(5,5) = "b"
         │   │       │   │       │   ├── closing_loc: (5,5)-(5,7) = "\":"
         │   │       │   │       │   └── unescaped: "b"
-        │   │       │   │       ├── value: ∅
+        │   │       │   │       ├── value:
+        │   │       │   │       │   @ ImplicitNode (location: (5,4)-(5,5))
+        │   │       │   │       │   └── value:
+        │   │       │   │       │       @ LocalVariableTargetNode (location: (5,4)-(5,5))
+        │   │       │   │       │       ├── name: :b
+        │   │       │   │       │       └── depth: 0
         │   │       │   │       └── operator_loc: ∅
         │   │       │   ├── rest: ∅
         │   │       │   ├── opening_loc: ∅

--- a/test/prism/snapshots/whitequark/pattern_matching_single_line_allowed_omission_of_parentheses.txt
+++ b/test/prism/snapshots/whitequark/pattern_matching_single_line_allowed_omission_of_parentheses.txt
@@ -91,7 +91,12 @@
         │   │   │       │   ├── value_loc: (5,10)-(5,11) = "a"
         │   │   │       │   ├── closing_loc: (5,11)-(5,12) = ":"
         │   │   │       │   └── unescaped: "a"
-        │   │   │       ├── value: ∅
+        │   │   │       ├── value:
+        │   │   │       │   @ ImplicitNode (location: (5,10)-(5,11))
+        │   │   │       │   └── value:
+        │   │   │       │       @ LocalVariableTargetNode (location: (5,10)-(5,11))
+        │   │   │       │       ├── name: :a
+        │   │   │       │       └── depth: 0
         │   │   │       └── operator_loc: ∅
         │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅
@@ -130,7 +135,12 @@
         │   │   │       │   ├── value_loc: (7,10)-(7,11) = "a"
         │   │   │       │   ├── closing_loc: (7,11)-(7,12) = ":"
         │   │   │       │   └── unescaped: "a"
-        │   │   │       ├── value: ∅
+        │   │   │       ├── value:
+        │   │   │       │   @ ImplicitNode (location: (7,10)-(7,11))
+        │   │   │       │   └── value:
+        │   │   │       │       @ LocalVariableTargetNode (location: (7,10)-(7,11))
+        │   │   │       │       ├── name: :a
+        │   │   │       │       └── depth: 0
         │   │   │       └── operator_loc: ∅
         │   │   ├── rest: ∅
         │   │   ├── opening_loc: ∅


### PR DESCRIPTION
This simplifies compiling it, since you can now compile the value as if it were always there. It also means you don't have to reparse the symbol to get the constant name.

This also makes `AssocNode#value` non-null, since there will now always be an explicit value or implicit value.