### PR TITLE
Support for Ruby 2.7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,35 @@ updates:
     directory: '/java-wasm'
     schedule:
       interval: 'weekly'
+  - package-ecosystem: 'bundler'
+    directory: '/gemfiles/2.7'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'bundler'
+    directory: '/gemfiles/3.0'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'bundler'
+    directory: '/gemfiles/3.1'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'bundler'
+    directory: '/gemfiles/3.2'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'bundler'
+    directory: '/gemfiles/3.3'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'bundler'
+    directory: '/gemfiles/3.4'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'bundler'
+    directory: '/gemfiles/jruby'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'bundler'
+    directory: '/gemfiles/truffleruby'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/cruby-bindings.yml
+++ b/.github/workflows/cruby-bindings.yml
@@ -1,4 +1,4 @@
-name: Ruby Core
+name: CRuby bindings
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"

--- a/.github/workflows/java-wasm-bindings.yml
+++ b/.github/workflows/java-wasm-bindings.yml
@@ -1,4 +1,4 @@
-name: Bindings to Chicory
+name: Java WASM bindings
 
 on:
   push:

--- a/.github/workflows/javascript-bindings.yml
+++ b/.github/workflows/javascript-bindings.yml
@@ -1,4 +1,4 @@
-name: JavaScript Bindings
+name: JavaScript bindings
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
         bundler-cache: true
     - name: Lint
       run: bundle exec rake lint
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
         bundler-cache: true
     - name: Check annotations
       run: |
@@ -73,19 +73,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby, jruby, truffleruby]
+        target:
+          - { ruby: "head", gemfile: "3.4" }
+          - { ruby: "jruby", gemfile: "jruby" }
+          - { ruby: "truffleruby", gemfile: "truffleruby" }
     runs-on: ubuntu-latest
     env:
       PRISM_FFI_BACKEND: "true"
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.target.gemfile }}/Gemfile
     steps:
       - uses: actions/checkout@v4
-      # The Gemfile.lock is different with PRISM_FFI_BACKEND=true for CRuby
-      - run: rm Gemfile.lock
-        if: matrix.ruby == 'ruby'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ${{ matrix.target.ruby }}
           bundler-cache: true
       - name: Run Ruby tests
         run: bundle exec rake
