### PR TITLE
Change binding power for modifiers in case-in nodes

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -14856,11 +14856,11 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
                     // for guard clauses in the form of `if` or `unless` statements.
                     if (accept1(parser, PM_TOKEN_KEYWORD_IF_MODIFIER)) {
                         pm_token_t keyword = parser->previous;
-                        pm_node_t *predicate = parse_value_expression(parser, PM_BINDING_POWER_DEFINED, true, PM_ERR_CONDITIONAL_IF_PREDICATE);
+                        pm_node_t *predicate = parse_value_expression(parser, PM_BINDING_POWER_COMPOSITION, true, PM_ERR_CONDITIONAL_IF_PREDICATE);
                         pattern = (pm_node_t *) pm_if_node_modifier_create(parser, pattern, &keyword, predicate);
                     } else if (accept1(parser, PM_TOKEN_KEYWORD_UNLESS_MODIFIER)) {
                         pm_token_t keyword = parser->previous;
-                        pm_node_t *predicate = parse_value_expression(parser, PM_BINDING_POWER_DEFINED, true, PM_ERR_CONDITIONAL_UNLESS_PREDICATE);
+                        pm_node_t *predicate = parse_value_expression(parser, PM_BINDING_POWER_COMPOSITION, true, PM_ERR_CONDITIONAL_UNLESS_PREDICATE);
                         pattern = (pm_node_t *) pm_unless_node_modifier_create(parser, pattern, &keyword, predicate);
                     }
 

--- a/test/prism/fixtures/case.txt
+++ b/test/prism/fixtures/case.txt
@@ -43,6 +43,11 @@ end
 
 case 1 in 2; in 3; end
 
+case a
+in b if c and d
+  e
+end
+
 1.then do
   case 1
   in ^_1

--- a/test/prism/snapshots/case.txt
+++ b/test/prism/snapshots/case.txt
@@ -1,8 +1,8 @@
-@ ProgramNode (location: (1,0)-(50,3))
-├── locals: []
+@ ProgramNode (location: (1,0)-(55,3))
+├── locals: [:b]
 └── statements:
-    @ StatementsNode (location: (1,0)-(50,3))
-    └── body: (length: 14)
+    @ StatementsNode (location: (1,0)-(55,3))
+    └── body: (length: 15)
         ├── @ CaseNode (location: (1,0)-(3,3))
         │   ├── predicate:
         │   │   @ SymbolNode (location: (1,5)-(1,8))
@@ -356,45 +356,114 @@
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (44,0)-(44,4) = "case"
         │   └── end_keyword_loc: (44,19)-(44,22) = "end"
-        └── @ CallNode (location: (46,0)-(50,3))
+        ├── @ CaseMatchNode (location: (46,0)-(49,3))
+        │   ├── predicate:
+        │   │   @ CallNode (location: (46,5)-(46,6))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :a
+        │   │   ├── message_loc: (46,5)-(46,6) = "a"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── conditions: (length: 1)
+        │   │   └── @ InNode (location: (47,0)-(48,3))
+        │   │       ├── pattern:
+        │   │       │   @ IfNode (location: (47,3)-(47,15))
+        │   │       │   ├── if_keyword_loc: (47,5)-(47,7) = "if"
+        │   │       │   ├── predicate:
+        │   │       │   │   @ AndNode (location: (47,8)-(47,15))
+        │   │       │   │   ├── left:
+        │   │       │   │   │   @ CallNode (location: (47,8)-(47,9))
+        │   │       │   │   │   ├── flags: variable_call, ignore_visibility
+        │   │       │   │   │   ├── receiver: ∅
+        │   │       │   │   │   ├── call_operator_loc: ∅
+        │   │       │   │   │   ├── name: :c
+        │   │       │   │   │   ├── message_loc: (47,8)-(47,9) = "c"
+        │   │       │   │   │   ├── opening_loc: ∅
+        │   │       │   │   │   ├── arguments: ∅
+        │   │       │   │   │   ├── closing_loc: ∅
+        │   │       │   │   │   └── block: ∅
+        │   │       │   │   ├── right:
+        │   │       │   │   │   @ CallNode (location: (47,14)-(47,15))
+        │   │       │   │   │   ├── flags: variable_call, ignore_visibility
+        │   │       │   │   │   ├── receiver: ∅
+        │   │       │   │   │   ├── call_operator_loc: ∅
+        │   │       │   │   │   ├── name: :d
+        │   │       │   │   │   ├── message_loc: (47,14)-(47,15) = "d"
+        │   │       │   │   │   ├── opening_loc: ∅
+        │   │       │   │   │   ├── arguments: ∅
+        │   │       │   │   │   ├── closing_loc: ∅
+        │   │       │   │   │   └── block: ∅
+        │   │       │   │   └── operator_loc: (47,10)-(47,13) = "and"
+        │   │       │   ├── then_keyword_loc: ∅
+        │   │       │   ├── statements:
+        │   │       │   │   @ StatementsNode (location: (47,3)-(47,4))
+        │   │       │   │   └── body: (length: 1)
+        │   │       │   │       └── @ LocalVariableTargetNode (location: (47,3)-(47,4))
+        │   │       │   │           ├── name: :b
+        │   │       │   │           └── depth: 0
+        │   │       │   ├── consequent: ∅
+        │   │       │   └── end_keyword_loc: ∅
+        │   │       ├── statements:
+        │   │       │   @ StatementsNode (location: (48,2)-(48,3))
+        │   │       │   └── body: (length: 1)
+        │   │       │       └── @ CallNode (location: (48,2)-(48,3))
+        │   │       │           ├── flags: variable_call, ignore_visibility
+        │   │       │           ├── receiver: ∅
+        │   │       │           ├── call_operator_loc: ∅
+        │   │       │           ├── name: :e
+        │   │       │           ├── message_loc: (48,2)-(48,3) = "e"
+        │   │       │           ├── opening_loc: ∅
+        │   │       │           ├── arguments: ∅
+        │   │       │           ├── closing_loc: ∅
+        │   │       │           └── block: ∅
+        │   │       ├── in_loc: (47,0)-(47,2) = "in"
+        │   │       └── then_loc: ∅
+        │   ├── consequent: ∅
+        │   ├── case_keyword_loc: (46,0)-(46,4) = "case"
+        │   └── end_keyword_loc: (49,0)-(49,3) = "end"
+        └── @ CallNode (location: (51,0)-(55,3))
             ├── flags: ∅
             ├── receiver:
