### PR TITLE
Add parentheses around macro arguments

### DIFF
--- a/templates/include/prism/ast.h.erb
+++ b/templates/include/prism/ast.h.erb
@@ -109,7 +109,7 @@ static const pm_node_flags_t PM_NODE_FLAG_COMMON_MASK = (1 << (PM_NODE_FLAG_BITS
  * Cast the type to an enum to allow the compiler to provide exhaustiveness
  * checking.
  */
-#define PM_NODE_TYPE(node) ((enum pm_node_type) node->type)
+#define PM_NODE_TYPE(node) ((enum pm_node_type) (node)->type)
 
 /**
  * Return true if the type of the given node matches the given type.


### PR DESCRIPTION
Unblocks https://github.com/ruby/ruby/pull/9806

```
../src/prism_compile.c: In function 'pm_compile_node':
../src/prism/ast.h:1045:53: error: 'struct pm_arguments_node' has no member named 'type'
 1045 | #define PM_NODE_TYPE(node) ((enum pm_node_type) node->type)
      |                                                     ^~
../src/prism/ast.h:1050:37: note: in expansion of macro 'PM_NODE_TYPE'
 1050 | #define PM_NODE_TYPE_P(node, type) (PM_NODE_TYPE(node) == (type))
      |                                     ^~~~~~~~~~~~
../src/prism_compile.c:4150:17: note: in expansion of macro 'PM_NODE_TYPE_P'
 4150 |                 PM_NODE_TYPE_P((pm_node_t *)call_node->arguments, PM_ARGUMENTS_NODE) &&
      |                 ^~~~~~~~~~~~~~
../src/compile.c: At top level:
```