@@ -235,16 +236,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "head", "jruby", "truffleruby"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-        - { ruby: truffleruby, os: windows-latest }
-    runs-on: ${{ matrix.os }}
+        target:
+          - { ruby: "2.7", os: "ubuntu-latest", gemfile: "2.7" }
+          - { ruby: "3.0", os: "ubuntu-latest", gemfile: "3.0" }
+          - { ruby: "3.1", os: "ubuntu-latest", gemfile: "3.1" }
+          - { ruby: "3.2", os: "ubuntu-latest", gemfile: "3.2" }
+          - { ruby: "3.3", os: "ubuntu-latest", gemfile: "3.3" }
+          - { ruby: "head", os: "ubuntu-latest", gemfile: "3.4" }
+          - { ruby: "jruby", os: "ubuntu-latest", gemfile: "jruby" }
+          - { ruby: "truffleruby", os: "ubuntu-latest", gemfile: "truffleruby" }
+
+          - { ruby: "2.7", os: "macos-latest", gemfile: "2.7" }
+          - { ruby: "3.0", os: "macos-latest", gemfile: "3.0" }
+          - { ruby: "3.1", os: "macos-latest", gemfile: "3.1" }
+          - { ruby: "3.2", os: "macos-latest", gemfile: "3.2" }
+          - { ruby: "3.3", os: "macos-latest", gemfile: "3.3" }
+          - { ruby: "head", os: "macos-latest", gemfile: "3.4" }
+          - { ruby: "jruby", os: "macos-latest", gemfile: "jruby" }
+          - { ruby: "truffleruby", os: "macos-latest", gemfile: "truffleruby" }
+
+          - { ruby: "2.7", os: "windows-latest", gemfile: "2.7" }
+          - { ruby: "3.0", os: "windows-latest", gemfile: "3.0" }
+          - { ruby: "3.1", os: "windows-latest", gemfile: "3.1" }
+          - { ruby: "3.2", os: "windows-latest", gemfile: "3.2" }
+          - { ruby: "3.3", os: "windows-latest", gemfile: "3.3" }
+          - { ruby: "head", os: "windows-latest", gemfile: "3.4" }
+          - { ruby: "jruby", os: "windows-latest", gemfile: "jruby" }
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.target.gemfile }}/Gemfile
+    runs-on: ${{ matrix.target.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
+        ruby-version: ${{ matrix.target.ruby }}
     - uses: actions/download-artifact@v4
       with:
         name: gem-package

--- a/.github/workflows/rust-bindings.yml
+++ b/.github/workflows/rust-bindings.yml
@@ -1,5 +1,4 @@
----
-name: Rust Bindings
+name: Rust bindings
 
 on:
   push:

--- a/.github/workflows/truffleruby-bindings.yml
+++ b/.github/workflows/truffleruby-bindings.yml
@@ -1,4 +1,4 @@
-name: Test Loader.java with TruffleRuby
+name: TruffleRuby bindings
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"

--- a/gemfiles/2.7/Gemfile
+++ b/gemfiles/2.7/Gemfile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby "~> 2.7.0"
+
+gemspec path: "../.."
+
+gem "ffi"
+gem "parser"
+gem "rake"
+gem "rake-compiler"
+gem "rbs"
+gem "test-unit"

--- a/gemfiles/2.7/Gemfile.lock
+++ b/gemfiles/2.7/Gemfile.lock
@@ -1,0 +1,39 @@
+PATH
+  remote: ../..
+  specs:
+    prism (0.21.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    ffi (1.16.3)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    power_assert (2.0.3)
+    racc (1.7.3)
+    rake (13.1.0)
+    rake-compiler (1.2.7)
+      rake
+    rbs (3.1.3)
+    test-unit (3.6.1)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ffi
+  parser
+  prism!
+  rake
+  rake-compiler
+  rbs
+  test-unit
+
+RUBY VERSION
+   ruby 2.7.8p225
+
+BUNDLED WITH
+   2.1.4

--- a/gemfiles/3.0/Gemfile
+++ b/gemfiles/3.0/Gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby "~> 3.0.0"
+
+gemspec path: "../.."
+
+gem "ffi"
+gem "parser"
+gem "rake"
+gem "rake-compiler"
+gem "rbs"
+gem "ruby_memcheck"
+gem "test-unit"

--- a/gemfiles/3.0/Gemfile.lock
+++ b/gemfiles/3.0/Gemfile.lock
@@ -1,0 +1,48 @@
+PATH
+  remote: ../..
+  specs:
+    prism (0.21.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    abbrev (0.1.2)
+    ast (2.4.2)
+    ffi (1.16.3)
+    mini_portile2 (2.8.5)
+    nokogiri (1.16.2)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    power_assert (2.0.3)
+    racc (1.7.3)
+    rake (13.1.0)
+    rake-compiler (1.2.7)
+      rake
+    rbs (3.4.3)
+      abbrev
+    ruby_memcheck (2.3.0)
+      nokogiri
+    test-unit (3.6.1)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ffi
+  parser
+  prism!
+  rake
+  rake-compiler
+  rbs
+  ruby_memcheck
+  test-unit
+
+RUBY VERSION
+   ruby 3.0.6p216
+
+BUNDLED WITH
+   2.2.33

--- a/gemfiles/3.1/Gemfile
+++ b/gemfiles/3.1/Gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby "~> 3.1.0"
+
+gemspec path: "../.."
+
+gem "ffi"
+gem "parser"
+gem "rake"
+gem "rake-compiler"
+gem "rbs"
+gem "ruby_memcheck"
+gem "test-unit"

--- a/gemfiles/3.1/Gemfile.lock
+++ b/gemfiles/3.1/Gemfile.lock
@@ -1,0 +1,48 @@
+PATH
+  remote: ../..
+  specs:
+    prism (0.21.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    abbrev (0.1.2)
+    ast (2.4.2)
+    ffi (1.16.3)
+    mini_portile2 (2.8.5)
+    nokogiri (1.16.2)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    power_assert (2.0.3)
+    racc (1.7.3)
+    rake (13.1.0)
+    rake-compiler (1.2.7)
+      rake
+    rbs (3.4.3)
+      abbrev
+    ruby_memcheck (2.3.0)
+      nokogiri
+    test-unit (3.6.1)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ffi
+  parser
+  prism!
+  rake
+  rake-compiler
+  rbs
+  ruby_memcheck
+  test-unit
+
+RUBY VERSION
+   ruby 3.1.4p223
+
+BUNDLED WITH
+   2.3.26

--- a/gemfiles/3.2/Gemfile
+++ b/gemfiles/3.2/Gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby "~> 3.2.0"
+
+gemspec path: "../.."
+
+gem "ffi"
+gem "parser"
+gem "rake"
+gem "rake-compiler"
+gem "rbs"
+gem "ruby_memcheck"
+gem "test-unit"

--- a/gemfiles/3.2/Gemfile.lock
+++ b/gemfiles/3.2/Gemfile.lock
@@ -1,0 +1,48 @@
+PATH
+  remote: ../..
+  specs:
+    prism (0.21.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    abbrev (0.1.2)
+    ast (2.4.2)
+    ffi (1.16.3)
+    mini_portile2 (2.8.5)
+    nokogiri (1.16.2)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    power_assert (2.0.3)
+    racc (1.7.3)
+    rake (13.1.0)
+    rake-compiler (1.2.7)
+      rake
+    rbs (3.4.3)
+      abbrev
+    ruby_memcheck (2.3.0)
+      nokogiri
+    test-unit (3.6.1)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ffi
+  parser
+  prism!
+  rake
+  rake-compiler
+  rbs
+  ruby_memcheck
+  test-unit
+
+RUBY VERSION
+   ruby 3.2.3p157
+
+BUNDLED WITH
+   2.4.19

--- a/gemfiles/3.3/Gemfile
+++ b/gemfiles/3.3/Gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby "~> 3.3.0"
+
+gemspec path: "../.."
+
+gem "ffi"
+gem "parser"
+gem "rake"
+gem "rake-compiler"
+gem "rbs"
+gem "ruby_memcheck"
+gem "test-unit"

--- a/gemfiles/3.3/Gemfile.lock
+++ b/gemfiles/3.3/Gemfile.lock
@@ -1,0 +1,48 @@
+PATH
+  remote: ../..
+  specs:
+    prism (0.21.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    abbrev (0.1.2)
+    ast (2.4.2)
+    ffi (1.16.3)
+    mini_portile2 (2.8.5)
+    nokogiri (1.16.2)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    power_assert (2.0.3)
+    racc (1.7.3)
+    rake (13.1.0)
+    rake-compiler (1.2.7)
+      rake
+    rbs (3.4.3)
+      abbrev
+    ruby_memcheck (2.3.0)
+      nokogiri
+    test-unit (3.6.1)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ffi
+  parser
+  prism!
+  rake
+  rake-compiler
+  rbs
+  ruby_memcheck
+  test-unit
+
+RUBY VERSION
+   ruby 3.3.0p0
+
+BUNDLED WITH
+   2.5.3

--- a/gemfiles/3.4/Gemfile
+++ b/gemfiles/3.4/Gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby "~> 3.4.0.dev"
+
+gemspec path: "../.."
+
+gem "ffi"
+gem "parser"
+gem "rake"
+gem "rake-compiler"
+gem "rbs"
+gem "ruby_memcheck"
+gem "test-unit"

--- a/gemfiles/3.4/Gemfile.lock
+++ b/gemfiles/3.4/Gemfile.lock
@@ -1,0 +1,48 @@
+PATH
+  remote: ../..
+  specs:
+    prism (0.21.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    abbrev (0.1.2)
+    ast (2.4.2)
+    ffi (1.16.3)
+    mini_portile2 (2.8.5)
+    nokogiri (1.16.2)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    power_assert (2.0.3)
+    racc (1.7.3)
+    rake (13.1.0)
+    rake-compiler (1.2.7)
+      rake
+    rbs (3.4.3)
+      abbrev
+    ruby_memcheck (2.3.0)
+      nokogiri
+    test-unit (3.6.1)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ffi
+  parser
+  prism!
+  rake
+  rake-compiler
+  rbs
+  ruby_memcheck
+  test-unit
+
+RUBY VERSION
+   ruby 3.4.0.dev
+
+BUNDLED WITH
+   2.6.0.dev

--- a/gemfiles/jruby/Gemfile
+++ b/gemfiles/jruby/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby "~> 3.1.4", engine: "jruby", engine_version: "~> 9.4.5"
+
+gemspec path: "../.."
+
+gem "parser"
+gem "rake"
+gem "rake-compiler"
+gem "test-unit"

--- a/gemfiles/jruby/Gemfile.lock
+++ b/gemfiles/jruby/Gemfile.lock
@@ -1,0 +1,36 @@
+PATH
+  remote: ../..
+  specs:
+    prism (0.21.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    power_assert (2.0.3)
+    racc (1.7.3-java)
+    rake (13.1.0)
+    rake-compiler (1.2.7)
+      rake
+    test-unit (3.6.1)
+      power_assert
+
+PLATFORMS
+  universal-java-11
+  universal-java-20
+
+DEPENDENCIES
+  parser
+  prism!
+  rake
+  rake-compiler
+  test-unit
+
+RUBY VERSION
+   ruby 3.1.4p0 (jruby 9.4.5.0)
+
+BUNDLED WITH
+   2.3.26

--- a/gemfiles/truffleruby/Gemfile
+++ b/gemfiles/truffleruby/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby "~> 3.2.2", engine: "truffleruby", engine_version: "~> 23.1.2"
+
+gemspec path: "../.."
+
+gem "parser"
+gem "rake"
+gem "rake-compiler"
+gem "test-unit"

--- a/gemfiles/truffleruby/Gemfile.lock
+++ b/gemfiles/truffleruby/Gemfile.lock
@@ -1,0 +1,35 @@
+PATH
+  remote: ../..
+  specs:
+    prism (0.21.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    power_assert (2.0.3)
+    racc (1.7.3)
+    rake (13.1.0)
+    rake-compiler (1.2.7)
+      rake
+    test-unit (3.6.1)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  parser
+  prism!
+  rake
+  rake-compiler
+  test-unit
+
+RUBY VERSION
+   ruby 3.2.2p0 (truffleruby 23.1.2)
+
+BUNDLED WITH
+   2.2.32

--- a/lib/prism/lex_compat.rb
+++ b/lib/prism/lex_compat.rb
@@ -860,7 +860,7 @@ module Prism
       previous = []
       results = []
 
-      Ripper.lex(source, raise_errors: true).each do |token|
+      lex(source).each do |token|
         case token[1]
         when :on_sp
           # skip
@@ -885,6 +885,21 @@ module Prism
       end
 
       results
+    end
+
+    private
+
+    if Ripper.method(:lex).parameters.assoc(:keyrest)
+      def lex(source)
+        Ripper.lex(source, raise_errors: true)
+      end
+    else
+      def lex(source)
+        ripper = Ripper::Lexer.new(source)
+        ripper.lex.tap do |result|
+          raise SyntaxError, ripper.errors.map(&:message).join(' ;') if ripper.errors.any?
+        end
+      end
     end
   end
 

--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -91,7 +91,8 @@ module Prism
   class Location
     # A Source object that is used to determine more information from the given
     # offset and length.
-    protected attr_reader :source
+    attr_reader :source
+    protected :source
 
     # The byte offset from the beginning of the source where this location
     # starts.

--- a/lib/prism/translation/parser/compiler.rb
+++ b/lib/prism/translation/parser/compiler.rb
@@ -1062,12 +1062,22 @@ module Prism
 
         # foo in bar
         # ^^^^^^^^^^
-        def visit_match_predicate_node(node)
-          builder.match_pattern_p(
-            visit(node.value),
-            token(node.operator_loc),
-            within_pattern { |compiler| node.pattern.accept(compiler) }
-          )
+        if RUBY_VERSION >= "3.0"
+          def visit_match_predicate_node(node)
+            builder.match_pattern_p(
+              visit(node.value),
+              token(node.operator_loc),
+              within_pattern { |compiler| node.pattern.accept(compiler) }
+            )
+          end
+        else
+          def visit_match_predicate_node(node)
+            builder.match_pattern(
+              visit(node.value),
+              token(node.operator_loc),
+              within_pattern { |compiler| node.pattern.accept(compiler) }
+            )
+          end
         end
 
         # foo => bar

--- a/prism.gemspec
+++ b/prism.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/ruby/prism"
   spec.license = "MIT"
 
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.require_paths = ["lib"]
   spec.files = [

--- a/rakelib/check_manifest.rake
+++ b/rakelib/check_manifest.rake
@@ -15,6 +15,7 @@ task check_manifest: :templates do
     build
     doc
     fuzz
+    gemfiles
     javascript
     java
     java-wasm

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -17,7 +17,6 @@ return if RUBY_ENGINE == "jruby" || RUBY_ENGINE == "truffleruby"
 # Don't bother trying to configure memcheck on old versions of Ruby.
 return if RUBY_VERSION < "3.0"
 
-
 begin
   require "ruby_memcheck"
   have_memcheck = true

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -89,11 +89,12 @@ module Prism
     #<%= line %>
     <%- end -%>
     <%- end -%>
-    <%= "private " if field.is_a?(Prism::FlagsField) %>attr_reader :<%= field.name %>
+    attr_reader :<%= field.name -%><%= "\n    private :#{field.name}" if field.is_a?(Prism::FlagsField) %>
 
     <%- end -%>
     # def initialize: (<%= (node.fields.map { |field| "#{field.rbs_class} #{field.name}" } + ["Location location"]).join(", ") %>) -> void
     def initialize(<%= (node.fields.map(&:name) + ["location"]).join(", ") %>)
+      @newline = false
       <%- node.fields.each do |field| -%>
       @<%= field.name %> = <%= field.name %>
       <%- end -%>

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -588,43 +588,45 @@ module Prism
       ]
     end
 
-    def test_cannot_assign_to_a_reserved_numbered_parameter
-      expected = BeginNode(
-        Location(),
-        StatementsNode([
-          LocalVariableWriteNode(:_1, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_2, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_3, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_4, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_5, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_6, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_7, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_8, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_9, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
-          LocalVariableWriteNode(:_10, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location())
-        ]),
-        nil,
-        nil,
-        nil,
-        Location()
-      )
-      source = <<~RUBY
-      begin
-        _1=:a;_2=:a;_3=:a;_4=:a;_5=:a
-        _6=:a;_7=:a;_8=:a;_9=:a;_10=:a
+    if RUBY_VERSION >= "3.0"
+      def test_cannot_assign_to_a_reserved_numbered_parameter
+        expected = BeginNode(
+          Location(),
+          StatementsNode([
+            LocalVariableWriteNode(:_1, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+            LocalVariableWriteNode(:_2, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+            LocalVariableWriteNode(:_3, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+            LocalVariableWriteNode(:_4, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+            LocalVariableWriteNode(:_5, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+            LocalVariableWriteNode(:_6, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+            LocalVariableWriteNode(:_7, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+            LocalVariableWriteNode(:_8, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+            LocalVariableWriteNode(:_9, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location()),
+            LocalVariableWriteNode(:_10, 0, Location(), SymbolNode(SymbolFlags::FORCED_US_ASCII_ENCODING, Location(), Location(), nil, "a"), Location())
+          ]),
+          nil,
+          nil,
+          nil,
+          Location()
+        )
+        source = <<~RUBY
+        begin
+          _1=:a;_2=:a;_3=:a;_4=:a;_5=:a
+          _6=:a;_7=:a;_8=:a;_9=:a;_10=:a
+        end
+        RUBY
+        assert_errors expected, source, [
+          ["_1 is reserved for numbered parameters", 8..10],
+          ["_2 is reserved for numbered parameters", 14..16],
+          ["_3 is reserved for numbered parameters", 20..22],
+          ["_4 is reserved for numbered parameters", 26..28],
+          ["_5 is reserved for numbered parameters", 32..34],
+          ["_6 is reserved for numbered parameters", 40..42],
+          ["_7 is reserved for numbered parameters", 46..48],
+          ["_8 is reserved for numbered parameters", 52..54],
+          ["_9 is reserved for numbered parameters", 58..60],
+        ]
       end
-      RUBY
-      assert_errors expected, source, [
-        ["_1 is reserved for numbered parameters", 8..10],
-        ["_2 is reserved for numbered parameters", 14..16],
-        ["_3 is reserved for numbered parameters", 20..22],
-        ["_4 is reserved for numbered parameters", 26..28],
-        ["_5 is reserved for numbered parameters", 32..34],
-        ["_6 is reserved for numbered parameters", 40..42],
-        ["_7 is reserved for numbered parameters", 46..48],
-        ["_8 is reserved for numbered parameters", 52..54],
-        ["_9 is reserved for numbered parameters", 58..60],
-      ]
     end
 
     def test_do_not_allow_trailing_commas_in_method_parameters
@@ -1344,23 +1346,25 @@ module Prism
       ]
     end
 
-    def test_writing_numbered_parameter
-      assert_errors expression("-> { _1 = 0 }"), "-> { _1 = 0 }", [
-        ["_1 is reserved for numbered parameters", 5..7]
-      ]
-    end
+    if RUBY_VERSION >= "3.0"
+      def test_writing_numbered_parameter
+        assert_errors expression("-> { _1 = 0 }"), "-> { _1 = 0 }", [
+          ["_1 is reserved for numbered parameters", 5..7]
+        ]
+      end
 
-    def test_targeting_numbered_parameter
-      assert_errors expression("-> { _1, = 0 }"), "-> { _1, = 0 }", [
-        ["_1 is reserved for numbered parameters", 5..7]
-      ]
-    end
+      def test_targeting_numbered_parameter
+        assert_errors expression("-> { _1, = 0 }"), "-> { _1, = 0 }", [
+          ["_1 is reserved for numbered parameters", 5..7]
+        ]
+      end
 
-    def test_defining_numbered_parameter
-      error_messages = ["_1 is reserved for numbered parameters"]
+      def test_defining_numbered_parameter
+        error_messages = ["_1 is reserved for numbered parameters"]
 
-      assert_error_messages "def _1; end", error_messages
-      assert_error_messages "def self._1; end", error_messages
+        assert_error_messages "def _1; end", error_messages
+        assert_error_messages "def self._1; end", error_messages
+      end
     end
 
     def test_double_scope_numbered_parameters
@@ -1409,11 +1413,13 @@ module Prism
       ]
     end
 
-    def test_numbered_parameters_in_block_arguments
-      source = "foo { |_1| }"
-      assert_errors expression(source), source, [
-        ["_1 is reserved for numbered parameters", 7..9],
-      ]
+    if RUBY_VERSION >= "3.0"
+      def test_numbered_parameters_in_block_arguments
+        source = "foo { |_1| }"
+        assert_errors expression(source), source, [
+          ["_1 is reserved for numbered parameters", 7..9],
+        ]
+      end
     end
 
     def test_conditional_predicate_closed

--- a/test/prism/test_helper.rb
+++ b/test/prism/test_helper.rb
@@ -43,15 +43,18 @@ module Prism
           )
         end
       when SourceFileNode
-        deconstructed_expected = expected.deconstruct_keys(nil)
-        deconstructed_actual = actual.deconstruct_keys(nil)
-        assert_equal deconstructed_expected.keys, deconstructed_actual.keys
+        expected_deconstruct = expected.deconstruct_keys(nil)
+        actual_deconstruct = actual.deconstruct_keys(nil)
+        assert_equal expected_deconstruct.keys, actual_deconstruct.keys
 
         # Filepaths can be different if test suites were run on different
         # machines. We accommodate for this by comparing the basenames, and not
         # the absolute filepaths.
-        assert_equal deconstructed_expected.except(:filepath), deconstructed_actual.except(:filepath)
-        assert_equal File.basename(deconstructed_expected[:filepath]), File.basename(deconstructed_actual[:filepath])
+        expected_filepath = expected_deconstruct.delete(:filepath)
+        actual_filepath = actual_deconstruct.delete(:filepath)
+
+        assert_equal expected_deconstruct, actual_deconstruct
+        assert_equal File.basename(expected_filepath), File.basename(actual_filepath)
       when Node
         deconstructed_expected = expected.deconstruct_keys(nil)
         deconstructed_actual = actual.deconstruct_keys(nil)


### PR DESCRIPTION
Importantly this does _not_ support the syntax version of Ruby 2.7, it merely allows prism to run with Ruby 2.7. The syntax version being parsed will still be 3.3 or 3.4, depending on the given options.