### PR TITLE
Amend assert in pm_utf_8_codepoint(), n=0 is fine

### DIFF
--- a/src/encoding.c
+++ b/src/encoding.c
@@ -2252,7 +2252,7 @@ static const uint8_t pm_utf_8_dfa[] = {
  */
 static pm_unicode_codepoint_t
 pm_utf_8_codepoint(const uint8_t *b, ptrdiff_t n, size_t *width) {
-    assert(n >= 1);
+    assert(n >= 0);
     size_t maximum = (size_t) n;
 
     uint32_t codepoint;

--- a/test/prism/format_errors_test.rb
+++ b/test/prism/format_errors_test.rb
@@ -12,6 +12,13 @@ module Prism
             | ^ unexpected '<', ignoring it
             |  ^ unexpected '>', ignoring it
       ERROR
+
+      assert_equal <<~'ERROR', Debug.format_errors('"%W"\u"', false)
+        > 1 | "%W"\u"
+            |     ^ expected a newline or semicolon after the statement
+            |     ^ invalid token
+            |        ^ expected a closing delimiter for the string literal
+      ERROR
     end
   end
 end


### PR DESCRIPTION
This assert used to trip in the included test:
```
./miniruby --parser=prism -e ' "%W"\u" '
```
