### PR TITLE
Fix Array pattern with command at end-of-file

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -10717,14 +10717,6 @@ match4(const pm_parser_t *parser, pm_token_type_t type1, pm_token_type_t type2, 
 }
 
 /**
- * Returns true if the current token is any of the five given types.
- */
-static inline bool
-match5(const pm_parser_t *parser, pm_token_type_t type1, pm_token_type_t type2, pm_token_type_t type3, pm_token_type_t type4, pm_token_type_t type5) {
-    return match1(parser, type1) || match1(parser, type2) || match1(parser, type3) || match1(parser, type4) || match1(parser, type5);
-}
-
-/**
  * Returns true if the current token is any of the six given types.
  */
 static inline bool
@@ -11360,7 +11352,7 @@ parse_statements(pm_parser_t *parser, pm_context_t context) {
             break;
         }
 
-        // If we have a terminator, then we will parse all consequtive terminators
+        // If we have a terminator, then we will parse all consecutive terminators
         // and then continue parsing the statements list.
         if (accept2(parser, PM_TOKEN_NEWLINE, PM_TOKEN_SEMICOLON)) {
             // If we have a terminator, then we will continue parsing the statements
@@ -14011,7 +14003,7 @@ parse_pattern(pm_parser_t *parser, bool top_pattern, pm_diagnostic_id_t diag_id)
         // Gather up all of the patterns into the list.
         while (accept1(parser, PM_TOKEN_COMMA)) {
             // Break early here in case we have a trailing comma.
-            if (match5(parser, PM_TOKEN_KEYWORD_THEN, PM_TOKEN_BRACE_RIGHT, PM_TOKEN_BRACKET_RIGHT, PM_TOKEN_NEWLINE, PM_TOKEN_SEMICOLON)) {
+            if (match6(parser, PM_TOKEN_KEYWORD_THEN, PM_TOKEN_BRACE_RIGHT, PM_TOKEN_BRACKET_RIGHT, PM_TOKEN_NEWLINE, PM_TOKEN_SEMICOLON, PM_TOKEN_EOF)) {
                 node = (pm_node_t *) pm_implicit_rest_node_create(parser, &parser->previous);
                 pm_node_list_append(&nodes, node);
                 break;

--- a/test/prism/fixtures/patterns.txt
+++ b/test/prism/fixtures/patterns.txt
@@ -88,6 +88,10 @@ foo => bar, *baz, qux
 foo => bar, baz, *qux
 foo => *bar, baz, *qux
 
+foo => bar,
+
+; # end the previous pattern for ParseTest#test_filepath_patterns.txt which parses the whole file at once
+
 foo => []
 foo => [[[[[]]]]]
 
@@ -123,6 +127,10 @@ foo in __FILE__
 foo in __LINE__
 foo in __ENCODING__
 foo in -> { bar }
+
+foo in bar,
+
+; # end the previous pattern for ParseTest#test_filepath_patterns.txt which parses the whole file at once
 
 case foo; in bar then end
 case foo; in 1 then end

--- a/test/prism/snapshots/patterns.txt
+++ b/test/prism/snapshots/patterns.txt
@@ -1,8 +1,8 @@
-@ ProgramNode (location: (1,0)-(209,5))
+@ ProgramNode (location: (1,0)-(217,5))
 ├── locals: [:bar, :baz, :qux, :b, :a, :foo, :x]
 └── statements:
-    @ StatementsNode (location: (1,0)-(209,5))
-    └── body: (length: 178)
+    @ StatementsNode (location: (1,0)-(217,5))
+    └── body: (length: 180)
         ├── @ MatchRequiredNode (location: (1,0)-(1,10))
         │   ├── value:
         │   │   @ CallNode (location: (1,0)-(1,3))
@@ -2102,7 +2102,7 @@
         │   │   ├── opening_loc: ∅
         │   │   └── closing_loc: ∅
         │   └── operator_loc: (89,4)-(89,6) = "=>"
-        ├── @ MatchRequiredNode (location: (91,0)-(91,9))
+        ├── @ MatchRequiredNode (location: (91,0)-(91,11))
         │   ├── value:
         │   │   @ CallNode (location: (91,0)-(91,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2115,91 +2115,19 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ ArrayPatternNode (location: (91,7)-(91,9))
-        │   │   ├── constant: ∅
-        │   │   ├── requireds: (length: 0)
-        │   │   ├── rest: ∅
-        │   │   ├── posts: (length: 0)
-        │   │   ├── opening_loc: (91,7)-(91,8) = "["
-        │   │   └── closing_loc: (91,8)-(91,9) = "]"
-        │   └── operator_loc: (91,4)-(91,6) = "=>"
-        ├── @ MatchRequiredNode (location: (92,0)-(92,17))
-        │   ├── value:
-        │   │   @ CallNode (location: (92,0)-(92,3))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (92,0)-(92,3) = "foo"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── pattern:
-        │   │   @ ArrayPatternNode (location: (92,7)-(92,17))
+        │   │   @ ArrayPatternNode (location: (91,7)-(91,11))
         │   │   ├── constant: ∅
         │   │   ├── requireds: (length: 1)
-        │   │   │   └── @ ArrayPatternNode (location: (92,8)-(92,16))
-        │   │   │       ├── constant: ∅
-        │   │   │       ├── requireds: (length: 1)
-        │   │   │       │   └── @ ArrayPatternNode (location: (92,9)-(92,15))
-        │   │   │       │       ├── constant: ∅
-        │   │   │       │       ├── requireds: (length: 1)
-        │   │   │       │       │   └── @ ArrayPatternNode (location: (92,10)-(92,14))
-        │   │   │       │       │       ├── constant: ∅
-        │   │   │       │       │       ├── requireds: (length: 1)
-        │   │   │       │       │       │   └── @ ArrayPatternNode (location: (92,11)-(92,13))
-        │   │   │       │       │       │       ├── constant: ∅
-        │   │   │       │       │       │       ├── requireds: (length: 0)
-        │   │   │       │       │       │       ├── rest: ∅
-        │   │   │       │       │       │       ├── posts: (length: 0)
-        │   │   │       │       │       │       ├── opening_loc: (92,11)-(92,12) = "["
-        │   │   │       │       │       │       └── closing_loc: (92,12)-(92,13) = "]"
-        │   │   │       │       │       ├── rest: ∅
-        │   │   │       │       │       ├── posts: (length: 0)
-        │   │   │       │       │       ├── opening_loc: (92,10)-(92,11) = "["
-        │   │   │       │       │       └── closing_loc: (92,13)-(92,14) = "]"
-        │   │   │       │       ├── rest: ∅
-        │   │   │       │       ├── posts: (length: 0)
-        │   │   │       │       ├── opening_loc: (92,9)-(92,10) = "["
-        │   │   │       │       └── closing_loc: (92,14)-(92,15) = "]"
-        │   │   │       ├── rest: ∅
-        │   │   │       ├── posts: (length: 0)
-        │   │   │       ├── opening_loc: (92,8)-(92,9) = "["
-        │   │   │       └── closing_loc: (92,15)-(92,16) = "]"
-        │   │   ├── rest: ∅
-        │   │   ├── posts: (length: 0)
-        │   │   ├── opening_loc: (92,7)-(92,8) = "["
-        │   │   └── closing_loc: (92,16)-(92,17) = "]"
-        │   └── operator_loc: (92,4)-(92,6) = "=>"
-        ├── @ MatchRequiredNode (location: (94,0)-(94,13))
-        │   ├── value:
-        │   │   @ CallNode (location: (94,0)-(94,3))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (94,0)-(94,3) = "foo"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── pattern:
-        │   │   @ ArrayPatternNode (location: (94,7)-(94,13))
-        │   │   ├── constant: ∅
-        │   │   ├── requireds: (length: 0)
-        │   │   ├── rest:
-        │   │   │   @ SplatNode (location: (94,8)-(94,12))
-        │   │   │   ├── operator_loc: (94,8)-(94,9) = "*"
-        │   │   │   └── expression:
-        │   │   │       @ LocalVariableTargetNode (location: (94,9)-(94,12))
+        │   │   │   └── @ LocalVariableTargetNode (location: (91,7)-(91,10))
         │   │   │       ├── name: :bar
         │   │   │       └── depth: 0
+        │   │   ├── rest:
+        │   │   │   @ ImplicitRestNode (location: (91,10)-(91,11))
         │   │   ├── posts: (length: 0)
-        │   │   ├── opening_loc: (94,7)-(94,8) = "["
-        │   │   └── closing_loc: (94,12)-(94,13) = "]"
-        │   └── operator_loc: (94,4)-(94,6) = "=>"
-        ├── @ MatchRequiredNode (location: (95,0)-(95,23))
+        │   │   ├── opening_loc: ∅
+        │   │   └── closing_loc: ∅
+        │   └── operator_loc: (91,4)-(91,6) = "=>"
+        ├── @ MatchRequiredNode (location: (95,0)-(95,9))
         │   ├── value:
         │   │   @ CallNode (location: (95,0)-(95,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2212,27 +2140,15 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ ArrayPatternNode (location: (95,7)-(95,23))
+        │   │   @ ArrayPatternNode (location: (95,7)-(95,9))
         │   │   ├── constant: ∅
         │   │   ├── requireds: (length: 0)
-        │   │   ├── rest:
-        │   │   │   @ SplatNode (location: (95,8)-(95,12))
-        │   │   │   ├── operator_loc: (95,8)-(95,9) = "*"
-        │   │   │   └── expression:
-        │   │   │       @ LocalVariableTargetNode (location: (95,9)-(95,12))
-        │   │   │       ├── name: :bar
-        │   │   │       └── depth: 0
-        │   │   ├── posts: (length: 2)
-        │   │   │   ├── @ LocalVariableTargetNode (location: (95,14)-(95,17))
-        │   │   │   │   ├── name: :baz
-        │   │   │   │   └── depth: 0
-        │   │   │   └── @ LocalVariableTargetNode (location: (95,19)-(95,22))
-        │   │   │       ├── name: :qux
-        │   │   │       └── depth: 0
+        │   │   ├── rest: ∅
+        │   │   ├── posts: (length: 0)
         │   │   ├── opening_loc: (95,7)-(95,8) = "["
-        │   │   └── closing_loc: (95,22)-(95,23) = "]"
+        │   │   └── closing_loc: (95,8)-(95,9) = "]"
         │   └── operator_loc: (95,4)-(95,6) = "=>"
-        ├── @ MatchRequiredNode (location: (96,0)-(96,23))
+        ├── @ MatchRequiredNode (location: (96,0)-(96,17))
         │   ├── value:
         │   │   @ CallNode (location: (96,0)-(96,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2245,60 +2161,43 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ ArrayPatternNode (location: (96,7)-(96,23))
+        │   │   @ ArrayPatternNode (location: (96,7)-(96,17))
         │   │   ├── constant: ∅
         │   │   ├── requireds: (length: 1)
-        │   │   │   └── @ LocalVariableTargetNode (location: (96,8)-(96,11))
-        │   │   │       ├── name: :bar
-        │   │   │       └── depth: 0
-        │   │   ├── rest:
-        │   │   │   @ SplatNode (location: (96,13)-(96,17))
-        │   │   │   ├── operator_loc: (96,13)-(96,14) = "*"
-        │   │   │   └── expression:
-        │   │   │       @ LocalVariableTargetNode (location: (96,14)-(96,17))
-        │   │   │       ├── name: :baz
-        │   │   │       └── depth: 0
-        │   │   ├── posts: (length: 1)
-        │   │   │   └── @ LocalVariableTargetNode (location: (96,19)-(96,22))
-        │   │   │       ├── name: :qux
-        │   │   │       └── depth: 0
-        │   │   ├── opening_loc: (96,7)-(96,8) = "["
-        │   │   └── closing_loc: (96,22)-(96,23) = "]"
-        │   └── operator_loc: (96,4)-(96,6) = "=>"
-        ├── @ MatchRequiredNode (location: (97,0)-(97,23))
-        │   ├── value:
-        │   │   @ CallNode (location: (97,0)-(97,3))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (97,0)-(97,3) = "foo"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── pattern:
-        │   │   @ ArrayPatternNode (location: (97,7)-(97,23))
-        │   │   ├── constant: ∅
-        │   │   ├── requireds: (length: 2)
-        │   │   │   ├── @ LocalVariableTargetNode (location: (97,8)-(97,11))
-        │   │   │   │   ├── name: :bar
-        │   │   │   │   └── depth: 0
-        │   │   │   └── @ LocalVariableTargetNode (location: (97,13)-(97,16))
-        │   │   │       ├── name: :baz
-        │   │   │       └── depth: 0
-        │   │   ├── rest:
-        │   │   │   @ SplatNode (location: (97,18)-(97,22))
-        │   │   │   ├── operator_loc: (97,18)-(97,19) = "*"
-        │   │   │   └── expression:
-        │   │   │       @ LocalVariableTargetNode (location: (97,19)-(97,22))
-        │   │   │       ├── name: :qux
-        │   │   │       └── depth: 0
+        │   │   │   └── @ ArrayPatternNode (location: (96,8)-(96,16))
+        │   │   │       ├── constant: ∅
+        │   │   │       ├── requireds: (length: 1)
+        │   │   │       │   └── @ ArrayPatternNode (location: (96,9)-(96,15))
+        │   │   │       │       ├── constant: ∅
+        │   │   │       │       ├── requireds: (length: 1)
+        │   │   │       │       │   └── @ ArrayPatternNode (location: (96,10)-(96,14))
+        │   │   │       │       │       ├── constant: ∅
+        │   │   │       │       │       ├── requireds: (length: 1)
+        │   │   │       │       │       │   └── @ ArrayPatternNode (location: (96,11)-(96,13))
+        │   │   │       │       │       │       ├── constant: ∅
+        │   │   │       │       │       │       ├── requireds: (length: 0)
+        │   │   │       │       │       │       ├── rest: ∅
+        │   │   │       │       │       │       ├── posts: (length: 0)
+        │   │   │       │       │       │       ├── opening_loc: (96,11)-(96,12) = "["
+        │   │   │       │       │       │       └── closing_loc: (96,12)-(96,13) = "]"
+        │   │   │       │       │       ├── rest: ∅
+        │   │   │       │       │       ├── posts: (length: 0)
+        │   │   │       │       │       ├── opening_loc: (96,10)-(96,11) = "["
+        │   │   │       │       │       └── closing_loc: (96,13)-(96,14) = "]"
+        │   │   │       │       ├── rest: ∅
+        │   │   │       │       ├── posts: (length: 0)
+        │   │   │       │       ├── opening_loc: (96,9)-(96,10) = "["
+        │   │   │       │       └── closing_loc: (96,14)-(96,15) = "]"
+        │   │   │       ├── rest: ∅
+        │   │   │       ├── posts: (length: 0)
+        │   │   │       ├── opening_loc: (96,8)-(96,9) = "["
+        │   │   │       └── closing_loc: (96,15)-(96,16) = "]"
+        │   │   ├── rest: ∅
         │   │   ├── posts: (length: 0)
-        │   │   ├── opening_loc: (97,7)-(97,8) = "["
-        │   │   └── closing_loc: (97,22)-(97,23) = "]"
-        │   └── operator_loc: (97,4)-(97,6) = "=>"
-        ├── @ MatchRequiredNode (location: (98,0)-(98,24))
+        │   │   ├── opening_loc: (96,7)-(96,8) = "["
+        │   │   └── closing_loc: (96,16)-(96,17) = "]"
+        │   └── operator_loc: (96,4)-(96,6) = "=>"
+        ├── @ MatchRequiredNode (location: (98,0)-(98,13))
         │   ├── value:
         │   │   @ CallNode (location: (98,0)-(98,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2311,30 +2210,54 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ FindPatternNode (location: (98,7)-(98,24))
+        │   │   @ ArrayPatternNode (location: (98,7)-(98,13))
         │   │   ├── constant: ∅
-        │   │   ├── left:
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── rest:
         │   │   │   @ SplatNode (location: (98,8)-(98,12))
         │   │   │   ├── operator_loc: (98,8)-(98,9) = "*"
         │   │   │   └── expression:
         │   │   │       @ LocalVariableTargetNode (location: (98,9)-(98,12))
         │   │   │       ├── name: :bar
         │   │   │       └── depth: 0
-        │   │   ├── requireds: (length: 1)
-        │   │   │   └── @ LocalVariableTargetNode (location: (98,14)-(98,17))
-        │   │   │       ├── name: :baz
-        │   │   │       └── depth: 0
-        │   │   ├── right:
-        │   │   │   @ SplatNode (location: (98,19)-(98,23))
-        │   │   │   ├── operator_loc: (98,19)-(98,20) = "*"
+        │   │   ├── posts: (length: 0)
+        │   │   ├── opening_loc: (98,7)-(98,8) = "["
+        │   │   └── closing_loc: (98,12)-(98,13) = "]"
+        │   └── operator_loc: (98,4)-(98,6) = "=>"
+        ├── @ MatchRequiredNode (location: (99,0)-(99,23))
+        │   ├── value:
+        │   │   @ CallNode (location: (99,0)-(99,3))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (99,0)-(99,3) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── pattern:
+        │   │   @ ArrayPatternNode (location: (99,7)-(99,23))
+        │   │   ├── constant: ∅
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── rest:
+        │   │   │   @ SplatNode (location: (99,8)-(99,12))
+        │   │   │   ├── operator_loc: (99,8)-(99,9) = "*"
         │   │   │   └── expression:
-        │   │   │       @ LocalVariableTargetNode (location: (98,20)-(98,23))
+        │   │   │       @ LocalVariableTargetNode (location: (99,9)-(99,12))
+        │   │   │       ├── name: :bar
+        │   │   │       └── depth: 0
+        │   │   ├── posts: (length: 2)
+        │   │   │   ├── @ LocalVariableTargetNode (location: (99,14)-(99,17))
+        │   │   │   │   ├── name: :baz
+        │   │   │   │   └── depth: 0
+        │   │   │   └── @ LocalVariableTargetNode (location: (99,19)-(99,22))
         │   │   │       ├── name: :qux
         │   │   │       └── depth: 0
-        │   │   ├── opening_loc: (98,7)-(98,8) = "["
-        │   │   └── closing_loc: (98,23)-(98,24) = "]"
-        │   └── operator_loc: (98,4)-(98,6) = "=>"
-        ├── @ MatchPredicateNode (location: (100,0)-(100,10))
+        │   │   ├── opening_loc: (99,7)-(99,8) = "["
+        │   │   └── closing_loc: (99,22)-(99,23) = "]"
+        │   └── operator_loc: (99,4)-(99,6) = "=>"
+        ├── @ MatchRequiredNode (location: (100,0)-(100,23))
         │   ├── value:
         │   │   @ CallNode (location: (100,0)-(100,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2347,11 +2270,27 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ LocalVariableTargetNode (location: (100,7)-(100,10))
-        │   │   ├── name: :bar
-        │   │   └── depth: 0
-        │   └── operator_loc: (100,4)-(100,6) = "in"
-        ├── @ MatchPredicateNode (location: (101,0)-(101,8))
+        │   │   @ ArrayPatternNode (location: (100,7)-(100,23))
+        │   │   ├── constant: ∅
+        │   │   ├── requireds: (length: 1)
+        │   │   │   └── @ LocalVariableTargetNode (location: (100,8)-(100,11))
+        │   │   │       ├── name: :bar
+        │   │   │       └── depth: 0
+        │   │   ├── rest:
+        │   │   │   @ SplatNode (location: (100,13)-(100,17))
+        │   │   │   ├── operator_loc: (100,13)-(100,14) = "*"
+        │   │   │   └── expression:
+        │   │   │       @ LocalVariableTargetNode (location: (100,14)-(100,17))
+        │   │   │       ├── name: :baz
+        │   │   │       └── depth: 0
+        │   │   ├── posts: (length: 1)
+        │   │   │   └── @ LocalVariableTargetNode (location: (100,19)-(100,22))
+        │   │   │       ├── name: :qux
+        │   │   │       └── depth: 0
+        │   │   ├── opening_loc: (100,7)-(100,8) = "["
+        │   │   └── closing_loc: (100,22)-(100,23) = "]"
+        │   └── operator_loc: (100,4)-(100,6) = "=>"
+        ├── @ MatchRequiredNode (location: (101,0)-(101,23))
         │   ├── value:
         │   │   @ CallNode (location: (101,0)-(101,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2364,10 +2303,27 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ IntegerNode (location: (101,7)-(101,8))
-        │   │   └── flags: decimal
-        │   └── operator_loc: (101,4)-(101,6) = "in"
-        ├── @ MatchPredicateNode (location: (102,0)-(102,10))
+        │   │   @ ArrayPatternNode (location: (101,7)-(101,23))
+        │   │   ├── constant: ∅
+        │   │   ├── requireds: (length: 2)
+        │   │   │   ├── @ LocalVariableTargetNode (location: (101,8)-(101,11))
+        │   │   │   │   ├── name: :bar
+        │   │   │   │   └── depth: 0
+        │   │   │   └── @ LocalVariableTargetNode (location: (101,13)-(101,16))
+        │   │   │       ├── name: :baz
+        │   │   │       └── depth: 0
+        │   │   ├── rest:
+        │   │   │   @ SplatNode (location: (101,18)-(101,22))
+        │   │   │   ├── operator_loc: (101,18)-(101,19) = "*"
+        │   │   │   └── expression:
+        │   │   │       @ LocalVariableTargetNode (location: (101,19)-(101,22))
+        │   │   │       ├── name: :qux
+        │   │   │       └── depth: 0
+        │   │   ├── posts: (length: 0)
+        │   │   ├── opening_loc: (101,7)-(101,8) = "["
+        │   │   └── closing_loc: (101,22)-(101,23) = "]"
+        │   └── operator_loc: (101,4)-(101,6) = "=>"
+        ├── @ MatchRequiredNode (location: (102,0)-(102,24))
         │   ├── value:
         │   │   @ CallNode (location: (102,0)-(102,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2380,27 +2336,30 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ FloatNode (location: (102,7)-(102,10))
-        │   └── operator_loc: (102,4)-(102,6) = "in"
-        ├── @ MatchPredicateNode (location: (103,0)-(103,9))
-        │   ├── value:
-        │   │   @ CallNode (location: (103,0)-(103,3))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (103,0)-(103,3) = "foo"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── pattern:
-        │   │   @ ImaginaryNode (location: (103,7)-(103,9))
-        │   │   └── numeric:
-        │   │       @ IntegerNode (location: (103,7)-(103,8))
-        │   │       └── flags: decimal
-        │   └── operator_loc: (103,4)-(103,6) = "in"
-        ├── @ MatchPredicateNode (location: (104,0)-(104,9))
+        │   │   @ FindPatternNode (location: (102,7)-(102,24))
+        │   │   ├── constant: ∅
+        │   │   ├── left:
+        │   │   │   @ SplatNode (location: (102,8)-(102,12))
+        │   │   │   ├── operator_loc: (102,8)-(102,9) = "*"
+        │   │   │   └── expression:
+        │   │   │       @ LocalVariableTargetNode (location: (102,9)-(102,12))
+        │   │   │       ├── name: :bar
+        │   │   │       └── depth: 0
+        │   │   ├── requireds: (length: 1)
+        │   │   │   └── @ LocalVariableTargetNode (location: (102,14)-(102,17))
+        │   │   │       ├── name: :baz
+        │   │   │       └── depth: 0
+        │   │   ├── right:
+        │   │   │   @ SplatNode (location: (102,19)-(102,23))
+        │   │   │   ├── operator_loc: (102,19)-(102,20) = "*"
+        │   │   │   └── expression:
+        │   │   │       @ LocalVariableTargetNode (location: (102,20)-(102,23))
+        │   │   │       ├── name: :qux
+        │   │   │       └── depth: 0
+        │   │   ├── opening_loc: (102,7)-(102,8) = "["
+        │   │   └── closing_loc: (102,23)-(102,24) = "]"
+        │   └── operator_loc: (102,4)-(102,6) = "=>"
+        ├── @ MatchPredicateNode (location: (104,0)-(104,10))
         │   ├── value:
         │   │   @ CallNode (location: (104,0)-(104,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2413,12 +2372,11 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ RationalNode (location: (104,7)-(104,9))
-        │   │   └── numeric:
-        │   │       @ IntegerNode (location: (104,7)-(104,8))
-        │   │       └── flags: decimal
+        │   │   @ LocalVariableTargetNode (location: (104,7)-(104,10))
+        │   │   ├── name: :bar
+        │   │   └── depth: 0
         │   └── operator_loc: (104,4)-(104,6) = "in"
-        ├── @ MatchPredicateNode (location: (105,0)-(105,11))
+        ├── @ MatchPredicateNode (location: (105,0)-(105,8))
         │   ├── value:
         │   │   @ CallNode (location: (105,0)-(105,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2431,14 +2389,10 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ SymbolNode (location: (105,7)-(105,11))
-        │   │   ├── flags: forced_us_ascii_encoding
-        │   │   ├── opening_loc: (105,7)-(105,8) = ":"
-        │   │   ├── value_loc: (105,8)-(105,11) = "foo"
-        │   │   ├── closing_loc: ∅
-        │   │   └── unescaped: "foo"
+        │   │   @ IntegerNode (location: (105,7)-(105,8))
+        │   │   └── flags: decimal
         │   └── operator_loc: (105,4)-(105,6) = "in"
-        ├── @ MatchPredicateNode (location: (106,0)-(106,14))
+        ├── @ MatchPredicateNode (location: (106,0)-(106,10))
         │   ├── value:
         │   │   @ CallNode (location: (106,0)-(106,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2451,14 +2405,9 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ SymbolNode (location: (106,7)-(106,14))
-        │   │   ├── flags: forced_us_ascii_encoding
-        │   │   ├── opening_loc: (106,7)-(106,10) = "%s["
-        │   │   ├── value_loc: (106,10)-(106,13) = "foo"
-        │   │   ├── closing_loc: (106,13)-(106,14) = "]"
-        │   │   └── unescaped: "foo"
+        │   │   @ FloatNode (location: (106,7)-(106,10))
         │   └── operator_loc: (106,4)-(106,6) = "in"
-        ├── @ MatchPredicateNode (location: (107,0)-(107,13))
+        ├── @ MatchPredicateNode (location: (107,0)-(107,9))
         │   ├── value:
         │   │   @ CallNode (location: (107,0)-(107,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2471,14 +2420,12 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ SymbolNode (location: (107,7)-(107,13))
-        │   │   ├── flags: forced_us_ascii_encoding
-        │   │   ├── opening_loc: (107,7)-(107,9) = ":\""
-        │   │   ├── value_loc: (107,9)-(107,12) = "foo"
-        │   │   ├── closing_loc: (107,12)-(107,13) = "\""
-        │   │   └── unescaped: "foo"
+        │   │   @ ImaginaryNode (location: (107,7)-(107,9))
+        │   │   └── numeric:
+        │   │       @ IntegerNode (location: (107,7)-(107,8))
+        │   │       └── flags: decimal
         │   └── operator_loc: (107,4)-(107,6) = "in"
-        ├── @ MatchPredicateNode (location: (108,0)-(108,12))
+        ├── @ MatchPredicateNode (location: (108,0)-(108,9))
         │   ├── value:
         │   │   @ CallNode (location: (108,0)-(108,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2491,14 +2438,12 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ RegularExpressionNode (location: (108,7)-(108,12))
-        │   │   ├── flags: ∅
-        │   │   ├── opening_loc: (108,7)-(108,8) = "/"
-        │   │   ├── content_loc: (108,8)-(108,11) = "foo"
-        │   │   ├── closing_loc: (108,11)-(108,12) = "/"
-        │   │   └── unescaped: "foo"
+        │   │   @ RationalNode (location: (108,7)-(108,9))
+        │   │   └── numeric:
+        │   │       @ IntegerNode (location: (108,7)-(108,8))
+        │   │       └── flags: decimal
         │   └── operator_loc: (108,4)-(108,6) = "in"
-        ├── @ MatchPredicateNode (location: (109,0)-(109,12))
+        ├── @ MatchPredicateNode (location: (109,0)-(109,11))
         │   ├── value:
         │   │   @ CallNode (location: (109,0)-(109,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2511,11 +2456,11 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ XStringNode (location: (109,7)-(109,12))
-        │   │   ├── flags: ∅
-        │   │   ├── opening_loc: (109,7)-(109,8) = "`"
-        │   │   ├── content_loc: (109,8)-(109,11) = "foo"
-        │   │   ├── closing_loc: (109,11)-(109,12) = "`"
+        │   │   @ SymbolNode (location: (109,7)-(109,11))
+        │   │   ├── flags: forced_us_ascii_encoding
+        │   │   ├── opening_loc: (109,7)-(109,8) = ":"
+        │   │   ├── value_loc: (109,8)-(109,11) = "foo"
+        │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "foo"
         │   └── operator_loc: (109,4)-(109,6) = "in"
         ├── @ MatchPredicateNode (location: (110,0)-(110,14))
@@ -2531,14 +2476,14 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ XStringNode (location: (110,7)-(110,14))
-        │   │   ├── flags: ∅
-        │   │   ├── opening_loc: (110,7)-(110,10) = "%x["
-        │   │   ├── content_loc: (110,10)-(110,13) = "foo"
+        │   │   @ SymbolNode (location: (110,7)-(110,14))
+        │   │   ├── flags: forced_us_ascii_encoding
+        │   │   ├── opening_loc: (110,7)-(110,10) = "%s["
+        │   │   ├── value_loc: (110,10)-(110,13) = "foo"
         │   │   ├── closing_loc: (110,13)-(110,14) = "]"
         │   │   └── unescaped: "foo"
         │   └── operator_loc: (110,4)-(110,6) = "in"
-        ├── @ MatchPredicateNode (location: (111,0)-(111,14))
+        ├── @ MatchPredicateNode (location: (111,0)-(111,13))
         │   ├── value:
         │   │   @ CallNode (location: (111,0)-(111,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2551,19 +2496,14 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ ArrayNode (location: (111,7)-(111,14))
-        │   │   ├── flags: ∅
-        │   │   ├── elements: (length: 1)
-        │   │   │   └── @ SymbolNode (location: (111,10)-(111,13))
-        │   │   │       ├── flags: forced_us_ascii_encoding
-        │   │   │       ├── opening_loc: ∅
-        │   │   │       ├── value_loc: (111,10)-(111,13) = "foo"
-        │   │   │       ├── closing_loc: ∅
-        │   │   │       └── unescaped: "foo"
-        │   │   ├── opening_loc: (111,7)-(111,10) = "%i["
-        │   │   └── closing_loc: (111,13)-(111,14) = "]"
+        │   │   @ SymbolNode (location: (111,7)-(111,13))
+        │   │   ├── flags: forced_us_ascii_encoding
+        │   │   ├── opening_loc: (111,7)-(111,9) = ":\""
+        │   │   ├── value_loc: (111,9)-(111,12) = "foo"
+        │   │   ├── closing_loc: (111,12)-(111,13) = "\""
+        │   │   └── unescaped: "foo"
         │   └── operator_loc: (111,4)-(111,6) = "in"
-        ├── @ MatchPredicateNode (location: (112,0)-(112,14))
+        ├── @ MatchPredicateNode (location: (112,0)-(112,12))
         │   ├── value:
         │   │   @ CallNode (location: (112,0)-(112,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2576,19 +2516,14 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ ArrayNode (location: (112,7)-(112,14))
+        │   │   @ RegularExpressionNode (location: (112,7)-(112,12))
         │   │   ├── flags: ∅
-        │   │   ├── elements: (length: 1)
-        │   │   │   └── @ SymbolNode (location: (112,10)-(112,13))
-        │   │   │       ├── flags: forced_us_ascii_encoding
-        │   │   │       ├── opening_loc: ∅
-        │   │   │       ├── value_loc: (112,10)-(112,13) = "foo"
-        │   │   │       ├── closing_loc: ∅
-        │   │   │       └── unescaped: "foo"
-        │   │   ├── opening_loc: (112,7)-(112,10) = "%I["
-        │   │   └── closing_loc: (112,13)-(112,14) = "]"
+        │   │   ├── opening_loc: (112,7)-(112,8) = "/"
+        │   │   ├── content_loc: (112,8)-(112,11) = "foo"
+        │   │   ├── closing_loc: (112,11)-(112,12) = "/"
+        │   │   └── unescaped: "foo"
         │   └── operator_loc: (112,4)-(112,6) = "in"
-        ├── @ MatchPredicateNode (location: (113,0)-(113,14))
+        ├── @ MatchPredicateNode (location: (113,0)-(113,12))
         │   ├── value:
         │   │   @ CallNode (location: (113,0)-(113,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2601,17 +2536,12 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ ArrayNode (location: (113,7)-(113,14))
+        │   │   @ XStringNode (location: (113,7)-(113,12))
         │   │   ├── flags: ∅
-        │   │   ├── elements: (length: 1)
-        │   │   │   └── @ StringNode (location: (113,10)-(113,13))
-        │   │   │       ├── flags: ∅
-        │   │   │       ├── opening_loc: ∅
-        │   │   │       ├── content_loc: (113,10)-(113,13) = "foo"
-        │   │   │       ├── closing_loc: ∅
-        │   │   │       └── unescaped: "foo"
-        │   │   ├── opening_loc: (113,7)-(113,10) = "%w["
-        │   │   └── closing_loc: (113,13)-(113,14) = "]"
+        │   │   ├── opening_loc: (113,7)-(113,8) = "`"
+        │   │   ├── content_loc: (113,8)-(113,11) = "foo"
+        │   │   ├── closing_loc: (113,11)-(113,12) = "`"
+        │   │   └── unescaped: "foo"
         │   └── operator_loc: (113,4)-(113,6) = "in"
         ├── @ MatchPredicateNode (location: (114,0)-(114,14))
         │   ├── value:
@@ -2626,17 +2556,12 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ ArrayNode (location: (114,7)-(114,14))
+        │   │   @ XStringNode (location: (114,7)-(114,14))
         │   │   ├── flags: ∅
-        │   │   ├── elements: (length: 1)
-        │   │   │   └── @ StringNode (location: (114,10)-(114,13))
-        │   │   │       ├── flags: ∅
-        │   │   │       ├── opening_loc: ∅
-        │   │   │       ├── content_loc: (114,10)-(114,13) = "foo"
-        │   │   │       ├── closing_loc: ∅
-        │   │   │       └── unescaped: "foo"
-        │   │   ├── opening_loc: (114,7)-(114,10) = "%W["
-        │   │   └── closing_loc: (114,13)-(114,14) = "]"
+        │   │   ├── opening_loc: (114,7)-(114,10) = "%x["
+        │   │   ├── content_loc: (114,10)-(114,13) = "foo"
+        │   │   ├── closing_loc: (114,13)-(114,14) = "]"
+        │   │   └── unescaped: "foo"
         │   └── operator_loc: (114,4)-(114,6) = "in"
         ├── @ MatchPredicateNode (location: (115,0)-(115,14))
         │   ├── value:
@@ -2651,12 +2576,17 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ StringNode (location: (115,7)-(115,14))
+        │   │   @ ArrayNode (location: (115,7)-(115,14))
         │   │   ├── flags: ∅
-        │   │   ├── opening_loc: (115,7)-(115,10) = "%q["
-        │   │   ├── content_loc: (115,10)-(115,13) = "foo"
-        │   │   ├── closing_loc: (115,13)-(115,14) = "]"
-        │   │   └── unescaped: "foo"
+        │   │   ├── elements: (length: 1)
+        │   │   │   └── @ SymbolNode (location: (115,10)-(115,13))
+        │   │   │       ├── flags: forced_us_ascii_encoding
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── value_loc: (115,10)-(115,13) = "foo"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "foo"
+        │   │   ├── opening_loc: (115,7)-(115,10) = "%i["
+        │   │   └── closing_loc: (115,13)-(115,14) = "]"
         │   └── operator_loc: (115,4)-(115,6) = "in"
         ├── @ MatchPredicateNode (location: (116,0)-(116,14))
         │   ├── value:
@@ -2671,14 +2601,19 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ StringNode (location: (116,7)-(116,14))
+        │   │   @ ArrayNode (location: (116,7)-(116,14))
         │   │   ├── flags: ∅
-        │   │   ├── opening_loc: (116,7)-(116,10) = "%Q["
-        │   │   ├── content_loc: (116,10)-(116,13) = "foo"
-        │   │   ├── closing_loc: (116,13)-(116,14) = "]"
-        │   │   └── unescaped: "foo"
+        │   │   ├── elements: (length: 1)
+        │   │   │   └── @ SymbolNode (location: (116,10)-(116,13))
+        │   │   │       ├── flags: forced_us_ascii_encoding
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── value_loc: (116,10)-(116,13) = "foo"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "foo"
+        │   │   ├── opening_loc: (116,7)-(116,10) = "%I["
+        │   │   └── closing_loc: (116,13)-(116,14) = "]"
         │   └── operator_loc: (116,4)-(116,6) = "in"
-        ├── @ MatchPredicateNode (location: (117,0)-(117,12))
+        ├── @ MatchPredicateNode (location: (117,0)-(117,14))
         │   ├── value:
         │   │   @ CallNode (location: (117,0)-(117,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2691,14 +2626,19 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ StringNode (location: (117,7)-(117,12))
+        │   │   @ ArrayNode (location: (117,7)-(117,14))
         │   │   ├── flags: ∅
-        │   │   ├── opening_loc: (117,7)-(117,8) = "\""
-        │   │   ├── content_loc: (117,8)-(117,11) = "foo"
-        │   │   ├── closing_loc: (117,11)-(117,12) = "\""
-        │   │   └── unescaped: "foo"
+        │   │   ├── elements: (length: 1)
+        │   │   │   └── @ StringNode (location: (117,10)-(117,13))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── content_loc: (117,10)-(117,13) = "foo"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "foo"
+        │   │   ├── opening_loc: (117,7)-(117,10) = "%w["
+        │   │   └── closing_loc: (117,13)-(117,14) = "]"
         │   └── operator_loc: (117,4)-(117,6) = "in"
-        ├── @ MatchPredicateNode (location: (118,0)-(118,10))
+        ├── @ MatchPredicateNode (location: (118,0)-(118,14))
         │   ├── value:
         │   │   @ CallNode (location: (118,0)-(118,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2711,9 +2651,19 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ NilNode (location: (118,7)-(118,10))
+        │   │   @ ArrayNode (location: (118,7)-(118,14))
+        │   │   ├── flags: ∅
+        │   │   ├── elements: (length: 1)
+        │   │   │   └── @ StringNode (location: (118,10)-(118,13))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── opening_loc: ∅
+        │   │   │       ├── content_loc: (118,10)-(118,13) = "foo"
+        │   │   │       ├── closing_loc: ∅
+        │   │   │       └── unescaped: "foo"
+        │   │   ├── opening_loc: (118,7)-(118,10) = "%W["
+        │   │   └── closing_loc: (118,13)-(118,14) = "]"
         │   └── operator_loc: (118,4)-(118,6) = "in"
-        ├── @ MatchPredicateNode (location: (119,0)-(119,11))
+        ├── @ MatchPredicateNode (location: (119,0)-(119,14))
         │   ├── value:
         │   │   @ CallNode (location: (119,0)-(119,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2726,9 +2676,14 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ SelfNode (location: (119,7)-(119,11))
+        │   │   @ StringNode (location: (119,7)-(119,14))
+        │   │   ├── flags: ∅
+        │   │   ├── opening_loc: (119,7)-(119,10) = "%q["
+        │   │   ├── content_loc: (119,10)-(119,13) = "foo"
+        │   │   ├── closing_loc: (119,13)-(119,14) = "]"
+        │   │   └── unescaped: "foo"
         │   └── operator_loc: (119,4)-(119,6) = "in"
-        ├── @ MatchPredicateNode (location: (120,0)-(120,11))
+        ├── @ MatchPredicateNode (location: (120,0)-(120,14))
         │   ├── value:
         │   │   @ CallNode (location: (120,0)-(120,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2741,7 +2696,12 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ TrueNode (location: (120,7)-(120,11))
+        │   │   @ StringNode (location: (120,7)-(120,14))
+        │   │   ├── flags: ∅
+        │   │   ├── opening_loc: (120,7)-(120,10) = "%Q["
+        │   │   ├── content_loc: (120,10)-(120,13) = "foo"
+        │   │   ├── closing_loc: (120,13)-(120,14) = "]"
+        │   │   └── unescaped: "foo"
         │   └── operator_loc: (120,4)-(120,6) = "in"
         ├── @ MatchPredicateNode (location: (121,0)-(121,12))
         │   ├── value:
@@ -2756,9 +2716,14 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ FalseNode (location: (121,7)-(121,12))
+        │   │   @ StringNode (location: (121,7)-(121,12))
+        │   │   ├── flags: ∅
+        │   │   ├── opening_loc: (121,7)-(121,8) = "\""
+        │   │   ├── content_loc: (121,8)-(121,11) = "foo"
+        │   │   ├── closing_loc: (121,11)-(121,12) = "\""
+        │   │   └── unescaped: "foo"
         │   └── operator_loc: (121,4)-(121,6) = "in"
-        ├── @ MatchPredicateNode (location: (122,0)-(122,15))
+        ├── @ MatchPredicateNode (location: (122,0)-(122,10))
         │   ├── value:
         │   │   @ CallNode (location: (122,0)-(122,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2771,10 +2736,9 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ SourceFileNode (location: (122,7)-(122,15))
-        │   │   └── filepath: "patterns.txt"
+        │   │   @ NilNode (location: (122,7)-(122,10))
         │   └── operator_loc: (122,4)-(122,6) = "in"
-        ├── @ MatchPredicateNode (location: (123,0)-(123,15))
+        ├── @ MatchPredicateNode (location: (123,0)-(123,11))
         │   ├── value:
         │   │   @ CallNode (location: (123,0)-(123,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2787,9 +2751,9 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ SourceLineNode (location: (123,7)-(123,15))
+        │   │   @ SelfNode (location: (123,7)-(123,11))
         │   └── operator_loc: (123,4)-(123,6) = "in"
-        ├── @ MatchPredicateNode (location: (124,0)-(124,19))
+        ├── @ MatchPredicateNode (location: (124,0)-(124,11))
         │   ├── value:
         │   │   @ CallNode (location: (124,0)-(124,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2802,9 +2766,9 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ SourceEncodingNode (location: (124,7)-(124,19))
+        │   │   @ TrueNode (location: (124,7)-(124,11))
         │   └── operator_loc: (124,4)-(124,6) = "in"
-        ├── @ MatchPredicateNode (location: (125,0)-(125,17))
+        ├── @ MatchPredicateNode (location: (125,0)-(125,12))
         │   ├── value:
         │   │   @ CallNode (location: (125,0)-(125,3))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -2817,220 +2781,106 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ LambdaNode (location: (125,7)-(125,17))
+        │   │   @ FalseNode (location: (125,7)-(125,12))
+        │   └── operator_loc: (125,4)-(125,6) = "in"
+        ├── @ MatchPredicateNode (location: (126,0)-(126,15))
+        │   ├── value:
+        │   │   @ CallNode (location: (126,0)-(126,3))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (126,0)-(126,3) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── pattern:
+        │   │   @ SourceFileNode (location: (126,7)-(126,15))
+        │   │   └── filepath: "patterns.txt"
+        │   └── operator_loc: (126,4)-(126,6) = "in"
+        ├── @ MatchPredicateNode (location: (127,0)-(127,15))
+        │   ├── value:
+        │   │   @ CallNode (location: (127,0)-(127,3))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (127,0)-(127,3) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── pattern:
+        │   │   @ SourceLineNode (location: (127,7)-(127,15))
+        │   └── operator_loc: (127,4)-(127,6) = "in"
+        ├── @ MatchPredicateNode (location: (128,0)-(128,19))
+        │   ├── value:
+        │   │   @ CallNode (location: (128,0)-(128,3))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (128,0)-(128,3) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── pattern:
+        │   │   @ SourceEncodingNode (location: (128,7)-(128,19))
+        │   └── operator_loc: (128,4)-(128,6) = "in"
+        ├── @ MatchPredicateNode (location: (129,0)-(129,17))
+        │   ├── value:
+        │   │   @ CallNode (location: (129,0)-(129,3))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (129,0)-(129,3) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── pattern:
+        │   │   @ LambdaNode (location: (129,7)-(129,17))
         │   │   ├── locals: []
-        │   │   ├── operator_loc: (125,7)-(125,9) = "->"
-        │   │   ├── opening_loc: (125,10)-(125,11) = "{"
-        │   │   ├── closing_loc: (125,16)-(125,17) = "}"
+        │   │   ├── operator_loc: (129,7)-(129,9) = "->"
+        │   │   ├── opening_loc: (129,10)-(129,11) = "{"
+        │   │   ├── closing_loc: (129,16)-(129,17) = "}"
         │   │   ├── parameters: ∅
         │   │   └── body:
-        │   │       @ StatementsNode (location: (125,12)-(125,15))
+        │   │       @ StatementsNode (location: (129,12)-(129,15))
         │   │       └── body: (length: 1)
-        │   │           └── @ LocalVariableReadNode (location: (125,12)-(125,15))
+        │   │           └── @ LocalVariableReadNode (location: (129,12)-(129,15))
         │   │               ├── name: :bar
         │   │               └── depth: 1
-        │   └── operator_loc: (125,4)-(125,6) = "in"
-        ├── @ CaseMatchNode (location: (127,0)-(127,25))
-        │   ├── predicate:
-        │   │   @ CallNode (location: (127,5)-(127,8))
+        │   └── operator_loc: (129,4)-(129,6) = "in"
+        ├── @ MatchPredicateNode (location: (131,0)-(131,11))
+        │   ├── value:
+        │   │   @ CallNode (location: (131,0)-(131,3))
         │   │   ├── flags: variable_call, ignore_visibility
         │   │   ├── receiver: ∅
         │   │   ├── call_operator_loc: ∅
         │   │   ├── name: :foo
-        │   │   ├── message_loc: (127,5)-(127,8) = "foo"
+        │   │   ├── message_loc: (131,0)-(131,3) = "foo"
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments: ∅
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
-        │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (127,10)-(127,21))
-        │   │       ├── pattern:
-        │   │       │   @ LocalVariableTargetNode (location: (127,13)-(127,16))
-        │   │       │   ├── name: :bar
-        │   │       │   └── depth: 0
-        │   │       ├── statements: ∅
-        │   │       ├── in_loc: (127,10)-(127,12) = "in"
-        │   │       └── then_loc: (127,17)-(127,21) = "then"
-        │   ├── consequent: ∅
-        │   ├── case_keyword_loc: (127,0)-(127,4) = "case"
-        │   └── end_keyword_loc: (127,22)-(127,25) = "end"
-        ├── @ CaseMatchNode (location: (128,0)-(128,23))
-        │   ├── predicate:
-        │   │   @ CallNode (location: (128,5)-(128,8))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (128,5)-(128,8) = "foo"
+        │   ├── pattern:
+        │   │   @ ArrayPatternNode (location: (131,7)-(131,11))
+        │   │   ├── constant: ∅
+        │   │   ├── requireds: (length: 1)
+        │   │   │   └── @ LocalVariableTargetNode (location: (131,7)-(131,10))
+        │   │   │       ├── name: :bar
+        │   │   │       └── depth: 0
+        │   │   ├── rest:
+        │   │   │   @ ImplicitRestNode (location: (131,10)-(131,11))
+        │   │   ├── posts: (length: 0)
         │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (128,10)-(128,19))
-        │   │       ├── pattern:
-        │   │       │   @ IntegerNode (location: (128,13)-(128,14))
-        │   │       │   └── flags: decimal
-        │   │       ├── statements: ∅
-        │   │       ├── in_loc: (128,10)-(128,12) = "in"
-        │   │       └── then_loc: (128,15)-(128,19) = "then"
-        │   ├── consequent: ∅
-        │   ├── case_keyword_loc: (128,0)-(128,4) = "case"
-        │   └── end_keyword_loc: (128,20)-(128,23) = "end"
-        ├── @ CaseMatchNode (location: (129,0)-(129,25))
-        │   ├── predicate:
-        │   │   @ CallNode (location: (129,5)-(129,8))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (129,5)-(129,8) = "foo"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (129,10)-(129,21))
-        │   │       ├── pattern:
-        │   │       │   @ FloatNode (location: (129,13)-(129,16))
-        │   │       ├── statements: ∅
-        │   │       ├── in_loc: (129,10)-(129,12) = "in"
-        │   │       └── then_loc: (129,17)-(129,21) = "then"
-        │   ├── consequent: ∅
-        │   ├── case_keyword_loc: (129,0)-(129,4) = "case"
-        │   └── end_keyword_loc: (129,22)-(129,25) = "end"
-        ├── @ CaseMatchNode (location: (130,0)-(130,24))
-        │   ├── predicate:
-        │   │   @ CallNode (location: (130,5)-(130,8))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (130,5)-(130,8) = "foo"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (130,10)-(130,20))
-        │   │       ├── pattern:
-        │   │       │   @ ImaginaryNode (location: (130,13)-(130,15))
-        │   │       │   └── numeric:
-        │   │       │       @ IntegerNode (location: (130,13)-(130,14))
-        │   │       │       └── flags: decimal
-        │   │       ├── statements: ∅
-        │   │       ├── in_loc: (130,10)-(130,12) = "in"
-        │   │       └── then_loc: (130,16)-(130,20) = "then"
-        │   ├── consequent: ∅
-        │   ├── case_keyword_loc: (130,0)-(130,4) = "case"
-        │   └── end_keyword_loc: (130,21)-(130,24) = "end"
-        ├── @ CaseMatchNode (location: (131,0)-(131,24))
-        │   ├── predicate:
-        │   │   @ CallNode (location: (131,5)-(131,8))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (131,5)-(131,8) = "foo"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (131,10)-(131,20))
-        │   │       ├── pattern:
-        │   │       │   @ RationalNode (location: (131,13)-(131,15))
-        │   │       │   └── numeric:
-        │   │       │       @ IntegerNode (location: (131,13)-(131,14))
-        │   │       │       └── flags: decimal
-        │   │       ├── statements: ∅
-        │   │       ├── in_loc: (131,10)-(131,12) = "in"
-        │   │       └── then_loc: (131,16)-(131,20) = "then"
-        │   ├── consequent: ∅
-        │   ├── case_keyword_loc: (131,0)-(131,4) = "case"
-        │   └── end_keyword_loc: (131,21)-(131,24) = "end"
-        ├── @ CaseMatchNode (location: (132,0)-(132,26))
-        │   ├── predicate:
-        │   │   @ CallNode (location: (132,5)-(132,8))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (132,5)-(132,8) = "foo"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (132,10)-(132,22))
-        │   │       ├── pattern:
-        │   │       │   @ SymbolNode (location: (132,13)-(132,17))
-        │   │       │   ├── flags: forced_us_ascii_encoding
-        │   │       │   ├── opening_loc: (132,13)-(132,14) = ":"
-        │   │       │   ├── value_loc: (132,14)-(132,17) = "foo"
-        │   │       │   ├── closing_loc: ∅
-        │   │       │   └── unescaped: "foo"
-        │   │       ├── statements: ∅
-        │   │       ├── in_loc: (132,10)-(132,12) = "in"
-        │   │       └── then_loc: (132,18)-(132,22) = "then"
-        │   ├── consequent: ∅
-        │   ├── case_keyword_loc: (132,0)-(132,4) = "case"
-        │   └── end_keyword_loc: (132,23)-(132,26) = "end"
-        ├── @ CaseMatchNode (location: (133,0)-(133,29))
-        │   ├── predicate:
-        │   │   @ CallNode (location: (133,5)-(133,8))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (133,5)-(133,8) = "foo"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (133,10)-(133,25))
-        │   │       ├── pattern:
-        │   │       │   @ SymbolNode (location: (133,13)-(133,20))
-        │   │       │   ├── flags: forced_us_ascii_encoding
-        │   │       │   ├── opening_loc: (133,13)-(133,16) = "%s["
-        │   │       │   ├── value_loc: (133,16)-(133,19) = "foo"
-        │   │       │   ├── closing_loc: (133,19)-(133,20) = "]"
-        │   │       │   └── unescaped: "foo"
-        │   │       ├── statements: ∅
-        │   │       ├── in_loc: (133,10)-(133,12) = "in"
-        │   │       └── then_loc: (133,21)-(133,25) = "then"
-        │   ├── consequent: ∅
-        │   ├── case_keyword_loc: (133,0)-(133,4) = "case"
-        │   └── end_keyword_loc: (133,26)-(133,29) = "end"
-        ├── @ CaseMatchNode (location: (134,0)-(134,28))
-        │   ├── predicate:
-        │   │   @ CallNode (location: (134,5)-(134,8))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (134,5)-(134,8) = "foo"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (134,10)-(134,24))
-        │   │       ├── pattern:
-        │   │       │   @ SymbolNode (location: (134,13)-(134,19))
-        │   │       │   ├── flags: forced_us_ascii_encoding
-        │   │       │   ├── opening_loc: (134,13)-(134,15) = ":\""
-        │   │       │   ├── value_loc: (134,15)-(134,18) = "foo"
-        │   │       │   ├── closing_loc: (134,18)-(134,19) = "\""
-        │   │       │   └── unescaped: "foo"
-        │   │       ├── statements: ∅
-        │   │       ├── in_loc: (134,10)-(134,12) = "in"
-        │   │       └── then_loc: (134,20)-(134,24) = "then"
-        │   ├── consequent: ∅
-        │   ├── case_keyword_loc: (134,0)-(134,4) = "case"
-        │   └── end_keyword_loc: (134,25)-(134,28) = "end"
-        ├── @ CaseMatchNode (location: (135,0)-(135,27))
+        │   │   └── closing_loc: ∅
+        │   └── operator_loc: (131,4)-(131,6) = "in"
+        ├── @ CaseMatchNode (location: (135,0)-(135,25))
         │   ├── predicate:
         │   │   @ CallNode (location: (135,5)-(135,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3043,21 +2893,18 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (135,10)-(135,23))
+        │   │   └── @ InNode (location: (135,10)-(135,21))
         │   │       ├── pattern:
-        │   │       │   @ RegularExpressionNode (location: (135,13)-(135,18))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (135,13)-(135,14) = "/"
-        │   │       │   ├── content_loc: (135,14)-(135,17) = "foo"
-        │   │       │   ├── closing_loc: (135,17)-(135,18) = "/"
-        │   │       │   └── unescaped: "foo"
+        │   │       │   @ LocalVariableTargetNode (location: (135,13)-(135,16))
+        │   │       │   ├── name: :bar
+        │   │       │   └── depth: 0
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (135,10)-(135,12) = "in"
-        │   │       └── then_loc: (135,19)-(135,23) = "then"
+        │   │       └── then_loc: (135,17)-(135,21) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (135,0)-(135,4) = "case"
-        │   └── end_keyword_loc: (135,24)-(135,27) = "end"
-        ├── @ CaseMatchNode (location: (136,0)-(136,27))
+        │   └── end_keyword_loc: (135,22)-(135,25) = "end"
+        ├── @ CaseMatchNode (location: (136,0)-(136,23))
         │   ├── predicate:
         │   │   @ CallNode (location: (136,5)-(136,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3070,21 +2917,17 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (136,10)-(136,23))
+        │   │   └── @ InNode (location: (136,10)-(136,19))
         │   │       ├── pattern:
-        │   │       │   @ XStringNode (location: (136,13)-(136,18))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (136,13)-(136,14) = "`"
-        │   │       │   ├── content_loc: (136,14)-(136,17) = "foo"
-        │   │       │   ├── closing_loc: (136,17)-(136,18) = "`"
-        │   │       │   └── unescaped: "foo"
+        │   │       │   @ IntegerNode (location: (136,13)-(136,14))
+        │   │       │   └── flags: decimal
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (136,10)-(136,12) = "in"
-        │   │       └── then_loc: (136,19)-(136,23) = "then"
+        │   │       └── then_loc: (136,15)-(136,19) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (136,0)-(136,4) = "case"
-        │   └── end_keyword_loc: (136,24)-(136,27) = "end"
-        ├── @ CaseMatchNode (location: (137,0)-(137,29))
+        │   └── end_keyword_loc: (136,20)-(136,23) = "end"
+        ├── @ CaseMatchNode (location: (137,0)-(137,25))
         │   ├── predicate:
         │   │   @ CallNode (location: (137,5)-(137,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3097,21 +2940,16 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (137,10)-(137,25))
+        │   │   └── @ InNode (location: (137,10)-(137,21))
         │   │       ├── pattern:
-        │   │       │   @ XStringNode (location: (137,13)-(137,20))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (137,13)-(137,16) = "%x["
-        │   │       │   ├── content_loc: (137,16)-(137,19) = "foo"
-        │   │       │   ├── closing_loc: (137,19)-(137,20) = "]"
-        │   │       │   └── unescaped: "foo"
+        │   │       │   @ FloatNode (location: (137,13)-(137,16))
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (137,10)-(137,12) = "in"
-        │   │       └── then_loc: (137,21)-(137,25) = "then"
+        │   │       └── then_loc: (137,17)-(137,21) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (137,0)-(137,4) = "case"
-        │   └── end_keyword_loc: (137,26)-(137,29) = "end"
-        ├── @ CaseMatchNode (location: (138,0)-(138,29))
+        │   └── end_keyword_loc: (137,22)-(137,25) = "end"
+        ├── @ CaseMatchNode (location: (138,0)-(138,24))
         │   ├── predicate:
         │   │   @ CallNode (location: (138,5)-(138,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3124,26 +2962,19 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (138,10)-(138,25))
+        │   │   └── @ InNode (location: (138,10)-(138,20))
         │   │       ├── pattern:
-        │   │       │   @ ArrayNode (location: (138,13)-(138,20))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── elements: (length: 1)
-        │   │       │   │   └── @ SymbolNode (location: (138,16)-(138,19))
-        │   │       │   │       ├── flags: forced_us_ascii_encoding
-        │   │       │   │       ├── opening_loc: ∅
-        │   │       │   │       ├── value_loc: (138,16)-(138,19) = "foo"
-        │   │       │   │       ├── closing_loc: ∅
-        │   │       │   │       └── unescaped: "foo"
-        │   │       │   ├── opening_loc: (138,13)-(138,16) = "%i["
-        │   │       │   └── closing_loc: (138,19)-(138,20) = "]"
+        │   │       │   @ ImaginaryNode (location: (138,13)-(138,15))
+        │   │       │   └── numeric:
+        │   │       │       @ IntegerNode (location: (138,13)-(138,14))
+        │   │       │       └── flags: decimal
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (138,10)-(138,12) = "in"
-        │   │       └── then_loc: (138,21)-(138,25) = "then"
+        │   │       └── then_loc: (138,16)-(138,20) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (138,0)-(138,4) = "case"
-        │   └── end_keyword_loc: (138,26)-(138,29) = "end"
-        ├── @ CaseMatchNode (location: (139,0)-(139,29))
+        │   └── end_keyword_loc: (138,21)-(138,24) = "end"
+        ├── @ CaseMatchNode (location: (139,0)-(139,24))
         │   ├── predicate:
         │   │   @ CallNode (location: (139,5)-(139,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3156,26 +2987,19 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (139,10)-(139,25))
+        │   │   └── @ InNode (location: (139,10)-(139,20))
         │   │       ├── pattern:
-        │   │       │   @ ArrayNode (location: (139,13)-(139,20))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── elements: (length: 1)
-        │   │       │   │   └── @ SymbolNode (location: (139,16)-(139,19))
-        │   │       │   │       ├── flags: forced_us_ascii_encoding
-        │   │       │   │       ├── opening_loc: ∅
-        │   │       │   │       ├── value_loc: (139,16)-(139,19) = "foo"
-        │   │       │   │       ├── closing_loc: ∅
-        │   │       │   │       └── unescaped: "foo"
-        │   │       │   ├── opening_loc: (139,13)-(139,16) = "%I["
-        │   │       │   └── closing_loc: (139,19)-(139,20) = "]"
+        │   │       │   @ RationalNode (location: (139,13)-(139,15))
+        │   │       │   └── numeric:
+        │   │       │       @ IntegerNode (location: (139,13)-(139,14))
+        │   │       │       └── flags: decimal
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (139,10)-(139,12) = "in"
-        │   │       └── then_loc: (139,21)-(139,25) = "then"
+        │   │       └── then_loc: (139,16)-(139,20) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (139,0)-(139,4) = "case"
-        │   └── end_keyword_loc: (139,26)-(139,29) = "end"
-        ├── @ CaseMatchNode (location: (140,0)-(140,29))
+        │   └── end_keyword_loc: (139,21)-(139,24) = "end"
+        ├── @ CaseMatchNode (location: (140,0)-(140,26))
         │   ├── predicate:
         │   │   @ CallNode (location: (140,5)-(140,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3188,25 +3012,20 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (140,10)-(140,25))
+        │   │   └── @ InNode (location: (140,10)-(140,22))
         │   │       ├── pattern:
-        │   │       │   @ ArrayNode (location: (140,13)-(140,20))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── elements: (length: 1)
-        │   │       │   │   └── @ StringNode (location: (140,16)-(140,19))
-        │   │       │   │       ├── flags: ∅
-        │   │       │   │       ├── opening_loc: ∅
-        │   │       │   │       ├── content_loc: (140,16)-(140,19) = "foo"
-        │   │       │   │       ├── closing_loc: ∅
-        │   │       │   │       └── unescaped: "foo"
-        │   │       │   ├── opening_loc: (140,13)-(140,16) = "%w["
-        │   │       │   └── closing_loc: (140,19)-(140,20) = "]"
+        │   │       │   @ SymbolNode (location: (140,13)-(140,17))
+        │   │       │   ├── flags: forced_us_ascii_encoding
+        │   │       │   ├── opening_loc: (140,13)-(140,14) = ":"
+        │   │       │   ├── value_loc: (140,14)-(140,17) = "foo"
+        │   │       │   ├── closing_loc: ∅
+        │   │       │   └── unescaped: "foo"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (140,10)-(140,12) = "in"
-        │   │       └── then_loc: (140,21)-(140,25) = "then"
+        │   │       └── then_loc: (140,18)-(140,22) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (140,0)-(140,4) = "case"
-        │   └── end_keyword_loc: (140,26)-(140,29) = "end"
+        │   └── end_keyword_loc: (140,23)-(140,26) = "end"
         ├── @ CaseMatchNode (location: (141,0)-(141,29))
         │   ├── predicate:
         │   │   @ CallNode (location: (141,5)-(141,8))
@@ -3222,24 +3041,19 @@
         │   ├── conditions: (length: 1)
         │   │   └── @ InNode (location: (141,10)-(141,25))
         │   │       ├── pattern:
-        │   │       │   @ ArrayNode (location: (141,13)-(141,20))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── elements: (length: 1)
-        │   │       │   │   └── @ StringNode (location: (141,16)-(141,19))
-        │   │       │   │       ├── flags: ∅
-        │   │       │   │       ├── opening_loc: ∅
-        │   │       │   │       ├── content_loc: (141,16)-(141,19) = "foo"
-        │   │       │   │       ├── closing_loc: ∅
-        │   │       │   │       └── unescaped: "foo"
-        │   │       │   ├── opening_loc: (141,13)-(141,16) = "%W["
-        │   │       │   └── closing_loc: (141,19)-(141,20) = "]"
+        │   │       │   @ SymbolNode (location: (141,13)-(141,20))
+        │   │       │   ├── flags: forced_us_ascii_encoding
+        │   │       │   ├── opening_loc: (141,13)-(141,16) = "%s["
+        │   │       │   ├── value_loc: (141,16)-(141,19) = "foo"
+        │   │       │   ├── closing_loc: (141,19)-(141,20) = "]"
+        │   │       │   └── unescaped: "foo"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (141,10)-(141,12) = "in"
         │   │       └── then_loc: (141,21)-(141,25) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (141,0)-(141,4) = "case"
         │   └── end_keyword_loc: (141,26)-(141,29) = "end"
-        ├── @ CaseMatchNode (location: (142,0)-(142,29))
+        ├── @ CaseMatchNode (location: (142,0)-(142,28))
         │   ├── predicate:
         │   │   @ CallNode (location: (142,5)-(142,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3252,21 +3066,21 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (142,10)-(142,25))
+        │   │   └── @ InNode (location: (142,10)-(142,24))
         │   │       ├── pattern:
-        │   │       │   @ StringNode (location: (142,13)-(142,20))
-        │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (142,13)-(142,16) = "%q["
-        │   │       │   ├── content_loc: (142,16)-(142,19) = "foo"
-        │   │       │   ├── closing_loc: (142,19)-(142,20) = "]"
+        │   │       │   @ SymbolNode (location: (142,13)-(142,19))
+        │   │       │   ├── flags: forced_us_ascii_encoding
+        │   │       │   ├── opening_loc: (142,13)-(142,15) = ":\""
+        │   │       │   ├── value_loc: (142,15)-(142,18) = "foo"
+        │   │       │   ├── closing_loc: (142,18)-(142,19) = "\""
         │   │       │   └── unescaped: "foo"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (142,10)-(142,12) = "in"
-        │   │       └── then_loc: (142,21)-(142,25) = "then"
+        │   │       └── then_loc: (142,20)-(142,24) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (142,0)-(142,4) = "case"
-        │   └── end_keyword_loc: (142,26)-(142,29) = "end"
-        ├── @ CaseMatchNode (location: (143,0)-(143,29))
+        │   └── end_keyword_loc: (142,25)-(142,28) = "end"
+        ├── @ CaseMatchNode (location: (143,0)-(143,27))
         │   ├── predicate:
         │   │   @ CallNode (location: (143,5)-(143,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3279,20 +3093,20 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (143,10)-(143,25))
+        │   │   └── @ InNode (location: (143,10)-(143,23))
         │   │       ├── pattern:
-        │   │       │   @ StringNode (location: (143,13)-(143,20))
+        │   │       │   @ RegularExpressionNode (location: (143,13)-(143,18))
         │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (143,13)-(143,16) = "%Q["
-        │   │       │   ├── content_loc: (143,16)-(143,19) = "foo"
-        │   │       │   ├── closing_loc: (143,19)-(143,20) = "]"
+        │   │       │   ├── opening_loc: (143,13)-(143,14) = "/"
+        │   │       │   ├── content_loc: (143,14)-(143,17) = "foo"
+        │   │       │   ├── closing_loc: (143,17)-(143,18) = "/"
         │   │       │   └── unescaped: "foo"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (143,10)-(143,12) = "in"
-        │   │       └── then_loc: (143,21)-(143,25) = "then"
+        │   │       └── then_loc: (143,19)-(143,23) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (143,0)-(143,4) = "case"
-        │   └── end_keyword_loc: (143,26)-(143,29) = "end"
+        │   └── end_keyword_loc: (143,24)-(143,27) = "end"
         ├── @ CaseMatchNode (location: (144,0)-(144,27))
         │   ├── predicate:
         │   │   @ CallNode (location: (144,5)-(144,8))
@@ -3308,11 +3122,11 @@
         │   ├── conditions: (length: 1)
         │   │   └── @ InNode (location: (144,10)-(144,23))
         │   │       ├── pattern:
-        │   │       │   @ StringNode (location: (144,13)-(144,18))
+        │   │       │   @ XStringNode (location: (144,13)-(144,18))
         │   │       │   ├── flags: ∅
-        │   │       │   ├── opening_loc: (144,13)-(144,14) = "\""
+        │   │       │   ├── opening_loc: (144,13)-(144,14) = "`"
         │   │       │   ├── content_loc: (144,14)-(144,17) = "foo"
-        │   │       │   ├── closing_loc: (144,17)-(144,18) = "\""
+        │   │       │   ├── closing_loc: (144,17)-(144,18) = "`"
         │   │       │   └── unescaped: "foo"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (144,10)-(144,12) = "in"
@@ -3320,7 +3134,7 @@
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (144,0)-(144,4) = "case"
         │   └── end_keyword_loc: (144,24)-(144,27) = "end"
-        ├── @ CaseMatchNode (location: (145,0)-(145,25))
+        ├── @ CaseMatchNode (location: (145,0)-(145,29))
         │   ├── predicate:
         │   │   @ CallNode (location: (145,5)-(145,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3333,16 +3147,21 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (145,10)-(145,21))
+        │   │   └── @ InNode (location: (145,10)-(145,25))
         │   │       ├── pattern:
-        │   │       │   @ NilNode (location: (145,13)-(145,16))
+        │   │       │   @ XStringNode (location: (145,13)-(145,20))
+        │   │       │   ├── flags: ∅
+        │   │       │   ├── opening_loc: (145,13)-(145,16) = "%x["
+        │   │       │   ├── content_loc: (145,16)-(145,19) = "foo"
+        │   │       │   ├── closing_loc: (145,19)-(145,20) = "]"
+        │   │       │   └── unescaped: "foo"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (145,10)-(145,12) = "in"
-        │   │       └── then_loc: (145,17)-(145,21) = "then"
+        │   │       └── then_loc: (145,21)-(145,25) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (145,0)-(145,4) = "case"
-        │   └── end_keyword_loc: (145,22)-(145,25) = "end"
-        ├── @ CaseMatchNode (location: (146,0)-(146,26))
+        │   └── end_keyword_loc: (145,26)-(145,29) = "end"
+        ├── @ CaseMatchNode (location: (146,0)-(146,29))
         │   ├── predicate:
         │   │   @ CallNode (location: (146,5)-(146,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3355,16 +3174,26 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (146,10)-(146,22))
+        │   │   └── @ InNode (location: (146,10)-(146,25))
         │   │       ├── pattern:
-        │   │       │   @ SelfNode (location: (146,13)-(146,17))
+        │   │       │   @ ArrayNode (location: (146,13)-(146,20))
+        │   │       │   ├── flags: ∅
+        │   │       │   ├── elements: (length: 1)
+        │   │       │   │   └── @ SymbolNode (location: (146,16)-(146,19))
+        │   │       │   │       ├── flags: forced_us_ascii_encoding
+        │   │       │   │       ├── opening_loc: ∅
+        │   │       │   │       ├── value_loc: (146,16)-(146,19) = "foo"
+        │   │       │   │       ├── closing_loc: ∅
+        │   │       │   │       └── unescaped: "foo"
+        │   │       │   ├── opening_loc: (146,13)-(146,16) = "%i["
+        │   │       │   └── closing_loc: (146,19)-(146,20) = "]"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (146,10)-(146,12) = "in"
-        │   │       └── then_loc: (146,18)-(146,22) = "then"
+        │   │       └── then_loc: (146,21)-(146,25) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (146,0)-(146,4) = "case"
-        │   └── end_keyword_loc: (146,23)-(146,26) = "end"
-        ├── @ CaseMatchNode (location: (147,0)-(147,26))
+        │   └── end_keyword_loc: (146,26)-(146,29) = "end"
+        ├── @ CaseMatchNode (location: (147,0)-(147,29))
         │   ├── predicate:
         │   │   @ CallNode (location: (147,5)-(147,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3377,16 +3206,26 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (147,10)-(147,22))
+        │   │   └── @ InNode (location: (147,10)-(147,25))
         │   │       ├── pattern:
-        │   │       │   @ TrueNode (location: (147,13)-(147,17))
+        │   │       │   @ ArrayNode (location: (147,13)-(147,20))
+        │   │       │   ├── flags: ∅
+        │   │       │   ├── elements: (length: 1)
+        │   │       │   │   └── @ SymbolNode (location: (147,16)-(147,19))
+        │   │       │   │       ├── flags: forced_us_ascii_encoding
+        │   │       │   │       ├── opening_loc: ∅
+        │   │       │   │       ├── value_loc: (147,16)-(147,19) = "foo"
+        │   │       │   │       ├── closing_loc: ∅
+        │   │       │   │       └── unescaped: "foo"
+        │   │       │   ├── opening_loc: (147,13)-(147,16) = "%I["
+        │   │       │   └── closing_loc: (147,19)-(147,20) = "]"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (147,10)-(147,12) = "in"
-        │   │       └── then_loc: (147,18)-(147,22) = "then"
+        │   │       └── then_loc: (147,21)-(147,25) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (147,0)-(147,4) = "case"
-        │   └── end_keyword_loc: (147,23)-(147,26) = "end"
-        ├── @ CaseMatchNode (location: (148,0)-(148,27))
+        │   └── end_keyword_loc: (147,26)-(147,29) = "end"
+        ├── @ CaseMatchNode (location: (148,0)-(148,29))
         │   ├── predicate:
         │   │   @ CallNode (location: (148,5)-(148,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3399,16 +3238,26 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (148,10)-(148,23))
+        │   │   └── @ InNode (location: (148,10)-(148,25))
         │   │       ├── pattern:
-        │   │       │   @ FalseNode (location: (148,13)-(148,18))
+        │   │       │   @ ArrayNode (location: (148,13)-(148,20))
+        │   │       │   ├── flags: ∅
+        │   │       │   ├── elements: (length: 1)
+        │   │       │   │   └── @ StringNode (location: (148,16)-(148,19))
+        │   │       │   │       ├── flags: ∅
+        │   │       │   │       ├── opening_loc: ∅
+        │   │       │   │       ├── content_loc: (148,16)-(148,19) = "foo"
+        │   │       │   │       ├── closing_loc: ∅
+        │   │       │   │       └── unescaped: "foo"
+        │   │       │   ├── opening_loc: (148,13)-(148,16) = "%w["
+        │   │       │   └── closing_loc: (148,19)-(148,20) = "]"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (148,10)-(148,12) = "in"
-        │   │       └── then_loc: (148,19)-(148,23) = "then"
+        │   │       └── then_loc: (148,21)-(148,25) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (148,0)-(148,4) = "case"
-        │   └── end_keyword_loc: (148,24)-(148,27) = "end"
-        ├── @ CaseMatchNode (location: (149,0)-(149,30))
+        │   └── end_keyword_loc: (148,26)-(148,29) = "end"
+        ├── @ CaseMatchNode (location: (149,0)-(149,29))
         │   ├── predicate:
         │   │   @ CallNode (location: (149,5)-(149,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3421,17 +3270,26 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (149,10)-(149,26))
+        │   │   └── @ InNode (location: (149,10)-(149,25))
         │   │       ├── pattern:
-        │   │       │   @ SourceFileNode (location: (149,13)-(149,21))
-        │   │       │   └── filepath: "patterns.txt"
+        │   │       │   @ ArrayNode (location: (149,13)-(149,20))
+        │   │       │   ├── flags: ∅
+        │   │       │   ├── elements: (length: 1)
+        │   │       │   │   └── @ StringNode (location: (149,16)-(149,19))
+        │   │       │   │       ├── flags: ∅
+        │   │       │   │       ├── opening_loc: ∅
+        │   │       │   │       ├── content_loc: (149,16)-(149,19) = "foo"
+        │   │       │   │       ├── closing_loc: ∅
+        │   │       │   │       └── unescaped: "foo"
+        │   │       │   ├── opening_loc: (149,13)-(149,16) = "%W["
+        │   │       │   └── closing_loc: (149,19)-(149,20) = "]"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (149,10)-(149,12) = "in"
-        │   │       └── then_loc: (149,22)-(149,26) = "then"
+        │   │       └── then_loc: (149,21)-(149,25) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (149,0)-(149,4) = "case"
-        │   └── end_keyword_loc: (149,27)-(149,30) = "end"
-        ├── @ CaseMatchNode (location: (150,0)-(150,30))
+        │   └── end_keyword_loc: (149,26)-(149,29) = "end"
+        ├── @ CaseMatchNode (location: (150,0)-(150,29))
         │   ├── predicate:
         │   │   @ CallNode (location: (150,5)-(150,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3444,16 +3302,21 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (150,10)-(150,26))
+        │   │   └── @ InNode (location: (150,10)-(150,25))
         │   │       ├── pattern:
-        │   │       │   @ SourceLineNode (location: (150,13)-(150,21))
+        │   │       │   @ StringNode (location: (150,13)-(150,20))
+        │   │       │   ├── flags: ∅
+        │   │       │   ├── opening_loc: (150,13)-(150,16) = "%q["
+        │   │       │   ├── content_loc: (150,16)-(150,19) = "foo"
+        │   │       │   ├── closing_loc: (150,19)-(150,20) = "]"
+        │   │       │   └── unescaped: "foo"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (150,10)-(150,12) = "in"
-        │   │       └── then_loc: (150,22)-(150,26) = "then"
+        │   │       └── then_loc: (150,21)-(150,25) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (150,0)-(150,4) = "case"
-        │   └── end_keyword_loc: (150,27)-(150,30) = "end"
-        ├── @ CaseMatchNode (location: (151,0)-(151,34))
+        │   └── end_keyword_loc: (150,26)-(150,29) = "end"
+        ├── @ CaseMatchNode (location: (151,0)-(151,29))
         │   ├── predicate:
         │   │   @ CallNode (location: (151,5)-(151,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3466,16 +3329,21 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (151,10)-(151,30))
+        │   │   └── @ InNode (location: (151,10)-(151,25))
         │   │       ├── pattern:
-        │   │       │   @ SourceEncodingNode (location: (151,13)-(151,25))
+        │   │       │   @ StringNode (location: (151,13)-(151,20))
+        │   │       │   ├── flags: ∅
+        │   │       │   ├── opening_loc: (151,13)-(151,16) = "%Q["
+        │   │       │   ├── content_loc: (151,16)-(151,19) = "foo"
+        │   │       │   ├── closing_loc: (151,19)-(151,20) = "]"
+        │   │       │   └── unescaped: "foo"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (151,10)-(151,12) = "in"
-        │   │       └── then_loc: (151,26)-(151,30) = "then"
+        │   │       └── then_loc: (151,21)-(151,25) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (151,0)-(151,4) = "case"
-        │   └── end_keyword_loc: (151,31)-(151,34) = "end"
-        ├── @ CaseMatchNode (location: (152,0)-(152,32))
+        │   └── end_keyword_loc: (151,26)-(151,29) = "end"
+        ├── @ CaseMatchNode (location: (152,0)-(152,27))
         │   ├── predicate:
         │   │   @ CallNode (location: (152,5)-(152,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3488,27 +3356,43 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (152,10)-(152,28))
+        │   │   └── @ InNode (location: (152,10)-(152,23))
         │   │       ├── pattern:
-        │   │       │   @ LambdaNode (location: (152,13)-(152,23))
-        │   │       │   ├── locals: []
-        │   │       │   ├── operator_loc: (152,13)-(152,15) = "->"
-        │   │       │   ├── opening_loc: (152,16)-(152,17) = "{"
-        │   │       │   ├── closing_loc: (152,22)-(152,23) = "}"
-        │   │       │   ├── parameters: ∅
-        │   │       │   └── body:
-        │   │       │       @ StatementsNode (location: (152,18)-(152,21))
-        │   │       │       └── body: (length: 1)
-        │   │       │           └── @ LocalVariableReadNode (location: (152,18)-(152,21))
-        │   │       │               ├── name: :bar
-        │   │       │               └── depth: 1
+        │   │       │   @ StringNode (location: (152,13)-(152,18))
+        │   │       │   ├── flags: ∅
+        │   │       │   ├── opening_loc: (152,13)-(152,14) = "\""
+        │   │       │   ├── content_loc: (152,14)-(152,17) = "foo"
+        │   │       │   ├── closing_loc: (152,17)-(152,18) = "\""
+        │   │       │   └── unescaped: "foo"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (152,10)-(152,12) = "in"
-        │   │       └── then_loc: (152,24)-(152,28) = "then"
+        │   │       └── then_loc: (152,19)-(152,23) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (152,0)-(152,4) = "case"
-        │   └── end_keyword_loc: (152,29)-(152,32) = "end"
-        ├── @ CaseMatchNode (location: (154,0)-(154,32))
+        │   └── end_keyword_loc: (152,24)-(152,27) = "end"
+        ├── @ CaseMatchNode (location: (153,0)-(153,25))
+        │   ├── predicate:
+        │   │   @ CallNode (location: (153,5)-(153,8))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (153,5)-(153,8) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── conditions: (length: 1)
+        │   │   └── @ InNode (location: (153,10)-(153,21))
+        │   │       ├── pattern:
+        │   │       │   @ NilNode (location: (153,13)-(153,16))
+        │   │       ├── statements: ∅
+        │   │       ├── in_loc: (153,10)-(153,12) = "in"
+        │   │       └── then_loc: (153,17)-(153,21) = "then"
+        │   ├── consequent: ∅
+        │   ├── case_keyword_loc: (153,0)-(153,4) = "case"
+        │   └── end_keyword_loc: (153,22)-(153,25) = "end"
+        ├── @ CaseMatchNode (location: (154,0)-(154,26))
         │   ├── predicate:
         │   │   @ CallNode (location: (154,5)-(154,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3521,30 +3405,16 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (154,10)-(154,28))
+        │   │   └── @ InNode (location: (154,10)-(154,22))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (154,13)-(154,23))
-        │   │       │   ├── if_keyword_loc: (154,17)-(154,19) = "if"
-        │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (154,20)-(154,23))
-        │   │       │   │   ├── name: :baz
-        │   │       │   │   └── depth: 0
-        │   │       │   ├── then_keyword_loc: ∅
-        │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (154,13)-(154,16))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ LocalVariableTargetNode (location: (154,13)-(154,16))
-        │   │       │   │           ├── name: :bar
-        │   │       │   │           └── depth: 0
-        │   │       │   ├── consequent: ∅
-        │   │       │   └── end_keyword_loc: ∅
+        │   │       │   @ SelfNode (location: (154,13)-(154,17))
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (154,10)-(154,12) = "in"
-        │   │       └── then_loc: (154,24)-(154,28) = "then"
+        │   │       └── then_loc: (154,18)-(154,22) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (154,0)-(154,4) = "case"
-        │   └── end_keyword_loc: (154,29)-(154,32) = "end"
-        ├── @ CaseMatchNode (location: (155,0)-(155,30))
+        │   └── end_keyword_loc: (154,23)-(154,26) = "end"
+        ├── @ CaseMatchNode (location: (155,0)-(155,26))
         │   ├── predicate:
         │   │   @ CallNode (location: (155,5)-(155,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3557,29 +3427,16 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (155,10)-(155,26))
+        │   │   └── @ InNode (location: (155,10)-(155,22))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (155,13)-(155,21))
-        │   │       │   ├── if_keyword_loc: (155,15)-(155,17) = "if"
-        │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (155,18)-(155,21))
-        │   │       │   │   ├── name: :baz
-        │   │       │   │   └── depth: 0
-        │   │       │   ├── then_keyword_loc: ∅
-        │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (155,13)-(155,14))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ IntegerNode (location: (155,13)-(155,14))
-        │   │       │   │           └── flags: decimal
-        │   │       │   ├── consequent: ∅
-        │   │       │   └── end_keyword_loc: ∅
+        │   │       │   @ TrueNode (location: (155,13)-(155,17))
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (155,10)-(155,12) = "in"
-        │   │       └── then_loc: (155,22)-(155,26) = "then"
+        │   │       └── then_loc: (155,18)-(155,22) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (155,0)-(155,4) = "case"
-        │   └── end_keyword_loc: (155,27)-(155,30) = "end"
-        ├── @ CaseMatchNode (location: (156,0)-(156,32))
+        │   └── end_keyword_loc: (155,23)-(155,26) = "end"
+        ├── @ CaseMatchNode (location: (156,0)-(156,27))
         │   ├── predicate:
         │   │   @ CallNode (location: (156,5)-(156,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3592,28 +3449,16 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (156,10)-(156,28))
+        │   │   └── @ InNode (location: (156,10)-(156,23))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (156,13)-(156,23))
-        │   │       │   ├── if_keyword_loc: (156,17)-(156,19) = "if"
-        │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (156,20)-(156,23))
-        │   │       │   │   ├── name: :baz
-        │   │       │   │   └── depth: 0
-        │   │       │   ├── then_keyword_loc: ∅
-        │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (156,13)-(156,16))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ FloatNode (location: (156,13)-(156,16))
-        │   │       │   ├── consequent: ∅
-        │   │       │   └── end_keyword_loc: ∅
+        │   │       │   @ FalseNode (location: (156,13)-(156,18))
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (156,10)-(156,12) = "in"
-        │   │       └── then_loc: (156,24)-(156,28) = "then"
+        │   │       └── then_loc: (156,19)-(156,23) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (156,0)-(156,4) = "case"
-        │   └── end_keyword_loc: (156,29)-(156,32) = "end"
-        ├── @ CaseMatchNode (location: (157,0)-(157,31))
+        │   └── end_keyword_loc: (156,24)-(156,27) = "end"
+        ├── @ CaseMatchNode (location: (157,0)-(157,30))
         │   ├── predicate:
         │   │   @ CallNode (location: (157,5)-(157,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3626,31 +3471,17 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (157,10)-(157,27))
+        │   │   └── @ InNode (location: (157,10)-(157,26))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (157,13)-(157,22))
-        │   │       │   ├── if_keyword_loc: (157,16)-(157,18) = "if"
-        │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (157,19)-(157,22))
-        │   │       │   │   ├── name: :baz
-        │   │       │   │   └── depth: 0
-        │   │       │   ├── then_keyword_loc: ∅
-        │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (157,13)-(157,15))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ ImaginaryNode (location: (157,13)-(157,15))
-        │   │       │   │           └── numeric:
-        │   │       │   │               @ IntegerNode (location: (157,13)-(157,14))
-        │   │       │   │               └── flags: decimal
-        │   │       │   ├── consequent: ∅
-        │   │       │   └── end_keyword_loc: ∅
+        │   │       │   @ SourceFileNode (location: (157,13)-(157,21))
+        │   │       │   └── filepath: "patterns.txt"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (157,10)-(157,12) = "in"
-        │   │       └── then_loc: (157,23)-(157,27) = "then"
+        │   │       └── then_loc: (157,22)-(157,26) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (157,0)-(157,4) = "case"
-        │   └── end_keyword_loc: (157,28)-(157,31) = "end"
-        ├── @ CaseMatchNode (location: (158,0)-(158,31))
+        │   └── end_keyword_loc: (157,27)-(157,30) = "end"
+        ├── @ CaseMatchNode (location: (158,0)-(158,30))
         │   ├── predicate:
         │   │   @ CallNode (location: (158,5)-(158,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3663,31 +3494,16 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (158,10)-(158,27))
+        │   │   └── @ InNode (location: (158,10)-(158,26))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (158,13)-(158,22))
-        │   │       │   ├── if_keyword_loc: (158,16)-(158,18) = "if"
-        │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (158,19)-(158,22))
-        │   │       │   │   ├── name: :baz
-        │   │       │   │   └── depth: 0
-        │   │       │   ├── then_keyword_loc: ∅
-        │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (158,13)-(158,15))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ RationalNode (location: (158,13)-(158,15))
-        │   │       │   │           └── numeric:
-        │   │       │   │               @ IntegerNode (location: (158,13)-(158,14))
-        │   │       │   │               └── flags: decimal
-        │   │       │   ├── consequent: ∅
-        │   │       │   └── end_keyword_loc: ∅
+        │   │       │   @ SourceLineNode (location: (158,13)-(158,21))
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (158,10)-(158,12) = "in"
-        │   │       └── then_loc: (158,23)-(158,27) = "then"
+        │   │       └── then_loc: (158,22)-(158,26) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (158,0)-(158,4) = "case"
-        │   └── end_keyword_loc: (158,28)-(158,31) = "end"
-        ├── @ CaseMatchNode (location: (159,0)-(159,33))
+        │   └── end_keyword_loc: (158,27)-(158,30) = "end"
+        ├── @ CaseMatchNode (location: (159,0)-(159,34))
         │   ├── predicate:
         │   │   @ CallNode (location: (159,5)-(159,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3700,33 +3516,16 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (159,10)-(159,29))
+        │   │   └── @ InNode (location: (159,10)-(159,30))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (159,13)-(159,24))
-        │   │       │   ├── if_keyword_loc: (159,18)-(159,20) = "if"
-        │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (159,21)-(159,24))
-        │   │       │   │   ├── name: :baz
-        │   │       │   │   └── depth: 0
-        │   │       │   ├── then_keyword_loc: ∅
-        │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (159,13)-(159,17))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ SymbolNode (location: (159,13)-(159,17))
-        │   │       │   │           ├── flags: forced_us_ascii_encoding
-        │   │       │   │           ├── opening_loc: (159,13)-(159,14) = ":"
-        │   │       │   │           ├── value_loc: (159,14)-(159,17) = "foo"
-        │   │       │   │           ├── closing_loc: ∅
-        │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
-        │   │       │   └── end_keyword_loc: ∅
+        │   │       │   @ SourceEncodingNode (location: (159,13)-(159,25))
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (159,10)-(159,12) = "in"
-        │   │       └── then_loc: (159,25)-(159,29) = "then"
+        │   │       └── then_loc: (159,26)-(159,30) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (159,0)-(159,4) = "case"
-        │   └── end_keyword_loc: (159,30)-(159,33) = "end"
-        ├── @ CaseMatchNode (location: (160,0)-(160,36))
+        │   └── end_keyword_loc: (159,31)-(159,34) = "end"
+        ├── @ CaseMatchNode (location: (160,0)-(160,32))
         │   ├── predicate:
         │   │   @ CallNode (location: (160,5)-(160,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3739,72 +3538,27 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (160,10)-(160,32))
+        │   │   └── @ InNode (location: (160,10)-(160,28))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (160,13)-(160,27))
-        │   │       │   ├── if_keyword_loc: (160,21)-(160,23) = "if"
-        │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (160,24)-(160,27))
-        │   │       │   │   ├── name: :baz
-        │   │       │   │   └── depth: 0
-        │   │       │   ├── then_keyword_loc: ∅
-        │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (160,13)-(160,20))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ SymbolNode (location: (160,13)-(160,20))
-        │   │       │   │           ├── flags: forced_us_ascii_encoding
-        │   │       │   │           ├── opening_loc: (160,13)-(160,16) = "%s["
-        │   │       │   │           ├── value_loc: (160,16)-(160,19) = "foo"
-        │   │       │   │           ├── closing_loc: (160,19)-(160,20) = "]"
-        │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
-        │   │       │   └── end_keyword_loc: ∅
+        │   │       │   @ LambdaNode (location: (160,13)-(160,23))
+        │   │       │   ├── locals: []
+        │   │       │   ├── operator_loc: (160,13)-(160,15) = "->"
+        │   │       │   ├── opening_loc: (160,16)-(160,17) = "{"
+        │   │       │   ├── closing_loc: (160,22)-(160,23) = "}"
+        │   │       │   ├── parameters: ∅
+        │   │       │   └── body:
+        │   │       │       @ StatementsNode (location: (160,18)-(160,21))
+        │   │       │       └── body: (length: 1)
+        │   │       │           └── @ LocalVariableReadNode (location: (160,18)-(160,21))
+        │   │       │               ├── name: :bar
+        │   │       │               └── depth: 1
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (160,10)-(160,12) = "in"
-        │   │       └── then_loc: (160,28)-(160,32) = "then"
+        │   │       └── then_loc: (160,24)-(160,28) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (160,0)-(160,4) = "case"
-        │   └── end_keyword_loc: (160,33)-(160,36) = "end"
-        ├── @ CaseMatchNode (location: (161,0)-(161,35))
-        │   ├── predicate:
-        │   │   @ CallNode (location: (161,5)-(161,8))
-        │   │   ├── flags: variable_call, ignore_visibility
-        │   │   ├── receiver: ∅
-        │   │   ├── call_operator_loc: ∅
-        │   │   ├── name: :foo
-        │   │   ├── message_loc: (161,5)-(161,8) = "foo"
-        │   │   ├── opening_loc: ∅
-        │   │   ├── arguments: ∅
-        │   │   ├── closing_loc: ∅
-        │   │   └── block: ∅
-        │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (161,10)-(161,31))
-        │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (161,13)-(161,26))
-        │   │       │   ├── if_keyword_loc: (161,20)-(161,22) = "if"
-        │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (161,23)-(161,26))
-        │   │       │   │   ├── name: :baz
-        │   │       │   │   └── depth: 0
-        │   │       │   ├── then_keyword_loc: ∅
-        │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (161,13)-(161,19))
-        │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ SymbolNode (location: (161,13)-(161,19))
-        │   │       │   │           ├── flags: forced_us_ascii_encoding
-        │   │       │   │           ├── opening_loc: (161,13)-(161,15) = ":\""
-        │   │       │   │           ├── value_loc: (161,15)-(161,18) = "foo"
-        │   │       │   │           ├── closing_loc: (161,18)-(161,19) = "\""
-        │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
-        │   │       │   └── end_keyword_loc: ∅
-        │   │       ├── statements: ∅
-        │   │       ├── in_loc: (161,10)-(161,12) = "in"
-        │   │       └── then_loc: (161,27)-(161,31) = "then"
-        │   ├── consequent: ∅
-        │   ├── case_keyword_loc: (161,0)-(161,4) = "case"
-        │   └── end_keyword_loc: (161,32)-(161,35) = "end"
-        ├── @ CaseMatchNode (location: (162,0)-(162,34))
+        │   └── end_keyword_loc: (160,29)-(160,32) = "end"
+        ├── @ CaseMatchNode (location: (162,0)-(162,32))
         │   ├── predicate:
         │   │   @ CallNode (location: (162,5)-(162,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3817,33 +3571,30 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (162,10)-(162,30))
+        │   │   └── @ InNode (location: (162,10)-(162,28))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (162,13)-(162,25))
-        │   │       │   ├── if_keyword_loc: (162,19)-(162,21) = "if"
+        │   │       │   @ IfNode (location: (162,13)-(162,23))
+        │   │       │   ├── if_keyword_loc: (162,17)-(162,19) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (162,22)-(162,25))
+        │   │       │   │   @ LocalVariableReadNode (location: (162,20)-(162,23))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (162,13)-(162,18))
+        │   │       │   │   @ StatementsNode (location: (162,13)-(162,16))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ RegularExpressionNode (location: (162,13)-(162,18))
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           ├── opening_loc: (162,13)-(162,14) = "/"
-        │   │       │   │           ├── content_loc: (162,14)-(162,17) = "foo"
-        │   │       │   │           ├── closing_loc: (162,17)-(162,18) = "/"
-        │   │       │   │           └── unescaped: "foo"
+        │   │       │   │       └── @ LocalVariableTargetNode (location: (162,13)-(162,16))
+        │   │       │   │           ├── name: :bar
+        │   │       │   │           └── depth: 0
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (162,10)-(162,12) = "in"
-        │   │       └── then_loc: (162,26)-(162,30) = "then"
+        │   │       └── then_loc: (162,24)-(162,28) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (162,0)-(162,4) = "case"
-        │   └── end_keyword_loc: (162,31)-(162,34) = "end"
-        ├── @ CaseMatchNode (location: (163,0)-(163,34))
+        │   └── end_keyword_loc: (162,29)-(162,32) = "end"
+        ├── @ CaseMatchNode (location: (163,0)-(163,30))
         │   ├── predicate:
         │   │   @ CallNode (location: (163,5)-(163,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3856,33 +3607,29 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (163,10)-(163,30))
+        │   │   └── @ InNode (location: (163,10)-(163,26))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (163,13)-(163,25))
-        │   │       │   ├── if_keyword_loc: (163,19)-(163,21) = "if"
+        │   │       │   @ IfNode (location: (163,13)-(163,21))
+        │   │       │   ├── if_keyword_loc: (163,15)-(163,17) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (163,22)-(163,25))
+        │   │       │   │   @ LocalVariableReadNode (location: (163,18)-(163,21))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (163,13)-(163,18))
+        │   │       │   │   @ StatementsNode (location: (163,13)-(163,14))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ XStringNode (location: (163,13)-(163,18))
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           ├── opening_loc: (163,13)-(163,14) = "`"
-        │   │       │   │           ├── content_loc: (163,14)-(163,17) = "foo"
-        │   │       │   │           ├── closing_loc: (163,17)-(163,18) = "`"
-        │   │       │   │           └── unescaped: "foo"
+        │   │       │   │       └── @ IntegerNode (location: (163,13)-(163,14))
+        │   │       │   │           └── flags: decimal
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (163,10)-(163,12) = "in"
-        │   │       └── then_loc: (163,26)-(163,30) = "then"
+        │   │       └── then_loc: (163,22)-(163,26) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (163,0)-(163,4) = "case"
-        │   └── end_keyword_loc: (163,31)-(163,34) = "end"
-        ├── @ CaseMatchNode (location: (164,0)-(164,36))
+        │   └── end_keyword_loc: (163,27)-(163,30) = "end"
+        ├── @ CaseMatchNode (location: (164,0)-(164,32))
         │   ├── predicate:
         │   │   @ CallNode (location: (164,5)-(164,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3895,33 +3642,28 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (164,10)-(164,32))
+        │   │   └── @ InNode (location: (164,10)-(164,28))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (164,13)-(164,27))
-        │   │       │   ├── if_keyword_loc: (164,21)-(164,23) = "if"
+        │   │       │   @ IfNode (location: (164,13)-(164,23))
+        │   │       │   ├── if_keyword_loc: (164,17)-(164,19) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (164,24)-(164,27))
+        │   │       │   │   @ LocalVariableReadNode (location: (164,20)-(164,23))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (164,13)-(164,20))
+        │   │       │   │   @ StatementsNode (location: (164,13)-(164,16))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ XStringNode (location: (164,13)-(164,20))
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           ├── opening_loc: (164,13)-(164,16) = "%x["
-        │   │       │   │           ├── content_loc: (164,16)-(164,19) = "foo"
-        │   │       │   │           ├── closing_loc: (164,19)-(164,20) = "]"
-        │   │       │   │           └── unescaped: "foo"
+        │   │       │   │       └── @ FloatNode (location: (164,13)-(164,16))
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (164,10)-(164,12) = "in"
-        │   │       └── then_loc: (164,28)-(164,32) = "then"
+        │   │       └── then_loc: (164,24)-(164,28) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (164,0)-(164,4) = "case"
-        │   └── end_keyword_loc: (164,33)-(164,36) = "end"
-        ├── @ CaseMatchNode (location: (165,0)-(165,36))
+        │   └── end_keyword_loc: (164,29)-(164,32) = "end"
+        ├── @ CaseMatchNode (location: (165,0)-(165,31))
         │   ├── predicate:
         │   │   @ CallNode (location: (165,5)-(165,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3934,38 +3676,31 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (165,10)-(165,32))
+        │   │   └── @ InNode (location: (165,10)-(165,27))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (165,13)-(165,27))
-        │   │       │   ├── if_keyword_loc: (165,21)-(165,23) = "if"
+        │   │       │   @ IfNode (location: (165,13)-(165,22))
+        │   │       │   ├── if_keyword_loc: (165,16)-(165,18) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (165,24)-(165,27))
+        │   │       │   │   @ LocalVariableReadNode (location: (165,19)-(165,22))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (165,13)-(165,20))
+        │   │       │   │   @ StatementsNode (location: (165,13)-(165,15))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ ArrayNode (location: (165,13)-(165,20))
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           ├── elements: (length: 1)
-        │   │       │   │           │   └── @ SymbolNode (location: (165,16)-(165,19))
-        │   │       │   │           │       ├── flags: forced_us_ascii_encoding
-        │   │       │   │           │       ├── opening_loc: ∅
-        │   │       │   │           │       ├── value_loc: (165,16)-(165,19) = "foo"
-        │   │       │   │           │       ├── closing_loc: ∅
-        │   │       │   │           │       └── unescaped: "foo"
-        │   │       │   │           ├── opening_loc: (165,13)-(165,16) = "%i["
-        │   │       │   │           └── closing_loc: (165,19)-(165,20) = "]"
+        │   │       │   │       └── @ ImaginaryNode (location: (165,13)-(165,15))
+        │   │       │   │           └── numeric:
+        │   │       │   │               @ IntegerNode (location: (165,13)-(165,14))
+        │   │       │   │               └── flags: decimal
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (165,10)-(165,12) = "in"
-        │   │       └── then_loc: (165,28)-(165,32) = "then"
+        │   │       └── then_loc: (165,23)-(165,27) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (165,0)-(165,4) = "case"
-        │   └── end_keyword_loc: (165,33)-(165,36) = "end"
-        ├── @ CaseMatchNode (location: (166,0)-(166,36))
+        │   └── end_keyword_loc: (165,28)-(165,31) = "end"
+        ├── @ CaseMatchNode (location: (166,0)-(166,31))
         │   ├── predicate:
         │   │   @ CallNode (location: (166,5)-(166,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -3978,38 +3713,31 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (166,10)-(166,32))
+        │   │   └── @ InNode (location: (166,10)-(166,27))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (166,13)-(166,27))
-        │   │       │   ├── if_keyword_loc: (166,21)-(166,23) = "if"
+        │   │       │   @ IfNode (location: (166,13)-(166,22))
+        │   │       │   ├── if_keyword_loc: (166,16)-(166,18) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (166,24)-(166,27))
+        │   │       │   │   @ LocalVariableReadNode (location: (166,19)-(166,22))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (166,13)-(166,20))
+        │   │       │   │   @ StatementsNode (location: (166,13)-(166,15))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ ArrayNode (location: (166,13)-(166,20))
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           ├── elements: (length: 1)
-        │   │       │   │           │   └── @ SymbolNode (location: (166,16)-(166,19))
-        │   │       │   │           │       ├── flags: forced_us_ascii_encoding
-        │   │       │   │           │       ├── opening_loc: ∅
-        │   │       │   │           │       ├── value_loc: (166,16)-(166,19) = "foo"
-        │   │       │   │           │       ├── closing_loc: ∅
-        │   │       │   │           │       └── unescaped: "foo"
-        │   │       │   │           ├── opening_loc: (166,13)-(166,16) = "%I["
-        │   │       │   │           └── closing_loc: (166,19)-(166,20) = "]"
+        │   │       │   │       └── @ RationalNode (location: (166,13)-(166,15))
+        │   │       │   │           └── numeric:
+        │   │       │   │               @ IntegerNode (location: (166,13)-(166,14))
+        │   │       │   │               └── flags: decimal
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (166,10)-(166,12) = "in"
-        │   │       └── then_loc: (166,28)-(166,32) = "then"
+        │   │       └── then_loc: (166,23)-(166,27) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (166,0)-(166,4) = "case"
-        │   └── end_keyword_loc: (166,33)-(166,36) = "end"
-        ├── @ CaseMatchNode (location: (167,0)-(167,36))
+        │   └── end_keyword_loc: (166,28)-(166,31) = "end"
+        ├── @ CaseMatchNode (location: (167,0)-(167,33))
         │   ├── predicate:
         │   │   @ CallNode (location: (167,5)-(167,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -4022,37 +3750,32 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (167,10)-(167,32))
+        │   │   └── @ InNode (location: (167,10)-(167,29))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (167,13)-(167,27))
-        │   │       │   ├── if_keyword_loc: (167,21)-(167,23) = "if"
+        │   │       │   @ IfNode (location: (167,13)-(167,24))
+        │   │       │   ├── if_keyword_loc: (167,18)-(167,20) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (167,24)-(167,27))
+        │   │       │   │   @ LocalVariableReadNode (location: (167,21)-(167,24))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (167,13)-(167,20))
+        │   │       │   │   @ StatementsNode (location: (167,13)-(167,17))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ ArrayNode (location: (167,13)-(167,20))
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           ├── elements: (length: 1)
-        │   │       │   │           │   └── @ StringNode (location: (167,16)-(167,19))
-        │   │       │   │           │       ├── flags: ∅
-        │   │       │   │           │       ├── opening_loc: ∅
-        │   │       │   │           │       ├── content_loc: (167,16)-(167,19) = "foo"
-        │   │       │   │           │       ├── closing_loc: ∅
-        │   │       │   │           │       └── unescaped: "foo"
-        │   │       │   │           ├── opening_loc: (167,13)-(167,16) = "%w["
-        │   │       │   │           └── closing_loc: (167,19)-(167,20) = "]"
+        │   │       │   │       └── @ SymbolNode (location: (167,13)-(167,17))
+        │   │       │   │           ├── flags: forced_us_ascii_encoding
+        │   │       │   │           ├── opening_loc: (167,13)-(167,14) = ":"
+        │   │       │   │           ├── value_loc: (167,14)-(167,17) = "foo"
+        │   │       │   │           ├── closing_loc: ∅
+        │   │       │   │           └── unescaped: "foo"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (167,10)-(167,12) = "in"
-        │   │       └── then_loc: (167,28)-(167,32) = "then"
+        │   │       └── then_loc: (167,25)-(167,29) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (167,0)-(167,4) = "case"
-        │   └── end_keyword_loc: (167,33)-(167,36) = "end"
+        │   └── end_keyword_loc: (167,30)-(167,33) = "end"
         ├── @ CaseMatchNode (location: (168,0)-(168,36))
         │   ├── predicate:
         │   │   @ CallNode (location: (168,5)-(168,8))
@@ -4078,17 +3801,12 @@
         │   │       │   ├── statements:
         │   │       │   │   @ StatementsNode (location: (168,13)-(168,20))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ ArrayNode (location: (168,13)-(168,20))
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           ├── elements: (length: 1)
-        │   │       │   │           │   └── @ StringNode (location: (168,16)-(168,19))
-        │   │       │   │           │       ├── flags: ∅
-        │   │       │   │           │       ├── opening_loc: ∅
-        │   │       │   │           │       ├── content_loc: (168,16)-(168,19) = "foo"
-        │   │       │   │           │       ├── closing_loc: ∅
-        │   │       │   │           │       └── unescaped: "foo"
-        │   │       │   │           ├── opening_loc: (168,13)-(168,16) = "%W["
-        │   │       │   │           └── closing_loc: (168,19)-(168,20) = "]"
+        │   │       │   │       └── @ SymbolNode (location: (168,13)-(168,20))
+        │   │       │   │           ├── flags: forced_us_ascii_encoding
+        │   │       │   │           ├── opening_loc: (168,13)-(168,16) = "%s["
+        │   │       │   │           ├── value_loc: (168,16)-(168,19) = "foo"
+        │   │       │   │           ├── closing_loc: (168,19)-(168,20) = "]"
+        │   │       │   │           └── unescaped: "foo"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
@@ -4097,7 +3815,7 @@
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (168,0)-(168,4) = "case"
         │   └── end_keyword_loc: (168,33)-(168,36) = "end"
-        ├── @ CaseMatchNode (location: (169,0)-(169,36))
+        ├── @ CaseMatchNode (location: (169,0)-(169,35))
         │   ├── predicate:
         │   │   @ CallNode (location: (169,5)-(169,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -4110,33 +3828,33 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (169,10)-(169,32))
+        │   │   └── @ InNode (location: (169,10)-(169,31))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (169,13)-(169,27))
-        │   │       │   ├── if_keyword_loc: (169,21)-(169,23) = "if"
+        │   │       │   @ IfNode (location: (169,13)-(169,26))
+        │   │       │   ├── if_keyword_loc: (169,20)-(169,22) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (169,24)-(169,27))
+        │   │       │   │   @ LocalVariableReadNode (location: (169,23)-(169,26))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (169,13)-(169,20))
+        │   │       │   │   @ StatementsNode (location: (169,13)-(169,19))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ StringNode (location: (169,13)-(169,20))
-        │   │       │   │           ├── flags: ∅
-        │   │       │   │           ├── opening_loc: (169,13)-(169,16) = "%q["
-        │   │       │   │           ├── content_loc: (169,16)-(169,19) = "foo"
-        │   │       │   │           ├── closing_loc: (169,19)-(169,20) = "]"
+        │   │       │   │       └── @ SymbolNode (location: (169,13)-(169,19))
+        │   │       │   │           ├── flags: forced_us_ascii_encoding
+        │   │       │   │           ├── opening_loc: (169,13)-(169,15) = ":\""
+        │   │       │   │           ├── value_loc: (169,15)-(169,18) = "foo"
+        │   │       │   │           ├── closing_loc: (169,18)-(169,19) = "\""
         │   │       │   │           └── unescaped: "foo"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (169,10)-(169,12) = "in"
-        │   │       └── then_loc: (169,28)-(169,32) = "then"
+        │   │       └── then_loc: (169,27)-(169,31) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (169,0)-(169,4) = "case"
-        │   └── end_keyword_loc: (169,33)-(169,36) = "end"
-        ├── @ CaseMatchNode (location: (170,0)-(170,36))
+        │   └── end_keyword_loc: (169,32)-(169,35) = "end"
+        ├── @ CaseMatchNode (location: (170,0)-(170,34))
         │   ├── predicate:
         │   │   @ CallNode (location: (170,5)-(170,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -4149,32 +3867,32 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (170,10)-(170,32))
+        │   │   └── @ InNode (location: (170,10)-(170,30))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (170,13)-(170,27))
-        │   │       │   ├── if_keyword_loc: (170,21)-(170,23) = "if"
+        │   │       │   @ IfNode (location: (170,13)-(170,25))
+        │   │       │   ├── if_keyword_loc: (170,19)-(170,21) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (170,24)-(170,27))
+        │   │       │   │   @ LocalVariableReadNode (location: (170,22)-(170,25))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (170,13)-(170,20))
+        │   │       │   │   @ StatementsNode (location: (170,13)-(170,18))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ StringNode (location: (170,13)-(170,20))
+        │   │       │   │       └── @ RegularExpressionNode (location: (170,13)-(170,18))
         │   │       │   │           ├── flags: ∅
-        │   │       │   │           ├── opening_loc: (170,13)-(170,16) = "%Q["
-        │   │       │   │           ├── content_loc: (170,16)-(170,19) = "foo"
-        │   │       │   │           ├── closing_loc: (170,19)-(170,20) = "]"
+        │   │       │   │           ├── opening_loc: (170,13)-(170,14) = "/"
+        │   │       │   │           ├── content_loc: (170,14)-(170,17) = "foo"
+        │   │       │   │           ├── closing_loc: (170,17)-(170,18) = "/"
         │   │       │   │           └── unescaped: "foo"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (170,10)-(170,12) = "in"
-        │   │       └── then_loc: (170,28)-(170,32) = "then"
+        │   │       └── then_loc: (170,26)-(170,30) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (170,0)-(170,4) = "case"
-        │   └── end_keyword_loc: (170,33)-(170,36) = "end"
+        │   └── end_keyword_loc: (170,31)-(170,34) = "end"
         ├── @ CaseMatchNode (location: (171,0)-(171,34))
         │   ├── predicate:
         │   │   @ CallNode (location: (171,5)-(171,8))
@@ -4200,11 +3918,11 @@
         │   │       │   ├── statements:
         │   │       │   │   @ StatementsNode (location: (171,13)-(171,18))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ StringNode (location: (171,13)-(171,18))
+        │   │       │   │       └── @ XStringNode (location: (171,13)-(171,18))
         │   │       │   │           ├── flags: ∅
-        │   │       │   │           ├── opening_loc: (171,13)-(171,14) = "\""
+        │   │       │   │           ├── opening_loc: (171,13)-(171,14) = "`"
         │   │       │   │           ├── content_loc: (171,14)-(171,17) = "foo"
-        │   │       │   │           ├── closing_loc: (171,17)-(171,18) = "\""
+        │   │       │   │           ├── closing_loc: (171,17)-(171,18) = "`"
         │   │       │   │           └── unescaped: "foo"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
@@ -4214,7 +3932,7 @@
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (171,0)-(171,4) = "case"
         │   └── end_keyword_loc: (171,31)-(171,34) = "end"
-        ├── @ CaseMatchNode (location: (172,0)-(172,32))
+        ├── @ CaseMatchNode (location: (172,0)-(172,36))
         │   ├── predicate:
         │   │   @ CallNode (location: (172,5)-(172,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -4227,28 +3945,33 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (172,10)-(172,28))
+        │   │   └── @ InNode (location: (172,10)-(172,32))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (172,13)-(172,23))
-        │   │       │   ├── if_keyword_loc: (172,17)-(172,19) = "if"
+        │   │       │   @ IfNode (location: (172,13)-(172,27))
+        │   │       │   ├── if_keyword_loc: (172,21)-(172,23) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (172,20)-(172,23))
+        │   │       │   │   @ LocalVariableReadNode (location: (172,24)-(172,27))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (172,13)-(172,16))
+        │   │       │   │   @ StatementsNode (location: (172,13)-(172,20))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ NilNode (location: (172,13)-(172,16))
+        │   │       │   │       └── @ XStringNode (location: (172,13)-(172,20))
+        │   │       │   │           ├── flags: ∅
+        │   │       │   │           ├── opening_loc: (172,13)-(172,16) = "%x["
+        │   │       │   │           ├── content_loc: (172,16)-(172,19) = "foo"
+        │   │       │   │           ├── closing_loc: (172,19)-(172,20) = "]"
+        │   │       │   │           └── unescaped: "foo"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (172,10)-(172,12) = "in"
-        │   │       └── then_loc: (172,24)-(172,28) = "then"
+        │   │       └── then_loc: (172,28)-(172,32) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (172,0)-(172,4) = "case"
-        │   └── end_keyword_loc: (172,29)-(172,32) = "end"
-        ├── @ CaseMatchNode (location: (173,0)-(173,33))
+        │   └── end_keyword_loc: (172,33)-(172,36) = "end"
+        ├── @ CaseMatchNode (location: (173,0)-(173,36))
         │   ├── predicate:
         │   │   @ CallNode (location: (173,5)-(173,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -4261,28 +3984,38 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (173,10)-(173,29))
+        │   │   └── @ InNode (location: (173,10)-(173,32))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (173,13)-(173,24))
-        │   │       │   ├── if_keyword_loc: (173,18)-(173,20) = "if"
+        │   │       │   @ IfNode (location: (173,13)-(173,27))
+        │   │       │   ├── if_keyword_loc: (173,21)-(173,23) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (173,21)-(173,24))
+        │   │       │   │   @ LocalVariableReadNode (location: (173,24)-(173,27))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (173,13)-(173,17))
+        │   │       │   │   @ StatementsNode (location: (173,13)-(173,20))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ SelfNode (location: (173,13)-(173,17))
+        │   │       │   │       └── @ ArrayNode (location: (173,13)-(173,20))
+        │   │       │   │           ├── flags: ∅
+        │   │       │   │           ├── elements: (length: 1)
+        │   │       │   │           │   └── @ SymbolNode (location: (173,16)-(173,19))
+        │   │       │   │           │       ├── flags: forced_us_ascii_encoding
+        │   │       │   │           │       ├── opening_loc: ∅
+        │   │       │   │           │       ├── value_loc: (173,16)-(173,19) = "foo"
+        │   │       │   │           │       ├── closing_loc: ∅
+        │   │       │   │           │       └── unescaped: "foo"
+        │   │       │   │           ├── opening_loc: (173,13)-(173,16) = "%i["
+        │   │       │   │           └── closing_loc: (173,19)-(173,20) = "]"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (173,10)-(173,12) = "in"
-        │   │       └── then_loc: (173,25)-(173,29) = "then"
+        │   │       └── then_loc: (173,28)-(173,32) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (173,0)-(173,4) = "case"
-        │   └── end_keyword_loc: (173,30)-(173,33) = "end"
-        ├── @ CaseMatchNode (location: (174,0)-(174,33))
+        │   └── end_keyword_loc: (173,33)-(173,36) = "end"
+        ├── @ CaseMatchNode (location: (174,0)-(174,36))
         │   ├── predicate:
         │   │   @ CallNode (location: (174,5)-(174,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -4295,28 +4028,38 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (174,10)-(174,29))
+        │   │   └── @ InNode (location: (174,10)-(174,32))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (174,13)-(174,24))
-        │   │       │   ├── if_keyword_loc: (174,18)-(174,20) = "if"
+        │   │       │   @ IfNode (location: (174,13)-(174,27))
+        │   │       │   ├── if_keyword_loc: (174,21)-(174,23) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (174,21)-(174,24))
+        │   │       │   │   @ LocalVariableReadNode (location: (174,24)-(174,27))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (174,13)-(174,17))
+        │   │       │   │   @ StatementsNode (location: (174,13)-(174,20))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ TrueNode (location: (174,13)-(174,17))
+        │   │       │   │       └── @ ArrayNode (location: (174,13)-(174,20))
+        │   │       │   │           ├── flags: ∅
+        │   │       │   │           ├── elements: (length: 1)
+        │   │       │   │           │   └── @ SymbolNode (location: (174,16)-(174,19))
+        │   │       │   │           │       ├── flags: forced_us_ascii_encoding
+        │   │       │   │           │       ├── opening_loc: ∅
+        │   │       │   │           │       ├── value_loc: (174,16)-(174,19) = "foo"
+        │   │       │   │           │       ├── closing_loc: ∅
+        │   │       │   │           │       └── unescaped: "foo"
+        │   │       │   │           ├── opening_loc: (174,13)-(174,16) = "%I["
+        │   │       │   │           └── closing_loc: (174,19)-(174,20) = "]"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (174,10)-(174,12) = "in"
-        │   │       └── then_loc: (174,25)-(174,29) = "then"
+        │   │       └── then_loc: (174,28)-(174,32) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (174,0)-(174,4) = "case"
-        │   └── end_keyword_loc: (174,30)-(174,33) = "end"
-        ├── @ CaseMatchNode (location: (175,0)-(175,34))
+        │   └── end_keyword_loc: (174,33)-(174,36) = "end"
+        ├── @ CaseMatchNode (location: (175,0)-(175,36))
         │   ├── predicate:
         │   │   @ CallNode (location: (175,5)-(175,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -4329,28 +4072,38 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (175,10)-(175,30))
+        │   │   └── @ InNode (location: (175,10)-(175,32))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (175,13)-(175,25))
-        │   │       │   ├── if_keyword_loc: (175,19)-(175,21) = "if"
+        │   │       │   @ IfNode (location: (175,13)-(175,27))
+        │   │       │   ├── if_keyword_loc: (175,21)-(175,23) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (175,22)-(175,25))
+        │   │       │   │   @ LocalVariableReadNode (location: (175,24)-(175,27))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (175,13)-(175,18))
+        │   │       │   │   @ StatementsNode (location: (175,13)-(175,20))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ FalseNode (location: (175,13)-(175,18))
+        │   │       │   │       └── @ ArrayNode (location: (175,13)-(175,20))
+        │   │       │   │           ├── flags: ∅
+        │   │       │   │           ├── elements: (length: 1)
+        │   │       │   │           │   └── @ StringNode (location: (175,16)-(175,19))
+        │   │       │   │           │       ├── flags: ∅
+        │   │       │   │           │       ├── opening_loc: ∅
+        │   │       │   │           │       ├── content_loc: (175,16)-(175,19) = "foo"
+        │   │       │   │           │       ├── closing_loc: ∅
+        │   │       │   │           │       └── unescaped: "foo"
+        │   │       │   │           ├── opening_loc: (175,13)-(175,16) = "%w["
+        │   │       │   │           └── closing_loc: (175,19)-(175,20) = "]"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (175,10)-(175,12) = "in"
-        │   │       └── then_loc: (175,26)-(175,30) = "then"
+        │   │       └── then_loc: (175,28)-(175,32) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (175,0)-(175,4) = "case"
-        │   └── end_keyword_loc: (175,31)-(175,34) = "end"
-        ├── @ CaseMatchNode (location: (176,0)-(176,37))
+        │   └── end_keyword_loc: (175,33)-(175,36) = "end"
+        ├── @ CaseMatchNode (location: (176,0)-(176,36))
         │   ├── predicate:
         │   │   @ CallNode (location: (176,5)-(176,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -4363,29 +4116,38 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (176,10)-(176,33))
+        │   │   └── @ InNode (location: (176,10)-(176,32))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (176,13)-(176,28))
-        │   │       │   ├── if_keyword_loc: (176,22)-(176,24) = "if"
+        │   │       │   @ IfNode (location: (176,13)-(176,27))
+        │   │       │   ├── if_keyword_loc: (176,21)-(176,23) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (176,25)-(176,28))
+        │   │       │   │   @ LocalVariableReadNode (location: (176,24)-(176,27))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (176,13)-(176,21))
+        │   │       │   │   @ StatementsNode (location: (176,13)-(176,20))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ SourceFileNode (location: (176,13)-(176,21))
-        │   │       │   │           └── filepath: "patterns.txt"
+        │   │       │   │       └── @ ArrayNode (location: (176,13)-(176,20))
+        │   │       │   │           ├── flags: ∅
+        │   │       │   │           ├── elements: (length: 1)
+        │   │       │   │           │   └── @ StringNode (location: (176,16)-(176,19))
+        │   │       │   │           │       ├── flags: ∅
+        │   │       │   │           │       ├── opening_loc: ∅
+        │   │       │   │           │       ├── content_loc: (176,16)-(176,19) = "foo"
+        │   │       │   │           │       ├── closing_loc: ∅
+        │   │       │   │           │       └── unescaped: "foo"
+        │   │       │   │           ├── opening_loc: (176,13)-(176,16) = "%W["
+        │   │       │   │           └── closing_loc: (176,19)-(176,20) = "]"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (176,10)-(176,12) = "in"
-        │   │       └── then_loc: (176,29)-(176,33) = "then"
+        │   │       └── then_loc: (176,28)-(176,32) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (176,0)-(176,4) = "case"
-        │   └── end_keyword_loc: (176,34)-(176,37) = "end"
-        ├── @ CaseMatchNode (location: (177,0)-(177,37))
+        │   └── end_keyword_loc: (176,33)-(176,36) = "end"
+        ├── @ CaseMatchNode (location: (177,0)-(177,36))
         │   ├── predicate:
         │   │   @ CallNode (location: (177,5)-(177,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -4398,28 +4160,33 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (177,10)-(177,33))
+        │   │   └── @ InNode (location: (177,10)-(177,32))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (177,13)-(177,28))
-        │   │       │   ├── if_keyword_loc: (177,22)-(177,24) = "if"
+        │   │       │   @ IfNode (location: (177,13)-(177,27))
+        │   │       │   ├── if_keyword_loc: (177,21)-(177,23) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (177,25)-(177,28))
+        │   │       │   │   @ LocalVariableReadNode (location: (177,24)-(177,27))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (177,13)-(177,21))
+        │   │       │   │   @ StatementsNode (location: (177,13)-(177,20))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ SourceLineNode (location: (177,13)-(177,21))
+        │   │       │   │       └── @ StringNode (location: (177,13)-(177,20))
+        │   │       │   │           ├── flags: ∅
+        │   │       │   │           ├── opening_loc: (177,13)-(177,16) = "%q["
+        │   │       │   │           ├── content_loc: (177,16)-(177,19) = "foo"
+        │   │       │   │           ├── closing_loc: (177,19)-(177,20) = "]"
+        │   │       │   │           └── unescaped: "foo"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (177,10)-(177,12) = "in"
-        │   │       └── then_loc: (177,29)-(177,33) = "then"
+        │   │       └── then_loc: (177,28)-(177,32) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (177,0)-(177,4) = "case"
-        │   └── end_keyword_loc: (177,34)-(177,37) = "end"
-        ├── @ CaseMatchNode (location: (178,0)-(178,41))
+        │   └── end_keyword_loc: (177,33)-(177,36) = "end"
+        ├── @ CaseMatchNode (location: (178,0)-(178,36))
         │   ├── predicate:
         │   │   @ CallNode (location: (178,5)-(178,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -4432,28 +4199,33 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (178,10)-(178,37))
+        │   │   └── @ InNode (location: (178,10)-(178,32))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (178,13)-(178,32))
-        │   │       │   ├── if_keyword_loc: (178,26)-(178,28) = "if"
+        │   │       │   @ IfNode (location: (178,13)-(178,27))
+        │   │       │   ├── if_keyword_loc: (178,21)-(178,23) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (178,29)-(178,32))
+        │   │       │   │   @ LocalVariableReadNode (location: (178,24)-(178,27))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (178,13)-(178,25))
+        │   │       │   │   @ StatementsNode (location: (178,13)-(178,20))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ SourceEncodingNode (location: (178,13)-(178,25))
+        │   │       │   │       └── @ StringNode (location: (178,13)-(178,20))
+        │   │       │   │           ├── flags: ∅
+        │   │       │   │           ├── opening_loc: (178,13)-(178,16) = "%Q["
+        │   │       │   │           ├── content_loc: (178,16)-(178,19) = "foo"
+        │   │       │   │           ├── closing_loc: (178,19)-(178,20) = "]"
+        │   │       │   │           └── unescaped: "foo"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (178,10)-(178,12) = "in"
-        │   │       └── then_loc: (178,33)-(178,37) = "then"
+        │   │       └── then_loc: (178,28)-(178,32) = "then"
         │   ├── consequent: ∅
         │   ├── case_keyword_loc: (178,0)-(178,4) = "case"
-        │   └── end_keyword_loc: (178,38)-(178,41) = "end"
-        ├── @ CaseMatchNode (location: (179,0)-(179,39))
+        │   └── end_keyword_loc: (178,33)-(178,36) = "end"
+        ├── @ CaseMatchNode (location: (179,0)-(179,34))
         │   ├── predicate:
         │   │   @ CallNode (location: (179,5)-(179,8))
         │   │   ├── flags: variable_call, ignore_visibility
@@ -4466,359 +4238,637 @@
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── conditions: (length: 1)
-        │   │   └── @ InNode (location: (179,10)-(179,35))
+        │   │   └── @ InNode (location: (179,10)-(179,30))
         │   │       ├── pattern:
-        │   │       │   @ IfNode (location: (179,13)-(179,30))
-        │   │       │   ├── if_keyword_loc: (179,24)-(179,26) = "if"
+        │   │       │   @ IfNode (location: (179,13)-(179,25))
+        │   │       │   ├── if_keyword_loc: (179,19)-(179,21) = "if"
         │   │       │   ├── predicate:
-        │   │       │   │   @ LocalVariableReadNode (location: (179,27)-(179,30))
+        │   │       │   │   @ LocalVariableReadNode (location: (179,22)-(179,25))
         │   │       │   │   ├── name: :baz
         │   │       │   │   └── depth: 0
         │   │       │   ├── then_keyword_loc: ∅
         │   │       │   ├── statements:
-        │   │       │   │   @ StatementsNode (location: (179,13)-(179,23))
+        │   │       │   │   @ StatementsNode (location: (179,13)-(179,18))
         │   │       │   │   └── body: (length: 1)
-        │   │       │   │       └── @ LambdaNode (location: (179,13)-(179,23))
+        │   │       │   │       └── @ StringNode (location: (179,13)-(179,18))
+        │   │       │   │           ├── flags: ∅
+        │   │       │   │           ├── opening_loc: (179,13)-(179,14) = "\""
+        │   │       │   │           ├── content_loc: (179,14)-(179,17) = "foo"
+        │   │       │   │           ├── closing_loc: (179,17)-(179,18) = "\""
+        │   │       │   │           └── unescaped: "foo"
+        │   │       │   ├── consequent: ∅
+        │   │       │   └── end_keyword_loc: ∅
+        │   │       ├── statements: ∅
+        │   │       ├── in_loc: (179,10)-(179,12) = "in"
+        │   │       └── then_loc: (179,26)-(179,30) = "then"
+        │   ├── consequent: ∅
+        │   ├── case_keyword_loc: (179,0)-(179,4) = "case"
+        │   └── end_keyword_loc: (179,31)-(179,34) = "end"
+        ├── @ CaseMatchNode (location: (180,0)-(180,32))
+        │   ├── predicate:
+        │   │   @ CallNode (location: (180,5)-(180,8))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (180,5)-(180,8) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── conditions: (length: 1)
+        │   │   └── @ InNode (location: (180,10)-(180,28))
+        │   │       ├── pattern:
+        │   │       │   @ IfNode (location: (180,13)-(180,23))
+        │   │       │   ├── if_keyword_loc: (180,17)-(180,19) = "if"
+        │   │       │   ├── predicate:
+        │   │       │   │   @ LocalVariableReadNode (location: (180,20)-(180,23))
+        │   │       │   │   ├── name: :baz
+        │   │       │   │   └── depth: 0
+        │   │       │   ├── then_keyword_loc: ∅
+        │   │       │   ├── statements:
+        │   │       │   │   @ StatementsNode (location: (180,13)-(180,16))
+        │   │       │   │   └── body: (length: 1)
+        │   │       │   │       └── @ NilNode (location: (180,13)-(180,16))
+        │   │       │   ├── consequent: ∅
+        │   │       │   └── end_keyword_loc: ∅
+        │   │       ├── statements: ∅
+        │   │       ├── in_loc: (180,10)-(180,12) = "in"
+        │   │       └── then_loc: (180,24)-(180,28) = "then"
+        │   ├── consequent: ∅
+        │   ├── case_keyword_loc: (180,0)-(180,4) = "case"
+        │   └── end_keyword_loc: (180,29)-(180,32) = "end"
+        ├── @ CaseMatchNode (location: (181,0)-(181,33))
+        │   ├── predicate:
+        │   │   @ CallNode (location: (181,5)-(181,8))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (181,5)-(181,8) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── conditions: (length: 1)
+        │   │   └── @ InNode (location: (181,10)-(181,29))
+        │   │       ├── pattern:
+        │   │       │   @ IfNode (location: (181,13)-(181,24))
+        │   │       │   ├── if_keyword_loc: (181,18)-(181,20) = "if"
+        │   │       │   ├── predicate:
+        │   │       │   │   @ LocalVariableReadNode (location: (181,21)-(181,24))
+        │   │       │   │   ├── name: :baz
+        │   │       │   │   └── depth: 0
+        │   │       │   ├── then_keyword_loc: ∅
+        │   │       │   ├── statements:
+        │   │       │   │   @ StatementsNode (location: (181,13)-(181,17))
+        │   │       │   │   └── body: (length: 1)
+        │   │       │   │       └── @ SelfNode (location: (181,13)-(181,17))
+        │   │       │   ├── consequent: ∅
+        │   │       │   └── end_keyword_loc: ∅
+        │   │       ├── statements: ∅
+        │   │       ├── in_loc: (181,10)-(181,12) = "in"
+        │   │       └── then_loc: (181,25)-(181,29) = "then"
+        │   ├── consequent: ∅
+        │   ├── case_keyword_loc: (181,0)-(181,4) = "case"
+        │   └── end_keyword_loc: (181,30)-(181,33) = "end"
+        ├── @ CaseMatchNode (location: (182,0)-(182,33))
+        │   ├── predicate:
+        │   │   @ CallNode (location: (182,5)-(182,8))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (182,5)-(182,8) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── conditions: (length: 1)
+        │   │   └── @ InNode (location: (182,10)-(182,29))
+        │   │       ├── pattern:
+        │   │       │   @ IfNode (location: (182,13)-(182,24))
+        │   │       │   ├── if_keyword_loc: (182,18)-(182,20) = "if"
+        │   │       │   ├── predicate:
+        │   │       │   │   @ LocalVariableReadNode (location: (182,21)-(182,24))
+        │   │       │   │   ├── name: :baz
+        │   │       │   │   └── depth: 0
+        │   │       │   ├── then_keyword_loc: ∅
+        │   │       │   ├── statements:
+        │   │       │   │   @ StatementsNode (location: (182,13)-(182,17))
+        │   │       │   │   └── body: (length: 1)
+        │   │       │   │       └── @ TrueNode (location: (182,13)-(182,17))
+        │   │       │   ├── consequent: ∅
+        │   │       │   └── end_keyword_loc: ∅
+        │   │       ├── statements: ∅
+        │   │       ├── in_loc: (182,10)-(182,12) = "in"
+        │   │       └── then_loc: (182,25)-(182,29) = "then"
+        │   ├── consequent: ∅
+        │   ├── case_keyword_loc: (182,0)-(182,4) = "case"
+        │   └── end_keyword_loc: (182,30)-(182,33) = "end"
+        ├── @ CaseMatchNode (location: (183,0)-(183,34))
+        │   ├── predicate:
+        │   │   @ CallNode (location: (183,5)-(183,8))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (183,5)-(183,8) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── conditions: (length: 1)
+        │   │   └── @ InNode (location: (183,10)-(183,30))
+        │   │       ├── pattern:
+        │   │       │   @ IfNode (location: (183,13)-(183,25))
+        │   │       │   ├── if_keyword_loc: (183,19)-(183,21) = "if"
+        │   │       │   ├── predicate:
+        │   │       │   │   @ LocalVariableReadNode (location: (183,22)-(183,25))
+        │   │       │   │   ├── name: :baz
+        │   │       │   │   └── depth: 0
+        │   │       │   ├── then_keyword_loc: ∅
+        │   │       │   ├── statements:
+        │   │       │   │   @ StatementsNode (location: (183,13)-(183,18))
+        │   │       │   │   └── body: (length: 1)
+        │   │       │   │       └── @ FalseNode (location: (183,13)-(183,18))
+        │   │       │   ├── consequent: ∅
+        │   │       │   └── end_keyword_loc: ∅
+        │   │       ├── statements: ∅
+        │   │       ├── in_loc: (183,10)-(183,12) = "in"
+        │   │       └── then_loc: (183,26)-(183,30) = "then"
+        │   ├── consequent: ∅
+        │   ├── case_keyword_loc: (183,0)-(183,4) = "case"
+        │   └── end_keyword_loc: (183,31)-(183,34) = "end"
+        ├── @ CaseMatchNode (location: (184,0)-(184,37))
+        │   ├── predicate:
+        │   │   @ CallNode (location: (184,5)-(184,8))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (184,5)-(184,8) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── conditions: (length: 1)
+        │   │   └── @ InNode (location: (184,10)-(184,33))
+        │   │       ├── pattern:
+        │   │       │   @ IfNode (location: (184,13)-(184,28))
+        │   │       │   ├── if_keyword_loc: (184,22)-(184,24) = "if"
+        │   │       │   ├── predicate:
+        │   │       │   │   @ LocalVariableReadNode (location: (184,25)-(184,28))
+        │   │       │   │   ├── name: :baz
+        │   │       │   │   └── depth: 0
+        │   │       │   ├── then_keyword_loc: ∅
+        │   │       │   ├── statements:
+        │   │       │   │   @ StatementsNode (location: (184,13)-(184,21))
+        │   │       │   │   └── body: (length: 1)
+        │   │       │   │       └── @ SourceFileNode (location: (184,13)-(184,21))
+        │   │       │   │           └── filepath: "patterns.txt"
+        │   │       │   ├── consequent: ∅
+        │   │       │   └── end_keyword_loc: ∅
+        │   │       ├── statements: ∅
+        │   │       ├── in_loc: (184,10)-(184,12) = "in"
+        │   │       └── then_loc: (184,29)-(184,33) = "then"
+        │   ├── consequent: ∅
+        │   ├── case_keyword_loc: (184,0)-(184,4) = "case"
+        │   └── end_keyword_loc: (184,34)-(184,37) = "end"
+        ├── @ CaseMatchNode (location: (185,0)-(185,37))
+        │   ├── predicate:
+        │   │   @ CallNode (location: (185,5)-(185,8))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (185,5)-(185,8) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── conditions: (length: 1)
+        │   │   └── @ InNode (location: (185,10)-(185,33))
+        │   │       ├── pattern:
+        │   │       │   @ IfNode (location: (185,13)-(185,28))
+        │   │       │   ├── if_keyword_loc: (185,22)-(185,24) = "if"
+        │   │       │   ├── predicate:
+        │   │       │   │   @ LocalVariableReadNode (location: (185,25)-(185,28))
+        │   │       │   │   ├── name: :baz
+        │   │       │   │   └── depth: 0
+        │   │       │   ├── then_keyword_loc: ∅
+        │   │       │   ├── statements:
+        │   │       │   │   @ StatementsNode (location: (185,13)-(185,21))
+        │   │       │   │   └── body: (length: 1)
+        │   │       │   │       └── @ SourceLineNode (location: (185,13)-(185,21))
+        │   │       │   ├── consequent: ∅
+        │   │       │   └── end_keyword_loc: ∅
+        │   │       ├── statements: ∅
+        │   │       ├── in_loc: (185,10)-(185,12) = "in"
+        │   │       └── then_loc: (185,29)-(185,33) = "then"
+        │   ├── consequent: ∅
+        │   ├── case_keyword_loc: (185,0)-(185,4) = "case"
+        │   └── end_keyword_loc: (185,34)-(185,37) = "end"
+        ├── @ CaseMatchNode (location: (186,0)-(186,41))
+        │   ├── predicate:
+        │   │   @ CallNode (location: (186,5)-(186,8))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (186,5)-(186,8) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── conditions: (length: 1)
+        │   │   └── @ InNode (location: (186,10)-(186,37))
+        │   │       ├── pattern:
+        │   │       │   @ IfNode (location: (186,13)-(186,32))
+        │   │       │   ├── if_keyword_loc: (186,26)-(186,28) = "if"
+        │   │       │   ├── predicate:
+        │   │       │   │   @ LocalVariableReadNode (location: (186,29)-(186,32))
+        │   │       │   │   ├── name: :baz
+        │   │       │   │   └── depth: 0
+        │   │       │   ├── then_keyword_loc: ∅
+        │   │       │   ├── statements:
+        │   │       │   │   @ StatementsNode (location: (186,13)-(186,25))
+        │   │       │   │   └── body: (length: 1)
+        │   │       │   │       └── @ SourceEncodingNode (location: (186,13)-(186,25))
+        │   │       │   ├── consequent: ∅
+        │   │       │   └── end_keyword_loc: ∅
+        │   │       ├── statements: ∅
+        │   │       ├── in_loc: (186,10)-(186,12) = "in"
+        │   │       └── then_loc: (186,33)-(186,37) = "then"
+        │   ├── consequent: ∅
+        │   ├── case_keyword_loc: (186,0)-(186,4) = "case"
+        │   └── end_keyword_loc: (186,38)-(186,41) = "end"
+        ├── @ CaseMatchNode (location: (187,0)-(187,39))
+        │   ├── predicate:
+        │   │   @ CallNode (location: (187,5)-(187,8))
+        │   │   ├── flags: variable_call, ignore_visibility
+        │   │   ├── receiver: ∅
+        │   │   ├── call_operator_loc: ∅
+        │   │   ├── name: :foo
+        │   │   ├── message_loc: (187,5)-(187,8) = "foo"
+        │   │   ├── opening_loc: ∅
+        │   │   ├── arguments: ∅
+        │   │   ├── closing_loc: ∅
+        │   │   └── block: ∅
+        │   ├── conditions: (length: 1)
+        │   │   └── @ InNode (location: (187,10)-(187,35))
+        │   │       ├── pattern:
+        │   │       │   @ IfNode (location: (187,13)-(187,30))
+        │   │       │   ├── if_keyword_loc: (187,24)-(187,26) = "if"
+        │   │       │   ├── predicate:
+        │   │       │   │   @ LocalVariableReadNode (location: (187,27)-(187,30))
+        │   │       │   │   ├── name: :baz
+        │   │       │   │   └── depth: 0
+        │   │       │   ├── then_keyword_loc: ∅
+        │   │       │   ├── statements:
+        │   │       │   │   @ StatementsNode (location: (187,13)-(187,23))
+        │   │       │   │   └── body: (length: 1)
+        │   │       │   │       └── @ LambdaNode (location: (187,13)-(187,23))
         │   │       │   │           ├── locals: []
-        │   │       │   │           ├── operator_loc: (179,13)-(179,15) = "->"
-        │   │       │   │           ├── opening_loc: (179,16)-(179,17) = "{"
-        │   │       │   │           ├── closing_loc: (179,22)-(179,23) = "}"
+        │   │       │   │           ├── operator_loc: (187,13)-(187,15) = "->"
+        │   │       │   │           ├── opening_loc: (187,16)-(187,17) = "{"
+        │   │       │   │           ├── closing_loc: (187,22)-(187,23) = "}"
         │   │       │   │           ├── parameters: ∅
         │   │       │   │           └── body:
-        │   │       │   │               @ StatementsNode (location: (179,18)-(179,21))
+        │   │       │   │               @ StatementsNode (location: (187,18)-(187,21))
         │   │       │   │               └── body: (length: 1)
-        │   │       │   │                   └── @ LocalVariableReadNode (location: (179,18)-(179,21))
+        │   │       │   │                   └── @ LocalVariableReadNode (location: (187,18)-(187,21))
         │   │       │   │                       ├── name: :bar
         │   │       │   │                       └── depth: 1
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
-        │   │       ├── in_loc: (179,10)-(179,12) = "in"
-        │   │       └── then_loc: (179,31)-(179,35) = "then"
+        │   │       ├── in_loc: (187,10)-(187,12) = "in"
+        │   │       └── then_loc: (187,31)-(187,35) = "then"
         │   ├── consequent: ∅
-        │   ├── case_keyword_loc: (179,0)-(179,4) = "case"
-        │   └── end_keyword_loc: (179,36)-(179,39) = "end"
-        ├── @ IfNode (location: (181,0)-(182,3))
-        │   ├── if_keyword_loc: (181,0)-(181,2) = "if"
+        │   ├── case_keyword_loc: (187,0)-(187,4) = "case"
+        │   └── end_keyword_loc: (187,36)-(187,39) = "end"
+        ├── @ IfNode (location: (189,0)-(190,3))
+        │   ├── if_keyword_loc: (189,0)-(189,2) = "if"
         │   ├── predicate:
-        │   │   @ MatchPredicateNode (location: (181,3)-(181,10))
+        │   │   @ MatchPredicateNode (location: (189,3)-(189,10))
         │   │   ├── value:
-        │   │   │   @ CallNode (location: (181,3)-(181,4))
+        │   │   │   @ CallNode (location: (189,3)-(189,4))
         │   │   │   ├── flags: variable_call, ignore_visibility
         │   │   │   ├── receiver: ∅
         │   │   │   ├── call_operator_loc: ∅
         │   │   │   ├── name: :a
-        │   │   │   ├── message_loc: (181,3)-(181,4) = "a"
+        │   │   │   ├── message_loc: (189,3)-(189,4) = "a"
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── arguments: ∅
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── block: ∅
         │   │   ├── pattern:
-        │   │   │   @ ArrayPatternNode (location: (181,8)-(181,10))
+        │   │   │   @ ArrayPatternNode (location: (189,8)-(189,10))
         │   │   │   ├── constant: ∅
         │   │   │   ├── requireds: (length: 0)
         │   │   │   ├── rest: ∅
         │   │   │   ├── posts: (length: 0)
-        │   │   │   ├── opening_loc: (181,8)-(181,9) = "["
-        │   │   │   └── closing_loc: (181,9)-(181,10) = "]"
-        │   │   └── operator_loc: (181,5)-(181,7) = "in"
+        │   │   │   ├── opening_loc: (189,8)-(189,9) = "["
+        │   │   │   └── closing_loc: (189,9)-(189,10) = "]"
+        │   │   └── operator_loc: (189,5)-(189,7) = "in"
         │   ├── then_keyword_loc: ∅
         │   ├── statements: ∅
         │   ├── consequent: ∅
-        │   └── end_keyword_loc: (182,0)-(182,3) = "end"
-        ├── @ MatchRequiredNode (location: (184,0)-(186,1))
+        │   └── end_keyword_loc: (190,0)-(190,3) = "end"
+        ├── @ MatchRequiredNode (location: (192,0)-(194,1))
         │   ├── value:
-        │   │   @ CallNode (location: (184,0)-(184,1))
+        │   │   @ CallNode (location: (192,0)-(192,1))
         │   │   ├── flags: variable_call, ignore_visibility
         │   │   ├── receiver: ∅
         │   │   ├── call_operator_loc: ∅
         │   │   ├── name: :a
-        │   │   ├── message_loc: (184,0)-(184,1) = "a"
+        │   │   ├── message_loc: (192,0)-(192,1) = "a"
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments: ∅
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ ArrayPatternNode (location: (184,5)-(186,1))
+        │   │   @ ArrayPatternNode (location: (192,5)-(194,1))
         │   │   ├── constant: ∅
         │   │   ├── requireds: (length: 1)
-        │   │   │   └── @ LocalVariableTargetNode (location: (185,2)-(185,3))
+        │   │   │   └── @ LocalVariableTargetNode (location: (193,2)-(193,3))
         │   │   │       ├── name: :b
         │   │   │       └── depth: 0
         │   │   ├── rest: ∅
         │   │   ├── posts: (length: 0)
-        │   │   ├── opening_loc: (184,5)-(184,6) = "["
-        │   │   └── closing_loc: (186,0)-(186,1) = "]"
-        │   └── operator_loc: (184,2)-(184,4) = "=>"
-        ├── @ MatchPredicateNode (location: (188,0)-(192,1))
+        │   │   ├── opening_loc: (192,5)-(192,6) = "["
+        │   │   └── closing_loc: (194,0)-(194,1) = "]"
+        │   └── operator_loc: (192,2)-(192,4) = "=>"
+        ├── @ MatchPredicateNode (location: (196,0)-(200,1))
         │   ├── value:
-        │   │   @ CallNode (location: (188,0)-(188,3))
+        │   │   @ CallNode (location: (196,0)-(196,3))
         │   │   ├── flags: variable_call, ignore_visibility
         │   │   ├── receiver: ∅
         │   │   ├── call_operator_loc: ∅
         │   │   ├── name: :foo
-        │   │   ├── message_loc: (188,0)-(188,3) = "foo"
+        │   │   ├── message_loc: (196,0)-(196,3) = "foo"
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments: ∅
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ HashPatternNode (location: (188,7)-(192,1))
+        │   │   @ HashPatternNode (location: (196,7)-(200,1))
         │   │   ├── constant:
-        │   │   │   @ ConstantReadNode (location: (188,7)-(188,8))
+        │   │   │   @ ConstantReadNode (location: (196,7)-(196,8))
         │   │   │   └── name: :A
         │   │   ├── elements: (length: 1)
-        │   │   │   └── @ AssocNode (location: (189,2)-(191,3))
+        │   │   │   └── @ AssocNode (location: (197,2)-(199,3))
         │   │   │       ├── key:
-        │   │   │       │   @ SymbolNode (location: (189,2)-(189,6))
+        │   │   │       │   @ SymbolNode (location: (197,2)-(197,6))
         │   │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   ├── opening_loc: ∅
-        │   │   │       │   ├── value_loc: (189,2)-(189,5) = "bar"
-        │   │   │       │   ├── closing_loc: (189,5)-(189,6) = ":"
+        │   │   │       │   ├── value_loc: (197,2)-(197,5) = "bar"
+        │   │   │       │   ├── closing_loc: (197,5)-(197,6) = ":"
         │   │   │       │   └── unescaped: "bar"
         │   │   │       ├── value:
-        │   │   │       │   @ HashPatternNode (location: (189,7)-(191,3))
+        │   │   │       │   @ HashPatternNode (location: (197,7)-(199,3))
         │   │   │       │   ├── constant:
-        │   │   │       │   │   @ ConstantReadNode (location: (189,7)-(189,8))
+        │   │   │       │   │   @ ConstantReadNode (location: (197,7)-(197,8))
         │   │   │       │   │   └── name: :B
         │   │   │       │   ├── elements: (length: 1)
-        │   │   │       │   │   └── @ AssocNode (location: (190,4)-(190,12))
+        │   │   │       │   │   └── @ AssocNode (location: (198,4)-(198,12))
         │   │   │       │   │       ├── key:
-        │   │   │       │   │       │   @ SymbolNode (location: (190,4)-(190,10))
+        │   │   │       │   │       │   @ SymbolNode (location: (198,4)-(198,10))
         │   │   │       │   │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │   │       │   ├── opening_loc: ∅
-        │   │   │       │   │       │   ├── value_loc: (190,4)-(190,9) = "value"
-        │   │   │       │   │       │   ├── closing_loc: (190,9)-(190,10) = ":"
+        │   │   │       │   │       │   ├── value_loc: (198,4)-(198,9) = "value"
+        │   │   │       │   │       │   ├── closing_loc: (198,9)-(198,10) = ":"
         │   │   │       │   │       │   └── unescaped: "value"
         │   │   │       │   │       ├── value:
-        │   │   │       │   │       │   @ LocalVariableTargetNode (location: (190,11)-(190,12))
+        │   │   │       │   │       │   @ LocalVariableTargetNode (location: (198,11)-(198,12))
         │   │   │       │   │       │   ├── name: :a
         │   │   │       │   │       │   └── depth: 0
         │   │   │       │   │       └── operator_loc: ∅
         │   │   │       │   ├── rest: ∅
-        │   │   │       │   ├── opening_loc: (189,8)-(189,9) = "["
-        │   │   │       │   └── closing_loc: (191,2)-(191,3) = "]"
+        │   │   │       │   ├── opening_loc: (197,8)-(197,9) = "["
+        │   │   │       │   └── closing_loc: (199,2)-(199,3) = "]"
         │   │   │       └── operator_loc: ∅
         │   │   ├── rest: ∅
-        │   │   ├── opening_loc: (188,8)-(188,9) = "["
-        │   │   └── closing_loc: (192,0)-(192,1) = "]"
-        │   └── operator_loc: (188,4)-(188,6) = "in"
-        ├── @ MatchPredicateNode (location: (194,0)-(194,17))
+        │   │   ├── opening_loc: (196,8)-(196,9) = "["
+        │   │   └── closing_loc: (200,0)-(200,1) = "]"
+        │   └── operator_loc: (196,4)-(196,6) = "in"
+        ├── @ MatchPredicateNode (location: (202,0)-(202,17))
         │   ├── value:
-        │   │   @ CallNode (location: (194,0)-(194,3))
+        │   │   @ CallNode (location: (202,0)-(202,3))
         │   │   ├── flags: variable_call, ignore_visibility
         │   │   ├── receiver: ∅
         │   │   ├── call_operator_loc: ∅
         │   │   ├── name: :foo
-        │   │   ├── message_loc: (194,0)-(194,3) = "foo"
+        │   │   ├── message_loc: (202,0)-(202,3) = "foo"
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments: ∅
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ CapturePatternNode (location: (194,7)-(194,17))
+        │   │   @ CapturePatternNode (location: (202,7)-(202,17))
         │   │   ├── value:
-        │   │   │   @ LocalVariableTargetNode (location: (194,7)-(194,10))
+        │   │   │   @ LocalVariableTargetNode (location: (202,7)-(202,10))
         │   │   │   ├── name: :bar
         │   │   │   └── depth: 0
         │   │   ├── target:
-        │   │   │   @ LocalVariableTargetNode (location: (194,14)-(194,17))
+        │   │   │   @ LocalVariableTargetNode (location: (202,14)-(202,17))
         │   │   │   ├── name: :baz
         │   │   │   └── depth: 0
-        │   │   └── operator_loc: (194,11)-(194,13) = "=>"
-        │   └── operator_loc: (194,4)-(194,6) = "in"
-        ├── @ MatchRequiredNode (location: (195,0)-(195,17))
+        │   │   └── operator_loc: (202,11)-(202,13) = "=>"
+        │   └── operator_loc: (202,4)-(202,6) = "in"
+        ├── @ MatchRequiredNode (location: (203,0)-(203,17))
         │   ├── value:
-        │   │   @ CallNode (location: (195,0)-(195,3))
+        │   │   @ CallNode (location: (203,0)-(203,3))
         │   │   ├── flags: variable_call, ignore_visibility
         │   │   ├── receiver: ∅
         │   │   ├── call_operator_loc: ∅
         │   │   ├── name: :foo
-        │   │   ├── message_loc: (195,0)-(195,3) = "foo"
+        │   │   ├── message_loc: (203,0)-(203,3) = "foo"
         │   │   ├── opening_loc: ∅
         │   │   ├── arguments: ∅
         │   │   ├── closing_loc: ∅
         │   │   └── block: ∅
         │   ├── pattern:
-        │   │   @ CapturePatternNode (location: (195,7)-(195,17))
+        │   │   @ CapturePatternNode (location: (203,7)-(203,17))
         │   │   ├── value:
-        │   │   │   @ LocalVariableTargetNode (location: (195,7)-(195,10))
+        │   │   │   @ LocalVariableTargetNode (location: (203,7)-(203,10))
         │   │   │   ├── name: :bar
         │   │   │   └── depth: 0
         │   │   ├── target:
-        │   │   │   @ LocalVariableTargetNode (location: (195,14)-(195,17))
+        │   │   │   @ LocalVariableTargetNode (location: (203,14)-(203,17))
         │   │   │   ├── name: :baz
         │   │   │   └── depth: 0
-        │   │   └── operator_loc: (195,11)-(195,13) = "=>"
-        │   └── operator_loc: (195,4)-(195,6) = "=>"
-        ├── @ MultiWriteNode (location: (197,0)-(197,20))
+        │   │   └── operator_loc: (203,11)-(203,13) = "=>"
+        │   └── operator_loc: (203,4)-(203,6) = "=>"
+        ├── @ MultiWriteNode (location: (205,0)-(205,20))
         │   ├── lefts: (length: 3)
-        │   │   ├── @ LocalVariableTargetNode (location: (197,0)-(197,3))
+        │   │   ├── @ LocalVariableTargetNode (location: (205,0)-(205,3))
         │   │   │   ├── name: :foo
         │   │   │   └── depth: 0
-        │   │   ├── @ LocalVariableTargetNode (location: (197,5)-(197,8))
+        │   │   ├── @ LocalVariableTargetNode (location: (205,5)-(205,8))
         │   │   │   ├── name: :bar
         │   │   │   └── depth: 0
-        │   │   └── @ LocalVariableTargetNode (location: (197,10)-(197,13))
+        │   │   └── @ LocalVariableTargetNode (location: (205,10)-(205,13))
         │   │       ├── name: :baz
         │   │       └── depth: 0
         │   ├── rest: ∅
         │   ├── rights: (length: 0)
         │   ├── lparen_loc: ∅
         │   ├── rparen_loc: ∅
-        │   ├── operator_loc: (197,14)-(197,15) = "="
+        │   ├── operator_loc: (205,14)-(205,15) = "="
         │   └── value:
-        │       @ ArrayNode (location: (197,16)-(197,20))
+        │       @ ArrayNode (location: (205,16)-(205,20))
         │       ├── flags: ∅
         │       ├── elements: (length: 2)
-        │       │   ├── @ IntegerNode (location: (197,16)-(197,17))
+        │       │   ├── @ IntegerNode (location: (205,16)-(205,17))
         │       │   │   └── flags: decimal
-        │       │   └── @ IntegerNode (location: (197,19)-(197,20))
+        │       │   └── @ IntegerNode (location: (205,19)-(205,20))
         │       │       └── flags: decimal
         │       ├── opening_loc: ∅
         │       └── closing_loc: ∅
-        ├── @ CallNode (location: (198,0)-(200,3))
+        ├── @ CallNode (location: (206,0)-(208,3))
         │   ├── flags: ignore_visibility
         │   ├── receiver: ∅
         │   ├── call_operator_loc: ∅
         │   ├── name: :foo
-        │   ├── message_loc: (198,0)-(198,3) = "foo"
+        │   ├── message_loc: (206,0)-(206,3) = "foo"
         │   ├── opening_loc: ∅
         │   ├── arguments: ∅
         │   ├── closing_loc: ∅
         │   └── block:
-        │       @ BlockNode (location: (198,4)-(200,3))
+        │       @ BlockNode (location: (206,4)-(208,3))
         │       ├── locals: []
         │       ├── parameters: ∅
         │       ├── body:
-        │       │   @ StatementsNode (location: (199,2)-(199,29))
+        │       │   @ StatementsNode (location: (207,2)-(207,29))
         │       │   └── body: (length: 1)
-        │       │       └── @ MatchRequiredNode (location: (199,2)-(199,29))
+        │       │       └── @ MatchRequiredNode (location: (207,2)-(207,29))
         │       │           ├── value:
-        │       │           │   @ ArrayNode (location: (199,2)-(199,8))
+        │       │           │   @ ArrayNode (location: (207,2)-(207,8))
         │       │           │   ├── flags: ∅
         │       │           │   ├── elements: (length: 2)
-        │       │           │   │   ├── @ IntegerNode (location: (199,3)-(199,4))
+        │       │           │   │   ├── @ IntegerNode (location: (207,3)-(207,4))
         │       │           │   │   │   └── flags: decimal
-        │       │           │   │   └── @ IntegerNode (location: (199,6)-(199,7))
+        │       │           │   │   └── @ IntegerNode (location: (207,6)-(207,7))
         │       │           │   │       └── flags: decimal
-        │       │           │   ├── opening_loc: (199,2)-(199,3) = "["
-        │       │           │   └── closing_loc: (199,7)-(199,8) = "]"
+        │       │           │   ├── opening_loc: (207,2)-(207,3) = "["
+        │       │           │   └── closing_loc: (207,7)-(207,8) = "]"
         │       │           ├── pattern:
-        │       │           │   @ CapturePatternNode (location: (199,12)-(199,29))
+        │       │           │   @ CapturePatternNode (location: (207,12)-(207,29))
         │       │           │   ├── value:
-        │       │           │   │   @ ArrayPatternNode (location: (199,12)-(199,22))
+        │       │           │   │   @ ArrayPatternNode (location: (207,12)-(207,22))
         │       │           │   │   ├── constant: ∅
         │       │           │   │   ├── requireds: (length: 2)
-        │       │           │   │   │   ├── @ LocalVariableTargetNode (location: (199,13)-(199,16))
+        │       │           │   │   │   ├── @ LocalVariableTargetNode (location: (207,13)-(207,16))
         │       │           │   │   │   │   ├── name: :foo
         │       │           │   │   │   │   └── depth: 1
-        │       │           │   │   │   └── @ LocalVariableTargetNode (location: (199,18)-(199,21))
+        │       │           │   │   │   └── @ LocalVariableTargetNode (location: (207,18)-(207,21))
         │       │           │   │   │       ├── name: :bar
         │       │           │   │   │       └── depth: 1
         │       │           │   │   ├── rest: ∅
         │       │           │   │   ├── posts: (length: 0)
-        │       │           │   │   ├── opening_loc: (199,12)-(199,13) = "["
-        │       │           │   │   └── closing_loc: (199,21)-(199,22) = "]"
+        │       │           │   │   ├── opening_loc: (207,12)-(207,13) = "["
+        │       │           │   │   └── closing_loc: (207,21)-(207,22) = "]"
         │       │           │   ├── target:
-        │       │           │   │   @ LocalVariableTargetNode (location: (199,26)-(199,29))
+        │       │           │   │   @ LocalVariableTargetNode (location: (207,26)-(207,29))
         │       │           │   │   ├── name: :baz
         │       │           │   │   └── depth: 1
-        │       │           │   └── operator_loc: (199,23)-(199,25) = "=>"
-        │       │           └── operator_loc: (199,9)-(199,11) = "=>"
-        │       ├── opening_loc: (198,4)-(198,6) = "do"
-        │       └── closing_loc: (200,0)-(200,3) = "end"
-        ├── @ MatchRequiredNode (location: (202,0)-(202,19))
+        │       │           │   └── operator_loc: (207,23)-(207,25) = "=>"
+        │       │           └── operator_loc: (207,9)-(207,11) = "=>"
+        │       ├── opening_loc: (206,4)-(206,6) = "do"
+        │       └── closing_loc: (208,0)-(208,3) = "end"
+        ├── @ MatchRequiredNode (location: (210,0)-(210,19))
         │   ├── value:
-        │   │   @ LocalVariableReadNode (location: (202,0)-(202,3))
+        │   │   @ LocalVariableReadNode (location: (210,0)-(210,3))
         │   │   ├── name: :foo
         │   │   └── depth: 0
         │   ├── pattern:
-        │   │   @ ArrayPatternNode (location: (202,7)-(202,19))
+        │   │   @ ArrayPatternNode (location: (210,7)-(210,19))
         │   │   ├── constant:
-        │   │   │   @ ConstantReadNode (location: (202,7)-(202,13))
+        │   │   │   @ ConstantReadNode (location: (210,7)-(210,13))
         │   │   │   └── name: :Object
         │   │   ├── requireds: (length: 1)
-        │   │   │   └── @ HashPatternNode (location: (202,14)-(202,18))
+        │   │   │   └── @ HashPatternNode (location: (210,14)-(210,18))
         │   │   │       ├── constant: ∅
         │   │   │       ├── elements: (length: 1)
-        │   │   │       │   └── @ AssocNode (location: (202,15)-(202,17))
+        │   │   │       │   └── @ AssocNode (location: (210,15)-(210,17))
         │   │   │       │       ├── key:
-        │   │   │       │       │   @ SymbolNode (location: (202,15)-(202,17))
+        │   │   │       │       │   @ SymbolNode (location: (210,15)-(210,17))
         │   │   │       │       │   ├── flags: forced_us_ascii_encoding
         │   │   │       │       │   ├── opening_loc: ∅
-        │   │   │       │       │   ├── value_loc: (202,15)-(202,16) = "x"
-        │   │   │       │       │   ├── closing_loc: (202,16)-(202,17) = ":"
+        │   │   │       │       │   ├── value_loc: (210,15)-(210,16) = "x"
+        │   │   │       │       │   ├── closing_loc: (210,16)-(210,17) = ":"
         │   │   │       │       │   └── unescaped: "x"
         │   │   │       │       ├── value:
-        │   │   │       │       │   @ ImplicitNode (location: (202,15)-(202,16))
+        │   │   │       │       │   @ ImplicitNode (location: (210,15)-(210,16))
         │   │   │       │       │   └── value:
-        │   │   │       │       │       @ LocalVariableTargetNode (location: (202,15)-(202,16))
+        │   │   │       │       │       @ LocalVariableTargetNode (location: (210,15)-(210,16))
         │   │   │       │       │       ├── name: :x
         │   │   │       │       │       └── depth: 0
         │   │   │       │       └── operator_loc: ∅
         │   │   │       ├── rest: ∅
-        │   │   │       ├── opening_loc: (202,14)-(202,15) = "{"
-        │   │   │       └── closing_loc: (202,17)-(202,18) = "}"
+        │   │   │       ├── opening_loc: (210,14)-(210,15) = "{"
+        │   │   │       └── closing_loc: (210,17)-(210,18) = "}"
         │   │   ├── rest: ∅
         │   │   ├── posts: (length: 0)
-        │   │   ├── opening_loc: (202,13)-(202,14) = "["
-        │   │   └── closing_loc: (202,18)-(202,19) = "]"
-        │   └── operator_loc: (202,4)-(202,6) = "=>"
-        ├── @ CallNode (location: (204,0)-(204,19))
+        │   │   ├── opening_loc: (210,13)-(210,14) = "["
+        │   │   └── closing_loc: (210,18)-(210,19) = "]"
+        │   └── operator_loc: (210,4)-(210,6) = "=>"
+        ├── @ CallNode (location: (212,0)-(212,19))
         │   ├── flags: ∅
         │   ├── receiver:
-        │   │   @ IntegerNode (location: (204,0)-(204,1))
+        │   │   @ IntegerNode (location: (212,0)-(212,1))
         │   │   └── flags: decimal
-        │   ├── call_operator_loc: (204,1)-(204,2) = "."
+        │   ├── call_operator_loc: (212,1)-(212,2) = "."
         │   ├── name: :then
-        │   ├── message_loc: (204,2)-(204,6) = "then"
+        │   ├── message_loc: (212,2)-(212,6) = "then"
         │   ├── opening_loc: ∅
         │   ├── arguments: ∅
         │   ├── closing_loc: ∅
         │   └── block:
-        │       @ BlockNode (location: (204,7)-(204,19))
+        │       @ BlockNode (location: (212,7)-(212,19))
         │       ├── locals: [:_1]
         │       ├── parameters:
-        │       │   @ NumberedParametersNode (location: (204,7)-(204,19))
+        │       │   @ NumberedParametersNode (location: (212,7)-(212,19))
         │       │   └── maximum: 1
         │       ├── body:
-        │       │   @ StatementsNode (location: (204,9)-(204,17))
+        │       │   @ StatementsNode (location: (212,9)-(212,17))
         │       │   └── body: (length: 1)
-        │       │       └── @ MatchPredicateNode (location: (204,9)-(204,17))
+        │       │       └── @ MatchPredicateNode (location: (212,9)-(212,17))
         │       │           ├── value:
-        │       │           │   @ IntegerNode (location: (204,9)-(204,10))
+        │       │           │   @ IntegerNode (location: (212,9)-(212,10))
         │       │           │   └── flags: decimal
         │       │           ├── pattern:
-        │       │           │   @ PinnedVariableNode (location: (204,14)-(204,17))
+        │       │           │   @ PinnedVariableNode (location: (212,14)-(212,17))
         │       │           │   ├── variable:
-        │       │           │   │   @ LocalVariableReadNode (location: (204,15)-(204,17))
+        │       │           │   │   @ LocalVariableReadNode (location: (212,15)-(212,17))
         │       │           │   │   ├── name: :_1
         │       │           │   │   └── depth: 0
-        │       │           │   └── operator_loc: (204,14)-(204,15) = "^"
-        │       │           └── operator_loc: (204,11)-(204,13) = "in"
-        │       ├── opening_loc: (204,7)-(204,8) = "{"
-        │       └── closing_loc: (204,18)-(204,19) = "}"
-        └── @ MultiWriteNode (location: (206,0)-(209,5))
+        │       │           │   └── operator_loc: (212,14)-(212,15) = "^"
+        │       │           └── operator_loc: (212,11)-(212,13) = "in"
+        │       ├── opening_loc: (212,7)-(212,8) = "{"
+        │       └── closing_loc: (212,18)-(212,19) = "}"
+        └── @ MultiWriteNode (location: (214,0)-(217,5))
             ├── lefts: (length: 2)
-            │   ├── @ LocalVariableTargetNode (location: (207,2)-(207,3))
+            │   ├── @ LocalVariableTargetNode (location: (215,2)-(215,3))
             │   │   ├── name: :a
             │   │   └── depth: 0
-            │   └── @ LocalVariableTargetNode (location: (208,2)-(208,3))
+            │   └── @ LocalVariableTargetNode (location: (216,2)-(216,3))
             │       ├── name: :b
             │       └── depth: 0
             ├── rest: ∅
             ├── rights: (length: 0)
-            ├── lparen_loc: (206,0)-(206,1) = "("
-            ├── rparen_loc: (209,0)-(209,1) = ")"
-            ├── operator_loc: (209,2)-(209,3) = "="
+            ├── lparen_loc: (214,0)-(214,1) = "("
+            ├── rparen_loc: (217,0)-(217,1) = ")"
+            ├── operator_loc: (217,2)-(217,3) = "="
             └── value:
-                @ CallNode (location: (209,4)-(209,5))
+                @ CallNode (location: (217,4)-(217,5))
                 ├── flags: variable_call, ignore_visibility
                 ├── receiver: ∅
                 ├── call_operator_loc: ∅
                 ├── name: :c
-                ├── message_loc: (209,4)-(209,5) = "c"
+                ├── message_loc: (217,4)-(217,5) = "c"
                 ├── opening_loc: ∅
                 ├── arguments: ∅
                 ├── closing_loc: ∅


### PR DESCRIPTION
This fixes an issue found in https://github.com/ruby/prism/issues/2309#issuecomment-1921624040

~~I can't just add the fixture in test/prism/fixtures/patterns-eof.txt because it requires an EOF to show up. Is it OK to start adding new fixture files?~~

~~I've run the rake task with an added semicolon which makes parsing work, then manually edited the snapshot to remove the last character from the various locations.~~

For `test_individual_snippets_` tests, the fixtures are split on two consecutive newlines and the newline is removed to create the snippets, so we can add a snippet for the issue.

https://github.com/etiennebarrie/prism/blob/3f6d57fd98f9a28a38c30bb43ba98efe56766a72/test/prism/parse_test.rb#L225-L226

But `test_filepath_patterns.txt` parses the whole file at once, so I had to add a separate snippet each time to end the previous pattern in the context of a file that continues.