### PR TITLE
Optimize also java

### DIFF
--- a/.github/workflows/java-wasm-bindings.yml
+++ b/.github/workflows/java-wasm-bindings.yml
@@ -2,15 +2,14 @@ name: Bindings to Chicory
 
 on:
   push:
-  # TEST
-  #   paths:
-  #     - ".github/workflows/java-wasm-bindings.yml"
-  #     - "include/"
-  #     - "src/"
-  #     - "*akefile*"
-  #   branches:
-  #     - main
-  # pull_request:
+    paths:
+      - ".github/workflows/java-wasm-bindings.yml"
+      - "include/"
+      - "src/"
+      - "*akefile*"
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/java-wasm-bindings.yml
+++ b/.github/workflows/java-wasm-bindings.yml
@@ -2,14 +2,15 @@ name: Bindings to Chicory
 
 on:
   push:
-    paths:
-      - ".github/workflows/java-wasm-bindings.yml"
-      - "include/"
-      - "src/"
-      - "*akefile*"
-    branches:
-      - main
-  pull_request:
+  # TEST
+  #   paths:
+  #     - ".github/workflows/java-wasm-bindings.yml"
+  #     - "include/"
+  #     - "src/"
+  #     - "*akefile*"
+  #   branches:
+  #     - main
+  # pull_request:
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ SOEXT := $(shell ruby -e 'puts RbConfig::CONFIG["SOEXT"]')
 
 CPPFLAGS := -Iinclude
 CFLAGS := -g -O2 -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion -Wno-missing-braces -fPIC -fvisibility=hidden
-JAVA_WASM_CFLAGS := -O0 -g -o -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion -Wno-missing-braces -fPIC -fvisibility=hidden -nostartfiles -Wl,--no-entry -Wl,
 CC := cc
 WASI_SDK_PATH := /opt/wasi-sdk
 
@@ -42,7 +41,7 @@ javascript/src/prism.wasm: Makefile $(SOURCES) $(HEADERS)
 
 java-wasm/src/test/resources/prism.wasm: Makefile $(SOURCES) $(HEADERS)
 	$(ECHO) "building $@"
-	$(Q) $(WASI_SDK_PATH)/bin/clang $(DEBUG_FLAGS) -DPRISM_EXPORT_SYMBOLS -D_WASI_EMULATED_MMAN -lwasi-emulated-mman $(CPPFLAGS) $(JAVA_WASM_CFLAGS) -Wl,--export-all -Wl,--no-entry -mexec-model=reactor -lc++ -lc++abi -o $@ $(SOURCES)
+	$(Q) $(WASI_SDK_PATH)/bin/clang $(DEBUG_FLAGS) -DPRISM_EXPORT_SYMBOLS -D_WASI_EMULATED_MMAN -lwasi-emulated-mman $(CPPFLAGS) $(CFLAGS) -Wl,--export-all -Wl,--no-entry -mexec-model=reactor -lc++ -lc++abi -o $@ $(SOURCES)
 
 build/shared/%.o: src/%.c Makefile $(HEADERS)
 	$(ECHO) "compiling $@"

--- a/java-wasm/pom.xml
+++ b/java-wasm/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.dylibso.chicory</groupId>
       <artifactId>runtime</artifactId>
-      <version>0.0.6</version>
+      <version>0.0.7</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Thanks to the work done by @mariofusco on perfecting the Control Flow we are now able to run the optimized version of `prism.wasm` in Chicory.