### PR TITLE
Implement file parsing error handling

### DIFF
--- a/bin/parse
+++ b/bin/parse
@@ -13,8 +13,6 @@ if ARGV[0] == "-e"
   result = Prism.parse(ARGV[1])
 else
   result = Prism.parse_file(ARGV[0] || "test.rb")
-
-  raise ArgumentError, "There was nothing to parse. You must pass source code with `-e` or a Ruby file." if result.nil?
 end
 
 result.mark_newlines! if ENV["MARK_NEWLINES"]

--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -160,8 +160,13 @@ module Prism
         pointer = FFI::MemoryPointer.new(SIZEOF)
 
         begin
-          raise unless LibRubyParser.pm_string_mapped_init(pointer, filepath)
-          yield new(pointer)
+          raise TypeError unless filepath.is_a?(String)
+
+          if LibRubyParser.pm_string_mapped_init(pointer, filepath)
+            yield new(pointer)
+          else
+            raise SystemCallError.new(filepath, FFI.errno)
+          end
         ensure
           LibRubyParser.pm_string_free(pointer)
           pointer.free

--- a/src/util/pm_string.c
+++ b/src/util/pm_string.c
@@ -65,7 +65,6 @@ pm_string_mapped_init(pm_string_t *string, const char *filepath) {
     HANDLE file = CreateFile(filepath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
     if (file == INVALID_HANDLE_VALUE) {
-        perror("CreateFile failed");
         return false;
     }
 
@@ -73,7 +72,6 @@ pm_string_mapped_init(pm_string_t *string, const char *filepath) {
     DWORD file_size = GetFileSize(file, NULL);
     if (file_size == INVALID_FILE_SIZE) {
         CloseHandle(file);
-        perror("GetFileSize failed");
         return false;
     }
 
@@ -90,7 +88,6 @@ pm_string_mapped_init(pm_string_t *string, const char *filepath) {
     HANDLE mapping = CreateFileMapping(file, NULL, PAGE_READONLY, 0, 0, NULL);
     if (mapping == NULL) {
         CloseHandle(file);
-        perror("CreateFileMapping failed");
         return false;
     }
 
@@ -100,7 +97,6 @@ pm_string_mapped_init(pm_string_t *string, const char *filepath) {
     CloseHandle(file);
 
     if (source == NULL) {
-        perror("MapViewOfFile failed");
         return false;
     }
 
@@ -110,7 +106,6 @@ pm_string_mapped_init(pm_string_t *string, const char *filepath) {
     // Open the file for reading
     int fd = open(filepath, O_RDONLY);
     if (fd == -1) {
-        perror("open");
         return false;
     }
 
@@ -118,7 +113,6 @@ pm_string_mapped_init(pm_string_t *string, const char *filepath) {
     struct stat sb;
     if (fstat(fd, &sb) == -1) {
         close(fd);
-        perror("fstat");
         return false;
     }
 
@@ -135,7 +129,6 @@ pm_string_mapped_init(pm_string_t *string, const char *filepath) {
 
     source = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (source == MAP_FAILED) {
-        perror("Map failed");
         return false;
     }
 

--- a/test/prism/parse_test.rb
+++ b/test/prism/parse_test.rb
@@ -69,11 +69,96 @@ module Prism
       assert_equal 5, tokens.length
     end
 
+    def test_dump_file
+      assert_nothing_raised do
+        Prism.dump_file(__FILE__)
+      end
+
+      error = assert_raise Errno::ENOENT do
+        Prism.dump_file("idontexist.rb")
+      end
+
+      assert_equal "No such file or directory - idontexist.rb", error.message
+
+      assert_raise TypeError do
+        Prism.dump_file(nil)
+      end
+    end
+
+    def test_lex_file
+      assert_nothing_raised do
+        Prism.lex_file(__FILE__)
+      end
+
+      error = assert_raise Errno::ENOENT do
+        Prism.lex_file("idontexist.rb")
+      end
+
+      assert_equal "No such file or directory - idontexist.rb", error.message
+
+      assert_raise TypeError do
+        Prism.lex_file(nil)
+      end
+    end
+
     def test_parse_lex_file
       node, tokens = Prism.parse_lex_file(__FILE__).value
 
       assert_kind_of ProgramNode, node
       refute_empty tokens
+
+      error = assert_raise Errno::ENOENT do
+        Prism.parse_lex_file("idontexist.rb")
+      end
+
+      assert_equal "No such file or directory - idontexist.rb", error.message
+
+      assert_raise TypeError do
+        Prism.parse_lex_file(nil)
+      end
+    end
+
+    def test_parse_file
+      node = Prism.parse_file(__FILE__).value
+      assert_kind_of ProgramNode, node
+
+      error = assert_raise Errno::ENOENT do
+        Prism.parse_file("idontexist.rb")
+      end
+
+      assert_equal "No such file or directory - idontexist.rb", error.message
+
+      assert_raise TypeError do
+        Prism.parse_file(nil)
+      end
+    end
+
+    def test_parse_file_success
+      assert_predicate Prism.parse_file_comments(__FILE__), :any?
+
+      error = assert_raise Errno::ENOENT do
+        Prism.parse_file_comments("idontexist.rb")
+      end
+
+      assert_equal "No such file or directory - idontexist.rb", error.message
+
+      assert_raise TypeError do
+        Prism.parse_file_comments(nil)
+      end
+    end
+
+    def test_parse_file_comments
+      assert_predicate Prism.parse_file_comments(__FILE__), :any?
+
+      error = assert_raise Errno::ENOENT do
+        Prism.parse_file_comments("idontexist.rb")
+      end
+
+      assert_equal "No such file or directory - idontexist.rb", error.message
+
+      assert_raise TypeError do
+        Prism.parse_file_comments(nil)
+      end
     end
 
     # To accurately compare against Ripper, we need to make sure that we're


### PR DESCRIPTION
Implement file parsing error handling

This PR implements proper file parsing error handling. Previously
`file_options` would call `pm_string_mapped_init` which would print an
error from `perror`. However this wouldn't raise a proper Ruby error so
it was just a string output. I've done the following:

- Raise an error from `rb_syserr_fail` with the filepath in
`file_options`.
- No longer return `Qnil` if `file_options` returns false (because now 
it will raise)
- Update `file_options` to return `static void` instead of `static
bool`.
- Update `file_options` and `profile_file` to check the type so when
passing `nil` we see a `TypeError`.
- Delete `perror` from `pm_string_mapped_init`
- Update `FFI` backend to raise appropriate errors when calling
`pm_string_mapped_init`.
- Add tests for `dump_file`, `lex_file`, `parse_file`,
`parse_file_comments`, `parse_lex_file`, and `parse_file_success?`,
when a file doesn't exist and for `nil`.
- Updates the `bin/parse` script to no longer raise it's own 
`ArgumentError` now that we raise a proper error.

Fixes: ruby/prism#2207