-            │   @ IntegerNode (location: (46,0)-(46,1))
+            │   @ IntegerNode (location: (51,0)-(51,1))
             │   └── flags: decimal
-            ├── call_operator_loc: (46,1)-(46,2) = "."
+            ├── call_operator_loc: (51,1)-(51,2) = "."
             ├── name: :then
-            ├── message_loc: (46,2)-(46,6) = "then"
+            ├── message_loc: (51,2)-(51,6) = "then"
             ├── opening_loc: ∅
             ├── arguments: ∅
             ├── closing_loc: ∅
             └── block:
-                @ BlockNode (location: (46,7)-(50,3))
+                @ BlockNode (location: (51,7)-(55,3))
                 ├── locals: [:_1]
                 ├── locals_body_index: 1
                 ├── parameters:
-                │   @ NumberedParametersNode (location: (46,7)-(50,3))
+                │   @ NumberedParametersNode (location: (51,7)-(55,3))
                 │   └── maximum: 1
                 ├── body:
-                │   @ StatementsNode (location: (47,2)-(49,5))
+                │   @ StatementsNode (location: (52,2)-(54,5))
                 │   └── body: (length: 1)
-                │       └── @ CaseMatchNode (location: (47,2)-(49,5))
+                │       └── @ CaseMatchNode (location: (52,2)-(54,5))
                 │           ├── predicate:
-                │           │   @ IntegerNode (location: (47,7)-(47,8))
+                │           │   @ IntegerNode (location: (52,7)-(52,8))
                 │           │   └── flags: decimal
                 │           ├── conditions: (length: 1)
-                │           │   └── @ InNode (location: (48,2)-(48,8))
+                │           │   └── @ InNode (location: (53,2)-(53,8))
                 │           │       ├── pattern:
-                │           │       │   @ PinnedVariableNode (location: (48,5)-(48,8))
+                │           │       │   @ PinnedVariableNode (location: (53,5)-(53,8))
                 │           │       │   ├── variable:
-                │           │       │   │   @ LocalVariableReadNode (location: (48,6)-(48,8))
+                │           │       │   │   @ LocalVariableReadNode (location: (53,6)-(53,8))
                 │           │       │   │   ├── name: :_1
                 │           │       │   │   └── depth: 0
-                │           │       │   └── operator_loc: (48,5)-(48,6) = "^"
+                │           │       │   └── operator_loc: (53,5)-(53,6) = "^"
                 │           │       ├── statements: ∅
-                │           │       ├── in_loc: (48,2)-(48,4) = "in"
+                │           │       ├── in_loc: (53,2)-(53,4) = "in"
                 │           │       └── then_loc: ∅
                 │           ├── consequent: ∅
-                │           ├── case_keyword_loc: (47,2)-(47,6) = "case"
-                │           └── end_keyword_loc: (49,2)-(49,5) = "end"
-                ├── opening_loc: (46,7)-(46,9) = "do"
-                └── closing_loc: (50,0)-(50,3) = "end"
+                │           ├── case_keyword_loc: (52,2)-(52,6) = "case"
+                │           └── end_keyword_loc: (54,2)-(54,5) = "end"
+                ├── opening_loc: (51,7)-(51,9) = "do"
+                └── closing_loc: (55,0)-(55,3) = "end"


### PR DESCRIPTION
pattern matching snippets like:

```
case a
in b if c and d
  e
end
```

fail with

```
Errors:
[#<Prism::ParseError @message="expected a delimiter after the predicates of a `when` clause" @location=#<Prism::Location @start_offset=18 @length=0 start_line=2>>, #<Prism::ParseError @message="cannot parse the expression" @location=#<Prism::Location @start_offset=18 @length=0 start_line=2>>]
```

because `PM_BINDING_POWER_DEFINED` goes after `PM_BINDING_POWER_COMPOSITION`, so `parse_value_expression()` only catches the `c` part and not the `and d`.

Switching to `PM_BINDING_POWER_COMPOSITION` fixed that.

I also wonder if we should change the error message to mention `in` instead of `when`? (since at the point of error I think we already know the type of node)