### PR TITLE
Track whether a Symbol should have its encoding changed from the source encoding.

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -5468,6 +5468,53 @@ pm_super_node_create(pm_parser_t *parser, const pm_token_t *keyword, pm_argument
 }
 
 /**
+ * Read through the contents of a string and check if it consists solely of US ASCII code points.
+ */
+static bool
+ascii_only_p( const pm_string_t *contents) {
+    const size_t length = contents->length;
+
+    for (size_t i = 0; i < length; i++) {
+        if (contents->source[i] & 0x80) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Ruby "downgrades" the encoding of Symbols to US-ASCII if the associated encoding is ASCII-compatible and
+ * the Symbol consists only of US-ASCII code points. Otherwise, the encoding may be explicitly set with an
+ * escape sequence.
+ */
+static inline pm_node_flags_t
+parse_symbol_encoding(const pm_parser_t *parser, const pm_string_t *contents) {
+    // Don't set any flags on the Symbol if it hasn't been populated yet.
+    if (contents->source == NULL) {
+        return 0;
+    }
+
+    // Ruby stipulates that all source files must use an ASCII-compatible encoding. Thus, all symbols appearing in
+    // source are eligible for "downgrading" to US-ASCII.
+    if (ascii_only_p(contents)) {
+        return PM_SYMBOL_FLAGS_FORCED_US_ASCII_ENCODING;
+    } else {
+        // A Symbol may optionally have its encoding explicitly set.
+        //
+        // NB: an explicitly set encoding is ignored by Ruby if the Symbol consists of only US ASCII code points.
+        if (parser->explicit_encoding != NULL) {
+            if (parser->explicit_encoding == PM_ENCODING_UTF_8_ENTRY) {
+                return PM_SYMBOL_FLAGS_FORCED_UTF8_ENCODING;
+            } else if (parser->encoding == PM_ENCODING_US_ASCII_ENTRY) {
+                return PM_SYMBOL_FLAGS_FORCED_BINARY_ENCODING;
+            }
+        }
+    }
+    return 0;
+}
+
+/**
  * Allocate and initialize a new SymbolNode node with the given unescaped
  * string.
  */
@@ -5489,6 +5536,8 @@ pm_symbol_node_create_unescaped(pm_parser_t *parser, const pm_token_t *opening, 
         .closing_loc = PM_OPTIONAL_LOCATION_TOKEN_VALUE(closing),
         .unescaped = *unescaped
     };
+
+    pm_node_flag_set((pm_node_t *)node, parse_symbol_encoding(parser, unescaped));
 
     return node;
 }
@@ -5528,6 +5577,7 @@ pm_symbol_node_label_create(pm_parser_t *parser, const pm_token_t *token) {
 
             assert((label.end - label.start) >= 0);
             pm_string_shared_init(&node->unescaped, label.start, label.end);
+            pm_node_flag_set((pm_node_t *)node, parse_symbol_encoding(parser, &node->unescaped));
             break;
         }
         case PM_TOKEN_MISSING: {
@@ -5589,6 +5639,8 @@ pm_string_node_to_symbol_node(pm_parser_t *parser, pm_string_node_t *node, const
         .closing_loc = PM_OPTIONAL_LOCATION_TOKEN_VALUE(closing),
         .unescaped = node->unescaped
     };
+
+    pm_node_flag_set((pm_node_t *)new_node, parse_symbol_encoding(parser, &node->unescaped));
 
     // We are explicitly _not_ using pm_node_destroy here because we don't want
     // to trash the unescaped string. We could instead copy the string if we
@@ -8111,7 +8163,6 @@ pm_token_buffer_push(pm_token_buffer_t *token_buffer, uint8_t byte) {
 /**
  * When we're about to return from lexing the current token and we know for sure
  * that we have found an escape sequence, this function is called to copy the
- *
  * contents of the token buffer into the current string on the parser so that it
  * can be attached to the correct node.
  */
@@ -8126,7 +8177,6 @@ pm_token_buffer_copy(pm_parser_t *parser, pm_token_buffer_t *token_buffer) {
  * string. If we haven't pushed anything into the buffer, this means that we
  * never found an escape sequence, so we can directly reference the bounds of
  * the current string. Either way, at the return of this function it is expected
- *
  * that parser->current_string is established in such a way that it can be
  * attached to a node.
  */
@@ -8144,7 +8194,6 @@ pm_token_buffer_flush(pm_parser_t *parser, pm_token_buffer_t *token_buffer) {
  * When we've found an escape sequence, we need to copy everything up to this
  * point into the buffer because we're about to provide a string that has
  * different content than a direct slice of the source.
- *
  *
  * It is expected that the parser's current token end will be pointing at one
  * byte past the backslash that starts the escape sequence.
@@ -12590,8 +12639,11 @@ PM_STATIC_ASSERT(__LINE__, ((int) PM_STRING_FLAGS_FORCED_UTF8_ENCODING) == ((int
 static inline pm_node_flags_t
 parse_unescaped_encoding(const pm_parser_t *parser) {
     if (parser->explicit_encoding != NULL) {
+        // If the there's an explicit encoding and it's using a UTF-8 escape sequence, then mark the string as UTF-8.
         if (parser->explicit_encoding == PM_ENCODING_UTF_8_ENTRY) {
             return PM_STRING_FLAGS_FORCED_UTF8_ENCODING;
+        // If there's a non-UTF-8 escape sequence being used, then the string uses the source encoding, unless the source
+        // is marked as US-ASCII. In that case the string is forced as ASCII-8BIT in order to keep the string valid.
         } else if (parser->encoding == PM_ENCODING_US_ASCII_ENTRY) {
             return PM_STRING_FLAGS_FORCED_BINARY_ENCODING;
         }
@@ -12744,6 +12796,7 @@ parse_operator_symbol(pm_parser_t *parser, const pm_token_t *opening, pm_lex_sta
     parser_lex(parser);
 
     pm_string_shared_init(&symbol->unescaped, parser->previous.start, end);
+    pm_node_flag_set((pm_node_t *)symbol, parse_symbol_encoding(parser, &symbol->unescaped));
     return (pm_node_t *) symbol;
 }
 
@@ -12782,6 +12835,8 @@ parse_symbol(pm_parser_t *parser, pm_lex_mode_t *lex_mode, pm_lex_state_t next_s
         pm_symbol_node_t *symbol = pm_symbol_node_create(parser, &opening, &parser->previous, &closing);
 
         pm_string_shared_init(&symbol->unescaped, parser->previous.start, parser->previous.end);
+        pm_node_flag_set((pm_node_t *)symbol, parse_symbol_encoding(parser, &symbol->unescaped));
+
         return (pm_node_t *) symbol;
     }
 
@@ -12867,6 +12922,7 @@ parse_symbol(pm_parser_t *parser, pm_lex_mode_t *lex_mode, pm_lex_state_t next_s
     } else {
         content = (pm_token_t) { .type = PM_TOKEN_STRING_CONTENT, .start = parser->previous.end, .end = parser->previous.end };
         pm_string_shared_init(&unescaped, content.start, content.end);
+
     }
 
     if (next_state != PM_LEX_STATE_NONE) {
@@ -12878,7 +12934,11 @@ parse_symbol(pm_parser_t *parser, pm_lex_mode_t *lex_mode, pm_lex_state_t next_s
     } else {
         expect1(parser, PM_TOKEN_STRING_END, PM_ERR_SYMBOL_TERM_DYNAMIC);
     }
-    return (pm_node_t *) pm_symbol_node_create_unescaped(parser, &opening, &content, &parser->previous, &unescaped);
+
+    pm_symbol_node_t *symbol_node = pm_symbol_node_create_unescaped(parser, &opening, &content, &parser->previous, &unescaped);
+    pm_node_flag_set((pm_node_t *)symbol_node, parse_symbol_encoding(parser, &symbol_node->unescaped));
+
+    return (pm_node_t *) symbol_node;
 }
 
 /**
@@ -12942,6 +13002,7 @@ parse_alias_argument(pm_parser_t *parser, bool first) {
             pm_symbol_node_t *symbol = pm_symbol_node_create(parser, &opening, &parser->previous, &closing);
 
             pm_string_shared_init(&symbol->unescaped, parser->previous.start, parser->previous.end);
+            pm_node_flag_set((pm_node_t *)symbol, parse_symbol_encoding(parser, &symbol->unescaped));
             return (pm_node_t *) symbol;
         }
         case PM_TOKEN_SYMBOL_BEGIN: {

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -416,7 +416,7 @@ module Prism
         ArgumentsNode(0, [
           KeywordHashNode(1, [
             AssocNode(
-              SymbolNode(0, nil, Location(), Location(), "foo"),
+              SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, nil, Location(), Location(), "foo"),
               expression("bar"),
               nil
             )
@@ -594,16 +594,16 @@ module Prism
       expected = BeginNode(
         Location(),
         StatementsNode([
-          LocalVariableWriteNode(:_1, 0, Location(), SymbolNode(0, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_2, 0, Location(), SymbolNode(0, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_3, 0, Location(), SymbolNode(0, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_4, 0, Location(), SymbolNode(0, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_5, 0, Location(), SymbolNode(0, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_6, 0, Location(), SymbolNode(0, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_7, 0, Location(), SymbolNode(0, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_8, 0, Location(), SymbolNode(0, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_9, 0, Location(), SymbolNode(0, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_10, 0, Location(), SymbolNode(0, Location(), Location(), nil, "a"), Location())
+          LocalVariableWriteNode(:_1, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+          LocalVariableWriteNode(:_2, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+          LocalVariableWriteNode(:_3, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+          LocalVariableWriteNode(:_4, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+          LocalVariableWriteNode(:_5, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+          LocalVariableWriteNode(:_6, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+          LocalVariableWriteNode(:_7, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+          LocalVariableWriteNode(:_8, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+          LocalVariableWriteNode(:_9, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+          LocalVariableWriteNode(:_10, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location())
         ]),
         nil,
         nil,
@@ -1004,7 +1004,7 @@ module Prism
 
     def test_case_without_when_clauses_errors_on_else_clause
       expected = CaseMatchNode(
-        SymbolNode(0, Location(), Location(), nil, "a"),
+        SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"),
         [],
         ElseNode(Location(), nil, Location()),
         Location(),
@@ -1018,7 +1018,7 @@ module Prism
 
     def test_case_without_clauses
       expected = CaseNode(
-        SymbolNode(0, Location(), Location(), nil, "a"),
+        SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"),
         [],
         nil,
         Location(),

--- a/test/prism/snapshots/alias.txt
+++ b/test/prism/snapshots/alias.txt
@@ -6,14 +6,14 @@
         ├── @ AliasMethodNode (location: (1,0)-(1,15))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (1,6)-(1,10))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (1,6)-(1,7) = ":"
         │   │   ├── value_loc: (1,7)-(1,10) = "foo"
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "foo"
         │   ├── old_name:
         │   │   @ SymbolNode (location: (1,11)-(1,15))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (1,11)-(1,12) = ":"
         │   │   ├── value_loc: (1,12)-(1,15) = "bar"
         │   │   ├── closing_loc: ∅
@@ -22,14 +22,14 @@
         ├── @ AliasMethodNode (location: (3,0)-(3,21))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (3,6)-(3,13))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (3,6)-(3,9) = "%s["
         │   │   ├── value_loc: (3,9)-(3,12) = "abc"
         │   │   ├── closing_loc: (3,12)-(3,13) = "]"
         │   │   └── unescaped: "abc"
         │   ├── old_name:
         │   │   @ SymbolNode (location: (3,14)-(3,21))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (3,14)-(3,17) = "%s["
         │   │   ├── value_loc: (3,17)-(3,20) = "def"
         │   │   ├── closing_loc: (3,20)-(3,21) = "]"
@@ -38,14 +38,14 @@
         ├── @ AliasMethodNode (location: (5,0)-(5,19))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (5,6)-(5,12))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (5,6)-(5,8) = ":'"
         │   │   ├── value_loc: (5,8)-(5,11) = "abc"
         │   │   ├── closing_loc: (5,11)-(5,12) = "'"
         │   │   └── unescaped: "abc"
         │   ├── old_name:
         │   │   @ SymbolNode (location: (5,13)-(5,19))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (5,13)-(5,15) = ":'"
         │   │   ├── value_loc: (5,15)-(5,18) = "def"
         │   │   ├── closing_loc: (5,18)-(5,19) = "'"
@@ -73,7 +73,7 @@
         │   │   └── closing_loc: (7,15)-(7,16) = "\""
         │   ├── old_name:
         │   │   @ SymbolNode (location: (7,17)-(7,23))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (7,17)-(7,19) = ":'"
         │   │   ├── value_loc: (7,19)-(7,22) = "def"
         │   │   ├── closing_loc: (7,22)-(7,23) = "'"
@@ -90,14 +90,14 @@
         ├── @ AliasMethodNode (location: (11,0)-(11,13))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (11,6)-(11,9))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: ∅
         │   │   ├── value_loc: (11,6)-(11,9) = "foo"
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "foo"
         │   ├── old_name:
         │   │   @ SymbolNode (location: (11,10)-(11,13))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: ∅
         │   │   ├── value_loc: (11,10)-(11,13) = "bar"
         │   │   ├── closing_loc: ∅
@@ -114,14 +114,14 @@
         ├── @ AliasMethodNode (location: (15,0)-(15,12))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (15,6)-(15,9))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: ∅
         │   │   ├── value_loc: (15,6)-(15,9) = "foo"
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "foo"
         │   ├── old_name:
         │   │   @ SymbolNode (location: (15,10)-(15,12))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: ∅
         │   │   ├── value_loc: (15,10)-(15,12) = "if"
         │   │   ├── closing_loc: ∅
@@ -130,14 +130,14 @@
         ├── @ AliasMethodNode (location: (17,0)-(17,13))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (17,6)-(17,9))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: ∅
         │   │   ├── value_loc: (17,6)-(17,9) = "foo"
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "foo"
         │   ├── old_name:
         │   │   @ SymbolNode (location: (17,10)-(17,13))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: ∅
         │   │   ├── value_loc: (17,10)-(17,13) = "<=>"
         │   │   ├── closing_loc: ∅
@@ -146,14 +146,14 @@
         ├── @ AliasMethodNode (location: (19,0)-(19,15))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (19,6)-(19,9))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (19,6)-(19,7) = ":"
         │   │   ├── value_loc: (19,7)-(19,9) = "=="
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "=="
         │   ├── old_name:
         │   │   @ SymbolNode (location: (19,10)-(19,15))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (19,10)-(19,11) = ":"
         │   │   ├── value_loc: (19,11)-(19,15) = "eql?"
         │   │   ├── closing_loc: ∅
@@ -162,14 +162,14 @@
         ├── @ AliasMethodNode (location: (21,0)-(21,9))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (21,6)-(21,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: ∅
         │   │   ├── value_loc: (21,6)-(21,7) = "A"
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "A"
         │   ├── old_name:
         │   │   @ SymbolNode (location: (21,8)-(21,9))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: ∅
         │   │   ├── value_loc: (21,8)-(21,9) = "B"
         │   │   ├── closing_loc: ∅
@@ -178,14 +178,14 @@
         └── @ AliasMethodNode (location: (23,0)-(23,11))
             ├── new_name:
             │   @ SymbolNode (location: (23,6)-(23,8))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (23,6)-(23,7) = ":"
             │   ├── value_loc: (23,7)-(23,8) = "A"
             │   ├── closing_loc: ∅
             │   └── unescaped: "A"
             ├── old_name:
             │   @ SymbolNode (location: (23,9)-(23,11))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (23,9)-(23,10) = ":"
             │   ├── value_loc: (23,10)-(23,11) = "B"
             │   ├── closing_loc: ∅

--- a/test/prism/snapshots/arrays.txt
+++ b/test/prism/snapshots/arrays.txt
@@ -84,7 +84,7 @@
         │   │           └── @ AssocNode (location: (5,1)-(5,12))
         │   │               ├── key:
         │   │               │   @ SymbolNode (location: (5,1)-(5,3))
-        │   │               │   ├── flags: ∅
+        │   │               │   ├── flags: forced_us_ascii_encoding
         │   │               │   ├── opening_loc: ∅
         │   │               │   ├── value_loc: (5,1)-(5,2) = "a"
         │   │               │   ├── closing_loc: (5,2)-(5,3) = ":"
@@ -94,13 +94,13 @@
         │   │               │   ├── flags: ∅
         │   │               │   ├── elements: (length: 2)
         │   │               │   │   ├── @ SymbolNode (location: (5,5)-(5,7))
-        │   │               │   │   │   ├── flags: ∅
+        │   │               │   │   │   ├── flags: forced_us_ascii_encoding
         │   │               │   │   │   ├── opening_loc: (5,5)-(5,6) = ":"
         │   │               │   │   │   ├── value_loc: (5,6)-(5,7) = "b"
         │   │               │   │   │   ├── closing_loc: ∅
         │   │               │   │   │   └── unescaped: "b"
         │   │               │   │   └── @ SymbolNode (location: (5,9)-(5,11))
-        │   │               │   │       ├── flags: ∅
+        │   │               │   │       ├── flags: forced_us_ascii_encoding
         │   │               │   │       ├── opening_loc: (5,9)-(5,10) = ":"
         │   │               │   │       ├── value_loc: (5,10)-(5,11) = "c"
         │   │               │   │       ├── closing_loc: ∅
@@ -114,19 +114,19 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 5)
         │   │   ├── @ SymbolNode (location: (9,1)-(9,3))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (9,1)-(9,2) = ":"
         │   │   │   ├── value_loc: (9,2)-(9,3) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   ├── @ SymbolNode (location: (9,5)-(9,7))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (9,5)-(9,6) = ":"
         │   │   │   ├── value_loc: (9,6)-(9,7) = "b"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "b"
         │   │   ├── @ SymbolNode (location: (10,0)-(10,2))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (10,0)-(10,1) = ":"
         │   │   │   ├── value_loc: (10,1)-(10,2) = "c"
         │   │   │   ├── closing_loc: ∅
@@ -134,7 +134,7 @@
         │   │   ├── @ IntegerNode (location: (10,3)-(10,4))
         │   │   │   └── flags: decimal
         │   │   └── @ SymbolNode (location: (14,0)-(14,2))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: (14,0)-(14,1) = ":"
         │   │       ├── value_loc: (14,1)-(14,2) = "d"
         │   │       ├── closing_loc: ∅
@@ -145,19 +145,19 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 5)
         │   │   ├── @ SymbolNode (location: (18,1)-(18,3))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (18,1)-(18,2) = ":"
         │   │   │   ├── value_loc: (18,2)-(18,3) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   ├── @ SymbolNode (location: (18,5)-(18,7))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (18,5)-(18,6) = ":"
         │   │   │   ├── value_loc: (18,6)-(18,7) = "b"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "b"
         │   │   ├── @ SymbolNode (location: (19,0)-(19,2))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (19,0)-(19,1) = ":"
         │   │   │   ├── value_loc: (19,1)-(19,2) = "c"
         │   │   │   ├── closing_loc: ∅
@@ -165,7 +165,7 @@
         │   │   ├── @ IntegerNode (location: (19,3)-(19,4))
         │   │   │   └── flags: decimal
         │   │   └── @ SymbolNode (location: (23,0)-(23,2))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: (23,0)-(23,1) = ":"
         │   │       ├── value_loc: (23,1)-(23,2) = "d"
         │   │       ├── closing_loc: ∅
@@ -768,19 +768,19 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 3)
         │   │   ├── @ SymbolNode (location: (62,3)-(62,6))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (62,3)-(62,6) = "one"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "one"
         │   │   ├── @ SymbolNode (location: (62,7)-(62,10))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (62,7)-(62,10) = "two"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "two"
         │   │   └── @ SymbolNode (location: (62,11)-(62,16))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (62,11)-(62,16) = "three"
         │   │       ├── closing_loc: ∅
@@ -820,19 +820,19 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 3)
         │   │   ├── @ SymbolNode (location: (69,3)-(69,6))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (69,3)-(69,6) = "one"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "one"
         │   │   ├── @ SymbolNode (location: (69,7)-(69,10))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (69,7)-(69,10) = "two"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "two"
         │   │   └── @ SymbolNode (location: (69,11)-(69,16))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (69,11)-(69,16) = "three"
         │   │       ├── closing_loc: ∅
@@ -872,19 +872,19 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 3)
         │   │   ├── @ SymbolNode (location: (76,3)-(76,6))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (76,3)-(76,6) = "one"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "one"
         │   │   ├── @ SymbolNode (location: (76,7)-(76,10))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (76,7)-(76,10) = "two"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "two"
         │   │   └── @ SymbolNode (location: (76,11)-(76,16))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (76,11)-(76,16) = "three"
         │   │       ├── closing_loc: ∅

--- a/test/prism/snapshots/begin_ensure.txt
+++ b/test/prism/snapshots/begin_ensure.txt
@@ -157,7 +157,7 @@
             │           │           ├── flags: ∅
             │           │           ├── receiver:
             │           │           │   @ SymbolNode (location: (15,11)-(15,13))
-            │           │           │   ├── flags: ∅
+            │           │           │   ├── flags: forced_us_ascii_encoding
             │           │           │   ├── opening_loc: (15,11)-(15,12) = ":"
             │           │           │   ├── value_loc: (15,12)-(15,13) = "s"
             │           │           │   ├── closing_loc: ∅

--- a/test/prism/snapshots/case.txt
+++ b/test/prism/snapshots/case.txt
@@ -6,7 +6,7 @@
         ├── @ CaseNode (location: (1,0)-(3,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (1,5)-(1,8))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (1,5)-(1,6) = ":"
         │   │   ├── value_loc: (1,6)-(1,8) = "hi"
         │   │   ├── closing_loc: ∅
@@ -16,7 +16,7 @@
         │   │       ├── keyword_loc: (2,0)-(2,4) = "when"
         │   │       ├── conditions: (length: 1)
         │   │       │   └── @ SymbolNode (location: (2,5)-(2,8))
-        │   │       │       ├── flags: ∅
+        │   │       │       ├── flags: forced_us_ascii_encoding
         │   │       │       ├── opening_loc: (2,5)-(2,6) = ":"
         │   │       │       ├── value_loc: (2,6)-(2,8) = "hi"
         │   │       │       ├── closing_loc: ∅
@@ -48,7 +48,7 @@
         │   │   │               │   ├── flags: ∅
         │   │   │               │   └── arguments: (length: 1)
         │   │   │               │       └── @ SymbolNode (location: (5,27)-(5,30))
-        │   │   │               │           ├── flags: ∅
+        │   │   │               │           ├── flags: forced_us_ascii_encoding
         │   │   │               │           ├── opening_loc: (5,27)-(5,28) = ":"
         │   │   │               │           ├── value_loc: (5,28)-(5,30) = "hi"
         │   │   │               │           ├── closing_loc: ∅
@@ -74,7 +74,7 @@
         │   │                   │   ├── flags: ∅
         │   │                   │   └── arguments: (length: 1)
         │   │                   │       └── @ SymbolNode (location: (5,49)-(5,53))
-        │   │                   │           ├── flags: ∅
+        │   │                   │           ├── flags: forced_us_ascii_encoding
         │   │                   │           ├── opening_loc: (5,49)-(5,50) = ":"
         │   │                   │           ├── value_loc: (5,50)-(5,53) = "bye"
         │   │                   │           ├── closing_loc: ∅
@@ -110,7 +110,7 @@
         ├── @ CaseNode (location: (9,0)-(13,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (9,5)-(9,8))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (9,5)-(9,6) = ":"
         │   │   ├── value_loc: (9,6)-(9,8) = "hi"
         │   │   ├── closing_loc: ∅
@@ -120,7 +120,7 @@
         │   │       ├── keyword_loc: (10,0)-(10,4) = "when"
         │   │       ├── conditions: (length: 1)
         │   │       │   └── @ SymbolNode (location: (10,5)-(10,8))
-        │   │       │       ├── flags: ∅
+        │   │       │       ├── flags: forced_us_ascii_encoding
         │   │       │       ├── opening_loc: (10,5)-(10,6) = ":"
         │   │       │       ├── value_loc: (10,6)-(10,8) = "hi"
         │   │       │       ├── closing_loc: ∅
@@ -133,7 +133,7 @@
         │   │   │   @ StatementsNode (location: (12,0)-(12,2))
         │   │   │   └── body: (length: 1)
         │   │   │       └── @ SymbolNode (location: (12,0)-(12,2))
-        │   │   │           ├── flags: ∅
+        │   │   │           ├── flags: forced_us_ascii_encoding
         │   │   │           ├── opening_loc: (12,0)-(12,1) = ":"
         │   │   │           ├── value_loc: (12,1)-(12,2) = "b"
         │   │   │           ├── closing_loc: ∅
@@ -249,7 +249,7 @@
         │   │       ├── keyword_loc: (28,3)-(28,7) = "when"
         │   │       ├── conditions: (length: 1)
         │   │       │   └── @ SymbolNode (location: (28,8)-(28,10))
-        │   │       │       ├── flags: ∅
+        │   │       │       ├── flags: forced_us_ascii_encoding
         │   │       │       ├── opening_loc: (28,8)-(28,9) = ":"
         │   │       │       ├── value_loc: (28,9)-(28,10) = "b"
         │   │       │       ├── closing_loc: ∅

--- a/test/prism/snapshots/dos_endings.txt
+++ b/test/prism/snapshots/dos_endings.txt
@@ -36,7 +36,7 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 1)
         │   │   └── @ SymbolNode (location: (4,3)-(5,1))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (4,3)-(5,1) = "a\\\r\nb"
         │   │       ├── closing_loc: ∅

--- a/test/prism/snapshots/global_variables.txt
+++ b/test/prism/snapshots/global_variables.txt
@@ -52,139 +52,139 @@
         ├── @ GlobalVariableReadNode (location: (47,0)-(47,3))
         │   └── name: :$-K
         ├── @ SymbolNode (location: (49,0)-(49,17))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (49,0)-(49,1) = ":"
         │   ├── value_loc: (49,1)-(49,17) = "$global_variable"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$global_variable"
         ├── @ SymbolNode (location: (51,0)-(51,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (51,0)-(51,1) = ":"
         │   ├── value_loc: (51,1)-(51,3) = "$_"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$_"
         ├── @ SymbolNode (location: (53,0)-(53,4))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (53,0)-(53,1) = ":"
         │   ├── value_loc: (53,1)-(53,4) = "$-w"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$-w"
         ├── @ SymbolNode (location: (55,0)-(55,11))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (55,0)-(55,1) = ":"
         │   ├── value_loc: (55,1)-(55,11) = "$LOAD_PATH"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$LOAD_PATH"
         ├── @ SymbolNode (location: (57,0)-(57,7))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (57,0)-(57,1) = ":"
         │   ├── value_loc: (57,1)-(57,7) = "$stdin"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$stdin"
         ├── @ SymbolNode (location: (59,0)-(59,8))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (59,0)-(59,1) = ":"
         │   ├── value_loc: (59,1)-(59,8) = "$stdout"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$stdout"
         ├── @ SymbolNode (location: (61,0)-(61,8))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (61,0)-(61,1) = ":"
         │   ├── value_loc: (61,1)-(61,8) = "$stderr"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$stderr"
         ├── @ SymbolNode (location: (63,0)-(63,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (63,0)-(63,1) = ":"
         │   ├── value_loc: (63,1)-(63,3) = "$!"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$!"
         ├── @ SymbolNode (location: (65,0)-(65,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (65,0)-(65,1) = ":"
         │   ├── value_loc: (65,1)-(65,3) = "$?"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$?"
         ├── @ SymbolNode (location: (67,0)-(67,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (67,0)-(67,1) = ":"
         │   ├── value_loc: (67,1)-(67,3) = "$~"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$~"
         ├── @ SymbolNode (location: (69,0)-(69,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (69,0)-(69,1) = ":"
         │   ├── value_loc: (69,1)-(69,3) = "$&"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$&"
         ├── @ SymbolNode (location: (71,0)-(71,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (71,0)-(71,1) = ":"
         │   ├── value_loc: (71,1)-(71,3) = "$`"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$`"
         ├── @ SymbolNode (location: (73,0)-(73,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (73,0)-(73,1) = ":"
         │   ├── value_loc: (73,1)-(73,3) = "$'"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$'"
         ├── @ SymbolNode (location: (75,0)-(75,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (75,0)-(75,1) = ":"
         │   ├── value_loc: (75,1)-(75,3) = "$+"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$+"
         ├── @ SymbolNode (location: (77,0)-(77,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (77,0)-(77,1) = ":"
         │   ├── value_loc: (77,1)-(77,3) = "$:"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$:"
         ├── @ SymbolNode (location: (79,0)-(79,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (79,0)-(79,1) = ":"
         │   ├── value_loc: (79,1)-(79,3) = "$;"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$;"
         ├── @ SymbolNode (location: (81,0)-(81,7))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (81,0)-(81,1) = ":"
         │   ├── value_loc: (81,1)-(81,7) = "$DEBUG"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$DEBUG"
         ├── @ SymbolNode (location: (83,0)-(83,10))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (83,0)-(83,1) = ":"
         │   ├── value_loc: (83,1)-(83,10) = "$FILENAME"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$FILENAME"
         ├── @ SymbolNode (location: (85,0)-(85,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (85,0)-(85,1) = ":"
         │   ├── value_loc: (85,1)-(85,3) = "$0"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$0"
         ├── @ SymbolNode (location: (87,0)-(87,4))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (87,0)-(87,1) = ":"
         │   ├── value_loc: (87,1)-(87,4) = "$-0"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$-0"
         ├── @ SymbolNode (location: (89,0)-(89,17))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (89,0)-(89,1) = ":"
         │   ├── value_loc: (89,1)-(89,17) = "$LOADED_FEATURES"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$LOADED_FEATURES"
         ├── @ SymbolNode (location: (91,0)-(91,9))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (91,0)-(91,1) = ":"
         │   ├── value_loc: (91,1)-(91,9) = "$VERBOSE"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$VERBOSE"
         └── @ SymbolNode (location: (93,0)-(93,4))
-            ├── flags: ∅
+            ├── flags: forced_us_ascii_encoding
             ├── opening_loc: (93,0)-(93,1) = ":"
             ├── value_loc: (93,1)-(93,4) = "$-K"
             ├── closing_loc: ∅

--- a/test/prism/snapshots/hashes.txt
+++ b/test/prism/snapshots/hashes.txt
@@ -110,7 +110,7 @@
         │   │   ├── @ AssocNode (location: (11,6)-(11,10))
         │   │   │   ├── key:
         │   │   │   │   @ SymbolNode (location: (11,6)-(11,8))
-        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── value_loc: (11,6)-(11,7) = "a"
         │   │   │   │   ├── closing_loc: (11,7)-(11,8) = ":"
@@ -130,7 +130,7 @@
         │   │   └── @ AssocNode (location: (12,6)-(12,10))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (12,6)-(12,8))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: ∅
         │   │       │   ├── value_loc: (12,6)-(12,7) = "c"
         │   │       │   ├── closing_loc: (12,7)-(12,8) = ":"
@@ -154,7 +154,7 @@
         │   │   ├── @ AssocNode (location: (18,2)-(18,6))
         │   │   │   ├── key:
         │   │   │   │   @ SymbolNode (location: (18,2)-(18,4))
-        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── value_loc: (18,2)-(18,3) = "a"
         │   │   │   │   ├── closing_loc: (18,3)-(18,4) = ":"
@@ -174,7 +174,7 @@
         │   │   ├── @ AssocNode (location: (18,8)-(18,12))
         │   │   │   ├── key:
         │   │   │   │   @ SymbolNode (location: (18,8)-(18,10))
-        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── value_loc: (18,8)-(18,9) = "c"
         │   │   │   │   ├── closing_loc: (18,9)-(18,10) = ":"
@@ -207,7 +207,7 @@
         │   │   └── @ AssocNode (location: (18,19)-(18,23))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (18,19)-(18,21))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: ∅
         │   │       │   ├── value_loc: (18,19)-(18,20) = "f"
         │   │       │   ├── closing_loc: (18,20)-(18,21) = ":"
@@ -231,7 +231,7 @@
         │   │   └── @ AssocNode (location: (20,2)-(20,10))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (20,2)-(20,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (20,2)-(20,3) = "\""
         │   │       │   ├── value_loc: (20,3)-(20,4) = "a"
         │   │       │   ├── closing_loc: (20,4)-(20,6) = "\":"
@@ -298,7 +298,7 @@
         │       │           │   ├── @ AssocNode (location: (25,4)-(25,6))
         │       │           │   │   ├── key:
         │       │           │   │   │   @ SymbolNode (location: (25,4)-(25,6))
-        │       │           │   │   │   ├── flags: ∅
+        │       │           │   │   │   ├── flags: forced_us_ascii_encoding
         │       │           │   │   │   ├── opening_loc: ∅
         │       │           │   │   │   ├── value_loc: (25,4)-(25,5) = "a"
         │       │           │   │   │   ├── closing_loc: (25,5)-(25,6) = ":"
@@ -313,7 +313,7 @@
         │       │           │   ├── @ AssocNode (location: (25,8)-(25,10))
         │       │           │   │   ├── key:
         │       │           │   │   │   @ SymbolNode (location: (25,8)-(25,10))
-        │       │           │   │   │   ├── flags: ∅
+        │       │           │   │   │   ├── flags: forced_us_ascii_encoding
         │       │           │   │   │   ├── opening_loc: ∅
         │       │           │   │   │   ├── value_loc: (25,8)-(25,9) = "b"
         │       │           │   │   │   ├── closing_loc: (25,9)-(25,10) = ":"
@@ -328,7 +328,7 @@
         │       │           │   ├── @ AssocNode (location: (25,12)-(25,14))
         │       │           │   │   ├── key:
         │       │           │   │   │   @ SymbolNode (location: (25,12)-(25,14))
-        │       │           │   │   │   ├── flags: ∅
+        │       │           │   │   │   ├── flags: forced_us_ascii_encoding
         │       │           │   │   │   ├── opening_loc: ∅
         │       │           │   │   │   ├── value_loc: (25,12)-(25,13) = "c"
         │       │           │   │   │   ├── closing_loc: (25,13)-(25,14) = ":"
@@ -350,7 +350,7 @@
         │       │           │   └── @ AssocNode (location: (25,16)-(25,18))
         │       │           │       ├── key:
         │       │           │       │   @ SymbolNode (location: (25,16)-(25,18))
-        │       │           │       │   ├── flags: ∅
+        │       │           │       │   ├── flags: forced_us_ascii_encoding
         │       │           │       │   ├── opening_loc: ∅
         │       │           │       │   ├── value_loc: (25,16)-(25,17) = "D"
         │       │           │       │   ├── closing_loc: (25,17)-(25,18) = ":"
@@ -370,7 +370,7 @@
             │   └── @ AssocNode (location: (28,2)-(28,7))
             │       ├── key:
             │       │   @ SymbolNode (location: (28,2)-(28,4))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: ∅
             │       │   ├── value_loc: (28,2)-(28,3) = "a"
             │       │   ├── closing_loc: (28,3)-(28,4) = ":"

--- a/test/prism/snapshots/if.txt
+++ b/test/prism/snapshots/if.txt
@@ -255,7 +255,7 @@
         │   │           │               └── @ AssocNode (location: (25,4)-(25,6))
         │   │           │                   ├── key:
         │   │           │                   │   @ SymbolNode (location: (25,4)-(25,6))
-        │   │           │                   │   ├── flags: ∅
+        │   │           │                   │   ├── flags: forced_us_ascii_encoding
         │   │           │                   │   ├── opening_loc: ∅
         │   │           │                   │   ├── value_loc: (25,4)-(25,5) = "b"
         │   │           │                   │   ├── closing_loc: (25,5)-(25,6) = ":"

--- a/test/prism/snapshots/method_calls.txt
+++ b/test/prism/snapshots/method_calls.txt
@@ -698,13 +698,13 @@
         │   │           │   ├── flags: ∅
         │   │           │   └── arguments: (length: 2)
         │   │           │       ├── @ SymbolNode (location: (51,4)-(51,6))
-        │   │           │       │   ├── flags: ∅
+        │   │           │       │   ├── flags: forced_us_ascii_encoding
         │   │           │       │   ├── opening_loc: (51,4)-(51,5) = ":"
         │   │           │       │   ├── value_loc: (51,5)-(51,6) = "a"
         │   │           │       │   ├── closing_loc: ∅
         │   │           │       │   └── unescaped: "a"
         │   │           │       └── @ SymbolNode (location: (51,8)-(51,10))
-        │   │           │           ├── flags: ∅
+        │   │           │           ├── flags: forced_us_ascii_encoding
         │   │           │           ├── opening_loc: (51,8)-(51,9) = ":"
         │   │           │           ├── value_loc: (51,9)-(51,10) = "b"
         │   │           │           ├── closing_loc: ∅
@@ -725,13 +725,13 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 2)
         │   │       ├── @ SymbolNode (location: (53,4)-(53,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (53,4)-(53,5) = ":"
         │   │       │   ├── value_loc: (53,5)-(53,6) = "a"
         │   │       │   ├── closing_loc: ∅
         │   │       │   └── unescaped: "a"
         │   │       └── @ SymbolNode (location: (55,2)-(55,4))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (55,2)-(55,3) = ":"
         │   │           ├── value_loc: (55,3)-(55,4) = "b"
         │   │           ├── closing_loc: ∅
@@ -776,7 +776,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 2)
         │   │       ├── @ SymbolNode (location: (60,4)-(60,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (60,4)-(60,5) = ":"
         │   │       │   ├── value_loc: (60,5)-(60,6) = "a"
         │   │       │   ├── closing_loc: ∅
@@ -787,7 +787,7 @@
         │   │               ├── @ AssocNode (location: (60,8)-(60,22))
         │   │               │   ├── key:
         │   │               │   │   @ SymbolNode (location: (60,8)-(60,10))
-        │   │               │   │   ├── flags: ∅
+        │   │               │   │   ├── flags: forced_us_ascii_encoding
         │   │               │   │   ├── opening_loc: (60,8)-(60,9) = ":"
         │   │               │   │   ├── value_loc: (60,9)-(60,10) = "h"
         │   │               │   │   ├── closing_loc: ∅
@@ -797,13 +797,13 @@
         │   │               │   │   ├── flags: ∅
         │   │               │   │   ├── elements: (length: 2)
         │   │               │   │   │   ├── @ SymbolNode (location: (60,15)-(60,17))
-        │   │               │   │   │   │   ├── flags: ∅
+        │   │               │   │   │   │   ├── flags: forced_us_ascii_encoding
         │   │               │   │   │   │   ├── opening_loc: (60,15)-(60,16) = ":"
         │   │               │   │   │   │   ├── value_loc: (60,16)-(60,17) = "x"
         │   │               │   │   │   │   ├── closing_loc: ∅
         │   │               │   │   │   │   └── unescaped: "x"
         │   │               │   │   │   └── @ SymbolNode (location: (60,19)-(60,21))
-        │   │               │   │   │       ├── flags: ∅
+        │   │               │   │   │       ├── flags: forced_us_ascii_encoding
         │   │               │   │   │       ├── opening_loc: (60,19)-(60,20) = ":"
         │   │               │   │   │       ├── value_loc: (60,20)-(60,21) = "y"
         │   │               │   │   │       ├── closing_loc: ∅
@@ -814,14 +814,14 @@
         │   │               └── @ AssocNode (location: (60,24)-(60,32))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (60,24)-(60,26))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (60,24)-(60,25) = ":"
         │   │                   │   ├── value_loc: (60,25)-(60,26) = "a"
         │   │                   │   ├── closing_loc: ∅
         │   │                   │   └── unescaped: "a"
         │   │                   ├── value:
         │   │                   │   @ SymbolNode (location: (60,30)-(60,32))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (60,30)-(60,31) = ":"
         │   │                   │   ├── value_loc: (60,31)-(60,32) = "b"
         │   │                   │   ├── closing_loc: ∅
@@ -832,7 +832,7 @@
         │       @ BlockArgumentNode (location: (60,34)-(60,39))
         │       ├── expression:
         │       │   @ SymbolNode (location: (60,35)-(60,39))
-        │       │   ├── flags: ∅
+        │       │   ├── flags: forced_us_ascii_encoding
         │       │   ├── opening_loc: (60,35)-(60,36) = ":"
         │       │   ├── value_loc: (60,36)-(60,39) = "bar"
         │       │   ├── closing_loc: ∅
@@ -857,14 +857,14 @@
         │   │           │   ├── @ AssocNode (location: (62,10)-(62,27))
         │   │           │   │   ├── key:
         │   │           │   │   │   @ SymbolNode (location: (62,10)-(62,16))
-        │   │           │   │   │   ├── flags: ∅
+        │   │           │   │   │   ├── flags: forced_us_ascii_encoding
         │   │           │   │   │   ├── opening_loc: (62,10)-(62,11) = ":"
         │   │           │   │   │   ├── value_loc: (62,11)-(62,16) = "there"
         │   │           │   │   │   ├── closing_loc: ∅
         │   │           │   │   │   └── unescaped: "there"
         │   │           │   │   ├── value:
         │   │           │   │   │   @ SymbolNode (location: (62,20)-(62,27))
-        │   │           │   │   │   ├── flags: ∅
+        │   │           │   │   │   ├── flags: forced_us_ascii_encoding
         │   │           │   │   │   ├── opening_loc: (62,20)-(62,21) = ":"
         │   │           │   │   │   ├── value_loc: (62,21)-(62,27) = "friend"
         │   │           │   │   │   ├── closing_loc: ∅
@@ -880,14 +880,14 @@
         │   │           │   └── @ AssocNode (location: (62,35)-(62,47))
         │   │           │       ├── key:
         │   │           │       │   @ SymbolNode (location: (62,35)-(62,42))
-        │   │           │       │   ├── flags: ∅
+        │   │           │       │   ├── flags: forced_us_ascii_encoding
         │   │           │       │   ├── opening_loc: ∅
         │   │           │       │   ├── value_loc: (62,35)-(62,41) = "whatup"
         │   │           │       │   ├── closing_loc: (62,41)-(62,42) = ":"
         │   │           │       │   └── unescaped: "whatup"
         │   │           │       ├── value:
         │   │           │       │   @ SymbolNode (location: (62,43)-(62,47))
-        │   │           │       │   ├── flags: ∅
+        │   │           │       │   ├── flags: forced_us_ascii_encoding
         │   │           │       │   ├── opening_loc: (62,43)-(62,44) = ":"
         │   │           │       │   ├── value_loc: (62,44)-(62,47) = "dog"
         │   │           │       │   ├── closing_loc: ∅
@@ -908,7 +908,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 2)
         │   │       ├── @ SymbolNode (location: (64,4)-(64,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (64,4)-(64,5) = ":"
         │   │       │   ├── value_loc: (64,5)-(64,6) = "a"
         │   │       │   ├── closing_loc: ∅
@@ -919,7 +919,7 @@
         │   │               └── @ AssocNode (location: (64,8)-(64,15))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (64,8)-(64,10))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (64,8)-(64,9) = "b"
         │   │                   │   ├── closing_loc: (64,9)-(64,10) = ":"
@@ -990,14 +990,14 @@
         │   │               └── @ AssocNode (location: (66,3)-(66,17))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (66,3)-(66,9))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (66,3)-(66,8) = "there"
         │   │                   │   ├── closing_loc: (66,8)-(66,9) = ":"
         │   │                   │   └── unescaped: "there"
         │   │                   ├── value:
         │   │                   │   @ SymbolNode (location: (66,10)-(66,17))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (66,10)-(66,11) = ":"
         │   │                   │   ├── value_loc: (66,11)-(66,17) = "friend"
         │   │                   │   ├── closing_loc: ∅
@@ -1022,14 +1022,14 @@
         │   │               ├── @ AssocNode (location: (68,3)-(68,20))
         │   │               │   ├── key:
         │   │               │   │   @ SymbolNode (location: (68,3)-(68,9))
-        │   │               │   │   ├── flags: ∅
+        │   │               │   │   ├── flags: forced_us_ascii_encoding
         │   │               │   │   ├── opening_loc: (68,3)-(68,4) = ":"
         │   │               │   │   ├── value_loc: (68,4)-(68,9) = "there"
         │   │               │   │   ├── closing_loc: ∅
         │   │               │   │   └── unescaped: "there"
         │   │               │   ├── value:
         │   │               │   │   @ SymbolNode (location: (68,13)-(68,20))
-        │   │               │   │   ├── flags: ∅
+        │   │               │   │   ├── flags: forced_us_ascii_encoding
         │   │               │   │   ├── opening_loc: (68,13)-(68,14) = ":"
         │   │               │   │   ├── value_loc: (68,14)-(68,20) = "friend"
         │   │               │   │   ├── closing_loc: ∅
@@ -1045,14 +1045,14 @@
         │   │               └── @ AssocNode (location: (68,28)-(68,40))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (68,28)-(68,35))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (68,28)-(68,34) = "whatup"
         │   │                   │   ├── closing_loc: (68,34)-(68,35) = ":"
         │   │                   │   └── unescaped: "whatup"
         │   │                   ├── value:
         │   │                   │   @ SymbolNode (location: (68,36)-(68,40))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (68,36)-(68,37) = ":"
         │   │                   │   ├── value_loc: (68,37)-(68,40) = "dog"
         │   │                   │   ├── closing_loc: ∅
@@ -1077,14 +1077,14 @@
         │   │               ├── @ AssocNode (location: (70,3)-(70,20))
         │   │               │   ├── key:
         │   │               │   │   @ SymbolNode (location: (70,3)-(70,9))
-        │   │               │   │   ├── flags: ∅
+        │   │               │   │   ├── flags: forced_us_ascii_encoding
         │   │               │   │   ├── opening_loc: (70,3)-(70,4) = ":"
         │   │               │   │   ├── value_loc: (70,4)-(70,9) = "there"
         │   │               │   │   ├── closing_loc: ∅
         │   │               │   │   └── unescaped: "there"
         │   │               │   ├── value:
         │   │               │   │   @ SymbolNode (location: (70,13)-(70,20))
-        │   │               │   │   ├── flags: ∅
+        │   │               │   │   ├── flags: forced_us_ascii_encoding
         │   │               │   │   ├── opening_loc: (70,13)-(70,14) = ":"
         │   │               │   │   ├── value_loc: (70,14)-(70,20) = "friend"
         │   │               │   │   ├── closing_loc: ∅
@@ -1100,14 +1100,14 @@
         │   │               └── @ AssocNode (location: (70,28)-(70,40))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (70,28)-(70,35))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (70,28)-(70,34) = "whatup"
         │   │                   │   ├── closing_loc: (70,34)-(70,35) = ":"
         │   │                   │   └── unescaped: "whatup"
         │   │                   ├── value:
         │   │                   │   @ SymbolNode (location: (70,36)-(70,40))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (70,36)-(70,37) = ":"
         │   │                   │   ├── value_loc: (70,37)-(70,40) = "dog"
         │   │                   │   ├── closing_loc: ∅
@@ -1132,7 +1132,7 @@
         │   │           │   ├── @ AssocNode (location: (72,6)-(72,13))
         │   │           │   │   ├── key:
         │   │           │   │   │   @ SymbolNode (location: (72,6)-(72,8))
-        │   │           │   │   │   ├── flags: ∅
+        │   │           │   │   │   ├── flags: forced_us_ascii_encoding
         │   │           │   │   │   ├── opening_loc: ∅
         │   │           │   │   │   ├── value_loc: (72,6)-(72,7) = "a"
         │   │           │   │   │   ├── closing_loc: (72,7)-(72,8) = ":"
@@ -1143,7 +1143,7 @@
         │   │           │   └── @ AssocNode (location: (72,15)-(72,23))
         │   │           │       ├── key:
         │   │           │       │   @ SymbolNode (location: (72,15)-(72,17))
-        │   │           │       │   ├── flags: ∅
+        │   │           │       │   ├── flags: forced_us_ascii_encoding
         │   │           │       │   ├── opening_loc: ∅
         │   │           │       │   ├── value_loc: (72,15)-(72,16) = "b"
         │   │           │       │   ├── closing_loc: (72,16)-(72,17) = ":"
@@ -1157,7 +1157,7 @@
         │       @ BlockArgumentNode (location: (72,28)-(72,35))
         │       ├── expression:
         │       │   @ SymbolNode (location: (72,29)-(72,35))
-        │       │   ├── flags: ∅
+        │       │   ├── flags: forced_us_ascii_encoding
         │       │   ├── opening_loc: (72,29)-(72,30) = ":"
         │       │   ├── value_loc: (72,30)-(72,35) = "block"
         │       │   ├── closing_loc: ∅
@@ -1180,14 +1180,14 @@
         │   │               └── @ AssocNode (location: (74,3)-(74,20))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (74,3)-(74,9))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (74,3)-(74,4) = ":"
         │   │                   │   ├── value_loc: (74,4)-(74,9) = "there"
         │   │                   │   ├── closing_loc: ∅
         │   │                   │   └── unescaped: "there"
         │   │                   ├── value:
         │   │                   │   @ SymbolNode (location: (74,13)-(74,20))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (74,13)-(74,14) = ":"
         │   │                   │   ├── value_loc: (74,14)-(74,20) = "friend"
         │   │                   │   ├── closing_loc: ∅
@@ -1207,13 +1207,13 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 2)
         │   │       ├── @ SymbolNode (location: (76,4)-(76,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (76,4)-(76,5) = ":"
         │   │       │   ├── value_loc: (76,5)-(76,6) = "a"
         │   │       │   ├── closing_loc: ∅
         │   │       │   └── unescaped: "a"
         │   │       └── @ SymbolNode (location: (77,0)-(77,2))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (77,0)-(77,1) = ":"
         │   │           ├── value_loc: (77,1)-(77,2) = "b"
         │   │           ├── closing_loc: ∅
@@ -1232,7 +1232,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 2)
         │   │       ├── @ SymbolNode (location: (81,0)-(81,2))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (81,0)-(81,1) = ":"
         │   │       │   ├── value_loc: (81,1)-(81,2) = "a"
         │   │       │   ├── closing_loc: ∅
@@ -1243,14 +1243,14 @@
         │   │               └── @ AssocNode (location: (82,0)-(82,5))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (82,0)-(82,2))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (82,0)-(82,1) = "b"
         │   │                   │   ├── closing_loc: (82,1)-(82,2) = ":"
         │   │                   │   └── unescaped: "b"
         │   │                   ├── value:
         │   │                   │   @ SymbolNode (location: (82,3)-(82,5))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (82,3)-(82,4) = ":"
         │   │                   │   ├── value_loc: (82,4)-(82,5) = "c"
         │   │                   │   ├── closing_loc: ∅
@@ -1271,7 +1271,7 @@
         │       @ BlockArgumentNode (location: (85,4)-(85,11))
         │       ├── expression:
         │       │   @ SymbolNode (location: (85,5)-(85,11))
-        │       │   ├── flags: ∅
+        │       │   ├── flags: forced_us_ascii_encoding
         │       │   ├── opening_loc: (85,5)-(85,6) = ":"
         │       │   ├── value_loc: (85,6)-(85,11) = "block"
         │       │   ├── closing_loc: ∅
@@ -1294,7 +1294,7 @@
         │   │               ├── @ AssocNode (location: (87,4)-(87,11))
         │   │               │   ├── key:
         │   │               │   │   @ SymbolNode (location: (87,4)-(87,6))
-        │   │               │   │   ├── flags: ∅
+        │   │               │   │   ├── flags: forced_us_ascii_encoding
         │   │               │   │   ├── opening_loc: ∅
         │   │               │   │   ├── value_loc: (87,4)-(87,5) = "a"
         │   │               │   │   ├── closing_loc: (87,5)-(87,6) = ":"
@@ -1305,7 +1305,7 @@
         │   │               └── @ AssocNode (location: (87,13)-(87,21))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (87,13)-(87,15))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (87,13)-(87,14) = "b"
         │   │                   │   ├── closing_loc: (87,14)-(87,15) = ":"
@@ -1318,7 +1318,7 @@
         │       @ BlockArgumentNode (location: (87,23)-(87,30))
         │       ├── expression:
         │       │   @ SymbolNode (location: (87,24)-(87,30))
-        │       │   ├── flags: ∅
+        │       │   ├── flags: forced_us_ascii_encoding
         │       │   ├── opening_loc: (87,24)-(87,25) = ":"
         │       │   ├── value_loc: (87,25)-(87,30) = "block"
         │       │   ├── closing_loc: ∅
@@ -1343,7 +1343,7 @@
         │   │               └── @ AssocNode (location: (89,13)-(89,21))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (89,13)-(89,19))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (89,13)-(89,18) = "kwarg"
         │   │                   │   ├── closing_loc: (89,18)-(89,19) = ":"
@@ -1449,7 +1449,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ SymbolNode (location: (97,8)-(97,12))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (97,8)-(97,9) = ":"
         │   │           ├── value_loc: (97,9)-(97,12) = "foo"
         │   │           ├── closing_loc: ∅
@@ -1476,7 +1476,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ SymbolNode (location: (99,8)-(99,12))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (99,8)-(99,9) = ":"
         │   │           ├── value_loc: (99,9)-(99,12) = "foo"
         │   │           ├── closing_loc: ∅
@@ -1503,7 +1503,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ SymbolNode (location: (101,8)-(101,12))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (101,8)-(101,9) = ":"
         │   │           ├── value_loc: (101,9)-(101,12) = "foo"
         │   │           ├── closing_loc: ∅
@@ -1534,7 +1534,7 @@
         │   │               └── @ AssocNode (location: (103,4)-(103,11))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (103,4)-(103,8))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (103,4)-(103,5) = "\""
         │   │                   │   ├── value_loc: (103,5)-(103,6) = "a"
         │   │                   │   ├── closing_loc: (103,6)-(103,8) = "\":"
@@ -1562,7 +1562,7 @@
         │   │               └── @ AssocNode (location: (105,4)-(105,28))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (105,4)-(105,8))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (105,4)-(105,7) = "bar"
         │   │                   │   ├── closing_loc: (105,7)-(105,8) = ":"
@@ -1574,7 +1574,7 @@
         │   │                   │   │   └── @ AssocNode (location: (105,11)-(105,26))
         │   │                   │   │       ├── key:
         │   │                   │   │       │   @ SymbolNode (location: (105,11)-(105,15))
-        │   │                   │   │       │   ├── flags: ∅
+        │   │                   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │                   │   │       │   ├── opening_loc: ∅
         │   │                   │   │       │   ├── value_loc: (105,11)-(105,14) = "baz"
         │   │                   │   │       │   ├── closing_loc: (105,14)-(105,15) = ":"
@@ -1619,7 +1619,7 @@
         │   │               └── @ AssocNode (location: (107,4)-(107,24))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (107,4)-(107,8))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (107,4)-(107,7) = "bar"
         │   │                   │   ├── closing_loc: (107,7)-(107,8) = ":"
@@ -1893,7 +1893,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 2)
         │   │       ├── @ SymbolNode (location: (119,4)-(119,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (119,4)-(119,5) = ":"
         │   │       │   ├── value_loc: (119,5)-(119,6) = "a"
         │   │       │   ├── closing_loc: ∅
@@ -1969,7 +1969,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 3)
         │   │       ├── @ SymbolNode (location: (126,4)-(126,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (126,4)-(126,5) = ":"
         │   │       │   ├── value_loc: (126,5)-(126,6) = "a"
         │   │       │   ├── closing_loc: ∅

--- a/test/prism/snapshots/methods.txt
+++ b/test/prism/snapshots/methods.txt
@@ -842,7 +842,7 @@
         │   │       │   │               ├── flags: ∅
         │   │       │   │               └── arguments: (length: 1)
         │   │       │   │                   └── @ SymbolNode (location: (99,7)-(99,10))
-        │   │       │   │                       ├── flags: ∅
+        │   │       │   │                       ├── flags: forced_us_ascii_encoding
         │   │       │   │                       ├── opening_loc: (99,7)-(99,8) = ":"
         │   │       │   │                       ├── value_loc: (99,8)-(99,10) = "hi"
         │   │       │   │                       ├── closing_loc: ∅
@@ -850,7 +850,7 @@
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       └── @ SymbolNode (location: (100,0)-(100,4))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (100,0)-(100,1) = ":"
         │   │           ├── value_loc: (100,1)-(100,4) = "bye"
         │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/patterns.txt
+++ b/test/prism/snapshots/patterns.txt
@@ -101,7 +101,7 @@
         │   │   └── block: ∅
         │   ├── pattern:
         │   │   @ SymbolNode (location: (6,7)-(6,11))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (6,7)-(6,8) = ":"
         │   │   ├── value_loc: (6,8)-(6,11) = "foo"
         │   │   ├── closing_loc: ∅
@@ -121,7 +121,7 @@
         │   │   └── block: ∅
         │   ├── pattern:
         │   │   @ SymbolNode (location: (7,7)-(7,14))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (7,7)-(7,10) = "%s["
         │   │   ├── value_loc: (7,10)-(7,13) = "foo"
         │   │   ├── closing_loc: (7,13)-(7,14) = "]"
@@ -141,7 +141,7 @@
         │   │   └── block: ∅
         │   ├── pattern:
         │   │   @ SymbolNode (location: (8,7)-(8,13))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (8,7)-(8,9) = ":\""
         │   │   ├── value_loc: (8,9)-(8,12) = "foo"
         │   │   ├── closing_loc: (8,12)-(8,13) = "\""
@@ -224,7 +224,7 @@
         │   │   ├── flags: ∅
         │   │   ├── elements: (length: 1)
         │   │   │   └── @ SymbolNode (location: (12,10)-(12,13))
-        │   │   │       ├── flags: ∅
+        │   │   │       ├── flags: forced_us_ascii_encoding
         │   │   │       ├── opening_loc: ∅
         │   │   │       ├── value_loc: (12,10)-(12,13) = "foo"
         │   │   │       ├── closing_loc: ∅
@@ -249,7 +249,7 @@
         │   │   ├── flags: ∅
         │   │   ├── elements: (length: 1)
         │   │   │   └── @ SymbolNode (location: (13,10)-(13,13))
-        │   │   │       ├── flags: ∅
+        │   │   │       ├── flags: forced_us_ascii_encoding
         │   │   │       ├── opening_loc: ∅
         │   │   │       ├── value_loc: (13,10)-(13,13) = "foo"
         │   │   │       ├── closing_loc: ∅
@@ -615,14 +615,14 @@
         │   │   ├── flags: ∅
         │   │   ├── left:
         │   │   │   @ SymbolNode (location: (32,7)-(32,11))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (32,7)-(32,8) = ":"
         │   │   │   ├── value_loc: (32,8)-(32,11) = "foo"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "foo"
         │   │   ├── right:
         │   │   │   @ SymbolNode (location: (32,15)-(32,19))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (32,15)-(32,16) = ":"
         │   │   │   ├── value_loc: (32,16)-(32,19) = "foo"
         │   │   │   ├── closing_loc: ∅
@@ -646,14 +646,14 @@
         │   │   ├── flags: ∅
         │   │   ├── left:
         │   │   │   @ SymbolNode (location: (33,7)-(33,14))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (33,7)-(33,10) = "%s["
         │   │   │   ├── value_loc: (33,10)-(33,13) = "foo"
         │   │   │   ├── closing_loc: (33,13)-(33,14) = "]"
         │   │   │   └── unescaped: "foo"
         │   │   ├── right:
         │   │   │   @ SymbolNode (location: (33,18)-(33,25))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (33,18)-(33,21) = "%s["
         │   │   │   ├── value_loc: (33,21)-(33,24) = "foo"
         │   │   │   ├── closing_loc: (33,24)-(33,25) = "]"
@@ -677,14 +677,14 @@
         │   │   ├── flags: ∅
         │   │   ├── left:
         │   │   │   @ SymbolNode (location: (34,7)-(34,13))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (34,7)-(34,9) = ":\""
         │   │   │   ├── value_loc: (34,9)-(34,12) = "foo"
         │   │   │   ├── closing_loc: (34,12)-(34,13) = "\""
         │   │   │   └── unescaped: "foo"
         │   │   ├── right:
         │   │   │   @ SymbolNode (location: (34,17)-(34,23))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (34,17)-(34,19) = ":\""
         │   │   │   ├── value_loc: (34,19)-(34,22) = "foo"
         │   │   │   ├── closing_loc: (34,22)-(34,23) = "\""
@@ -804,7 +804,7 @@
         │   │   │   ├── flags: ∅
         │   │   │   ├── elements: (length: 1)
         │   │   │   │   └── @ SymbolNode (location: (38,10)-(38,13))
-        │   │   │   │       ├── flags: ∅
+        │   │   │   │       ├── flags: forced_us_ascii_encoding
         │   │   │   │       ├── opening_loc: ∅
         │   │   │   │       ├── value_loc: (38,10)-(38,13) = "foo"
         │   │   │   │       ├── closing_loc: ∅
@@ -816,7 +816,7 @@
         │   │   │   ├── flags: ∅
         │   │   │   ├── elements: (length: 1)
         │   │   │   │   └── @ SymbolNode (location: (38,21)-(38,24))
-        │   │   │   │       ├── flags: ∅
+        │   │   │   │       ├── flags: forced_us_ascii_encoding
         │   │   │   │       ├── opening_loc: ∅
         │   │   │   │       ├── value_loc: (38,21)-(38,24) = "foo"
         │   │   │   │       ├── closing_loc: ∅
@@ -845,7 +845,7 @@
         │   │   │   ├── flags: ∅
         │   │   │   ├── elements: (length: 1)
         │   │   │   │   └── @ SymbolNode (location: (39,10)-(39,13))
-        │   │   │   │       ├── flags: ∅
+        │   │   │   │       ├── flags: forced_us_ascii_encoding
         │   │   │   │       ├── opening_loc: ∅
         │   │   │   │       ├── value_loc: (39,10)-(39,13) = "foo"
         │   │   │   │       ├── closing_loc: ∅
@@ -857,7 +857,7 @@
         │   │   │   ├── flags: ∅
         │   │   │   ├── elements: (length: 1)
         │   │   │   │   └── @ SymbolNode (location: (39,21)-(39,24))
-        │   │   │   │       ├── flags: ∅
+        │   │   │   │       ├── flags: forced_us_ascii_encoding
         │   │   │   │       ├── opening_loc: ∅
         │   │   │   │       ├── value_loc: (39,21)-(39,24) = "foo"
         │   │   │   │       ├── closing_loc: ∅
@@ -2435,7 +2435,7 @@
         │   │   └── block: ∅
         │   ├── pattern:
         │   │   @ SymbolNode (location: (105,7)-(105,11))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (105,7)-(105,8) = ":"
         │   │   ├── value_loc: (105,8)-(105,11) = "foo"
         │   │   ├── closing_loc: ∅
@@ -2455,7 +2455,7 @@
         │   │   └── block: ∅
         │   ├── pattern:
         │   │   @ SymbolNode (location: (106,7)-(106,14))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (106,7)-(106,10) = "%s["
         │   │   ├── value_loc: (106,10)-(106,13) = "foo"
         │   │   ├── closing_loc: (106,13)-(106,14) = "]"
@@ -2475,7 +2475,7 @@
         │   │   └── block: ∅
         │   ├── pattern:
         │   │   @ SymbolNode (location: (107,7)-(107,13))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (107,7)-(107,9) = ":\""
         │   │   ├── value_loc: (107,9)-(107,12) = "foo"
         │   │   ├── closing_loc: (107,12)-(107,13) = "\""
@@ -2558,7 +2558,7 @@
         │   │   ├── flags: ∅
         │   │   ├── elements: (length: 1)
         │   │   │   └── @ SymbolNode (location: (111,10)-(111,13))
-        │   │   │       ├── flags: ∅
+        │   │   │       ├── flags: forced_us_ascii_encoding
         │   │   │       ├── opening_loc: ∅
         │   │   │       ├── value_loc: (111,10)-(111,13) = "foo"
         │   │   │       ├── closing_loc: ∅
@@ -2583,7 +2583,7 @@
         │   │   ├── flags: ∅
         │   │   ├── elements: (length: 1)
         │   │   │   └── @ SymbolNode (location: (112,10)-(112,13))
-        │   │   │       ├── flags: ∅
+        │   │   │       ├── flags: forced_us_ascii_encoding
         │   │   │       ├── opening_loc: ∅
         │   │   │       ├── value_loc: (112,10)-(112,13) = "foo"
         │   │   │       ├── closing_loc: ∅
@@ -2969,7 +2969,7 @@
         │   │   └── @ InNode (location: (132,10)-(132,22))
         │   │       ├── pattern:
         │   │       │   @ SymbolNode (location: (132,13)-(132,17))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (132,13)-(132,14) = ":"
         │   │       │   ├── value_loc: (132,14)-(132,17) = "foo"
         │   │       │   ├── closing_loc: ∅
@@ -2996,7 +2996,7 @@
         │   │   └── @ InNode (location: (133,10)-(133,25))
         │   │       ├── pattern:
         │   │       │   @ SymbolNode (location: (133,13)-(133,20))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (133,13)-(133,16) = "%s["
         │   │       │   ├── value_loc: (133,16)-(133,19) = "foo"
         │   │       │   ├── closing_loc: (133,19)-(133,20) = "]"
@@ -3023,7 +3023,7 @@
         │   │   └── @ InNode (location: (134,10)-(134,24))
         │   │       ├── pattern:
         │   │       │   @ SymbolNode (location: (134,13)-(134,19))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (134,13)-(134,15) = ":\""
         │   │       │   ├── value_loc: (134,15)-(134,18) = "foo"
         │   │       │   ├── closing_loc: (134,18)-(134,19) = "\""
@@ -3134,7 +3134,7 @@
         │   │       │   ├── flags: ∅
         │   │       │   ├── elements: (length: 1)
         │   │       │   │   └── @ SymbolNode (location: (138,16)-(138,19))
-        │   │       │   │       ├── flags: ∅
+        │   │       │   │       ├── flags: forced_us_ascii_encoding
         │   │       │   │       ├── opening_loc: ∅
         │   │       │   │       ├── value_loc: (138,16)-(138,19) = "foo"
         │   │       │   │       ├── closing_loc: ∅
@@ -3166,7 +3166,7 @@
         │   │       │   ├── flags: ∅
         │   │       │   ├── elements: (length: 1)
         │   │       │   │   └── @ SymbolNode (location: (139,16)-(139,19))
-        │   │       │   │       ├── flags: ∅
+        │   │       │   │       ├── flags: forced_us_ascii_encoding
         │   │       │   │       ├── opening_loc: ∅
         │   │       │   │       ├── value_loc: (139,16)-(139,19) = "foo"
         │   │       │   │       ├── closing_loc: ∅
@@ -3718,7 +3718,7 @@
         │   │       │   │   @ StatementsNode (location: (159,13)-(159,17))
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ SymbolNode (location: (159,13)-(159,17))
-        │   │       │   │           ├── flags: ∅
+        │   │       │   │           ├── flags: forced_us_ascii_encoding
         │   │       │   │           ├── opening_loc: (159,13)-(159,14) = ":"
         │   │       │   │           ├── value_loc: (159,14)-(159,17) = "foo"
         │   │       │   │           ├── closing_loc: ∅
@@ -3757,7 +3757,7 @@
         │   │       │   │   @ StatementsNode (location: (160,13)-(160,20))
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ SymbolNode (location: (160,13)-(160,20))
-        │   │       │   │           ├── flags: ∅
+        │   │       │   │           ├── flags: forced_us_ascii_encoding
         │   │       │   │           ├── opening_loc: (160,13)-(160,16) = "%s["
         │   │       │   │           ├── value_loc: (160,16)-(160,19) = "foo"
         │   │       │   │           ├── closing_loc: (160,19)-(160,20) = "]"
@@ -3796,7 +3796,7 @@
         │   │       │   │   @ StatementsNode (location: (161,13)-(161,19))
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ SymbolNode (location: (161,13)-(161,19))
-        │   │       │   │           ├── flags: ∅
+        │   │       │   │           ├── flags: forced_us_ascii_encoding
         │   │       │   │           ├── opening_loc: (161,13)-(161,15) = ":\""
         │   │       │   │           ├── value_loc: (161,15)-(161,18) = "foo"
         │   │       │   │           ├── closing_loc: (161,18)-(161,19) = "\""
@@ -3955,7 +3955,7 @@
         │   │       │   │           ├── flags: ∅
         │   │       │   │           ├── elements: (length: 1)
         │   │       │   │           │   └── @ SymbolNode (location: (165,16)-(165,19))
-        │   │       │   │           │       ├── flags: ∅
+        │   │       │   │           │       ├── flags: forced_us_ascii_encoding
         │   │       │   │           │       ├── opening_loc: ∅
         │   │       │   │           │       ├── value_loc: (165,16)-(165,19) = "foo"
         │   │       │   │           │       ├── closing_loc: ∅
@@ -3999,7 +3999,7 @@
         │   │       │   │           ├── flags: ∅
         │   │       │   │           ├── elements: (length: 1)
         │   │       │   │           │   └── @ SymbolNode (location: (166,16)-(166,19))
-        │   │       │   │           │       ├── flags: ∅
+        │   │       │   │           │       ├── flags: forced_us_ascii_encoding
         │   │       │   │           │       ├── opening_loc: ∅
         │   │       │   │           │       ├── value_loc: (166,16)-(166,19) = "foo"
         │   │       │   │           │       ├── closing_loc: ∅
@@ -4577,7 +4577,7 @@
         │   │   │   └── @ AssocNode (location: (189,2)-(191,3))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (189,2)-(189,6))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (189,2)-(189,5) = "bar"
         │   │   │       │   ├── closing_loc: (189,5)-(189,6) = ":"
@@ -4591,7 +4591,7 @@
         │   │   │       │   │   └── @ AssocNode (location: (190,4)-(190,12))
         │   │   │       │   │       ├── key:
         │   │   │       │   │       │   @ SymbolNode (location: (190,4)-(190,10))
-        │   │   │       │   │       │   ├── flags: ∅
+        │   │   │       │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   │       │   ├── opening_loc: ∅
         │   │   │       │   │       │   ├── value_loc: (190,4)-(190,9) = "value"
         │   │   │       │   │       │   ├── closing_loc: (190,9)-(190,10) = ":"
@@ -4752,7 +4752,7 @@
         │   │   │       │   └── @ AssocNode (location: (202,15)-(202,17))
         │   │   │       │       ├── key:
         │   │   │       │       │   @ SymbolNode (location: (202,15)-(202,17))
-        │   │   │       │       │   ├── flags: ∅
+        │   │   │       │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │       │   ├── opening_loc: ∅
         │   │   │       │       │   ├── value_loc: (202,15)-(202,16) = "x"
         │   │   │       │       │   ├── closing_loc: (202,16)-(202,17) = ":"

--- a/test/prism/snapshots/ranges.txt
+++ b/test/prism/snapshots/ranges.txt
@@ -74,7 +74,7 @@
         │   │   └── @ AssocNode (location: (9,2)-(9,13))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (9,2)-(9,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: ∅
         │   │       │   ├── value_loc: (9,2)-(9,5) = "foo"
         │   │       │   ├── closing_loc: (9,5)-(9,6) = ":"
@@ -125,7 +125,7 @@
         │   │   └── @ AssocNode (location: (15,2)-(15,12))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (15,2)-(15,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: ∅
         │   │       │   ├── value_loc: (15,2)-(15,5) = "foo"
         │   │       │   ├── closing_loc: (15,5)-(15,6) = ":"

--- a/test/prism/snapshots/rescue.txt
+++ b/test/prism/snapshots/rescue.txt
@@ -349,7 +349,7 @@
             │   │           │               └── @ AssocNode (location: (29,4)-(29,6))
             │   │           │                   ├── key:
             │   │           │                   │   @ SymbolNode (location: (29,4)-(29,6))
-            │   │           │                   │   ├── flags: ∅
+            │   │           │                   │   ├── flags: forced_us_ascii_encoding
             │   │           │                   │   ├── opening_loc: ∅
             │   │           │                   │   ├── value_loc: (29,4)-(29,5) = "b"
             │   │           │                   │   ├── closing_loc: (29,5)-(29,6) = ":"

--- a/test/prism/snapshots/seattlerb/TestRubyParserShared.txt
+++ b/test/prism/snapshots/seattlerb/TestRubyParserShared.txt
@@ -12,13 +12,13 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 2)
         │   │   ├── @ SymbolNode (location: (7,0)-(7,5))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (7,0)-(7,5) = "line2"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "line2"
         │   │   └── @ SymbolNode (location: (8,0)-(8,5))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (8,0)-(8,5) = "line3"
         │   │       ├── closing_loc: ∅
@@ -56,13 +56,13 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 2)
         │   │   ├── @ SymbolNode (location: (27,0)-(27,5))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (27,0)-(27,5) = "line2"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "line2"
         │   │   └── @ SymbolNode (location: (28,0)-(28,5))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (28,0)-(28,5) = "line3"
         │   │       ├── closing_loc: ∅
@@ -101,13 +101,13 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 2)
         │   │   ├── @ SymbolNode (location: (47,0)-(47,6))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (47,0)-(47,1) = ":"
         │   │   │   ├── value_loc: (47,1)-(47,6) = "line2"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "line2"
         │   │   └── @ SymbolNode (location: (48,0)-(48,6))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: (48,0)-(48,1) = ":"
         │   │       ├── value_loc: (48,1)-(48,6) = "line3"
         │   │       ├── closing_loc: ∅
@@ -289,13 +289,13 @@
         │   │           │   ├── flags: ∅
         │   │           │   ├── elements: (length: 2)
         │   │           │   │   ├── @ SymbolNode (location: (76,4)-(76,10))
-        │   │           │   │   │   ├── flags: ∅
+        │   │           │   │   │   ├── flags: forced_us_ascii_encoding
         │   │           │   │   │   ├── opening_loc: (76,4)-(76,5) = ":"
         │   │           │   │   │   ├── value_loc: (76,5)-(76,10) = "line3"
         │   │           │   │   │   ├── closing_loc: ∅
         │   │           │   │   │   └── unescaped: "line3"
         │   │           │   │   └── @ SymbolNode (location: (77,4)-(77,10))
-        │   │           │   │       ├── flags: ∅
+        │   │           │   │       ├── flags: forced_us_ascii_encoding
         │   │           │   │       ├── opening_loc: (77,4)-(77,5) = ":"
         │   │           │   │       ├── value_loc: (77,5)-(77,10) = "line4"
         │   │           │   │       ├── closing_loc: ∅
@@ -346,13 +346,13 @@
             │   ├── flags: ∅
             │   └── arguments: (length: 2)
             │       ├── @ SymbolNode (location: (90,0)-(90,6))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: (90,0)-(90,1) = ":"
             │       │   ├── value_loc: (90,1)-(90,6) = "line2"
             │       │   ├── closing_loc: ∅
             │       │   └── unescaped: "line2"
             │       └── @ SymbolNode (location: (91,0)-(91,6))
-            │           ├── flags: ∅
+            │           ├── flags: forced_us_ascii_encoding
             │           ├── opening_loc: (91,0)-(91,1) = ":"
             │           ├── value_loc: (91,1)-(91,6) = "line3"
             │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/alias_resword.txt
+++ b/test/prism/snapshots/seattlerb/alias_resword.txt
@@ -6,14 +6,14 @@
         └── @ AliasMethodNode (location: (1,0)-(1,12))
             ├── new_name:
             │   @ SymbolNode (location: (1,6)-(1,8))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: ∅
             │   ├── value_loc: (1,6)-(1,8) = "in"
             │   ├── closing_loc: ∅
             │   └── unescaped: "in"
             ├── old_name:
             │   @ SymbolNode (location: (1,9)-(1,12))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: ∅
             │   ├── value_loc: (1,9)-(1,12) = "out"
             │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/assoc__bare.txt
+++ b/test/prism/snapshots/seattlerb/assoc__bare.txt
@@ -9,7 +9,7 @@
             │   └── @ AssocNode (location: (1,2)-(1,4))
             │       ├── key:
             │       │   @ SymbolNode (location: (1,2)-(1,4))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: ∅
             │       │   ├── value_loc: (1,2)-(1,3) = "y"
             │       │   ├── closing_loc: (1,3)-(1,4) = ":"

--- a/test/prism/snapshots/seattlerb/assoc_label.txt
+++ b/test/prism/snapshots/seattlerb/assoc_label.txt
@@ -20,7 +20,7 @@
             │               └── @ AssocNode (location: (1,2)-(1,5))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (1,2)-(1,4))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: ∅
             │                   │   ├── value_loc: (1,2)-(1,3) = "b"
             │                   │   ├── closing_loc: (1,3)-(1,4) = ":"

--- a/test/prism/snapshots/seattlerb/block_command_operation_colon.txt
+++ b/test/prism/snapshots/seattlerb/block_command_operation_colon.txt
@@ -18,7 +18,7 @@
             │   │   ├── flags: ∅
             │   │   └── arguments: (length: 1)
             │   │       └── @ SymbolNode (location: (1,2)-(1,4))
-            │   │           ├── flags: ∅
+            │   │           ├── flags: forced_us_ascii_encoding
             │   │           ├── opening_loc: (1,2)-(1,3) = ":"
             │   │           ├── value_loc: (1,3)-(1,4) = "b"
             │   │           ├── closing_loc: ∅
@@ -41,7 +41,7 @@
             │   ├── flags: ∅
             │   └── arguments: (length: 1)
             │       └── @ SymbolNode (location: (1,15)-(1,17))
-            │           ├── flags: ∅
+            │           ├── flags: forced_us_ascii_encoding
             │           ├── opening_loc: (1,15)-(1,16) = ":"
             │           ├── value_loc: (1,16)-(1,17) = "d"
             │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/block_command_operation_dot.txt
+++ b/test/prism/snapshots/seattlerb/block_command_operation_dot.txt
@@ -18,7 +18,7 @@
             │   │   ├── flags: ∅
             │   │   └── arguments: (length: 1)
             │   │       └── @ SymbolNode (location: (1,2)-(1,4))
-            │   │           ├── flags: ∅
+            │   │           ├── flags: forced_us_ascii_encoding
             │   │           ├── opening_loc: (1,2)-(1,3) = ":"
             │   │           ├── value_loc: (1,3)-(1,4) = "b"
             │   │           ├── closing_loc: ∅
@@ -41,7 +41,7 @@
             │   ├── flags: ∅
             │   └── arguments: (length: 1)
             │       └── @ SymbolNode (location: (1,14)-(1,16))
-            │           ├── flags: ∅
+            │           ├── flags: forced_us_ascii_encoding
             │           ├── opening_loc: (1,14)-(1,15) = ":"
             │           ├── value_loc: (1,15)-(1,16) = "d"
             │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/block_kwarg_lvar.txt
+++ b/test/prism/snapshots/seattlerb/block_kwarg_lvar.txt
@@ -31,7 +31,7 @@
                 │   │   │       ├── name_loc: (1,6)-(1,9) = "kw:"
                 │   │   │       └── value:
                 │   │   │           @ SymbolNode (location: (1,10)-(1,14))
-                │   │   │           ├── flags: ∅
+                │   │   │           ├── flags: forced_us_ascii_encoding
                 │   │   │           ├── opening_loc: (1,10)-(1,11) = ":"
                 │   │   │           ├── value_loc: (1,11)-(1,14) = "val"
                 │   │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/block_kwarg_lvar_multiple.txt
+++ b/test/prism/snapshots/seattlerb/block_kwarg_lvar_multiple.txt
@@ -31,7 +31,7 @@
                 │   │   │   │   ├── name_loc: (1,6)-(1,9) = "kw:"
                 │   │   │   │   └── value:
                 │   │   │   │       @ SymbolNode (location: (1,10)-(1,14))
-                │   │   │   │       ├── flags: ∅
+                │   │   │   │       ├── flags: forced_us_ascii_encoding
                 │   │   │   │       ├── opening_loc: (1,10)-(1,11) = ":"
                 │   │   │   │       ├── value_loc: (1,11)-(1,14) = "val"
                 │   │   │   │       ├── closing_loc: ∅
@@ -42,7 +42,7 @@
                 │   │   │       ├── name_loc: (1,16)-(1,20) = "kw2:"
                 │   │   │       └── value:
                 │   │   │           @ SymbolNode (location: (1,21)-(1,26))
-                │   │   │           ├── flags: ∅
+                │   │   │           ├── flags: forced_us_ascii_encoding
                 │   │   │           ├── opening_loc: (1,21)-(1,22) = ":"
                 │   │   │           ├── value_loc: (1,22)-(1,26) = "val2"
                 │   │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/block_optarg.txt
+++ b/test/prism/snapshots/seattlerb/block_optarg.txt
@@ -29,7 +29,7 @@
                 │   │   │       ├── operator_loc: (1,7)-(1,8) = "="
                 │   │   │       └── value:
                 │   │   │           @ SymbolNode (location: (1,9)-(1,11))
-                │   │   │           ├── flags: ∅
+                │   │   │           ├── flags: forced_us_ascii_encoding
                 │   │   │           ├── opening_loc: (1,9)-(1,10) = ":"
                 │   │   │           ├── value_loc: (1,10)-(1,11) = "c"
                 │   │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/block_reg_optarg.txt
+++ b/test/prism/snapshots/seattlerb/block_reg_optarg.txt
@@ -32,7 +32,7 @@
                 │   │   │       ├── operator_loc: (1,10)-(1,11) = "="
                 │   │   │       └── value:
                 │   │   │           @ SymbolNode (location: (1,12)-(1,14))
-                │   │   │           ├── flags: ∅
+                │   │   │           ├── flags: forced_us_ascii_encoding
                 │   │   │           ├── opening_loc: (1,12)-(1,13) = ":"
                 │   │   │           ├── value_loc: (1,13)-(1,14) = "d"
                 │   │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/bug_215.txt
+++ b/test/prism/snapshots/seattlerb/bug_215.txt
@@ -6,7 +6,7 @@
         └── @ UndefNode (location: (1,0)-(1,13))
             ├── names: (length: 1)
             │   └── @ SymbolNode (location: (1,6)-(1,13))
-            │       ├── flags: ∅
+            │       ├── flags: forced_us_ascii_encoding
             │       ├── opening_loc: (1,6)-(1,9) = "%s("
             │       ├── value_loc: (1,9)-(1,12) = "foo"
             │       ├── closing_loc: (1,12)-(1,13) = ")"

--- a/test/prism/snapshots/seattlerb/bug_249.txt
+++ b/test/prism/snapshots/seattlerb/bug_249.txt
@@ -71,7 +71,7 @@
             │               └── @ AssocNode (location: (4,11)-(4,28))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (4,11)-(4,14))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: (4,11)-(4,12) = ":"
             │                   │   ├── value_loc: (4,12)-(4,14) = "at"
             │                   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/bug_case_when_regexp.txt
+++ b/test/prism/snapshots/seattlerb/bug_case_when_regexp.txt
@@ -6,7 +6,7 @@
         └── @ CaseNode (location: (1,0)-(1,26))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "x"
             │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/bug_hash_args.txt
+++ b/test/prism/snapshots/seattlerb/bug_hash_args.txt
@@ -15,7 +15,7 @@
             │   ├── flags: ∅
             │   └── arguments: (length: 2)
             │       ├── @ SymbolNode (location: (1,4)-(1,8))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: (1,4)-(1,5) = ":"
             │       │   ├── value_loc: (1,5)-(1,8) = "bar"
             │       │   ├── closing_loc: ∅
@@ -26,7 +26,7 @@
             │               └── @ AssocNode (location: (1,10)-(1,18))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (1,10)-(1,14))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: ∅
             │                   │   ├── value_loc: (1,10)-(1,13) = "baz"
             │                   │   ├── closing_loc: (1,13)-(1,14) = ":"

--- a/test/prism/snapshots/seattlerb/bug_hash_args_trailing_comma.txt
+++ b/test/prism/snapshots/seattlerb/bug_hash_args_trailing_comma.txt
@@ -15,7 +15,7 @@
             │   ├── flags: ∅
             │   └── arguments: (length: 2)
             │       ├── @ SymbolNode (location: (1,4)-(1,8))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: (1,4)-(1,5) = ":"
             │       │   ├── value_loc: (1,5)-(1,8) = "bar"
             │       │   ├── closing_loc: ∅
@@ -26,7 +26,7 @@
             │               └── @ AssocNode (location: (1,10)-(1,18))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (1,10)-(1,14))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: ∅
             │                   │   ├── value_loc: (1,10)-(1,13) = "baz"
             │                   │   ├── closing_loc: (1,13)-(1,14) = ":"

--- a/test/prism/snapshots/seattlerb/call_arg_assoc_kwsplat.txt
+++ b/test/prism/snapshots/seattlerb/call_arg_assoc_kwsplat.txt
@@ -22,7 +22,7 @@
             │               ├── @ AssocNode (location: (1,5)-(1,10))
             │               │   ├── key:
             │               │   │   @ SymbolNode (location: (1,5)-(1,8))
-            │               │   │   ├── flags: ∅
+            │               │   │   ├── flags: forced_us_ascii_encoding
             │               │   │   ├── opening_loc: ∅
             │               │   │   ├── value_loc: (1,5)-(1,7) = "kw"
             │               │   │   ├── closing_loc: (1,7)-(1,8) = ":"

--- a/test/prism/snapshots/seattlerb/call_args_assoc_quoted.txt
+++ b/test/prism/snapshots/seattlerb/call_args_assoc_quoted.txt
@@ -62,7 +62,7 @@
         │   │               └── @ AssocNode (location: (3,2)-(3,8))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (3,2)-(3,6))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (3,2)-(3,3) = "\""
         │   │                   │   ├── value_loc: (3,3)-(3,4) = "k"
         │   │                   │   ├── closing_loc: (3,4)-(3,6) = "\":"
@@ -90,7 +90,7 @@
             │               └── @ AssocNode (location: (5,2)-(5,8))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (5,2)-(5,6))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: (5,2)-(5,3) = "'"
             │                   │   ├── value_loc: (5,3)-(5,4) = "k"
             │                   │   ├── closing_loc: (5,4)-(5,6) = "':"

--- a/test/prism/snapshots/seattlerb/call_array_arg.txt
+++ b/test/prism/snapshots/seattlerb/call_array_arg.txt
@@ -20,13 +20,13 @@
             │           ├── flags: ∅
             │           ├── elements: (length: 2)
             │           │   ├── @ SymbolNode (location: (1,6)-(1,8))
-            │           │   │   ├── flags: ∅
+            │           │   │   ├── flags: forced_us_ascii_encoding
             │           │   │   ├── opening_loc: (1,6)-(1,7) = ":"
             │           │   │   ├── value_loc: (1,7)-(1,8) = "b"
             │           │   │   ├── closing_loc: ∅
             │           │   │   └── unescaped: "b"
             │           │   └── @ SymbolNode (location: (1,10)-(1,12))
-            │           │       ├── flags: ∅
+            │           │       ├── flags: forced_us_ascii_encoding
             │           │       ├── opening_loc: (1,10)-(1,11) = ":"
             │           │       ├── value_loc: (1,11)-(1,12) = "c"
             │           │       ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/call_array_lit_inline_hash.txt
+++ b/test/prism/snapshots/seattlerb/call_array_lit_inline_hash.txt
@@ -18,7 +18,7 @@
             │           ├── flags: ∅
             │           ├── elements: (length: 2)
             │           │   ├── @ SymbolNode (location: (1,3)-(1,5))
-            │           │   │   ├── flags: ∅
+            │           │   │   ├── flags: forced_us_ascii_encoding
             │           │   │   ├── opening_loc: (1,3)-(1,4) = ":"
             │           │   │   ├── value_loc: (1,4)-(1,5) = "b"
             │           │   │   ├── closing_loc: ∅
@@ -29,7 +29,7 @@
             │           │           └── @ AssocNode (location: (1,7)-(1,14))
             │           │               ├── key:
             │           │               │   @ SymbolNode (location: (1,7)-(1,9))
-            │           │               │   ├── flags: ∅
+            │           │               │   ├── flags: forced_us_ascii_encoding
             │           │               │   ├── opening_loc: (1,7)-(1,8) = ":"
             │           │               │   ├── value_loc: (1,8)-(1,9) = "c"
             │           │               │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/call_assoc_new.txt
+++ b/test/prism/snapshots/seattlerb/call_assoc_new.txt
@@ -20,7 +20,7 @@
             │               └── @ AssocNode (location: (1,2)-(1,5))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (1,2)-(1,4))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: ∅
             │                   │   ├── value_loc: (1,2)-(1,3) = "a"
             │                   │   ├── closing_loc: (1,3)-(1,4) = ":"

--- a/test/prism/snapshots/seattlerb/call_assoc_new_if_multiline.txt
+++ b/test/prism/snapshots/seattlerb/call_assoc_new_if_multiline.txt
@@ -20,7 +20,7 @@
             │               └── @ AssocNode (location: (1,2)-(5,3))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (1,2)-(1,4))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: ∅
             │                   │   ├── value_loc: (1,2)-(1,3) = "b"
             │                   │   ├── closing_loc: (1,3)-(1,4) = ":"
@@ -30,7 +30,7 @@
             │                   │   ├── if_keyword_loc: (1,5)-(1,7) = "if"
             │                   │   ├── predicate:
             │                   │   │   @ SymbolNode (location: (1,8)-(1,10))
-            │                   │   │   ├── flags: ∅
+            │                   │   │   ├── flags: forced_us_ascii_encoding
             │                   │   │   ├── opening_loc: (1,8)-(1,9) = ":"
             │                   │   │   ├── value_loc: (1,9)-(1,10) = "c"
             │                   │   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in.txt
+++ b/test/prism/snapshots/seattlerb/case_in.txt
@@ -6,7 +6,7 @@
         ├── @ CaseMatchNode (location: (1,0)-(3,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (1,5)-(1,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (1,5)-(1,6) = ":"
         │   │   ├── value_loc: (1,6)-(1,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -20,7 +20,7 @@
         │   │       │   │   └── @ AssocNode (location: (2,4)-(2,8))
         │   │       │   │       ├── key:
         │   │       │   │       │   @ SymbolNode (location: (2,4)-(2,8))
-        │   │       │   │       │   ├── flags: ∅
+        │   │       │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   │       │   ├── opening_loc: (2,4)-(2,5) = "\""
         │   │       │   │       │   ├── value_loc: (2,5)-(2,6) = "b"
         │   │       │   │       │   ├── closing_loc: (2,6)-(2,8) = "\":"
@@ -39,7 +39,7 @@
         ├── @ CaseMatchNode (location: (5,0)-(7,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (5,5)-(5,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (5,5)-(5,6) = ":"
         │   │   ├── value_loc: (5,6)-(5,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -51,13 +51,13 @@
         │   │       │   ├── flags: ∅
         │   │       │   ├── elements: (length: 2)
         │   │       │   │   ├── @ SymbolNode (location: (6,6)-(6,7))
-        │   │       │   │   │   ├── flags: ∅
+        │   │       │   │   │   ├── flags: forced_us_ascii_encoding
         │   │       │   │   │   ├── opening_loc: ∅
         │   │       │   │   │   ├── value_loc: (6,6)-(6,7) = "a"
         │   │       │   │   │   ├── closing_loc: ∅
         │   │       │   │   │   └── unescaped: "a"
         │   │       │   │   └── @ SymbolNode (location: (6,8)-(6,9))
-        │   │       │   │       ├── flags: ∅
+        │   │       │   │       ├── flags: forced_us_ascii_encoding
         │   │       │   │       ├── opening_loc: ∅
         │   │       │   │       ├── value_loc: (6,8)-(6,9) = "b"
         │   │       │   │       ├── closing_loc: ∅
@@ -73,7 +73,7 @@
         ├── @ CaseMatchNode (location: (9,0)-(11,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (9,5)-(9,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (9,5)-(9,6) = ":"
         │   │   ├── value_loc: (9,6)-(9,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -107,7 +107,7 @@
         ├── @ CaseMatchNode (location: (13,0)-(15,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (13,5)-(13,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (13,5)-(13,6) = ":"
         │   │   ├── value_loc: (13,6)-(13,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -119,13 +119,13 @@
         │   │       │   ├── flags: ∅
         │   │       │   ├── elements: (length: 2)
         │   │       │   │   ├── @ SymbolNode (location: (14,6)-(14,7))
-        │   │       │   │   │   ├── flags: ∅
+        │   │       │   │   │   ├── flags: forced_us_ascii_encoding
         │   │       │   │   │   ├── opening_loc: ∅
         │   │       │   │   │   ├── value_loc: (14,6)-(14,7) = "a"
         │   │       │   │   │   ├── closing_loc: ∅
         │   │       │   │   │   └── unescaped: "a"
         │   │       │   │   └── @ SymbolNode (location: (14,8)-(14,9))
-        │   │       │   │       ├── flags: ∅
+        │   │       │   │       ├── flags: forced_us_ascii_encoding
         │   │       │   │       ├── opening_loc: ∅
         │   │       │   │       ├── value_loc: (14,8)-(14,9) = "b"
         │   │       │   │       ├── closing_loc: ∅
@@ -141,7 +141,7 @@
         ├── @ CaseMatchNode (location: (17,0)-(19,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (17,5)-(17,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (17,5)-(17,6) = ":"
         │   │   ├── value_loc: (17,6)-(17,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -175,7 +175,7 @@
         ├── @ CaseMatchNode (location: (21,0)-(23,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (21,5)-(21,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (21,5)-(21,6) = ":"
         │   │   ├── value_loc: (21,6)-(21,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -199,7 +199,7 @@
         ├── @ CaseMatchNode (location: (25,0)-(27,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (25,5)-(25,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (25,5)-(25,6) = ":"
         │   │   ├── value_loc: (25,6)-(25,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -223,7 +223,7 @@
         ├── @ CaseMatchNode (location: (29,0)-(31,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (29,5)-(29,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (29,5)-(29,6) = ":"
         │   │   ├── value_loc: (29,6)-(29,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -247,7 +247,7 @@
         ├── @ CaseMatchNode (location: (33,0)-(35,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (33,5)-(33,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (33,5)-(33,6) = ":"
         │   │   ├── value_loc: (33,6)-(33,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -273,7 +273,7 @@
         ├── @ CaseMatchNode (location: (37,0)-(39,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (37,5)-(37,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (37,5)-(37,6) = ":"
         │   │   ├── value_loc: (37,6)-(37,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -292,7 +292,7 @@
         ├── @ CaseMatchNode (location: (41,0)-(43,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (41,5)-(41,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (41,5)-(41,6) = ":"
         │   │   ├── value_loc: (41,6)-(41,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -318,7 +318,7 @@
         ├── @ CaseMatchNode (location: (45,0)-(47,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (45,5)-(45,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (45,5)-(45,6) = ":"
         │   │   ├── value_loc: (45,6)-(45,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -341,7 +341,7 @@
         ├── @ CaseMatchNode (location: (49,0)-(51,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (49,5)-(49,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (49,5)-(49,6) = ":"
         │   │   ├── value_loc: (49,6)-(49,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -353,7 +353,7 @@
         │   │       │   ├── constant: ∅
         │   │       │   ├── requireds: (length: 1)
         │   │       │   │   └── @ SymbolNode (location: (50,3)-(50,5))
-        │   │       │   │       ├── flags: ∅
+        │   │       │   │       ├── flags: forced_us_ascii_encoding
         │   │       │   │       ├── opening_loc: (50,3)-(50,4) = ":"
         │   │       │   │       ├── value_loc: (50,4)-(50,5) = "b"
         │   │       │   │       ├── closing_loc: ∅
@@ -367,7 +367,7 @@
         │   │       │   │       └── depth: 0
         │   │       │   ├── posts: (length: 1)
         │   │       │   │   └── @ SymbolNode (location: (50,11)-(50,13))
-        │   │       │   │       ├── flags: ∅
+        │   │       │   │       ├── flags: forced_us_ascii_encoding
         │   │       │   │       ├── opening_loc: (50,11)-(50,12) = ":"
         │   │       │   │       ├── value_loc: (50,12)-(50,13) = "c"
         │   │       │   │       ├── closing_loc: ∅
@@ -383,7 +383,7 @@
         ├── @ CaseMatchNode (location: (53,0)-(55,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (53,5)-(53,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (53,5)-(53,6) = ":"
         │   │   ├── value_loc: (53,6)-(53,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -395,7 +395,7 @@
         │   │       │   ├── constant: ∅
         │   │       │   ├── requireds: (length: 2)
         │   │       │   │   ├── @ SymbolNode (location: (54,3)-(54,5))
-        │   │       │   │   │   ├── flags: ∅
+        │   │       │   │   │   ├── flags: forced_us_ascii_encoding
         │   │       │   │   │   ├── opening_loc: (54,3)-(54,4) = ":"
         │   │       │   │   │   ├── value_loc: (54,4)-(54,5) = "b"
         │   │       │   │   │   ├── closing_loc: ∅
@@ -404,7 +404,7 @@
         │   │       │   │       ├── constant: ∅
         │   │       │   │       ├── requireds: (length: 1)
         │   │       │   │       │   └── @ SymbolNode (location: (54,8)-(54,10))
-        │   │       │   │       │       ├── flags: ∅
+        │   │       │   │       │       ├── flags: forced_us_ascii_encoding
         │   │       │   │       │       ├── opening_loc: (54,8)-(54,9) = ":"
         │   │       │   │       │       ├── value_loc: (54,9)-(54,10) = "c"
         │   │       │   │       │       ├── closing_loc: ∅
@@ -426,7 +426,7 @@
         ├── @ CaseMatchNode (location: (57,0)-(59,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (57,5)-(57,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (57,5)-(57,6) = ":"
         │   │   ├── value_loc: (57,6)-(57,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -452,7 +452,7 @@
         ├── @ CaseMatchNode (location: (61,0)-(63,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (61,5)-(61,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (61,5)-(61,6) = ":"
         │   │   ├── value_loc: (61,6)-(61,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -493,7 +493,7 @@
         ├── @ CaseMatchNode (location: (65,0)-(67,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (65,5)-(65,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (65,5)-(65,6) = ":"
         │   │   ├── value_loc: (65,6)-(65,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -534,7 +534,7 @@
         ├── @ CaseMatchNode (location: (69,0)-(71,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (69,5)-(69,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (69,5)-(69,6) = ":"
         │   │   ├── value_loc: (69,6)-(69,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -588,7 +588,7 @@
         ├── @ CaseMatchNode (location: (73,0)-(75,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (73,5)-(73,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (73,5)-(73,6) = ":"
         │   │   ├── value_loc: (73,6)-(73,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -600,7 +600,7 @@
         │   │       │   ├── constant: ∅
         │   │       │   ├── requireds: (length: 4)
         │   │       │   │   ├── @ SymbolNode (location: (74,4)-(74,6))
-        │   │       │   │   │   ├── flags: ∅
+        │   │       │   │   │   ├── flags: forced_us_ascii_encoding
         │   │       │   │   │   ├── opening_loc: (74,4)-(74,5) = ":"
         │   │       │   │   │   ├── value_loc: (74,5)-(74,6) = "a"
         │   │       │   │   │   ├── closing_loc: ∅
@@ -615,7 +615,7 @@
         │   │       │   │       ├── constant: ∅
         │   │       │   │       ├── requireds: (length: 1)
         │   │       │   │       │   └── @ SymbolNode (location: (74,15)-(74,17))
-        │   │       │   │       │       ├── flags: ∅
+        │   │       │   │       │       ├── flags: forced_us_ascii_encoding
         │   │       │   │       │       ├── opening_loc: (74,15)-(74,16) = ":"
         │   │       │   │       │       ├── value_loc: (74,16)-(74,17) = "d"
         │   │       │   │       │       ├── closing_loc: ∅
@@ -644,7 +644,7 @@
         ├── @ CaseMatchNode (location: (77,0)-(79,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (77,5)-(77,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (77,5)-(77,6) = ":"
         │   │   ├── value_loc: (77,6)-(77,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -675,7 +675,7 @@
         ├── @ CaseMatchNode (location: (81,0)-(83,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (81,5)-(81,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (81,5)-(81,6) = ":"
         │   │   ├── value_loc: (81,6)-(81,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -690,7 +690,7 @@
         │   │       │   │   │   ├── constant: ∅
         │   │       │   │   │   ├── requireds: (length: 2)
         │   │       │   │   │   │   ├── @ SymbolNode (location: (82,5)-(82,7))
-        │   │       │   │   │   │   │   ├── flags: ∅
+        │   │       │   │   │   │   │   ├── flags: forced_us_ascii_encoding
         │   │       │   │   │   │   │   ├── opening_loc: (82,5)-(82,6) = ":"
         │   │       │   │   │   │   │   ├── value_loc: (82,6)-(82,7) = "b"
         │   │       │   │   │   │   │   ├── closing_loc: ∅
@@ -706,7 +706,7 @@
         │   │       │   │       ├── constant: ∅
         │   │       │   │       ├── requireds: (length: 2)
         │   │       │   │       │   ├── @ SymbolNode (location: (82,14)-(82,16))
-        │   │       │   │       │   │   ├── flags: ∅
+        │   │       │   │       │   │   ├── flags: forced_us_ascii_encoding
         │   │       │   │       │   │   ├── opening_loc: (82,14)-(82,15) = ":"
         │   │       │   │       │   │   ├── value_loc: (82,15)-(82,16) = "d"
         │   │       │   │       │   │   ├── closing_loc: ∅
@@ -734,7 +734,7 @@
         ├── @ CaseMatchNode (location: (85,0)-(87,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (85,5)-(85,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (85,5)-(85,6) = ":"
         │   │   ├── value_loc: (85,6)-(85,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -758,7 +758,7 @@
         ├── @ CaseMatchNode (location: (89,0)-(91,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (89,5)-(89,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (89,5)-(89,6) = ":"
         │   │   ├── value_loc: (89,6)-(89,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -797,7 +797,7 @@
         ├── @ CaseMatchNode (location: (93,0)-(95,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (93,5)-(93,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (93,5)-(93,6) = ":"
         │   │   ├── value_loc: (93,6)-(93,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -836,7 +836,7 @@
         ├── @ CaseMatchNode (location: (97,0)-(99,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (97,5)-(97,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (97,5)-(97,6) = ":"
         │   │   ├── value_loc: (97,6)-(97,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -859,7 +859,7 @@
         ├── @ CaseMatchNode (location: (101,0)-(103,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (101,5)-(101,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (101,5)-(101,6) = ":"
         │   │   ├── value_loc: (101,6)-(101,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -886,7 +886,7 @@
         ├── @ CaseMatchNode (location: (105,0)-(107,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (105,5)-(105,7))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (105,5)-(105,6) = ":"
         │   │   ├── value_loc: (105,6)-(105,7) = "a"
         │   │   ├── closing_loc: ∅
@@ -900,7 +900,7 @@
         │   │       │   │   └── @ AssocNode (location: (106,5)-(106,9))
         │   │       │   │       ├── key:
         │   │       │   │       │   @ SymbolNode (location: (106,5)-(106,9))
-        │   │       │   │       │   ├── flags: ∅
+        │   │       │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   │       │   ├── opening_loc: (106,5)-(106,6) = "\""
         │   │       │   │       │   ├── value_loc: (106,6)-(106,7) = "b"
         │   │       │   │       │   ├── closing_loc: (106,7)-(106,9) = "\":"
@@ -919,7 +919,7 @@
         └── @ CaseMatchNode (location: (109,0)-(111,3))
             ├── predicate:
             │   @ SymbolNode (location: (109,5)-(109,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (109,5)-(109,6) = ":"
             │   ├── value_loc: (109,6)-(109,7) = "a"
             │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_31.txt
+++ b/test/prism/snapshots/seattlerb/case_in_31.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -18,7 +18,7 @@
             │       │   ├── constant: ∅
             │       │   ├── requireds: (length: 1)
             │       │   │   └── @ SymbolNode (location: (2,4)-(2,6))
-            │       │   │       ├── flags: ∅
+            │       │   │       ├── flags: forced_us_ascii_encoding
             │       │   │       ├── opening_loc: (2,4)-(2,5) = ":"
             │       │   │       ├── value_loc: (2,5)-(2,6) = "b"
             │       │   │       ├── closing_loc: ∅
@@ -37,7 +37,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "d"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_37.txt
+++ b/test/prism/snapshots/seattlerb/case_in_37.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -20,7 +20,7 @@
             │       │   │   └── @ AssocNode (location: (2,5)-(2,17))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,5)-(2,7))
-            │       │   │       │   ├── flags: ∅
+            │       │   │       │   ├── flags: forced_us_ascii_encoding
             │       │   │       │   ├── opening_loc: ∅
             │       │   │       │   ├── value_loc: (2,5)-(2,6) = "b"
             │       │   │       │   ├── closing_loc: (2,6)-(2,7) = ":"
@@ -46,7 +46,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "c"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_42.txt
+++ b/test/prism/snapshots/seattlerb/case_in_42.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(3,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -18,7 +18,7 @@
             │       │   ├── constant: ∅
             │       │   ├── requireds: (length: 1)
             │       │   │   └── @ SymbolNode (location: (2,3)-(2,5))
-            │       │   │       ├── flags: ∅
+            │       │   │       ├── flags: forced_us_ascii_encoding
             │       │   │       ├── opening_loc: (2,3)-(2,4) = ":"
             │       │   │       ├── value_loc: (2,4)-(2,5) = "b"
             │       │   │       ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_42_2.txt
+++ b/test/prism/snapshots/seattlerb/case_in_42_2.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(3,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_47.txt
+++ b/test/prism/snapshots/seattlerb/case_in_47.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -23,13 +23,13 @@
             │       │   │   └── expression: ∅
             │       │   ├── posts: (length: 2)
             │       │   │   ├── @ SymbolNode (location: (2,7)-(2,9))
-            │       │   │   │   ├── flags: ∅
+            │       │   │   │   ├── flags: forced_us_ascii_encoding
             │       │   │   │   ├── opening_loc: (2,7)-(2,8) = ":"
             │       │   │   │   ├── value_loc: (2,8)-(2,9) = "b"
             │       │   │   │   ├── closing_loc: ∅
             │       │   │   │   └── unescaped: "b"
             │       │   │   └── @ SymbolNode (location: (2,11)-(2,13))
-            │       │   │       ├── flags: ∅
+            │       │   │       ├── flags: forced_us_ascii_encoding
             │       │   │       ├── opening_loc: (2,11)-(2,12) = ":"
             │       │   │       ├── value_loc: (2,12)-(2,13) = "c"
             │       │   │       ├── closing_loc: ∅
@@ -40,7 +40,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "d"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_67.txt
+++ b/test/prism/snapshots/seattlerb/case_in_67.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(3,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_86.txt
+++ b/test/prism/snapshots/seattlerb/case_in_86.txt
@@ -9,13 +9,13 @@
             │   ├── flags: ∅
             │   ├── elements: (length: 2)
             │   │   ├── @ SymbolNode (location: (1,6)-(1,8))
-            │   │   │   ├── flags: ∅
+            │   │   │   ├── flags: forced_us_ascii_encoding
             │   │   │   ├── opening_loc: (1,6)-(1,7) = ":"
             │   │   │   ├── value_loc: (1,7)-(1,8) = "a"
             │   │   │   ├── closing_loc: ∅
             │   │   │   └── unescaped: "a"
             │   │   └── @ SymbolNode (location: (1,10)-(1,12))
-            │   │       ├── flags: ∅
+            │   │       ├── flags: forced_us_ascii_encoding
             │   │       ├── opening_loc: (1,10)-(1,11) = ":"
             │   │       ├── value_loc: (1,11)-(1,12) = "b"
             │   │       ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_86_2.txt
+++ b/test/prism/snapshots/seattlerb/case_in_86_2.txt
@@ -9,13 +9,13 @@
             │   ├── flags: ∅
             │   ├── elements: (length: 2)
             │   │   ├── @ SymbolNode (location: (1,6)-(1,8))
-            │   │   │   ├── flags: ∅
+            │   │   │   ├── flags: forced_us_ascii_encoding
             │   │   │   ├── opening_loc: (1,6)-(1,7) = ":"
             │   │   │   ├── value_loc: (1,7)-(1,8) = "a"
             │   │   │   ├── closing_loc: ∅
             │   │   │   └── unescaped: "a"
             │   │   └── @ SymbolNode (location: (1,10)-(1,12))
-            │   │       ├── flags: ∅
+            │   │       ├── flags: forced_us_ascii_encoding
             │   │       ├── opening_loc: (1,10)-(1,11) = ":"
             │   │       ├── value_loc: (1,11)-(1,12) = "b"
             │   │       ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_array_pat_const.txt
+++ b/test/prism/snapshots/seattlerb/case_in_array_pat_const.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -30,7 +30,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "d"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_array_pat_const2.txt
+++ b/test/prism/snapshots/seattlerb/case_in_array_pat_const2.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -36,7 +36,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "e"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_array_pat_paren_assign.txt
+++ b/test/prism/snapshots/seattlerb/case_in_array_pat_paren_assign.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -36,7 +36,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "d"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_const.txt
+++ b/test/prism/snapshots/seattlerb/case_in_const.txt
@@ -16,7 +16,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "b"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_else.txt
+++ b/test/prism/snapshots/seattlerb/case_in_else.txt
@@ -16,7 +16,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "b"
             │       │           ├── closing_loc: ∅
@@ -30,7 +30,7 @@
             │   │   @ StatementsNode (location: (5,2)-(5,4))
             │   │   └── body: (length: 1)
             │   │       └── @ SymbolNode (location: (5,2)-(5,4))
-            │   │           ├── flags: ∅
+            │   │           ├── flags: forced_us_ascii_encoding
             │   │           ├── opening_loc: (5,2)-(5,3) = ":"
             │   │           ├── value_loc: (5,3)-(5,4) = "c"
             │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_find.txt
+++ b/test/prism/snapshots/seattlerb/case_in_find.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(3,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -25,7 +25,7 @@
             │       │   │       └── depth: 0
             │       │   ├── requireds: (length: 1)
             │       │   │   └── @ SymbolNode (location: (2,9)-(2,11))
-            │       │   │       ├── flags: ∅
+            │       │   │       ├── flags: forced_us_ascii_encoding
             │       │   │       ├── opening_loc: (2,9)-(2,10) = ":"
             │       │   │       ├── value_loc: (2,10)-(2,11) = "+"
             │       │   │       ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_find_array.txt
+++ b/test/prism/snapshots/seattlerb/case_in_find_array.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(3,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -22,7 +22,7 @@
             │       │   │   └── expression: ∅
             │       │   ├── requireds: (length: 2)
             │       │   │   ├── @ SymbolNode (location: (2,7)-(2,9))
-            │       │   │   │   ├── flags: ∅
+            │       │   │   │   ├── flags: forced_us_ascii_encoding
             │       │   │   │   ├── opening_loc: (2,7)-(2,8) = ":"
             │       │   │   │   ├── value_loc: (2,8)-(2,9) = "b"
             │       │   │   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -20,7 +20,7 @@
             │       │   │   ├── @ AssocNode (location: (2,5)-(2,11))
             │       │   │   │   ├── key:
             │       │   │   │   │   @ SymbolNode (location: (2,5)-(2,7))
-            │       │   │   │   │   ├── flags: ∅
+            │       │   │   │   │   ├── flags: forced_us_ascii_encoding
             │       │   │   │   │   ├── opening_loc: ∅
             │       │   │   │   │   ├── value_loc: (2,5)-(2,6) = "b"
             │       │   │   │   │   ├── closing_loc: (2,6)-(2,7) = ":"
@@ -36,7 +36,7 @@
             │       │   │   └── @ AssocNode (location: (2,13)-(2,19))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,13)-(2,15))
-            │       │   │       │   ├── flags: ∅
+            │       │   │       │   ├── flags: forced_us_ascii_encoding
             │       │   │       │   ├── opening_loc: ∅
             │       │   │       │   ├── value_loc: (2,13)-(2,14) = "d"
             │       │   │       │   ├── closing_loc: (2,14)-(2,15) = ":"
@@ -56,7 +56,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "f"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_assign.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_assign.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -20,7 +20,7 @@
             │       │   │   ├── @ AssocNode (location: (2,5)-(2,20))
             │       │   │   │   ├── key:
             │       │   │   │   │   @ SymbolNode (location: (2,5)-(2,7))
-            │       │   │   │   │   ├── flags: ∅
+            │       │   │   │   │   ├── flags: forced_us_ascii_encoding
             │       │   │   │   │   ├── opening_loc: ∅
             │       │   │   │   │   ├── value_loc: (2,5)-(2,6) = "b"
             │       │   │   │   │   ├── closing_loc: (2,6)-(2,7) = ":"
@@ -39,7 +39,7 @@
             │       │   │   ├── @ AssocNode (location: (2,22)-(2,28))
             │       │   │   │   ├── key:
             │       │   │   │   │   @ SymbolNode (location: (2,22)-(2,24))
-            │       │   │   │   │   ├── flags: ∅
+            │       │   │   │   │   ├── flags: forced_us_ascii_encoding
             │       │   │   │   │   ├── opening_loc: ∅
             │       │   │   │   │   ├── value_loc: (2,22)-(2,23) = "d"
             │       │   │   │   │   ├── closing_loc: (2,23)-(2,24) = ":"
@@ -55,7 +55,7 @@
             │       │   │   └── @ AssocNode (location: (2,30)-(2,32))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,30)-(2,32))
-            │       │   │       │   ├── flags: ∅
+            │       │   │       │   ├── flags: forced_us_ascii_encoding
             │       │   │       │   ├── opening_loc: ∅
             │       │   │       │   ├── value_loc: (2,30)-(2,31) = "f"
             │       │   │       │   ├── closing_loc: (2,31)-(2,32) = ":"
@@ -69,7 +69,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "g"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_assign.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_assign.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -22,7 +22,7 @@
             │       │   │   └── @ AssocNode (location: (2,5)-(2,10))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,5)-(2,7))
-            │       │   │       │   ├── flags: ∅
+            │       │   │       │   ├── flags: forced_us_ascii_encoding
             │       │   │       │   ├── opening_loc: ∅
             │       │   │       │   ├── value_loc: (2,5)-(2,6) = "a"
             │       │   │       │   ├── closing_loc: (2,6)-(2,7) = ":"
@@ -38,7 +38,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "d"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_true.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_true.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -20,7 +20,7 @@
             │       │   │   └── @ AssocNode (location: (2,3)-(2,10))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,3)-(2,5))
-            │       │   │       │   ├── flags: ∅
+            │       │   │       │   ├── flags: forced_us_ascii_encoding
             │       │   │       │   ├── opening_loc: ∅
             │       │   │       │   ├── value_loc: (2,3)-(2,4) = "b"
             │       │   │       │   ├── closing_loc: (2,4)-(2,5) = ":"
@@ -35,7 +35,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "c"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_rest.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_rest.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(3,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -20,7 +20,7 @@
             │       │   │   └── @ AssocNode (location: (2,3)-(2,7))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,3)-(2,5))
-            │       │   │       │   ├── flags: ∅
+            │       │   │       │   ├── flags: forced_us_ascii_encoding
             │       │   │       │   ├── opening_loc: ∅
             │       │   │       │   ├── value_loc: (2,3)-(2,4) = "b"
             │       │   │       │   ├── closing_loc: (2,4)-(2,5) = ":"
@@ -43,7 +43,7 @@
             │       │   @ StatementsNode (location: (2,21)-(2,23))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (2,21)-(2,23))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (2,21)-(2,22) = ":"
             │       │           ├── value_loc: (2,22)-(2,23) = "d"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_rest_solo.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_rest_solo.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(3,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -30,7 +30,7 @@
             │       │   @ StatementsNode (location: (2,15)-(2,17))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (2,15)-(2,17))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (2,15)-(2,16) = ":"
             │       │           ├── value_loc: (2,16)-(2,17) = "d"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_if_unless_post_mod.txt
+++ b/test/prism/snapshots/seattlerb/case_in_if_unless_post_mod.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(6,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -30,7 +30,7 @@
             │   │   │   @ StatementsNode (location: (3,2)-(3,4))
             │   │   │   └── body: (length: 1)
             │   │   │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │   │   │           ├── flags: ∅
+            │   │   │           ├── flags: forced_us_ascii_encoding
             │   │   │           ├── opening_loc: (3,2)-(3,3) = ":"
             │   │   │           ├── value_loc: (3,3)-(3,4) = "C"
             │   │   │           ├── closing_loc: ∅
@@ -55,7 +55,7 @@
             │       │   @ StatementsNode (location: (5,2)-(5,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (5,2)-(5,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (5,2)-(5,3) = ":"
             │       │           ├── value_loc: (5,3)-(5,4) = "E"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_multiple.txt
+++ b/test/prism/snapshots/seattlerb/case_in_multiple.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(6,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -26,7 +26,7 @@
             │   │   │   @ StatementsNode (location: (3,2)-(3,4))
             │   │   │   └── body: (length: 1)
             │   │   │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │   │   │           ├── flags: ∅
+            │   │   │           ├── flags: forced_us_ascii_encoding
             │   │   │           ├── opening_loc: (3,2)-(3,3) = ":"
             │   │   │           ├── value_loc: (3,3)-(3,4) = "C"
             │   │   │           ├── closing_loc: ∅
@@ -47,7 +47,7 @@
             │       │   @ StatementsNode (location: (5,2)-(5,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (5,2)-(5,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (5,2)-(5,3) = ":"
             │       │           ├── value_loc: (5,3)-(5,4) = "F"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/case_in_or.txt
+++ b/test/prism/snapshots/seattlerb/case_in_or.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -26,7 +26,7 @@
             │       │   @ StatementsNode (location: (3,2)-(3,4))
             │       │   └── body: (length: 1)
             │       │       └── @ SymbolNode (location: (3,2)-(3,4))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: forced_us_ascii_encoding
             │       │           ├── opening_loc: (3,2)-(3,3) = ":"
             │       │           ├── value_loc: (3,3)-(3,4) = "d"
             │       │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/defn_args_forward_args.txt
+++ b/test/prism/snapshots/seattlerb/defn_args_forward_args.txt
@@ -41,7 +41,7 @@
             │           │   ├── flags: ∅
             │           │   └── arguments: (length: 3)
             │           │       ├── @ SymbolNode (location: (1,23)-(1,27))
-            │           │       │   ├── flags: ∅
+            │           │       │   ├── flags: forced_us_ascii_encoding
             │           │       │   ├── opening_loc: (1,23)-(1,24) = ":"
             │           │       │   ├── value_loc: (1,24)-(1,27) = "get"
             │           │       │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/defn_kwarg_lvar.txt
+++ b/test/prism/snapshots/seattlerb/defn_kwarg_lvar.txt
@@ -20,7 +20,7 @@
             │   │       ├── name_loc: (1,8)-(1,11) = "kw:"
             │   │       └── value:
             │   │           @ SymbolNode (location: (1,12)-(1,16))
-            │   │           ├── flags: ∅
+            │   │           ├── flags: forced_us_ascii_encoding
             │   │           ├── opening_loc: (1,12)-(1,13) = ":"
             │   │           ├── value_loc: (1,13)-(1,16) = "val"
             │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/defn_reg_opt_reg.txt
+++ b/test/prism/snapshots/seattlerb/defn_reg_opt_reg.txt
@@ -21,7 +21,7 @@
             │   │       ├── operator_loc: (1,11)-(1,12) = "="
             │   │       └── value:
             │   │           @ SymbolNode (location: (1,13)-(1,15))
-            │   │           ├── flags: ∅
+            │   │           ├── flags: forced_us_ascii_encoding
             │   │           ├── opening_loc: (1,13)-(1,14) = ":"
             │   │           ├── value_loc: (1,14)-(1,15) = "c"
             │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/difficult2_.txt
+++ b/test/prism/snapshots/seattlerb/difficult2_.txt
@@ -58,7 +58,7 @@
             │               └── @ AssocNode (location: (2,2)-(2,6))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (2,2)-(2,4))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: ∅
             │                   │   ├── value_loc: (2,2)-(2,3) = "d"
             │                   │   ├── closing_loc: (2,3)-(2,4) = ":"

--- a/test/prism/snapshots/seattlerb/difficult7_.txt
+++ b/test/prism/snapshots/seattlerb/difficult7_.txt
@@ -9,7 +9,7 @@
             │   ├── @ AssocNode (location: (2,8)-(2,33))
             │   │   ├── key:
             │   │   │   @ SymbolNode (location: (2,8)-(2,10))
-            │   │   │   ├── flags: ∅
+            │   │   │   ├── flags: forced_us_ascii_encoding
             │   │   │   ├── opening_loc: ∅
             │   │   │   ├── value_loc: (2,8)-(2,9) = "a"
             │   │   │   ├── closing_loc: (2,9)-(2,10) = ":"
@@ -83,7 +83,7 @@
             │   └── @ AssocNode (location: (3,8)-(3,14))
             │       ├── key:
             │       │   @ SymbolNode (location: (3,8)-(3,10))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: ∅
             │       │   ├── value_loc: (3,8)-(3,9) = "e"
             │       │   ├── closing_loc: (3,9)-(3,10) = ":"

--- a/test/prism/snapshots/seattlerb/dstr_lex_state.txt
+++ b/test/prism/snapshots/seattlerb/dstr_lex_state.txt
@@ -23,7 +23,7 @@
             │       │           │   ├── flags: ∅
             │       │           │   └── arguments: (length: 1)
             │       │           │       └── @ SymbolNode (location: (1,4)-(1,6))
-            │       │           │           ├── flags: ∅
+            │       │           │           ├── flags: forced_us_ascii_encoding
             │       │           │           ├── opening_loc: (1,4)-(1,5) = ":"
             │       │           │           ├── value_loc: (1,5)-(1,6) = "a"
             │       │           │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/dsym_esc_to_sym.txt
+++ b/test/prism/snapshots/seattlerb/dsym_esc_to_sym.txt
@@ -4,7 +4,7 @@
     @ StatementsNode (location: (1,0)-(1,17))
     └── body: (length: 1)
         └── @ SymbolNode (location: (1,0)-(1,17))
-            ├── flags: ∅
+            ├── flags: forced_utf8_encoding
             ├── opening_loc: (1,0)-(1,2) = ":\""
             ├── value_loc: (1,2)-(1,16) = "Variet\\303\\240"
             ├── closing_loc: (1,16)-(1,17) = "\""

--- a/test/prism/snapshots/seattlerb/dsym_to_sym.txt
+++ b/test/prism/snapshots/seattlerb/dsym_to_sym.txt
@@ -6,14 +6,14 @@
         ├── @ AliasMethodNode (location: (1,0)-(1,17))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (1,6)-(1,11))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (1,6)-(1,8) = ":\""
         │   │   ├── value_loc: (1,8)-(1,10) = "<<"
         │   │   ├── closing_loc: (1,10)-(1,11) = "\""
         │   │   └── unescaped: "<<"
         │   ├── old_name:
         │   │   @ SymbolNode (location: (1,12)-(1,17))
-        │   │   ├── flags: ∅
+        │   │   ├── flags: forced_us_ascii_encoding
         │   │   ├── opening_loc: (1,12)-(1,14) = ":\""
         │   │   ├── value_loc: (1,14)-(1,16) = ">>"
         │   │   ├── closing_loc: (1,16)-(1,17) = "\""
@@ -22,14 +22,14 @@
         └── @ AliasMethodNode (location: (3,0)-(3,13))
             ├── new_name:
             │   @ SymbolNode (location: (3,6)-(3,9))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (3,6)-(3,7) = ":"
             │   ├── value_loc: (3,7)-(3,9) = "<<"
             │   ├── closing_loc: ∅
             │   └── unescaped: "<<"
             ├── old_name:
             │   @ SymbolNode (location: (3,10)-(3,13))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (3,10)-(3,11) = ":"
             │   ├── value_loc: (3,11)-(3,13) = ">>"
             │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/if_symbol.txt
+++ b/test/prism/snapshots/seattlerb/if_symbol.txt
@@ -18,7 +18,7 @@
             │   │   ├── flags: ∅
             │   │   └── arguments: (length: 1)
             │   │       └── @ SymbolNode (location: (1,5)-(1,7))
-            │   │           ├── flags: ∅
+            │   │           ├── flags: forced_us_ascii_encoding
             │   │           ├── opening_loc: (1,5)-(1,6) = ":"
             │   │           ├── value_loc: (1,6)-(1,7) = "x"
             │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/interpolated_symbol_array_line_breaks.txt
+++ b/test/prism/snapshots/seattlerb/interpolated_symbol_array_line_breaks.txt
@@ -7,13 +7,13 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 2)
         │   │   ├── @ SymbolNode (location: (2,0)-(2,1))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (2,0)-(2,1) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   └── @ SymbolNode (location: (3,0)-(3,1))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (3,0)-(3,1) = "b"
         │   │       ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/multiline_hash_declaration.txt
+++ b/test/prism/snapshots/seattlerb/multiline_hash_declaration.txt
@@ -20,7 +20,7 @@
         │   │               └── @ AssocNode (location: (1,2)-(3,1))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (1,2)-(1,8))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (1,2)-(1,7) = "state"
         │   │                   │   ├── closing_loc: (1,7)-(1,8) = ":"
@@ -50,7 +50,7 @@
         │   │               └── @ AssocNode (location: (5,2)-(6,1))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (5,2)-(5,8))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (5,2)-(5,7) = "state"
         │   │                   │   ├── closing_loc: (5,7)-(5,8) = ":"
@@ -80,7 +80,7 @@
             │               └── @ AssocNode (location: (8,2)-(8,11))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (8,2)-(8,8))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: ∅
             │                   │   ├── value_loc: (8,2)-(8,7) = "state"
             │                   │   ├── closing_loc: (8,7)-(8,8) = ":"

--- a/test/prism/snapshots/seattlerb/non_interpolated_symbol_array_line_breaks.txt
+++ b/test/prism/snapshots/seattlerb/non_interpolated_symbol_array_line_breaks.txt
@@ -7,13 +7,13 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 2)
         │   │   ├── @ SymbolNode (location: (2,0)-(2,1))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (2,0)-(2,1) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   └── @ SymbolNode (location: (3,0)-(3,1))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (3,0)-(3,1) = "b"
         │   │       ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/op_asgn_index_command_call.txt
+++ b/test/prism/snapshots/seattlerb/op_asgn_index_command_call.txt
@@ -23,7 +23,7 @@
             │   ├── flags: ∅
             │   └── arguments: (length: 1)
             │       └── @ SymbolNode (location: (1,2)-(1,4))
-            │           ├── flags: ∅
+            │           ├── flags: forced_us_ascii_encoding
             │           ├── opening_loc: (1,2)-(1,3) = ":"
             │           ├── value_loc: (1,3)-(1,4) = "b"
             │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/parse_line_hash_lit.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_hash_lit.txt
@@ -9,7 +9,7 @@
             │   └── @ AssocNode (location: (2,0)-(2,8))
             │       ├── key:
             │       │   @ SymbolNode (location: (2,0)-(2,3))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: (2,0)-(2,1) = ":"
             │       │   ├── value_loc: (2,1)-(2,3) = "s1"
             │       │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/parse_pattern_058.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_058.txt
@@ -11,7 +11,7 @@
             │   │   └── @ AssocNode (location: (1,6)-(1,10))
             │   │       ├── key:
             │   │       │   @ SymbolNode (location: (1,6)-(1,8))
-            │   │       │   ├── flags: ∅
+            │   │       │   ├── flags: forced_us_ascii_encoding
             │   │       │   ├── opening_loc: ∅
             │   │       │   ├── value_loc: (1,6)-(1,7) = "a"
             │   │       │   ├── closing_loc: (1,7)-(1,8) = ":"
@@ -30,7 +30,7 @@
             │       │   │   └── @ AssocNode (location: (2,4)-(2,6))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,4)-(2,6))
-            │       │   │       │   ├── flags: ∅
+            │       │   │       │   ├── flags: forced_us_ascii_encoding
             │       │   │       │   ├── opening_loc: ∅
             │       │   │       │   ├── value_loc: (2,4)-(2,5) = "a"
             │       │   │       │   ├── closing_loc: (2,5)-(2,6) = ":"

--- a/test/prism/snapshots/seattlerb/parse_pattern_058_2.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_058_2.txt
@@ -11,7 +11,7 @@
             │   │   └── @ AssocNode (location: (1,6)-(1,10))
             │   │       ├── key:
             │   │       │   @ SymbolNode (location: (1,6)-(1,8))
-            │   │       │   ├── flags: ∅
+            │   │       │   ├── flags: forced_us_ascii_encoding
             │   │       │   ├── opening_loc: ∅
             │   │       │   ├── value_loc: (1,6)-(1,7) = "a"
             │   │       │   ├── closing_loc: (1,7)-(1,8) = ":"
@@ -30,7 +30,7 @@
             │       │   │   └── @ AssocNode (location: (2,4)-(2,6))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,4)-(2,6))
-            │       │   │       │   ├── flags: ∅
+            │       │   │       │   ├── flags: forced_us_ascii_encoding
             │       │   │       │   ├── opening_loc: ∅
             │       │   │       │   ├── value_loc: (2,4)-(2,5) = "a"
             │       │   │       │   ├── closing_loc: (2,5)-(2,6) = ":"

--- a/test/prism/snapshots/seattlerb/parse_pattern_069.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_069.txt
@@ -6,7 +6,7 @@
         └── @ CaseMatchNode (location: (1,0)-(4,3))
             ├── predicate:
             │   @ SymbolNode (location: (1,5)-(1,7))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,5)-(1,6) = ":"
             │   ├── value_loc: (1,6)-(1,7) = "a"
             │   ├── closing_loc: ∅
@@ -22,7 +22,7 @@
             │       │   │   └── @ AssocNode (location: (2,10)-(2,14))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,10)-(2,12))
-            │       │   │       │   ├── flags: ∅
+            │       │   │       │   ├── flags: forced_us_ascii_encoding
             │       │   │       │   ├── opening_loc: ∅
             │       │   │       │   ├── value_loc: (2,10)-(2,11) = "b"
             │       │   │       │   ├── closing_loc: (2,11)-(2,12) = ":"

--- a/test/prism/snapshots/seattlerb/parse_pattern_076.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_076.txt
@@ -11,7 +11,7 @@
             │   │   └── @ AssocNode (location: (1,6)-(1,10))
             │   │       ├── key:
             │   │       │   @ SymbolNode (location: (1,6)-(1,8))
-            │   │       │   ├── flags: ∅
+            │   │       │   ├── flags: forced_us_ascii_encoding
             │   │       │   ├── opening_loc: ∅
             │   │       │   ├── value_loc: (1,6)-(1,7) = "a"
             │   │       │   ├── closing_loc: (1,7)-(1,8) = ":"
@@ -30,7 +30,7 @@
             │       │   │   └── @ AssocNode (location: (2,4)-(2,8))
             │       │   │       ├── key:
             │       │   │       │   @ SymbolNode (location: (2,4)-(2,6))
-            │       │   │       │   ├── flags: ∅
+            │       │   │       │   ├── flags: forced_us_ascii_encoding
             │       │   │       │   ├── opening_loc: ∅
             │       │   │       │   ├── value_loc: (2,4)-(2,5) = "a"
             │       │   │       │   ├── closing_loc: (2,5)-(2,6) = ":"

--- a/test/prism/snapshots/seattlerb/qsymbols.txt
+++ b/test/prism/snapshots/seattlerb/qsymbols.txt
@@ -7,19 +7,19 @@
             ├── flags: ∅
             ├── elements: (length: 3)
             │   ├── @ SymbolNode (location: (1,3)-(1,4))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: ∅
             │   │   ├── value_loc: (1,3)-(1,4) = "a"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "a"
             │   ├── @ SymbolNode (location: (1,5)-(1,6))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: ∅
             │   │   ├── value_loc: (1,5)-(1,6) = "b"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "b"
             │   └── @ SymbolNode (location: (1,7)-(1,8))
-            │       ├── flags: ∅
+            │       ├── flags: forced_us_ascii_encoding
             │       ├── opening_loc: ∅
             │       ├── value_loc: (1,7)-(1,8) = "c"
             │       ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/qsymbols_interp.txt
+++ b/test/prism/snapshots/seattlerb/qsymbols_interp.txt
@@ -7,7 +7,7 @@
             ├── flags: ∅
             ├── elements: (length: 3)
             │   ├── @ SymbolNode (location: (1,3)-(1,4))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: ∅
             │   │   ├── value_loc: (1,3)-(1,4) = "a"
             │   │   ├── closing_loc: ∅
@@ -46,7 +46,7 @@
             │   │   │       └── closing_loc: (1,11)-(1,12) = "}"
             │   │   └── closing_loc: ∅
             │   └── @ SymbolNode (location: (1,13)-(1,14))
-            │       ├── flags: ∅
+            │       ├── flags: forced_us_ascii_encoding
             │       ├── opening_loc: ∅
             │       ├── value_loc: (1,13)-(1,14) = "c"
             │       ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/quoted_symbol_hash_arg.txt
+++ b/test/prism/snapshots/seattlerb/quoted_symbol_hash_arg.txt
@@ -20,7 +20,7 @@
             │               └── @ AssocNode (location: (1,5)-(1,12))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (1,5)-(1,9))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: (1,5)-(1,6) = "'"
             │                   │   ├── value_loc: (1,6)-(1,7) = "a"
             │                   │   ├── closing_loc: (1,7)-(1,9) = "':"

--- a/test/prism/snapshots/seattlerb/quoted_symbol_keys.txt
+++ b/test/prism/snapshots/seattlerb/quoted_symbol_keys.txt
@@ -9,14 +9,14 @@
             │   └── @ AssocNode (location: (1,2)-(1,9))
             │       ├── key:
             │       │   @ SymbolNode (location: (1,2)-(1,6))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: (1,2)-(1,3) = "'"
             │       │   ├── value_loc: (1,3)-(1,4) = "a"
             │       │   ├── closing_loc: (1,4)-(1,6) = "':"
             │       │   └── unescaped: "a"
             │       ├── value:
             │       │   @ SymbolNode (location: (1,7)-(1,9))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: (1,7)-(1,8) = ":"
             │       │   ├── value_loc: (1,8)-(1,9) = "b"
             │       │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/rescue_do_end_ensure_result.txt
+++ b/test/prism/snapshots/seattlerb/rescue_do_end_ensure_result.txt
@@ -27,7 +27,7 @@
             │       │   │   @ StatementsNode (location: (2,2)-(2,8))
             │       │   │   └── body: (length: 1)
             │       │   │       └── @ SymbolNode (location: (2,2)-(2,8))
-            │       │   │           ├── flags: ∅
+            │       │   │           ├── flags: forced_us_ascii_encoding
             │       │   │           ├── opening_loc: (2,2)-(2,3) = ":"
             │       │   │           ├── value_loc: (2,3)-(2,8) = "begin"
             │       │   │           ├── closing_loc: ∅
@@ -41,7 +41,7 @@
             │       │   │   │   @ StatementsNode (location: (4,2)-(4,9))
             │       │   │   │   └── body: (length: 1)
             │       │   │   │       └── @ SymbolNode (location: (4,2)-(4,9))
-            │       │   │   │           ├── flags: ∅
+            │       │   │   │           ├── flags: forced_us_ascii_encoding
             │       │   │   │           ├── opening_loc: (4,2)-(4,3) = ":"
             │       │   │   │           ├── value_loc: (4,3)-(4,9) = "ensure"
             │       │   │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/rescue_do_end_no_raise.txt
+++ b/test/prism/snapshots/seattlerb/rescue_do_end_no_raise.txt
@@ -24,7 +24,7 @@
                 │   │   @ StatementsNode (location: (2,2)-(2,8))
                 │   │   └── body: (length: 1)
                 │   │       └── @ SymbolNode (location: (2,2)-(2,8))
-                │   │           ├── flags: ∅
+                │   │           ├── flags: forced_us_ascii_encoding
                 │   │           ├── opening_loc: (2,2)-(2,3) = ":"
                 │   │           ├── value_loc: (2,3)-(2,8) = "begin"
                 │   │           ├── closing_loc: ∅
@@ -39,7 +39,7 @@
                 │   │   │   @ StatementsNode (location: (4,2)-(4,9))
                 │   │   │   └── body: (length: 1)
                 │   │   │       └── @ SymbolNode (location: (4,2)-(4,9))
-                │   │   │           ├── flags: ∅
+                │   │   │           ├── flags: forced_us_ascii_encoding
                 │   │   │           ├── opening_loc: (4,2)-(4,3) = ":"
                 │   │   │           ├── value_loc: (4,3)-(4,9) = "rescue"
                 │   │   │           ├── closing_loc: ∅
@@ -52,7 +52,7 @@
                 │   │   │   @ StatementsNode (location: (6,2)-(6,7))
                 │   │   │   └── body: (length: 1)
                 │   │   │       └── @ SymbolNode (location: (6,2)-(6,7))
-                │   │   │           ├── flags: ∅
+                │   │   │           ├── flags: forced_us_ascii_encoding
                 │   │   │           ├── opening_loc: (6,2)-(6,3) = ":"
                 │   │   │           ├── value_loc: (6,3)-(6,7) = "else"
                 │   │   │           ├── closing_loc: ∅
@@ -65,7 +65,7 @@
                 │   │   │   @ StatementsNode (location: (8,2)-(8,9))
                 │   │   │   └── body: (length: 1)
                 │   │   │       └── @ SymbolNode (location: (8,2)-(8,9))
-                │   │   │           ├── flags: ∅
+                │   │   │           ├── flags: forced_us_ascii_encoding
                 │   │   │           ├── opening_loc: (8,2)-(8,3) = ":"
                 │   │   │           ├── value_loc: (8,3)-(8,9) = "ensure"
                 │   │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/rescue_do_end_raised.txt
+++ b/test/prism/snapshots/seattlerb/rescue_do_end_raised.txt
@@ -42,7 +42,7 @@
                 │   │   │   @ StatementsNode (location: (4,2)-(4,9))
                 │   │   │   └── body: (length: 1)
                 │   │   │       └── @ SymbolNode (location: (4,2)-(4,9))
-                │   │   │           ├── flags: ∅
+                │   │   │           ├── flags: forced_us_ascii_encoding
                 │   │   │           ├── opening_loc: (4,2)-(4,3) = ":"
                 │   │   │           ├── value_loc: (4,3)-(4,9) = "ensure"
                 │   │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/rescue_do_end_rescued.txt
+++ b/test/prism/snapshots/seattlerb/rescue_do_end_rescued.txt
@@ -43,7 +43,7 @@
                 │   │   │   @ StatementsNode (location: (4,2)-(4,9))
                 │   │   │   └── body: (length: 1)
                 │   │   │       └── @ SymbolNode (location: (4,2)-(4,9))
-                │   │   │           ├── flags: ∅
+                │   │   │           ├── flags: forced_us_ascii_encoding
                 │   │   │           ├── opening_loc: (4,2)-(4,3) = ":"
                 │   │   │           ├── value_loc: (4,3)-(4,9) = "rescue"
                 │   │   │           ├── closing_loc: ∅
@@ -56,7 +56,7 @@
                 │   │   │   @ StatementsNode (location: (6,2)-(6,7))
                 │   │   │   └── body: (length: 1)
                 │   │   │       └── @ SymbolNode (location: (6,2)-(6,7))
-                │   │   │           ├── flags: ∅
+                │   │   │           ├── flags: forced_us_ascii_encoding
                 │   │   │           ├── opening_loc: (6,2)-(6,3) = ":"
                 │   │   │           ├── value_loc: (6,3)-(6,7) = "else"
                 │   │   │           ├── closing_loc: ∅
@@ -69,7 +69,7 @@
                 │   │   │   @ StatementsNode (location: (8,2)-(8,9))
                 │   │   │   └── body: (length: 1)
                 │   │   │       └── @ SymbolNode (location: (8,2)-(8,9))
-                │   │   │           ├── flags: ∅
+                │   │   │           ├── flags: forced_us_ascii_encoding
                 │   │   │           ├── opening_loc: (8,2)-(8,3) = ":"
                 │   │   │           ├── value_loc: (8,3)-(8,9) = "ensure"
                 │   │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/return_call_assocs.txt
+++ b/test/prism/snapshots/seattlerb/return_call_assocs.txt
@@ -17,7 +17,7 @@
         │                   └── @ AssocNode (location: (1,10)-(1,17))
         │                       ├── key:
         │                       │   @ SymbolNode (location: (1,10)-(1,12))
-        │                       │   ├── flags: ∅
+        │                       │   ├── flags: forced_us_ascii_encoding
         │                       │   ├── opening_loc: (1,10)-(1,11) = ":"
         │                       │   ├── value_loc: (1,11)-(1,12) = "z"
         │                       │   ├── closing_loc: ∅
@@ -40,7 +40,7 @@
         │                   ├── @ AssocNode (location: (3,10)-(3,17))
         │                   │   ├── key:
         │                   │   │   @ SymbolNode (location: (3,10)-(3,12))
-        │                   │   │   ├── flags: ∅
+        │                   │   │   ├── flags: forced_us_ascii_encoding
         │                   │   │   ├── opening_loc: (3,10)-(3,11) = ":"
         │                   │   │   ├── value_loc: (3,11)-(3,12) = "z"
         │                   │   │   ├── closing_loc: ∅
@@ -52,7 +52,7 @@
         │                   └── @ AssocNode (location: (3,19)-(3,26))
         │                       ├── key:
         │                       │   @ SymbolNode (location: (3,19)-(3,21))
-        │                       │   ├── flags: ∅
+        │                       │   ├── flags: forced_us_ascii_encoding
         │                       │   ├── opening_loc: (3,19)-(3,20) = ":"
         │                       │   ├── value_loc: (3,20)-(3,21) = "w"
         │                       │   ├── closing_loc: ∅
@@ -84,7 +84,7 @@
         │               │               └── @ AssocNode (location: (5,9)-(5,14))
         │               │                   ├── key:
         │               │                   │   @ SymbolNode (location: (5,9)-(5,11))
-        │               │                   │   ├── flags: ∅
+        │               │                   │   ├── flags: forced_us_ascii_encoding
         │               │                   │   ├── opening_loc: (5,9)-(5,10) = ":"
         │               │                   │   ├── value_loc: (5,10)-(5,11) = "z"
         │               │                   │   ├── closing_loc: ∅
@@ -118,7 +118,7 @@
         │               │               └── @ AssocNode (location: (7,9)-(7,12))
         │               │                   ├── key:
         │               │                   │   @ SymbolNode (location: (7,9)-(7,11))
-        │               │                   │   ├── flags: ∅
+        │               │                   │   ├── flags: forced_us_ascii_encoding
         │               │                   │   ├── opening_loc: ∅
         │               │                   │   ├── value_loc: (7,9)-(7,10) = "z"
         │               │                   │   ├── closing_loc: (7,10)-(7,11) = ":"
@@ -152,7 +152,7 @@
         │               │               └── @ AssocNode (location: (9,9)-(9,12))
         │               │                   ├── key:
         │               │                   │   @ SymbolNode (location: (9,9)-(9,11))
-        │               │                   │   ├── flags: ∅
+        │               │                   │   ├── flags: forced_us_ascii_encoding
         │               │                   │   ├── opening_loc: ∅
         │               │                   │   ├── value_loc: (9,9)-(9,10) = "z"
         │               │                   │   ├── closing_loc: (9,10)-(9,11) = ":"

--- a/test/prism/snapshots/seattlerb/symbol_empty.txt
+++ b/test/prism/snapshots/seattlerb/symbol_empty.txt
@@ -4,7 +4,7 @@
     @ StatementsNode (location: (1,0)-(1,3))
     └── body: (length: 1)
         └── @ SymbolNode (location: (1,0)-(1,3))
-            ├── flags: ∅
+            ├── flags: forced_us_ascii_encoding
             ├── opening_loc: (1,0)-(1,2) = ":'"
             ├── value_loc: (1,2)-(1,2) = ""
             ├── closing_loc: (1,2)-(1,3) = "'"

--- a/test/prism/snapshots/seattlerb/symbols.txt
+++ b/test/prism/snapshots/seattlerb/symbols.txt
@@ -7,19 +7,19 @@
             ├── flags: ∅
             ├── elements: (length: 3)
             │   ├── @ SymbolNode (location: (1,3)-(1,4))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: ∅
             │   │   ├── value_loc: (1,3)-(1,4) = "a"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "a"
             │   ├── @ SymbolNode (location: (1,5)-(1,6))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: ∅
             │   │   ├── value_loc: (1,5)-(1,6) = "b"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "b"
             │   └── @ SymbolNode (location: (1,7)-(1,8))
-            │       ├── flags: ∅
+            │       ├── flags: forced_us_ascii_encoding
             │       ├── opening_loc: ∅
             │       ├── value_loc: (1,7)-(1,8) = "c"
             │       ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/symbols_interp.txt
+++ b/test/prism/snapshots/seattlerb/symbols_interp.txt
@@ -7,19 +7,19 @@
             ├── flags: ∅
             ├── elements: (length: 3)
             │   ├── @ SymbolNode (location: (1,3)-(1,4))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: ∅
             │   │   ├── value_loc: (1,3)-(1,4) = "a"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "a"
             │   ├── @ SymbolNode (location: (1,5)-(1,12))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: ∅
             │   │   ├── value_loc: (1,5)-(1,12) = "b\#{1+1}"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "b\#{1+1}"
             │   └── @ SymbolNode (location: (1,13)-(1,14))
-            │       ├── flags: ∅
+            │       ├── flags: forced_us_ascii_encoding
             │       ├── opening_loc: ∅
             │       ├── value_loc: (1,13)-(1,14) = "c"
             │       ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/unary_plus_on_literal.txt
+++ b/test/prism/snapshots/seattlerb/unary_plus_on_literal.txt
@@ -7,7 +7,7 @@
             ├── flags: ∅
             ├── receiver:
             │   @ SymbolNode (location: (1,1)-(1,3))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,1)-(1,2) = ":"
             │   ├── value_loc: (1,2)-(1,3) = "a"
             │   ├── closing_loc: ∅

--- a/test/prism/snapshots/seattlerb/yield_call_assocs.txt
+++ b/test/prism/snapshots/seattlerb/yield_call_assocs.txt
@@ -18,7 +18,7 @@
         │   │               └── @ AssocNode (location: (1,9)-(1,16))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (1,9)-(1,11))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (1,9)-(1,10) = ":"
         │   │                   │   ├── value_loc: (1,10)-(1,11) = "z"
         │   │                   │   ├── closing_loc: ∅
@@ -43,7 +43,7 @@
         │   │               ├── @ AssocNode (location: (3,9)-(3,16))
         │   │               │   ├── key:
         │   │               │   │   @ SymbolNode (location: (3,9)-(3,11))
-        │   │               │   │   ├── flags: ∅
+        │   │               │   │   ├── flags: forced_us_ascii_encoding
         │   │               │   │   ├── opening_loc: (3,9)-(3,10) = ":"
         │   │               │   │   ├── value_loc: (3,10)-(3,11) = "z"
         │   │               │   │   ├── closing_loc: ∅
@@ -55,7 +55,7 @@
         │   │               └── @ AssocNode (location: (3,18)-(3,25))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (3,18)-(3,20))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (3,18)-(3,19) = ":"
         │   │                   │   ├── value_loc: (3,19)-(3,20) = "w"
         │   │                   │   ├── closing_loc: ∅
@@ -89,7 +89,7 @@
         │   │           │               └── @ AssocNode (location: (5,8)-(5,13))
         │   │           │                   ├── key:
         │   │           │                   │   @ SymbolNode (location: (5,8)-(5,10))
-        │   │           │                   │   ├── flags: ∅
+        │   │           │                   │   ├── flags: forced_us_ascii_encoding
         │   │           │                   │   ├── opening_loc: (5,8)-(5,9) = ":"
         │   │           │                   │   ├── value_loc: (5,9)-(5,10) = "z"
         │   │           │                   │   ├── closing_loc: ∅
@@ -125,7 +125,7 @@
         │   │           │               └── @ AssocNode (location: (7,8)-(7,11))
         │   │           │                   ├── key:
         │   │           │                   │   @ SymbolNode (location: (7,8)-(7,10))
-        │   │           │                   │   ├── flags: ∅
+        │   │           │                   │   ├── flags: forced_us_ascii_encoding
         │   │           │                   │   ├── opening_loc: ∅
         │   │           │                   │   ├── value_loc: (7,8)-(7,9) = "z"
         │   │           │                   │   ├── closing_loc: (7,9)-(7,10) = ":"
@@ -161,7 +161,7 @@
         │   │           │               └── @ AssocNode (location: (9,8)-(9,11))
         │   │           │                   ├── key:
         │   │           │                   │   @ SymbolNode (location: (9,8)-(9,10))
-        │   │           │                   │   ├── flags: ∅
+        │   │           │                   │   ├── flags: forced_us_ascii_encoding
         │   │           │                   │   ├── opening_loc: ∅
         │   │           │                   │   ├── value_loc: (9,8)-(9,9) = "z"
         │   │           │                   │   ├── closing_loc: (9,9)-(9,10) = ":"

--- a/test/prism/snapshots/spanning_heredoc.txt
+++ b/test/prism/snapshots/spanning_heredoc.txt
@@ -260,13 +260,13 @@
         │   │           ├── flags: ∅
         │   │           ├── elements: (length: 2)
         │   │           │   ├── @ SymbolNode (location: (41,12)-(41,14))
-        │   │           │   │   ├── flags: ∅
+        │   │           │   │   ├── flags: forced_us_ascii_encoding
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── value_loc: (41,12)-(41,14) = "n\\"
         │   │           │   │   ├── closing_loc: ∅
         │   │           │   │   └── unescaped: "n\n"
         │   │           │   └── @ SymbolNode (location: (44,0)-(44,1))
-        │   │           │       ├── flags: ∅
+        │   │           │       ├── flags: forced_us_ascii_encoding
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── value_loc: (44,0)-(44,1) = "n"
         │   │           │       ├── closing_loc: ∅
@@ -299,7 +299,7 @@
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── parts: (length: 2)
         │   │           │       │   ├── @ SymbolNode (location: (48,12)-(48,14))
-        │   │           │       │   │   ├── flags: ∅
+        │   │           │       │   │   ├── flags: forced_us_ascii_encoding
         │   │           │       │   │   ├── opening_loc: ∅
         │   │           │       │   │   ├── value_loc: (48,12)-(48,14) = "p\\"
         │   │           │       │   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/spanning_heredoc_newlines.txt
+++ b/test/prism/snapshots/spanning_heredoc_newlines.txt
@@ -121,7 +121,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ SymbolNode (location: (17,4)-(20,0))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (17,4)-(18,0) = "%s\n"
         │   │           ├── value_loc: (18,0)-(18,0) = ""
         │   │           ├── closing_loc: (19,0)-(20,0) = "\n"

--- a/test/prism/snapshots/strings.txt
+++ b/test/prism/snapshots/strings.txt
@@ -177,7 +177,7 @@
         │   ├── closing_loc: (43,6)-(43,7) = "}"
         │   └── unescaped: "abc"
         ├── @ SymbolNode (location: (45,0)-(45,7))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (45,0)-(45,3) = "%s["
         │   ├── value_loc: (45,3)-(45,6) = "abc"
         │   ├── closing_loc: (45,6)-(45,7) = "]"

--- a/test/prism/snapshots/super.txt
+++ b/test/prism/snapshots/super.txt
@@ -46,7 +46,7 @@
         │       @ BlockArgumentNode (location: (9,6)-(9,11))
         │       ├── expression:
         │       │   @ SymbolNode (location: (9,7)-(9,11))
-        │       │   ├── flags: ∅
+        │       │   ├── flags: forced_us_ascii_encoding
         │       │   ├── opening_loc: (9,7)-(9,8) = ":"
         │       │   ├── value_loc: (9,8)-(9,11) = "foo"
         │       │   ├── closing_loc: ∅
@@ -61,7 +61,7 @@
         │       @ BlockArgumentNode (location: (11,6)-(11,11))
         │       ├── expression:
         │       │   @ SymbolNode (location: (11,7)-(11,11))
-        │       │   ├── flags: ∅
+        │       │   ├── flags: forced_us_ascii_encoding
         │       │   ├── opening_loc: (11,7)-(11,8) = ":"
         │       │   ├── value_loc: (11,8)-(11,11) = "foo"
         │       │   ├── closing_loc: ∅
@@ -116,7 +116,7 @@
                 @ BlockArgumentNode (location: (17,15)-(17,20))
                 ├── expression:
                 │   @ SymbolNode (location: (17,16)-(17,20))
-                │   ├── flags: ∅
+                │   ├── flags: forced_us_ascii_encoding
                 │   ├── opening_loc: (17,16)-(17,17) = ":"
                 │   ├── value_loc: (17,17)-(17,20) = "foo"
                 │   ├── closing_loc: ∅

--- a/test/prism/snapshots/symbols.txt
+++ b/test/prism/snapshots/symbols.txt
@@ -4,7 +4,7 @@
     @ StatementsNode (location: (1,0)-(93,13))
     └── body: (length: 47)
         ├── @ SymbolNode (location: (1,0)-(1,6))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (1,0)-(1,2) = ":'"
         │   ├── value_loc: (1,2)-(1,5) = "abc"
         │   ├── closing_loc: (1,5)-(1,6) = "'"
@@ -77,61 +77,61 @@
         │   ├── opening_loc: (7,0)-(7,1) = "["
         │   └── closing_loc: (7,19)-(7,20) = "]"
         ├── @ SymbolNode (location: (9,0)-(9,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (9,0)-(9,1) = ":"
         │   ├── value_loc: (9,1)-(9,3) = "-@"
         │   ├── closing_loc: ∅
         │   └── unescaped: "-@"
         ├── @ SymbolNode (location: (11,0)-(11,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (11,0)-(11,1) = ":"
         │   ├── value_loc: (11,1)-(11,2) = "-"
         │   ├── closing_loc: ∅
         │   └── unescaped: "-"
         ├── @ SymbolNode (location: (13,0)-(13,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (13,0)-(13,1) = ":"
         │   ├── value_loc: (13,1)-(13,2) = "%"
         │   ├── closing_loc: ∅
         │   └── unescaped: "%"
         ├── @ SymbolNode (location: (15,0)-(15,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (15,0)-(15,1) = ":"
         │   ├── value_loc: (15,1)-(15,2) = "|"
         │   ├── closing_loc: ∅
         │   └── unescaped: "|"
         ├── @ SymbolNode (location: (17,0)-(17,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (17,0)-(17,1) = ":"
         │   ├── value_loc: (17,1)-(17,3) = "+@"
         │   ├── closing_loc: ∅
         │   └── unescaped: "+@"
         ├── @ SymbolNode (location: (19,0)-(19,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (19,0)-(19,1) = ":"
         │   ├── value_loc: (19,1)-(19,2) = "+"
         │   ├── closing_loc: ∅
         │   └── unescaped: "+"
         ├── @ SymbolNode (location: (21,0)-(21,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (21,0)-(21,1) = ":"
         │   ├── value_loc: (21,1)-(21,2) = "/"
         │   ├── closing_loc: ∅
         │   └── unescaped: "/"
         ├── @ SymbolNode (location: (23,0)-(23,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (23,0)-(23,1) = ":"
         │   ├── value_loc: (23,1)-(23,3) = "**"
         │   ├── closing_loc: ∅
         │   └── unescaped: "**"
         ├── @ SymbolNode (location: (25,0)-(25,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (25,0)-(25,1) = ":"
         │   ├── value_loc: (25,1)-(25,2) = "*"
         │   ├── closing_loc: ∅
         │   └── unescaped: "*"
         ├── @ SymbolNode (location: (27,0)-(27,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (27,0)-(27,1) = ":"
         │   ├── value_loc: (27,1)-(27,3) = "~@"
         │   ├── closing_loc: ∅
@@ -153,13 +153,13 @@
         │   ├── opening_loc: (29,0)-(29,1) = "["
         │   └── closing_loc: (29,15)-(29,16) = "]"
         ├── @ SymbolNode (location: (31,0)-(31,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (31,0)-(31,1) = ":"
         │   ├── value_loc: (31,1)-(31,2) = "~"
         │   ├── closing_loc: ∅
         │   └── unescaped: "~"
         ├── @ SymbolNode (location: (33,0)-(33,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (33,0)-(33,1) = ":"
         │   ├── value_loc: (33,1)-(33,2) = "a"
         │   ├── closing_loc: ∅
@@ -168,19 +168,19 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 3)
         │   │   ├── @ SymbolNode (location: (35,3)-(35,4))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (35,3)-(35,4) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   ├── @ SymbolNode (location: (35,5)-(35,6))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (35,5)-(35,6) = "b"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "b"
         │   │   └── @ SymbolNode (location: (35,7)-(35,8))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (35,7)-(35,8) = "c"
         │   │       ├── closing_loc: ∅
@@ -191,25 +191,25 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 4)
         │   │   ├── @ SymbolNode (location: (37,3)-(37,4))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (37,3)-(37,4) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   ├── @ SymbolNode (location: (37,5)-(37,10))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (37,5)-(37,10) = "b\#{1}"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "b\#{1}"
         │   │   ├── @ SymbolNode (location: (37,11)-(37,16))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (37,11)-(37,16) = "\#{2}c"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "\#{2}c"
         │   │   └── @ SymbolNode (location: (37,17)-(37,23))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (37,17)-(37,23) = "d\#{3}f"
         │   │       ├── closing_loc: ∅
@@ -220,7 +220,7 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 4)
         │   │   ├── @ SymbolNode (location: (39,3)-(39,4))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (39,3)-(39,4) = "a"
         │   │   │   ├── closing_loc: ∅
@@ -288,7 +288,7 @@
         │   ├── opening_loc: (39,0)-(39,3) = "%I["
         │   └── closing_loc: (39,23)-(39,24) = "]"
         ├── @ SymbolNode (location: (41,0)-(41,4))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (41,0)-(41,1) = ":"
         │   ├── value_loc: (41,1)-(41,4) = "@@a"
         │   ├── closing_loc: ∅
@@ -303,7 +303,7 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 1)
         │   │   └── @ SymbolNode (location: (45,3)-(45,6))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (45,3)-(45,6) = "a\\b"
         │   │       ├── closing_loc: ∅
@@ -311,145 +311,145 @@
         │   ├── opening_loc: (45,0)-(45,3) = "%i["
         │   └── closing_loc: (45,6)-(45,7) = "]"
         ├── @ SymbolNode (location: (47,0)-(47,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (47,0)-(47,1) = ":"
         │   ├── value_loc: (47,1)-(47,3) = "$a"
         │   ├── closing_loc: ∅
         │   └── unescaped: "$a"
         ├── @ SymbolNode (location: (49,0)-(49,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (49,0)-(49,1) = ":"
         │   ├── value_loc: (49,1)-(49,3) = "@a"
         │   ├── closing_loc: ∅
         │   └── unescaped: "@a"
         ├── @ SymbolNode (location: (51,0)-(51,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (51,0)-(51,1) = ":"
         │   ├── value_loc: (51,1)-(51,3) = "do"
         │   ├── closing_loc: ∅
         │   └── unescaped: "do"
         ├── @ SymbolNode (location: (53,0)-(53,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (53,0)-(53,1) = ":"
         │   ├── value_loc: (53,1)-(53,2) = "&"
         │   ├── closing_loc: ∅
         │   └── unescaped: "&"
         ├── @ SymbolNode (location: (55,0)-(55,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (55,0)-(55,1) = ":"
         │   ├── value_loc: (55,1)-(55,2) = "`"
         │   ├── closing_loc: ∅
         │   └── unescaped: "`"
         ├── @ SymbolNode (location: (57,0)-(57,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (57,0)-(57,1) = ":"
         │   ├── value_loc: (57,1)-(57,3) = "!@"
         │   ├── closing_loc: ∅
         │   └── unescaped: "!"
         ├── @ SymbolNode (location: (59,0)-(59,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (59,0)-(59,1) = ":"
         │   ├── value_loc: (59,1)-(59,3) = "!~"
         │   ├── closing_loc: ∅
         │   └── unescaped: "!~"
         ├── @ SymbolNode (location: (61,0)-(61,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (61,0)-(61,1) = ":"
         │   ├── value_loc: (61,1)-(61,2) = "!"
         │   ├── closing_loc: ∅
         │   └── unescaped: "!"
         ├── @ SymbolNode (location: (63,0)-(63,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (63,0)-(63,1) = ":"
         │   ├── value_loc: (63,1)-(63,3) = "[]"
         │   ├── closing_loc: ∅
         │   └── unescaped: "[]"
         ├── @ SymbolNode (location: (65,0)-(65,4))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (65,0)-(65,1) = ":"
         │   ├── value_loc: (65,1)-(65,4) = "[]="
         │   ├── closing_loc: ∅
         │   └── unescaped: "[]="
         ├── @ SymbolNode (location: (67,0)-(67,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (67,0)-(67,1) = ":"
         │   ├── value_loc: (67,1)-(67,2) = "^"
         │   ├── closing_loc: ∅
         │   └── unescaped: "^"
         ├── @ SymbolNode (location: (69,0)-(69,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (69,0)-(69,1) = ":"
         │   ├── value_loc: (69,1)-(69,3) = "=="
         │   ├── closing_loc: ∅
         │   └── unescaped: "=="
         ├── @ SymbolNode (location: (71,0)-(71,4))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (71,0)-(71,1) = ":"
         │   ├── value_loc: (71,1)-(71,4) = "==="
         │   ├── closing_loc: ∅
         │   └── unescaped: "==="
         ├── @ SymbolNode (location: (73,0)-(73,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (73,0)-(73,1) = ":"
         │   ├── value_loc: (73,1)-(73,3) = "=~"
         │   ├── closing_loc: ∅
         │   └── unescaped: "=~"
         ├── @ SymbolNode (location: (75,0)-(75,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (75,0)-(75,1) = ":"
         │   ├── value_loc: (75,1)-(75,3) = ">="
         │   ├── closing_loc: ∅
         │   └── unescaped: ">="
         ├── @ SymbolNode (location: (77,0)-(77,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (77,0)-(77,1) = ":"
         │   ├── value_loc: (77,1)-(77,3) = ">>"
         │   ├── closing_loc: ∅
         │   └── unescaped: ">>"
         ├── @ SymbolNode (location: (79,0)-(79,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (79,0)-(79,1) = ":"
         │   ├── value_loc: (79,1)-(79,2) = ">"
         │   ├── closing_loc: ∅
         │   └── unescaped: ">"
         ├── @ SymbolNode (location: (81,0)-(81,4))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (81,0)-(81,1) = ":"
         │   ├── value_loc: (81,1)-(81,4) = "<=>"
         │   ├── closing_loc: ∅
         │   └── unescaped: "<=>"
         ├── @ SymbolNode (location: (83,0)-(83,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (83,0)-(83,1) = ":"
         │   ├── value_loc: (83,1)-(83,3) = "<="
         │   ├── closing_loc: ∅
         │   └── unescaped: "<="
         ├── @ SymbolNode (location: (85,0)-(85,3))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (85,0)-(85,1) = ":"
         │   ├── value_loc: (85,1)-(85,3) = "<<"
         │   ├── closing_loc: ∅
         │   └── unescaped: "<<"
         ├── @ SymbolNode (location: (87,0)-(87,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (87,0)-(87,1) = ":"
         │   ├── value_loc: (87,1)-(87,2) = "<"
         │   ├── closing_loc: ∅
         │   └── unescaped: "<"
         ├── @ SymbolNode (location: (89,0)-(89,9))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (89,0)-(89,1) = ":"
         │   ├── value_loc: (89,1)-(89,9) = "__LINE__"
         │   ├── closing_loc: ∅
         │   └── unescaped: "__LINE__"
         ├── @ SymbolNode (location: (91,0)-(91,9))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (91,0)-(91,1) = ":"
         │   ├── value_loc: (91,1)-(91,9) = "__FILE__"
         │   ├── closing_loc: ∅
         │   └── unescaped: "__FILE__"
         └── @ SymbolNode (location: (93,0)-(93,13))
-            ├── flags: ∅
+            ├── flags: forced_us_ascii_encoding
             ├── opening_loc: (93,0)-(93,1) = ":"
             ├── value_loc: (93,1)-(93,13) = "__ENCODING__"
             ├── closing_loc: ∅

--- a/test/prism/snapshots/undef.txt
+++ b/test/prism/snapshots/undef.txt
@@ -39,7 +39,7 @@
         ├── @ UndefNode (location: (7,0)-(7,9))
         │   ├── names: (length: 1)
         │   │   └── @ SymbolNode (location: (7,6)-(7,9))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (7,6)-(7,9) = "<=>"
         │   │       ├── closing_loc: ∅
@@ -48,7 +48,7 @@
         ├── @ UndefNode (location: (9,0)-(9,8))
         │   ├── names: (length: 1)
         │   │   └── @ SymbolNode (location: (9,6)-(9,8))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: (9,6)-(9,7) = ":"
         │   │       ├── value_loc: (9,7)-(9,8) = "a"
         │   │       ├── closing_loc: ∅
@@ -57,19 +57,19 @@
         ├── @ UndefNode (location: (11,0)-(11,16))
         │   ├── names: (length: 3)
         │   │   ├── @ SymbolNode (location: (11,6)-(11,8))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (11,6)-(11,7) = ":"
         │   │   │   ├── value_loc: (11,7)-(11,8) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   ├── @ SymbolNode (location: (11,10)-(11,12))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: (11,10)-(11,11) = ":"
         │   │   │   ├── value_loc: (11,11)-(11,12) = "b"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "b"
         │   │   └── @ SymbolNode (location: (11,14)-(11,16))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: (11,14)-(11,15) = ":"
         │   │       ├── value_loc: (11,15)-(11,16) = "c"
         │   │       ├── closing_loc: ∅
@@ -78,7 +78,7 @@
         ├── @ UndefNode (location: (13,0)-(13,12))
         │   ├── names: (length: 1)
         │   │   └── @ SymbolNode (location: (13,6)-(13,12))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: (13,6)-(13,8) = ":'"
         │   │       ├── value_loc: (13,8)-(13,11) = "abc"
         │   │       ├── closing_loc: (13,11)-(13,12) = "'"

--- a/test/prism/snapshots/unless.txt
+++ b/test/prism/snapshots/unless.txt
@@ -115,13 +115,13 @@
             │           │   ├── flags: ∅
             │           │   └── arguments: (length: 2)
             │           │       ├── @ SymbolNode (location: (14,4)-(14,6))
-            │           │       │   ├── flags: ∅
+            │           │       │   ├── flags: forced_us_ascii_encoding
             │           │       │   ├── opening_loc: (14,4)-(14,5) = ":"
             │           │       │   ├── value_loc: (14,5)-(14,6) = "a"
             │           │       │   ├── closing_loc: ∅
             │           │       │   └── unescaped: "a"
             │           │       └── @ SymbolNode (location: (14,8)-(14,10))
-            │           │           ├── flags: ∅
+            │           │           ├── flags: forced_us_ascii_encoding
             │           │           ├── opening_loc: (14,8)-(14,9) = ":"
             │           │           ├── value_loc: (14,9)-(14,10) = "b"
             │           │           ├── closing_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/alias.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/alias.txt
@@ -14,14 +14,14 @@
         └── @ AliasMethodNode (location: (2,0)-(2,15))
             ├── new_name:
             │   @ SymbolNode (location: (2,6)-(2,10))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (2,6)-(2,7) = ":"
             │   ├── value_loc: (2,7)-(2,10) = "foo"
             │   ├── closing_loc: ∅
             │   └── unescaped: "foo"
             ├── old_name:
             │   @ SymbolNode (location: (2,11)-(2,15))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (2,11)-(2,12) = ":"
             │   ├── value_loc: (2,12)-(2,15) = "bar"
             │   ├── closing_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/case.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/case.txt
@@ -225,7 +225,7 @@
         │   │           @ StatementsNode (location: (20,2)-(20,8))
         │   │           └── body: (length: 1)
         │   │               └── @ SymbolNode (location: (20,2)-(20,8))
-        │   │                   ├── flags: ∅
+        │   │                   ├── flags: forced_us_ascii_encoding
         │   │                   ├── opening_loc: (20,2)-(20,3) = ":"
         │   │                   ├── value_loc: (20,3)-(20,8) = "other"
         │   │                   ├── closing_loc: ∅
@@ -266,7 +266,7 @@
         │   │           @ StatementsNode (location: (24,2)-(24,8))
         │   │           └── body: (length: 1)
         │   │               └── @ SymbolNode (location: (24,2)-(24,8))
-        │   │                   ├── flags: ∅
+        │   │                   ├── flags: forced_us_ascii_encoding
         │   │                   ├── opening_loc: (24,2)-(24,3) = ":"
         │   │                   ├── value_loc: (24,3)-(24,8) = "value"
         │   │                   ├── closing_loc: ∅
@@ -320,7 +320,7 @@
         │   │   │   @ StatementsNode (location: (30,2)-(30,6))
         │   │   │   └── body: (length: 1)
         │   │   │       └── @ SymbolNode (location: (30,2)-(30,6))
-        │   │   │           ├── flags: ∅
+        │   │   │           ├── flags: forced_us_ascii_encoding
         │   │   │           ├── opening_loc: (30,2)-(30,3) = ":"
         │   │   │           ├── value_loc: (30,3)-(30,6) = "foo"
         │   │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/class.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/class.txt
@@ -202,7 +202,7 @@
         │   │           │   @ StatementsNode (location: (30,4)-(30,8))
         │   │           │   └── body: (length: 1)
         │   │           │       └── @ SymbolNode (location: (30,4)-(30,8))
-        │   │           │           ├── flags: ∅
+        │   │           │           ├── flags: forced_us_ascii_encoding
         │   │           │           ├── opening_loc: (30,4)-(30,5) = ":"
         │   │           │           ├── value_loc: (30,5)-(30,8) = "bar"
         │   │           │           ├── closing_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/if.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/if.txt
@@ -268,7 +268,7 @@
             │       │   ├── name_loc: (34,2)-(34,6) = "pair"
             │       │   ├── value:
             │       │   │   @ SymbolNode (location: (34,9)-(34,13))
-            │       │   │   ├── flags: ∅
+            │       │   │   ├── flags: forced_us_ascii_encoding
             │       │   │   ├── opening_loc: (34,9)-(34,10) = ":"
             │       │   │   ├── value_loc: (34,10)-(34,13) = "foo"
             │       │   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/kwbegin.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/kwbegin.txt
@@ -479,7 +479,7 @@
             │           │   @ UndefNode (location: (79,2)-(79,12))
             │           │   ├── names: (length: 1)
             │           │   │   └── @ SymbolNode (location: (79,8)-(79,12))
-            │           │   │       ├── flags: ∅
+            │           │   │       ├── flags: forced_us_ascii_encoding
             │           │   │       ├── opening_loc: (79,8)-(79,9) = ":"
             │           │   │       ├── value_loc: (79,9)-(79,12) = "bar"
             │           │   │       ├── closing_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/literal.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/literal.txt
@@ -46,7 +46,7 @@
         │   │       │   └── unescaped: "bar"
         │   │       ├── value:
         │   │       │   @ SymbolNode (location: (1,32)-(1,36))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (1,32)-(1,33) = ":"
         │   │       │   ├── value_loc: (1,33)-(1,36) = "baz"
         │   │       │   ├── closing_loc: ∅
@@ -82,7 +82,7 @@
         │   │       │   └── unescaped: "bar"
         │   │       ├── value:
         │   │       │   @ SymbolNode (location: (4,25)-(4,29))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (4,25)-(4,26) = ":"
         │   │       │   ├── value_loc: (4,26)-(4,29) = "baz"
         │   │       │   ├── closing_loc: ∅
@@ -516,31 +516,31 @@
         │   ├── closing_loc: (42,2)-(42,3) = "`"
         │   └── unescaped: "\""
         ├── @ SymbolNode (location: (43,0)-(43,4))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (43,0)-(43,1) = ":"
         │   ├── value_loc: (43,1)-(43,4) = "foo"
         │   ├── closing_loc: ∅
         │   └── unescaped: "foo"
         ├── @ SymbolNode (location: (44,0)-(44,6))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (44,0)-(44,2) = ":\""
         │   ├── value_loc: (44,2)-(44,5) = "A B"
         │   ├── closing_loc: (44,5)-(44,6) = "\""
         │   └── unescaped: "A B"
         ├── @ SymbolNode (location: (45,0)-(45,4))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (45,0)-(45,1) = ":"
         │   ├── value_loc: (45,1)-(45,4) = "foo"
         │   ├── closing_loc: ∅
         │   └── unescaped: "foo"
         ├── @ SymbolNode (location: (46,0)-(46,6))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (46,0)-(46,2) = ":\""
         │   ├── value_loc: (46,2)-(46,5) = "A B"
         │   ├── closing_loc: (46,5)-(46,6) = "\""
         │   └── unescaped: "A B"
         ├── @ SymbolNode (location: (47,0)-(47,7))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (47,0)-(47,2) = ":\""
         │   ├── value_loc: (47,2)-(47,6) = "A\\\"B"
         │   ├── closing_loc: (47,6)-(47,7) = "\""
@@ -915,7 +915,7 @@
         │   │   ├── @ AssocNode (location: (76,2)-(76,19))
         │   │   │   ├── key:
         │   │   │   │   @ SymbolNode (location: (76,2)-(76,4))
-        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── value_loc: (76,2)-(76,3) = "a"
         │   │   │   │   ├── closing_loc: (76,3)-(76,4) = ":"
@@ -947,7 +947,7 @@
         │   │   └── @ AssocNode (location: (76,21)-(76,25))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (76,21)-(76,23))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: ∅
         │   │       │   ├── value_loc: (76,21)-(76,22) = "b"
         │   │       │   ├── closing_loc: (76,22)-(76,23) = ":"
@@ -963,7 +963,7 @@
         │   │   ├── @ AssocNode (location: (77,2)-(77,6))
         │   │   │   ├── key:
         │   │   │   │   @ SymbolNode (location: (77,2)-(77,4))
-        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── value_loc: (77,2)-(77,3) = "a"
         │   │   │   │   ├── closing_loc: (77,3)-(77,4) = ":"
@@ -975,7 +975,7 @@
         │   │   └── @ AssocNode (location: (77,8)-(77,12))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (77,8)-(77,10))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: ∅
         │   │       │   ├── value_loc: (77,8)-(77,9) = "b"
         │   │       │   ├── closing_loc: (77,9)-(77,10) = ":"
@@ -991,14 +991,14 @@
         │   │   └── @ AssocNode (location: (78,2)-(78,7))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (78,2)-(78,4))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: ∅
         │   │       │   ├── value_loc: (78,2)-(78,3) = "a"
         │   │       │   ├── closing_loc: (78,3)-(78,4) = ":"
         │   │       │   └── unescaped: "a"
         │   │       ├── value:
         │   │       │   @ SymbolNode (location: (78,5)-(78,7))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (78,5)-(78,6) = ":"
         │   │       │   ├── value_loc: (78,6)-(78,7) = "a"
         │   │       │   ├── closing_loc: ∅
@@ -1011,7 +1011,7 @@
         │   │   └── @ AssocNode (location: (79,2)-(79,13))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (79,2)-(79,8))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (79,2)-(79,4) = ":\""
         │   │       │   ├── value_loc: (79,4)-(79,7) = "a b"
         │   │       │   ├── closing_loc: (79,7)-(79,8) = "\""
@@ -1027,7 +1027,7 @@
         │   │   └── @ AssocNode (location: (80,2)-(80,10))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (80,2)-(80,5))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (80,2)-(80,3) = ":"
         │   │       │   ├── value_loc: (80,3)-(80,5) = "-@"
         │   │       │   ├── closing_loc: ∅
@@ -1105,7 +1105,7 @@
         │       ├── opening_loc: (83,4)-(83,5) = "{"
         │       └── closing_loc: (86,0)-(86,1) = "}"
         ├── @ SymbolNode (location: (87,0)-(88,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (87,0)-(87,2) = ":\""
         │   ├── value_loc: (87,2)-(88,1) = "a\\\\\nb"
         │   ├── closing_loc: (88,1)-(88,2) = "\""

--- a/test/prism/snapshots/unparser/corpus/literal/module.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/module.txt
@@ -91,7 +91,7 @@
             │           │   @ StatementsNode (location: (14,4)-(14,8))
             │           │   └── body: (length: 1)
             │           │       └── @ SymbolNode (location: (14,4)-(14,8))
-            │           │           ├── flags: ∅
+            │           │           ├── flags: forced_us_ascii_encoding
             │           │           ├── opening_loc: (14,4)-(14,5) = ":"
             │           │           ├── value_loc: (14,5)-(14,8) = "bar"
             │           │           ├── closing_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/pattern.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/pattern.txt
@@ -84,7 +84,7 @@
         │   │   │   │   │   └── @ AssocNode (location: (6,5)-(6,7))
         │   │   │   │   │       ├── key:
         │   │   │   │   │       │   @ SymbolNode (location: (6,5)-(6,7))
-        │   │   │   │   │       │   ├── flags: ∅
+        │   │   │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │   │   │       │   ├── opening_loc: ∅
         │   │   │   │   │       │   ├── value_loc: (6,5)-(6,6) = "x"
         │   │   │   │   │       │   ├── closing_loc: (6,6)-(6,7) = ":"
@@ -176,7 +176,7 @@
         │   │   │   │   │   ├── @ AssocNode (location: (14,4)-(14,8))
         │   │   │   │   │   │   ├── key:
         │   │   │   │   │   │   │   @ SymbolNode (location: (14,4)-(14,6))
-        │   │   │   │   │   │   │   ├── flags: ∅
+        │   │   │   │   │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   │   │   │   ├── value_loc: (14,4)-(14,5) = "a"
         │   │   │   │   │   │   │   ├── closing_loc: (14,5)-(14,6) = ":"
@@ -188,7 +188,7 @@
         │   │   │   │   │   └── @ AssocNode (location: (14,10)-(14,15))
         │   │   │   │   │       ├── key:
         │   │   │   │   │       │   @ SymbolNode (location: (14,10)-(14,13))
-        │   │   │   │   │       │   ├── flags: ∅
+        │   │   │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │   │   │       │   ├── opening_loc: ∅
         │   │   │   │   │       │   ├── value_loc: (14,10)-(14,12) = "aa"
         │   │   │   │   │       │   ├── closing_loc: (14,12)-(14,13) = ":"
@@ -245,7 +245,7 @@
         │   │   │   │   │   └── @ AssocNode (location: (20,4)-(20,10))
         │   │   │   │   │       ├── key:
         │   │   │   │   │       │   @ SymbolNode (location: (20,4)-(20,8))
-        │   │   │   │   │       │   ├── flags: ∅
+        │   │   │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │   │   │       │   ├── opening_loc: (20,4)-(20,5) = "\""
         │   │   │   │   │       │   ├── value_loc: (20,5)-(20,6) = "a"
         │   │   │   │   │       │   ├── closing_loc: (20,6)-(20,8) = "\":"

--- a/test/prism/snapshots/unparser/corpus/literal/send.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/send.txt
@@ -170,7 +170,7 @@
         │   │   │   │       │   ├── equal_loc: ∅
         │   │   │   │       │   └── end_keyword_loc: (17,0)-(17,3) = "end"
         │   │   │   │       └── @ SymbolNode (location: (17,5)-(17,9))
-        │   │   │   │           ├── flags: ∅
+        │   │   │   │           ├── flags: forced_us_ascii_encoding
         │   │   │   │           ├── opening_loc: (17,5)-(17,6) = ":"
         │   │   │   │           ├── value_loc: (17,6)-(17,9) = "bar"
         │   │   │   │           ├── closing_loc: ∅
@@ -440,7 +440,7 @@
         │   │   │           │   ├── flags: ∅
         │   │   │           │   └── arguments: (length: 1)
         │   │   │           │       └── @ SymbolNode (location: (37,10)-(37,14))
-        │   │   │           │           ├── flags: ∅
+        │   │   │           │           ├── flags: forced_us_ascii_encoding
         │   │   │           │           ├── opening_loc: (37,10)-(37,11) = ":"
         │   │   │           │           ├── value_loc: (37,11)-(37,14) = "foo"
         │   │   │           │           ├── closing_loc: ∅
@@ -544,7 +544,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ SymbolNode (location: (40,9)-(40,13))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (40,9)-(40,10) = ":"
         │   │           ├── value_loc: (40,10)-(40,13) = "foo"
         │   │           ├── closing_loc: ∅
@@ -1207,7 +1207,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ SymbolNode (location: (62,8)-(62,12))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (62,8)-(62,9) = ":"
         │   │           ├── value_loc: (62,9)-(62,12) = "baz"
         │   │           ├── closing_loc: ∅
@@ -1254,7 +1254,7 @@
         │   │               └── @ AssocNode (location: (63,8)-(63,16))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (63,8)-(63,12))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (63,8)-(63,11) = "baz"
         │   │                   │   ├── closing_loc: (63,11)-(63,12) = ":"
@@ -1498,7 +1498,7 @@
         │   │       │   │   └── @ AssocNode (location: (68,10)-(68,18))
         │   │       │   │       ├── key:
         │   │       │   │       │   @ SymbolNode (location: (68,10)-(68,14))
-        │   │       │   │       │   ├── flags: ∅
+        │   │       │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   │       │   ├── opening_loc: ∅
         │   │       │   │       │   ├── value_loc: (68,10)-(68,13) = "foo"
         │   │       │   │       │   ├── closing_loc: (68,13)-(68,14) = ":"
@@ -1550,7 +1550,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ SymbolNode (location: (69,8)-(69,12))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (69,8)-(69,9) = ":"
         │   │           ├── value_loc: (69,9)-(69,12) = "baz"
         │   │           ├── closing_loc: ∅
@@ -1574,7 +1574,7 @@
         │   │               └── @ AssocNode (location: (70,4)-(70,8))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (70,4)-(70,6))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (70,4)-(70,5) = "a"
         │   │                   │   ├── closing_loc: (70,5)-(70,6) = ":"
@@ -1620,7 +1620,7 @@
         │   │               └── @ AssocNode (location: (71,6)-(71,10))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (71,6)-(71,8))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (71,6)-(71,7) = "a"
         │   │                   │   ├── closing_loc: (71,7)-(71,8) = ":"
@@ -1785,7 +1785,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ SymbolNode (location: (77,9)-(77,13))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (77,9)-(77,10) = ":"
         │   │           ├── value_loc: (77,10)-(77,13) = "bar"
         │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/undef.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/undef.txt
@@ -6,7 +6,7 @@
         ├── @ UndefNode (location: (1,0)-(1,10))
         │   ├── names: (length: 1)
         │   │   └── @ SymbolNode (location: (1,6)-(1,10))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: (1,6)-(1,7) = ":"
         │   │       ├── value_loc: (1,7)-(1,10) = "foo"
         │   │       ├── closing_loc: ∅
@@ -15,13 +15,13 @@
         └── @ UndefNode (location: (2,0)-(2,16))
             ├── names: (length: 2)
             │   ├── @ SymbolNode (location: (2,6)-(2,10))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: (2,6)-(2,7) = ":"
             │   │   ├── value_loc: (2,7)-(2,10) = "foo"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "foo"
             │   └── @ SymbolNode (location: (2,12)-(2,16))
-            │       ├── flags: ∅
+            │       ├── flags: forced_us_ascii_encoding
             │       ├── opening_loc: (2,12)-(2,13) = ":"
             │       ├── value_loc: (2,13)-(2,16) = "bar"
             │       ├── closing_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/while.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/while.txt
@@ -646,7 +646,7 @@
         │       @ StatementsNode (location: (63,2)-(63,7))
         │       └── body: (length: 1)
         │           └── @ SymbolNode (location: (63,2)-(63,7))
-        │               ├── flags: ∅
+        │               ├── flags: forced_us_ascii_encoding
         │               ├── opening_loc: (63,2)-(63,3) = ":"
         │               ├── value_loc: (63,3)-(63,7) = "body"
         │               ├── closing_loc: ∅
@@ -701,7 +701,7 @@
                 @ StatementsNode (location: (72,2)-(72,7))
                 └── body: (length: 1)
                     └── @ SymbolNode (location: (72,2)-(72,7))
-                        ├── flags: ∅
+                        ├── flags: forced_us_ascii_encoding
                         ├── opening_loc: (72,2)-(72,3) = ":"
                         ├── value_loc: (72,3)-(72,7) = "body"
                         ├── closing_loc: ∅

--- a/test/prism/snapshots/until.txt
+++ b/test/prism/snapshots/until.txt
@@ -91,13 +91,13 @@
         │               │   ├── flags: ∅
         │               │   └── arguments: (length: 2)
         │               │       ├── @ SymbolNode (location: (11,4)-(11,6))
-        │               │       │   ├── flags: ∅
+        │               │       │   ├── flags: forced_us_ascii_encoding
         │               │       │   ├── opening_loc: (11,4)-(11,5) = ":"
         │               │       │   ├── value_loc: (11,5)-(11,6) = "a"
         │               │       │   ├── closing_loc: ∅
         │               │       │   └── unescaped: "a"
         │               │       └── @ SymbolNode (location: (11,8)-(11,10))
-        │               │           ├── flags: ∅
+        │               │           ├── flags: forced_us_ascii_encoding
         │               │           ├── opening_loc: (11,8)-(11,9) = ":"
         │               │           ├── value_loc: (11,9)-(11,10) = "b"
         │               │           ├── closing_loc: ∅

--- a/test/prism/snapshots/while.txt
+++ b/test/prism/snapshots/while.txt
@@ -91,13 +91,13 @@
         │               │   ├── flags: ∅
         │               │   └── arguments: (length: 2)
         │               │       ├── @ SymbolNode (location: (11,4)-(11,6))
-        │               │       │   ├── flags: ∅
+        │               │       │   ├── flags: forced_us_ascii_encoding
         │               │       │   ├── opening_loc: (11,4)-(11,5) = ":"
         │               │       │   ├── value_loc: (11,5)-(11,6) = "a"
         │               │       │   ├── closing_loc: ∅
         │               │       │   └── unescaped: "a"
         │               │       └── @ SymbolNode (location: (11,8)-(11,10))
-        │               │           ├── flags: ∅
+        │               │           ├── flags: forced_us_ascii_encoding
         │               │           ├── opening_loc: (11,8)-(11,9) = ":"
         │               │           ├── value_loc: (11,9)-(11,10) = "b"
         │               │           ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/alias.txt
+++ b/test/prism/snapshots/whitequark/alias.txt
@@ -6,14 +6,14 @@
         └── @ AliasMethodNode (location: (1,0)-(1,14))
             ├── new_name:
             │   @ SymbolNode (location: (1,6)-(1,10))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: (1,6)-(1,7) = ":"
             │   ├── value_loc: (1,7)-(1,10) = "foo"
             │   ├── closing_loc: ∅
             │   └── unescaped: "foo"
             ├── old_name:
             │   @ SymbolNode (location: (1,11)-(1,14))
-            │   ├── flags: ∅
+            │   ├── flags: forced_us_ascii_encoding
             │   ├── opening_loc: ∅
             │   ├── value_loc: (1,11)-(1,14) = "bar"
             │   ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/arg_label.txt
+++ b/test/prism/snapshots/whitequark/arg_label.txt
@@ -23,7 +23,7 @@
         │   │           │   ├── flags: ∅
         │   │           │   └── arguments: (length: 1)
         │   │           │       └── @ SymbolNode (location: (2,2)-(2,4))
-        │   │           │           ├── flags: ∅
+        │   │           │           ├── flags: forced_us_ascii_encoding
         │   │           │           ├── opening_loc: (2,2)-(2,3) = ":"
         │   │           │           ├── value_loc: (2,3)-(2,4) = "b"
         │   │           │           ├── closing_loc: ∅
@@ -58,7 +58,7 @@
         │   │           │   ├── flags: ∅
         │   │           │   └── arguments: (length: 1)
         │   │           │       └── @ SymbolNode (location: (4,11)-(4,13))
-        │   │           │           ├── flags: ∅
+        │   │           │           ├── flags: forced_us_ascii_encoding
         │   │           │           ├── opening_loc: (4,11)-(4,12) = ":"
         │   │           │           ├── value_loc: (4,12)-(4,13) = "b"
         │   │           │           ├── closing_loc: ∅
@@ -107,7 +107,7 @@
                 │           │   ├── flags: ∅
                 │           │   └── arguments: (length: 1)
                 │           │       └── @ SymbolNode (location: (6,8)-(6,10))
-                │           │           ├── flags: ∅
+                │           │           ├── flags: forced_us_ascii_encoding
                 │           │           ├── opening_loc: (6,8)-(6,9) = ":"
                 │           │           ├── value_loc: (6,9)-(6,10) = "b"
                 │           │           ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/args_args_assocs.txt
+++ b/test/prism/snapshots/whitequark/args_args_assocs.txt
@@ -30,7 +30,7 @@
         │   │               └── @ AssocNode (location: (1,9)-(1,18))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (1,9)-(1,13))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (1,9)-(1,10) = ":"
         │   │                   │   ├── value_loc: (1,10)-(1,13) = "foo"
         │   │                   │   ├── closing_loc: ∅
@@ -68,7 +68,7 @@
             │               └── @ AssocNode (location: (3,9)-(3,18))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (3,9)-(3,13))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: (3,9)-(3,10) = ":"
             │                   │   ├── value_loc: (3,10)-(3,13) = "foo"
             │                   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/args_args_assocs_comma.txt
+++ b/test/prism/snapshots/whitequark/args_args_assocs_comma.txt
@@ -40,7 +40,7 @@
             │               └── @ AssocNode (location: (1,9)-(1,18))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (1,9)-(1,13))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: (1,9)-(1,10) = ":"
             │                   │   ├── value_loc: (1,10)-(1,13) = "baz"
             │                   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/args_assocs.txt
+++ b/test/prism/snapshots/whitequark/args_assocs.txt
@@ -20,7 +20,7 @@
         │   │               └── @ AssocNode (location: (1,4)-(1,13))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (1,4)-(1,8))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (1,4)-(1,5) = ":"
         │   │                   │   ├── value_loc: (1,5)-(1,8) = "foo"
         │   │                   │   ├── closing_loc: ∅
@@ -48,7 +48,7 @@
         │   │               └── @ AssocNode (location: (3,4)-(3,13))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (3,4)-(3,8))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (3,4)-(3,5) = ":"
         │   │                   │   ├── value_loc: (3,5)-(3,8) = "foo"
         │   │                   │   ├── closing_loc: ∅
@@ -100,7 +100,7 @@
         │   │               └── @ AssocNode (location: (5,14)-(5,21))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (5,14)-(5,16))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (5,14)-(5,15) = ":"
         │   │                   │   ├── value_loc: (5,15)-(5,16) = "a"
         │   │                   │   ├── closing_loc: ∅
@@ -129,7 +129,7 @@
         │   │               └── @ AssocNode (location: (7,5)-(7,14))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (7,5)-(7,9))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (7,5)-(7,6) = ":"
         │   │                   │   ├── value_loc: (7,6)-(7,9) = "bar"
         │   │                   │   ├── closing_loc: ∅
@@ -153,7 +153,7 @@
         │   │               └── @ AssocNode (location: (9,6)-(9,16))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (9,6)-(9,10))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (9,6)-(9,7) = ":"
         │   │                   │   ├── value_loc: (9,7)-(9,10) = "foo"
         │   │                   │   ├── closing_loc: ∅
@@ -177,7 +177,7 @@
             │               └── @ AssocNode (location: (11,6)-(11,16))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (11,6)-(11,10))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: (11,6)-(11,7) = ":"
             │                   │   ├── value_loc: (11,7)-(11,10) = "foo"
             │                   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/args_assocs_comma.txt
+++ b/test/prism/snapshots/whitequark/args_assocs_comma.txt
@@ -30,7 +30,7 @@
             │               └── @ AssocNode (location: (1,4)-(1,13))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (1,4)-(1,8))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: (1,4)-(1,5) = ":"
             │                   │   ├── value_loc: (1,5)-(1,8) = "baz"
             │                   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/args_assocs_legacy.txt
+++ b/test/prism/snapshots/whitequark/args_assocs_legacy.txt
@@ -20,7 +20,7 @@
         │   │               └── @ AssocNode (location: (1,4)-(1,13))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (1,4)-(1,8))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (1,4)-(1,5) = ":"
         │   │                   │   ├── value_loc: (1,5)-(1,8) = "foo"
         │   │                   │   ├── closing_loc: ∅
@@ -48,7 +48,7 @@
         │   │               └── @ AssocNode (location: (3,4)-(3,13))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (3,4)-(3,8))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (3,4)-(3,5) = ":"
         │   │                   │   ├── value_loc: (3,5)-(3,8) = "foo"
         │   │                   │   ├── closing_loc: ∅
@@ -100,7 +100,7 @@
         │   │               └── @ AssocNode (location: (5,14)-(5,21))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (5,14)-(5,16))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (5,14)-(5,15) = ":"
         │   │                   │   ├── value_loc: (5,15)-(5,16) = "a"
         │   │                   │   ├── closing_loc: ∅
@@ -129,7 +129,7 @@
         │   │               └── @ AssocNode (location: (7,5)-(7,14))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (7,5)-(7,9))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (7,5)-(7,6) = ":"
         │   │                   │   ├── value_loc: (7,6)-(7,9) = "bar"
         │   │                   │   ├── closing_loc: ∅
@@ -153,7 +153,7 @@
         │   │               └── @ AssocNode (location: (9,6)-(9,16))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (9,6)-(9,10))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (9,6)-(9,7) = ":"
         │   │                   │   ├── value_loc: (9,7)-(9,10) = "foo"
         │   │                   │   ├── closing_loc: ∅
@@ -177,7 +177,7 @@
             │               └── @ AssocNode (location: (11,6)-(11,16))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (11,6)-(11,10))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: (11,6)-(11,7) = ":"
             │                   │   ├── value_loc: (11,7)-(11,10) = "foo"
             │                   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/array_symbols.txt
+++ b/test/prism/snapshots/whitequark/array_symbols.txt
@@ -7,13 +7,13 @@
             ├── flags: ∅
             ├── elements: (length: 2)
             │   ├── @ SymbolNode (location: (1,3)-(1,6))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: ∅
             │   │   ├── value_loc: (1,3)-(1,6) = "foo"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "foo"
             │   └── @ SymbolNode (location: (1,7)-(1,10))
-            │       ├── flags: ∅
+            │       ├── flags: forced_us_ascii_encoding
             │       ├── opening_loc: ∅
             │       ├── value_loc: (1,7)-(1,10) = "bar"
             │       ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/array_symbols_interp.txt
+++ b/test/prism/snapshots/whitequark/array_symbols_interp.txt
@@ -7,7 +7,7 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 2)
         │   │   ├── @ SymbolNode (location: (1,3)-(1,6))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (1,3)-(1,6) = "foo"
         │   │   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/bug_cmdarg.txt
+++ b/test/prism/snapshots/whitequark/bug_cmdarg.txt
@@ -20,7 +20,7 @@
         │   │               └── @ AssocNode (location: (1,7)-(1,15))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (1,7)-(1,10))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (1,7)-(1,9) = "do"
         │   │                   │   ├── closing_loc: (1,9)-(1,10) = ":"
@@ -70,7 +70,7 @@
             │               └── @ AssocNode (location: (5,2)-(5,26))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (5,2)-(5,4))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: ∅
             │                   │   ├── value_loc: (5,2)-(5,3) = "x"
             │                   │   ├── closing_loc: (5,3)-(5,4) = ":"

--- a/test/prism/snapshots/whitequark/bug_do_block_in_hash_brace.txt
+++ b/test/prism/snapshots/whitequark/bug_do_block_in_hash_brace.txt
@@ -15,7 +15,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 2)
         │   │       ├── @ SymbolNode (location: (1,2)-(1,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (1,2)-(1,3) = ":"
         │   │       │   ├── value_loc: (1,3)-(1,6) = "foo"
         │   │       │   ├── closing_loc: ∅
@@ -26,7 +26,7 @@
         │   │           │   ├── @ AssocNode (location: (1,9)-(1,25))
         │   │           │   │   ├── key:
         │   │           │   │   │   @ SymbolNode (location: (1,9)-(1,13))
-        │   │           │   │   │   ├── flags: ∅
+        │   │           │   │   │   ├── flags: forced_us_ascii_encoding
         │   │           │   │   │   ├── opening_loc: (1,9)-(1,10) = "\""
         │   │           │   │   │   ├── value_loc: (1,10)-(1,11) = "a"
         │   │           │   │   │   ├── closing_loc: (1,11)-(1,13) = "\":"
@@ -53,7 +53,7 @@
         │   │           │   └── @ AssocNode (location: (1,27)-(1,41))
         │   │           │       ├── key:
         │   │           │       │   @ SymbolNode (location: (1,27)-(1,29))
-        │   │           │       │   ├── flags: ∅
+        │   │           │       │   ├── flags: forced_us_ascii_encoding
         │   │           │       │   ├── opening_loc: ∅
         │   │           │       │   ├── value_loc: (1,27)-(1,28) = "b"
         │   │           │       │   ├── closing_loc: (1,28)-(1,29) = ":"
@@ -92,7 +92,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 2)
         │   │       ├── @ SymbolNode (location: (3,2)-(3,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (3,2)-(3,3) = ":"
         │   │       │   ├── value_loc: (3,3)-(3,6) = "foo"
         │   │       │   ├── closing_loc: ∅
@@ -123,7 +123,7 @@
         │   │           │   └── @ AssocNode (location: (3,25)-(3,39))
         │   │           │       ├── key:
         │   │           │       │   @ SymbolNode (location: (3,25)-(3,27))
-        │   │           │       │   ├── flags: ∅
+        │   │           │       │   ├── flags: forced_us_ascii_encoding
         │   │           │       │   ├── opening_loc: ∅
         │   │           │       │   ├── value_loc: (3,25)-(3,26) = "b"
         │   │           │       │   ├── closing_loc: (3,26)-(3,27) = ":"
@@ -162,7 +162,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 2)
         │   │       ├── @ SymbolNode (location: (5,2)-(5,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (5,2)-(5,3) = ":"
         │   │       │   ├── value_loc: (5,3)-(5,6) = "foo"
         │   │       │   ├── closing_loc: ∅
@@ -173,7 +173,7 @@
         │   │           │   ├── @ AssocNode (location: (5,9)-(5,26))
         │   │           │   │   ├── key:
         │   │           │   │   │   @ SymbolNode (location: (5,9)-(5,11))
-        │   │           │   │   │   ├── flags: ∅
+        │   │           │   │   │   ├── flags: forced_us_ascii_encoding
         │   │           │   │   │   ├── opening_loc: (5,9)-(5,10) = ":"
         │   │           │   │   │   ├── value_loc: (5,10)-(5,11) = "a"
         │   │           │   │   │   ├── closing_loc: ∅
@@ -200,7 +200,7 @@
         │   │           │   └── @ AssocNode (location: (5,28)-(5,42))
         │   │           │       ├── key:
         │   │           │       │   @ SymbolNode (location: (5,28)-(5,30))
-        │   │           │       │   ├── flags: ∅
+        │   │           │       │   ├── flags: forced_us_ascii_encoding
         │   │           │       │   ├── opening_loc: ∅
         │   │           │       │   ├── value_loc: (5,28)-(5,29) = "b"
         │   │           │       │   ├── closing_loc: (5,29)-(5,30) = ":"
@@ -239,7 +239,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 2)
         │   │       ├── @ SymbolNode (location: (7,2)-(7,6))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (7,2)-(7,3) = ":"
         │   │       │   ├── value_loc: (7,3)-(7,6) = "foo"
         │   │       │   ├── closing_loc: ∅
@@ -250,7 +250,7 @@
         │   │           │   ├── @ AssocNode (location: (7,9)-(7,23))
         │   │           │   │   ├── key:
         │   │           │   │   │   @ SymbolNode (location: (7,9)-(7,11))
-        │   │           │   │   │   ├── flags: ∅
+        │   │           │   │   │   ├── flags: forced_us_ascii_encoding
         │   │           │   │   │   ├── opening_loc: ∅
         │   │           │   │   │   ├── value_loc: (7,9)-(7,10) = "a"
         │   │           │   │   │   ├── closing_loc: (7,10)-(7,11) = ":"
@@ -277,7 +277,7 @@
         │   │           │   └── @ AssocNode (location: (7,25)-(7,39))
         │   │           │       ├── key:
         │   │           │       │   @ SymbolNode (location: (7,25)-(7,27))
-        │   │           │       │   ├── flags: ∅
+        │   │           │       │   ├── flags: forced_us_ascii_encoding
         │   │           │       │   ├── opening_loc: ∅
         │   │           │       │   ├── value_loc: (7,25)-(7,26) = "b"
         │   │           │       │   ├── closing_loc: (7,26)-(7,27) = ":"
@@ -316,7 +316,7 @@
             │   ├── flags: ∅
             │   └── arguments: (length: 2)
             │       ├── @ SymbolNode (location: (9,2)-(9,6))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: (9,2)-(9,3) = ":"
             │       │   ├── value_loc: (9,3)-(9,6) = "foo"
             │       │   ├── closing_loc: ∅
@@ -365,7 +365,7 @@
             │           │   └── @ AssocNode (location: (9,37)-(9,51))
             │           │       ├── key:
             │           │       │   @ SymbolNode (location: (9,37)-(9,39))
-            │           │       │   ├── flags: ∅
+            │           │       │   ├── flags: forced_us_ascii_encoding
             │           │       │   ├── opening_loc: ∅
             │           │       │   ├── value_loc: (9,37)-(9,38) = "b"
             │           │       │   ├── closing_loc: (9,38)-(9,39) = ":"

--- a/test/prism/snapshots/whitequark/class_super_label.txt
+++ b/test/prism/snapshots/whitequark/class_super_label.txt
@@ -23,7 +23,7 @@
             │   │   ├── flags: ∅
             │   │   └── arguments: (length: 1)
             │   │       └── @ SymbolNode (location: (1,13)-(1,15))
-            │   │           ├── flags: ∅
+            │   │           ├── flags: forced_us_ascii_encoding
             │   │           ├── opening_loc: (1,13)-(1,14) = ":"
             │   │           ├── value_loc: (1,14)-(1,15) = "b"
             │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/forwarded_kwrestarg_with_additional_kwarg.txt
+++ b/test/prism/snapshots/whitequark/forwarded_kwrestarg_with_additional_kwarg.txt
@@ -44,7 +44,7 @@
             │           │               └── @ AssocNode (location: (1,21)-(1,35))
             │           │                   ├── key:
             │           │                   │   @ SymbolNode (location: (1,21)-(1,30))
-            │           │                   │   ├── flags: ∅
+            │           │                   │   ├── flags: forced_us_ascii_encoding
             │           │                   │   ├── opening_loc: ∅
             │           │                   │   ├── value_loc: (1,21)-(1,29) = "from_foo"
             │           │                   │   ├── closing_loc: (1,29)-(1,30) = ":"

--- a/test/prism/snapshots/whitequark/hash_hashrocket.txt
+++ b/test/prism/snapshots/whitequark/hash_hashrocket.txt
@@ -29,7 +29,7 @@
             │   └── @ AssocNode (location: (3,10)-(3,23))
             │       ├── key:
             │       │   @ SymbolNode (location: (3,10)-(3,14))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: (3,10)-(3,11) = ":"
             │       │   ├── value_loc: (3,11)-(3,14) = "foo"
             │       │   ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/hash_kwsplat.txt
+++ b/test/prism/snapshots/whitequark/hash_kwsplat.txt
@@ -9,7 +9,7 @@
             │   ├── @ AssocNode (location: (1,2)-(1,8))
             │   │   ├── key:
             │   │   │   @ SymbolNode (location: (1,2)-(1,6))
-            │   │   │   ├── flags: ∅
+            │   │   │   ├── flags: forced_us_ascii_encoding
             │   │   │   ├── opening_loc: ∅
             │   │   │   ├── value_loc: (1,2)-(1,5) = "foo"
             │   │   │   ├── closing_loc: (1,5)-(1,6) = ":"

--- a/test/prism/snapshots/whitequark/hash_label.txt
+++ b/test/prism/snapshots/whitequark/hash_label.txt
@@ -9,7 +9,7 @@
             │   └── @ AssocNode (location: (1,2)-(1,8))
             │       ├── key:
             │       │   @ SymbolNode (location: (1,2)-(1,6))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: ∅
             │       │   ├── value_loc: (1,2)-(1,5) = "foo"
             │       │   ├── closing_loc: (1,5)-(1,6) = ":"

--- a/test/prism/snapshots/whitequark/hash_label_end.txt
+++ b/test/prism/snapshots/whitequark/hash_label_end.txt
@@ -55,7 +55,7 @@
         │   │   └── @ AssocNode (location: (3,2)-(3,10))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (3,2)-(3,8))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: (3,2)-(3,3) = "'"
         │   │       │   ├── value_loc: (3,3)-(3,6) = "foo"
         │   │       │   ├── closing_loc: (3,6)-(3,8) = "':"
@@ -71,7 +71,7 @@
             │   ├── @ AssocNode (location: (5,2)-(5,10))
             │   │   ├── key:
             │   │   │   @ SymbolNode (location: (5,2)-(5,8))
-            │   │   │   ├── flags: ∅
+            │   │   │   ├── flags: forced_us_ascii_encoding
             │   │   │   ├── opening_loc: (5,2)-(5,3) = "'"
             │   │   │   ├── value_loc: (5,3)-(5,6) = "foo"
             │   │   │   ├── closing_loc: (5,6)-(5,8) = "':"
@@ -83,7 +83,7 @@
             │   └── @ AssocNode (location: (5,12)-(5,21))
             │       ├── key:
             │       │   @ SymbolNode (location: (5,12)-(5,18))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: (5,12)-(5,13) = "'"
             │       │   ├── value_loc: (5,13)-(5,16) = "bar"
             │       │   ├── closing_loc: (5,16)-(5,18) = "':"

--- a/test/prism/snapshots/whitequark/hash_pair_value_omission.txt
+++ b/test/prism/snapshots/whitequark/hash_pair_value_omission.txt
@@ -9,7 +9,7 @@
         │   │   └── @ AssocNode (location: (1,1)-(1,5))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (1,1)-(1,5))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: ∅
         │   │       │   ├── value_loc: (1,1)-(1,4) = "BAR"
         │   │       │   ├── closing_loc: (1,4)-(1,5) = ":"
@@ -27,7 +27,7 @@
         │   │   ├── @ AssocNode (location: (3,1)-(3,3))
         │   │   │   ├── key:
         │   │   │   │   @ SymbolNode (location: (3,1)-(3,3))
-        │   │   │   │   ├── flags: ∅
+        │   │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── value_loc: (3,1)-(3,2) = "a"
         │   │   │   │   ├── closing_loc: (3,2)-(3,3) = ":"
@@ -49,7 +49,7 @@
         │   │   └── @ AssocNode (location: (3,5)-(3,7))
         │   │       ├── key:
         │   │       │   @ SymbolNode (location: (3,5)-(3,7))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   ├── opening_loc: ∅
         │   │       │   ├── value_loc: (3,5)-(3,6) = "b"
         │   │       │   ├── closing_loc: (3,6)-(3,7) = ":"
@@ -75,7 +75,7 @@
             │   └── @ AssocNode (location: (5,1)-(5,6))
             │       ├── key:
             │       │   @ SymbolNode (location: (5,1)-(5,6))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: ∅
             │       │   ├── value_loc: (5,1)-(5,5) = "puts"
             │       │   ├── closing_loc: (5,5)-(5,6) = ":"

--- a/test/prism/snapshots/whitequark/interp_digit_var.txt
+++ b/test/prism/snapshots/whitequark/interp_digit_var.txt
@@ -19,7 +19,7 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 1)
         │   │   └── @ SymbolNode (location: (5,4)-(5,7))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (5,4)-(5,7) = "\#@1"
         │   │       ├── closing_loc: ∅
@@ -30,7 +30,7 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 1)
         │   │   └── @ SymbolNode (location: (7,4)-(7,8))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (7,4)-(7,8) = "\#@@1"
         │   │       ├── closing_loc: ∅
@@ -75,7 +75,7 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 1)
         │   │   └── @ SymbolNode (location: (17,5)-(17,8))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (17,5)-(17,8) = "\#@1"
         │   │       ├── closing_loc: ∅
@@ -86,7 +86,7 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 1)
         │   │   └── @ SymbolNode (location: (19,5)-(19,9))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (19,5)-(19,9) = "\#@@1"
         │   │       ├── closing_loc: ∅
@@ -118,13 +118,13 @@
         │   ├── closing_loc: (27,8)-(27,9) = "}"
         │   └── unescaped: "\#@@1"
         ├── @ SymbolNode (location: (29,1)-(29,8))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (29,1)-(29,4) = "%s{"
         │   ├── value_loc: (29,4)-(29,7) = "\#@1"
         │   ├── closing_loc: (29,7)-(29,8) = "}"
         │   └── unescaped: "\#@1"
         ├── @ SymbolNode (location: (31,1)-(31,9))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (31,1)-(31,4) = "%s{"
         │   ├── value_loc: (31,4)-(31,8) = "\#@@1"
         │   ├── closing_loc: (31,8)-(31,9) = "}"
@@ -200,25 +200,25 @@
         │   ├── closing_loc: (51,6)-(51,7) = "/"
         │   └── unescaped: "\#@@1"
         ├── @ SymbolNode (location: (53,1)-(53,7))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (53,1)-(53,3) = ":\""
         │   ├── value_loc: (53,3)-(53,6) = "\#@1"
         │   ├── closing_loc: (53,6)-(53,7) = "\""
         │   └── unescaped: "\#@1"
         ├── @ SymbolNode (location: (55,1)-(55,8))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (55,1)-(55,3) = ":\""
         │   ├── value_loc: (55,3)-(55,7) = "\#@@1"
         │   ├── closing_loc: (55,7)-(55,8) = "\""
         │   └── unescaped: "\#@@1"
         ├── @ SymbolNode (location: (57,1)-(57,7))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (57,1)-(57,3) = ":'"
         │   ├── value_loc: (57,3)-(57,6) = "\#@1"
         │   ├── closing_loc: (57,6)-(57,7) = "'"
         │   └── unescaped: "\#@1"
         ├── @ SymbolNode (location: (59,1)-(59,8))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (59,1)-(59,3) = ":'"
         │   ├── value_loc: (59,3)-(59,7) = "\#@@1"
         │   ├── closing_loc: (59,7)-(59,8) = "'"

--- a/test/prism/snapshots/whitequark/keyword_argument_omission.txt
+++ b/test/prism/snapshots/whitequark/keyword_argument_omission.txt
@@ -20,7 +20,7 @@
             │               ├── @ AssocNode (location: (1,4)-(1,6))
             │               │   ├── key:
             │               │   │   @ SymbolNode (location: (1,4)-(1,6))
-            │               │   │   ├── flags: ∅
+            │               │   │   ├── flags: forced_us_ascii_encoding
             │               │   │   ├── opening_loc: ∅
             │               │   │   ├── value_loc: (1,4)-(1,5) = "a"
             │               │   │   ├── closing_loc: (1,5)-(1,6) = ":"
@@ -42,7 +42,7 @@
             │               └── @ AssocNode (location: (1,8)-(1,10))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (1,8)-(1,10))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: ∅
             │                   │   ├── value_loc: (1,8)-(1,9) = "b"
             │                   │   ├── closing_loc: (1,9)-(1,10) = ":"

--- a/test/prism/snapshots/whitequark/lbrace_arg_after_command_args.txt
+++ b/test/prism/snapshots/whitequark/lbrace_arg_after_command_args.txt
@@ -19,7 +19,7 @@
             │           │   @ StatementsNode (location: (1,5)-(1,7))
             │           │   └── body: (length: 1)
             │           │       └── @ SymbolNode (location: (1,5)-(1,7))
-            │           │           ├── flags: ∅
+            │           │           ├── flags: forced_us_ascii_encoding
             │           │           ├── opening_loc: (1,5)-(1,6) = ":"
             │           │           ├── value_loc: (1,6)-(1,7) = "a"
             │           │           ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/multiple_pattern_matches.txt
+++ b/test/prism/snapshots/whitequark/multiple_pattern_matches.txt
@@ -11,7 +11,7 @@
         │   │   │   └── @ AssocNode (location: (1,1)-(1,5))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (1,1)-(1,3))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (1,1)-(1,2) = "a"
         │   │   │       │   ├── closing_loc: (1,2)-(1,3) = ":"
@@ -28,7 +28,7 @@
         │   │   │   └── @ AssocNode (location: (1,10)-(1,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (1,10)-(1,12))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (1,10)-(1,11) = "a"
         │   │   │       │   ├── closing_loc: (1,11)-(1,12) = ":"
@@ -47,7 +47,7 @@
         │   │   │   └── @ AssocNode (location: (2,1)-(2,5))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (2,1)-(2,3))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (2,1)-(2,2) = "a"
         │   │   │       │   ├── closing_loc: (2,2)-(2,3) = ":"
@@ -64,7 +64,7 @@
         │   │   │   └── @ AssocNode (location: (2,10)-(2,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (2,10)-(2,12))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (2,10)-(2,11) = "a"
         │   │   │       │   ├── closing_loc: (2,11)-(2,12) = ":"
@@ -83,7 +83,7 @@
         │   │   │   └── @ AssocNode (location: (4,1)-(4,5))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (4,1)-(4,3))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (4,1)-(4,2) = "a"
         │   │   │       │   ├── closing_loc: (4,2)-(4,3) = ":"
@@ -100,7 +100,7 @@
         │   │   │   └── @ AssocNode (location: (4,10)-(4,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (4,10)-(4,12))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (4,10)-(4,11) = "a"
         │   │   │       │   ├── closing_loc: (4,11)-(4,12) = ":"
@@ -119,7 +119,7 @@
             │   │   └── @ AssocNode (location: (5,1)-(5,5))
             │   │       ├── key:
             │   │       │   @ SymbolNode (location: (5,1)-(5,3))
-            │   │       │   ├── flags: ∅
+            │   │       │   ├── flags: forced_us_ascii_encoding
             │   │       │   ├── opening_loc: ∅
             │   │       │   ├── value_loc: (5,1)-(5,2) = "a"
             │   │       │   ├── closing_loc: (5,2)-(5,3) = ":"
@@ -136,7 +136,7 @@
             │   │   └── @ AssocNode (location: (5,10)-(5,12))
             │   │       ├── key:
             │   │       │   @ SymbolNode (location: (5,10)-(5,12))
-            │   │       │   ├── flags: ∅
+            │   │       │   ├── flags: forced_us_ascii_encoding
             │   │       │   ├── opening_loc: ∅
             │   │       │   ├── value_loc: (5,10)-(5,11) = "a"
             │   │       │   ├── closing_loc: (5,11)-(5,12) = ":"

--- a/test/prism/snapshots/whitequark/newline_in_hash_argument.txt
+++ b/test/prism/snapshots/whitequark/newline_in_hash_argument.txt
@@ -24,7 +24,7 @@
         │   │   │   │   │   └── @ AssocNode (location: (2,3)-(2,5))
         │   │   │   │   │       ├── key:
         │   │   │   │   │       │   @ SymbolNode (location: (2,3)-(2,5))
-        │   │   │   │   │       │   ├── flags: ∅
+        │   │   │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │   │   │       │   ├── opening_loc: ∅
         │   │   │   │   │       │   ├── value_loc: (2,3)-(2,4) = "a"
         │   │   │   │   │       │   ├── closing_loc: (2,4)-(2,5) = ":"
@@ -50,7 +50,7 @@
         │   │       │   │   └── @ AssocNode (location: (5,3)-(5,7))
         │   │       │   │       ├── key:
         │   │       │   │       │   @ SymbolNode (location: (5,3)-(5,7))
-        │   │       │   │       │   ├── flags: ∅
+        │   │       │   │       │   ├── flags: forced_us_ascii_encoding
         │   │       │   │       │   ├── opening_loc: (5,3)-(5,4) = "\""
         │   │       │   │       │   ├── value_loc: (5,4)-(5,5) = "b"
         │   │       │   │       │   ├── closing_loc: (5,5)-(5,7) = "\":"
@@ -98,7 +98,7 @@
         │   │               └── @ AssocNode (location: (10,8)-(11,1))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (10,8)-(10,14))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: (10,8)-(10,9) = "\""
         │   │                   │   ├── value_loc: (10,9)-(10,12) = "foo"
         │   │                   │   ├── closing_loc: (10,12)-(10,14) = "\":"
@@ -136,7 +136,7 @@
             │               └── @ AssocNode (location: (13,8)-(14,1))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (13,8)-(13,12))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: ∅
             │                   │   ├── value_loc: (13,8)-(13,11) = "foo"
             │                   │   ├── closing_loc: (13,11)-(13,12) = ":"

--- a/test/prism/snapshots/whitequark/parser_bug_525.txt
+++ b/test/prism/snapshots/whitequark/parser_bug_525.txt
@@ -20,7 +20,7 @@
             │               └── @ AssocNode (location: (1,3)-(1,11))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (1,3)-(1,5))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: (1,3)-(1,4) = ":"
             │                   │   ├── value_loc: (1,4)-(1,5) = "k"
             │                   │   ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.txt
+++ b/test/prism/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.txt
@@ -13,7 +13,7 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 1)
         │   │   └── @ SymbolNode (location: (4,3)-(5,1))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (4,3)-(5,1) = "a\\\nb"
         │   │       ├── closing_loc: ∅
@@ -41,7 +41,7 @@
         │   ├── flags: ∅
         │   ├── elements: (length: 1)
         │   │   └── @ SymbolNode (location: (13,3)-(14,1))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (13,3)-(14,1) = "a\\\nb"
         │   │       ├── closing_loc: ∅
@@ -61,7 +61,7 @@
         │   ├── closing_loc: (20,1)-(20,2) = "}"
         │   └── unescaped: "ab"
         ├── @ SymbolNode (location: (22,0)-(23,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (22,0)-(22,3) = "%s{"
         │   ├── value_loc: (22,3)-(23,1) = "a\\\nb"
         │   ├── closing_loc: (23,1)-(23,2) = "}"
@@ -102,13 +102,13 @@
         │   ├── closing_loc: (38,1)-(38,2) = "/"
         │   └── unescaped: "ab"
         ├── @ SymbolNode (location: (40,0)-(41,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (40,0)-(40,2) = ":\""
         │   ├── value_loc: (40,2)-(41,1) = "a\\\nb"
         │   ├── closing_loc: (41,1)-(41,2) = "\""
         │   └── unescaped: "ab"
         ├── @ SymbolNode (location: (43,0)-(44,2))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (43,0)-(43,2) = ":'"
         │   ├── value_loc: (43,2)-(44,1) = "a\\\nb"
         │   ├── closing_loc: (44,1)-(44,2) = "'"

--- a/test/prism/snapshots/whitequark/pattern_matching_single_line_allowed_omission_of_parentheses.txt
+++ b/test/prism/snapshots/whitequark/pattern_matching_single_line_allowed_omission_of_parentheses.txt
@@ -69,7 +69,7 @@
         │   │   │   └── @ AssocNode (location: (5,1)-(5,5))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (5,1)-(5,3))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (5,1)-(5,2) = "a"
         │   │   │       │   ├── closing_loc: (5,2)-(5,3) = ":"
@@ -86,7 +86,7 @@
         │   │   │   └── @ AssocNode (location: (5,10)-(5,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (5,10)-(5,12))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (5,10)-(5,11) = "a"
         │   │   │       │   ├── closing_loc: (5,11)-(5,12) = ":"
@@ -108,7 +108,7 @@
         │   │   │   └── @ AssocNode (location: (7,1)-(7,5))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (7,1)-(7,3))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (7,1)-(7,2) = "a"
         │   │   │       │   ├── closing_loc: (7,2)-(7,3) = ":"
@@ -125,7 +125,7 @@
         │   │   │   └── @ AssocNode (location: (7,10)-(7,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (7,10)-(7,12))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (7,10)-(7,11) = "a"
         │   │   │       │   ├── closing_loc: (7,11)-(7,12) = ":"
@@ -147,14 +147,14 @@
         │   │   │   └── @ AssocNode (location: (9,1)-(9,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (9,1)-(9,5))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (9,1)-(9,4) = "key"
         │   │   │       │   ├── closing_loc: (9,4)-(9,5) = ":"
         │   │   │       │   └── unescaped: "key"
         │   │   │       ├── value:
         │   │   │       │   @ SymbolNode (location: (9,6)-(9,12))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: (9,6)-(9,7) = ":"
         │   │   │       │   ├── value_loc: (9,7)-(9,12) = "value"
         │   │   │       │   ├── closing_loc: ∅
@@ -168,7 +168,7 @@
         │   │   │   └── @ AssocNode (location: (9,17)-(9,27))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (9,17)-(9,21))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (9,17)-(9,20) = "key"
         │   │   │       │   ├── closing_loc: (9,20)-(9,21) = ":"
@@ -193,14 +193,14 @@
         │   │   │   └── @ AssocNode (location: (11,1)-(11,12))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (11,1)-(11,5))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (11,1)-(11,4) = "key"
         │   │   │       │   ├── closing_loc: (11,4)-(11,5) = ":"
         │   │   │       │   └── unescaped: "key"
         │   │   │       ├── value:
         │   │   │       │   @ SymbolNode (location: (11,6)-(11,12))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: (11,6)-(11,7) = ":"
         │   │   │       │   ├── value_loc: (11,7)-(11,12) = "value"
         │   │   │       │   ├── closing_loc: ∅
@@ -214,7 +214,7 @@
         │   │   │   └── @ AssocNode (location: (11,17)-(11,27))
         │   │   │       ├── key:
         │   │   │       │   @ SymbolNode (location: (11,17)-(11,21))
-        │   │   │       │   ├── flags: ∅
+        │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
         │   │   │       │   ├── value_loc: (11,17)-(11,20) = "key"
         │   │   │       │   ├── closing_loc: (11,20)-(11,21) = ":"

--- a/test/prism/snapshots/whitequark/ruby_bug_10279.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_10279.txt
@@ -9,7 +9,7 @@
             │   └── @ AssocNode (location: (1,1)-(1,23))
             │       ├── key:
             │       │   @ SymbolNode (location: (1,1)-(1,3))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: forced_us_ascii_encoding
             │       │   ├── opening_loc: ∅
             │       │   ├── value_loc: (1,1)-(1,2) = "a"
             │       │   ├── closing_loc: (1,2)-(1,3) = ":"

--- a/test/prism/snapshots/whitequark/ruby_bug_11380.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_11380.txt
@@ -25,7 +25,7 @@
             │       │       @ StatementsNode (location: (1,7)-(1,13))
             │       │       └── body: (length: 1)
             │       │           └── @ SymbolNode (location: (1,7)-(1,13))
-            │       │               ├── flags: ∅
+            │       │               ├── flags: forced_us_ascii_encoding
             │       │               ├── opening_loc: (1,7)-(1,8) = ":"
             │       │               ├── value_loc: (1,8)-(1,13) = "hello"
             │       │               ├── closing_loc: ∅
@@ -36,7 +36,7 @@
             │               └── @ AssocNode (location: (1,17)-(1,21))
             │                   ├── key:
             │                   │   @ SymbolNode (location: (1,17)-(1,19))
-            │                   │   ├── flags: ∅
+            │                   │   ├── flags: forced_us_ascii_encoding
             │                   │   ├── opening_loc: ∅
             │                   │   ├── value_loc: (1,17)-(1,18) = "a"
             │                   │   ├── closing_loc: (1,18)-(1,19) = ":"

--- a/test/prism/snapshots/whitequark/ruby_bug_11873_a.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_11873_a.txt
@@ -284,7 +284,7 @@
         │   │       │   ├── closing_loc: (9,7)-(9,8) = ")"
         │   │       │   └── block: ∅
         │   │       └── @ SymbolNode (location: (9,10)-(9,12))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (9,10)-(9,11) = ":"
         │   │           ├── value_loc: (9,11)-(9,12) = "e"
         │   │           ├── closing_loc: ∅
@@ -579,7 +579,7 @@
         │   │       │   ├── closing_loc: (19,8)-(19,9) = ")"
         │   │       │   └── block: ∅
         │   │       └── @ SymbolNode (location: (19,11)-(19,13))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (19,11)-(19,12) = ":"
         │   │           ├── value_loc: (19,12)-(19,13) = "e"
         │   │           ├── closing_loc: ∅
@@ -904,7 +904,7 @@
         │   │       │       ├── opening_loc: (29,3)-(29,4) = "{"
         │   │       │       └── closing_loc: (29,7)-(29,8) = "}"
         │   │       └── @ SymbolNode (location: (29,10)-(29,12))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: forced_us_ascii_encoding
         │   │           ├── opening_loc: (29,10)-(29,11) = ":"
         │   │           ├── value_loc: (29,11)-(29,12) = "e"
         │   │           ├── closing_loc: ∅
@@ -1229,7 +1229,7 @@
             │       │       ├── opening_loc: (39,3)-(39,4) = "{"
             │       │       └── closing_loc: (39,8)-(39,9) = "}"
             │       └── @ SymbolNode (location: (39,11)-(39,13))
-            │           ├── flags: ∅
+            │           ├── flags: forced_us_ascii_encoding
             │           ├── opening_loc: (39,11)-(39,12) = ":"
             │           ├── value_loc: (39,12)-(39,13) = "e"
             │           ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_12073.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_12073.txt
@@ -28,7 +28,7 @@
         │   │               └── @ AssocNode (location: (1,9)-(1,13))
         │   │                   ├── key:
         │   │                   │   @ SymbolNode (location: (1,9)-(1,11))
-        │   │                   │   ├── flags: ∅
+        │   │                   │   ├── flags: forced_us_ascii_encoding
         │   │                   │   ├── opening_loc: ∅
         │   │                   │   ├── value_loc: (1,9)-(1,10) = "b"
         │   │                   │   ├── closing_loc: (1,10)-(1,11) = ":"

--- a/test/prism/snapshots/whitequark/ruby_bug_12669.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_12669.txt
@@ -23,7 +23,7 @@
         │   │   │   │   ├── flags: ∅
         │   │   │   │   └── arguments: (length: 1)
         │   │   │   │       └── @ SymbolNode (location: (1,16)-(1,18))
-        │   │   │   │           ├── flags: ∅
+        │   │   │   │           ├── flags: forced_us_ascii_encoding
         │   │   │   │           ├── opening_loc: (1,16)-(1,17) = ":"
         │   │   │   │           ├── value_loc: (1,17)-(1,18) = "x"
         │   │   │   │           ├── closing_loc: ∅
@@ -57,7 +57,7 @@
         │   │   │   │   ├── flags: ∅
         │   │   │   │   └── arguments: (length: 1)
         │   │   │   │       └── @ SymbolNode (location: (3,15)-(3,17))
-        │   │   │   │           ├── flags: ∅
+        │   │   │   │           ├── flags: forced_us_ascii_encoding
         │   │   │   │           ├── opening_loc: (3,15)-(3,16) = ":"
         │   │   │   │           ├── value_loc: (3,16)-(3,17) = "x"
         │   │   │   │           ├── closing_loc: ∅
@@ -89,7 +89,7 @@
         │   │   │   │   ├── flags: ∅
         │   │   │   │   └── arguments: (length: 1)
         │   │   │   │       └── @ SymbolNode (location: (5,15)-(5,17))
-        │   │   │   │           ├── flags: ∅
+        │   │   │   │           ├── flags: forced_us_ascii_encoding
         │   │   │   │           ├── opening_loc: (5,15)-(5,16) = ":"
         │   │   │   │           ├── value_loc: (5,16)-(5,17) = "x"
         │   │   │   │           ├── closing_loc: ∅
@@ -122,7 +122,7 @@
             │   │   │   ├── flags: ∅
             │   │   │   └── arguments: (length: 1)
             │   │   │       └── @ SymbolNode (location: (7,14)-(7,16))
-            │   │   │           ├── flags: ∅
+            │   │   │           ├── flags: forced_us_ascii_encoding
             │   │   │           ├── opening_loc: (7,14)-(7,15) = ":"
             │   │   │           ├── value_loc: (7,15)-(7,16) = "x"
             │   │   │           ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_9669.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_9669.txt
@@ -45,7 +45,7 @@
             │   │   └── @ AssocNode (location: (6,0)-(7,1))
             │   │       ├── key:
             │   │       │   @ SymbolNode (location: (6,0)-(6,2))
-            │   │       │   ├── flags: ∅
+            │   │       │   ├── flags: forced_us_ascii_encoding
             │   │       │   ├── opening_loc: ∅
             │   │       │   ├── value_loc: (6,0)-(6,1) = "a"
             │   │       │   ├── closing_loc: (6,1)-(6,2) = ":"

--- a/test/prism/snapshots/whitequark/symbol_plain.txt
+++ b/test/prism/snapshots/whitequark/symbol_plain.txt
@@ -4,13 +4,13 @@
     @ StatementsNode (location: (1,0)-(3,4))
     └── body: (length: 2)
         ├── @ SymbolNode (location: (1,0)-(1,6))
-        │   ├── flags: ∅
+        │   ├── flags: forced_us_ascii_encoding
         │   ├── opening_loc: (1,0)-(1,2) = ":'"
         │   ├── value_loc: (1,2)-(1,5) = "foo"
         │   ├── closing_loc: (1,5)-(1,6) = "'"
         │   └── unescaped: "foo"
         └── @ SymbolNode (location: (3,0)-(3,4))
-            ├── flags: ∅
+            ├── flags: forced_us_ascii_encoding
             ├── opening_loc: (3,0)-(3,1) = ":"
             ├── value_loc: (3,1)-(3,4) = "foo"
             ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/undef.txt
+++ b/test/prism/snapshots/whitequark/undef.txt
@@ -12,7 +12,7 @@
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "foo"
             │   ├── @ SymbolNode (location: (1,11)-(1,15))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: (1,11)-(1,12) = ":"
             │   │   ├── value_loc: (1,12)-(1,15) = "bar"
             │   │   ├── closing_loc: ∅


### PR DESCRIPTION
Ruby sets a `Symbol` literal's encoding to US-ASCII if the symbols consists only of US ASCII code points. Character escapes can also lead a `Symbol` to have a different encoding than its source's encoding. We need to track this for proper Ruby semantics.

Determining if a `Symbol` is ASCII-only requires performing a linear scan through its associated string. Ideally, the attached string would have an indication of whether it is ASCII-only, but we don't have that in place today. I think having the code range calculated by the lexer would be beneficial in general, but I'll leave that for future work. We currently determine a string's bounds in `pm_strpbrk`, so that strikes me as the most natural place to track if a string is ASCII-only. However, that would mean visiting each byte ourselves in Prism rather than delegating work to `strchr`. I don't know if supported platforms instrinsify `strchr` and didn't want to inadvertently harm performance.

In speaking with @kddnewton, we decided to perform an extra string walk for the time being. To keep the cost down, the scan only happens with strings associated with a `Symbol` (see: `parse_symbol_encoding`). The `SymbolNode` will track if it's ASCII-only via its flags.

Unfortunately, this approach means we need to hook in at various points because there are several different ways in which we create `SymbolNode` instances. In addition to `Symbol` literals, they come up in keyword arguments, `case` statements, and there's special handling of `Symbol` literals of operators. In some cases we eagerly populate the string. Other times the string data is filled in after the node is created. I think I've hit all of the cases we need to and I've added some tests to _test/prism/encoding_test.rb_ to verify.

Fixes #1998.