### PR TITLE
.travis.yml: Add Travis Ubuntu jammy arm64/ppc64le/s390x cases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+
+dist: jammy
+
+matrix:
+  include:
+    - arch: arm64
+    - arch: ppc64le
+    - arch: s390x
+  allow_failures:
+    - arch: ppc64le
+  fast_finish: true
+
+before_script:
+  # Enable the verbose option in mkmf.rb to print the compiling commands.
+  - export MAKEFLAGS="V=1"

--- a/rakelib/check_manifest.rake
+++ b/rakelib/check_manifest.rake
@@ -35,6 +35,7 @@ task check_manifest: :templates do
     .gitattributes
     .gitignore
     .gitmodules
+    .travis.yml
     *.iml
     Doxyfile
     Gemfile


### PR DESCRIPTION
This PR is to add Travis arm64/ppc64le/s390x cases to this repository. Because this repository's commits are synchronized to ruby/ruby repository (automatically?). Then I recently saw 2 issues on Travis CI on ruby/ruby that are related to non-x86_64 CPU architectures. The 1st issue was s390x issue https://github.com/ruby/ruby/commit/34c688b163aa44ff319575c3b3d7d6a5c0dc5260, and the 2nd issue was that maybe the https://github.com/ruby/ruby/commit/770b5499a550956001b879abb5bbd205eabda19f - [the Travis CI log](https://app.travis-ci.com/github/ruby/ruby/builds/268685089) made Travis CI ppc64le/s390x/arm32 cases fail.

The [ruby/ruby Travis CI arm32](https://github.com/ruby/ruby/blob/master/.travis.yml) is emulated by specifying the arm32 compiler `arm-linux-gnueabihf-gcc`, and using `setarch linux32 --verbose --32bit` in the processes of compiling and running tests. So, I wanted to apply this way to the ruby/prism too. If we use this way, we may need to implement a logic to specify the compiler in the `ext/prism/extconf.rb`. I didn't add the arm32 case right now as it looks hard. You may find a way to add the arm32 case it by yourself.

I see ppc64le case always fails. So, I added it to the `allow_failures`. After you fix the issue in ppc64le case, you can remove the part of the code in `.travis.yml`.

---

To prevent Travis in ruby/ruby from failing when ruby/prism's commits are synchronized to ruby/ruby.
