### PR TITLE
Fix overlapping memcpy

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -18061,7 +18061,9 @@ pm_parser_errors_format_sort(const pm_list_t *error_list, const pm_newline_list_
 
         // Now we're going to shift all of the errors after this one down one
         // index to make room for the new error.
-        memcpy(&errors[index + 1], &errors[index], sizeof(pm_error_t) * (error_list->size - index - 1));
+        if (index + 1 < error_list->size) {
+            memmove(&errors[index + 1], &errors[index], sizeof(pm_error_t) * (error_list->size - index - 1));
+        }
 
         // Finally, we'll insert the error into the array.
         uint32_t column_end;


### PR DESCRIPTION
It's UB to use memcpy with overlapping source and destination. This
might be causing crashes on 32 bit platforms and on OpenBSD. Use memmove
instead. Add a bounds check while we're at it since it's unclear whether
one-past-end pointer with n=0 is UB.
