### PR TITLE
Symbol encoding follow-up

### DIFF
--- a/test/prism/snapshots/undef.txt
+++ b/test/prism/snapshots/undef.txt
@@ -6,7 +6,7 @@
         ├── @ UndefNode (location: (1,0)-(1,7))
         │   ├── names: (length: 1)
         │   │   └── @ SymbolNode (location: (1,6)-(1,7))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (1,6)-(1,7) = "a"
         │   │       ├── closing_loc: ∅
@@ -15,13 +15,13 @@
         ├── @ UndefNode (location: (3,0)-(3,10))
         │   ├── names: (length: 2)
         │   │   ├── @ SymbolNode (location: (3,6)-(3,7))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: forced_us_ascii_encoding
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── value_loc: (3,6)-(3,7) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   └── @ SymbolNode (location: (3,9)-(3,10))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (3,9)-(3,10) = "b"
         │   │       ├── closing_loc: ∅
@@ -30,7 +30,7 @@
         ├── @ UndefNode (location: (5,0)-(5,8))
         │   ├── names: (length: 1)
         │   │   └── @ SymbolNode (location: (5,6)-(5,8))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (5,6)-(5,8) = "if"
         │   │       ├── closing_loc: ∅
@@ -108,7 +108,7 @@
         └── @ UndefNode (location: (17,0)-(17,14))
             ├── names: (length: 1)
             │   └── @ SymbolNode (location: (17,6)-(17,14))
-            │       ├── flags: ∅
+            │       ├── flags: forced_us_ascii_encoding
             │       ├── opening_loc: ∅
             │       ├── value_loc: (17,6)-(17,14) = "Constant"
             │       ├── closing_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/semantic/undef.txt
+++ b/test/prism/snapshots/unparser/corpus/semantic/undef.txt
@@ -6,7 +6,7 @@
         ├── @ UndefNode (location: (1,0)-(1,9))
         │   ├── names: (length: 1)
         │   │   └── @ SymbolNode (location: (1,6)-(1,9))
-        │   │       ├── flags: ∅
+        │   │       ├── flags: forced_us_ascii_encoding
         │   │       ├── opening_loc: ∅
         │   │       ├── value_loc: (1,6)-(1,9) = "foo"
         │   │       ├── closing_loc: ∅
@@ -15,13 +15,13 @@
         └── @ UndefNode (location: (2,0)-(2,14))
             ├── names: (length: 2)
             │   ├── @ SymbolNode (location: (2,6)-(2,9))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: ∅
             │   │   ├── value_loc: (2,6)-(2,9) = "foo"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "foo"
             │   └── @ SymbolNode (location: (2,11)-(2,14))
-            │       ├── flags: ∅
+            │       ├── flags: forced_us_ascii_encoding
             │       ├── opening_loc: ∅
             │       ├── value_loc: (2,11)-(2,14) = "bar"
             │       ├── closing_loc: ∅

--- a/test/prism/snapshots/whitequark/undef.txt
+++ b/test/prism/snapshots/whitequark/undef.txt
@@ -6,7 +6,7 @@
         └── @ UndefNode (location: (1,0)-(1,27))
             ├── names: (length: 3)
             │   ├── @ SymbolNode (location: (1,6)-(1,9))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: forced_us_ascii_encoding
             │   │   ├── opening_loc: ∅
             │   │   ├── value_loc: (1,6)-(1,9) = "foo"
             │   │   ├── closing_loc: ∅


### PR DESCRIPTION
Ensure we don't accidentally parse the symbol encoding twice, and ensure we parse it in every circumstance we need to by requiring it as a parameter.