### PR TITLE
More visitors and tests for RipperCompat

### DIFF
--- a/test/prism/ripper_compat_test.rb
+++ b/test/prism/ripper_compat_test.rb
@@ -10,6 +10,32 @@ module Prism
       assert_equivalent("6 / 7; 8 % 9")
     end
 
+    def test_unary
+      assert_equivalent("-7")
+    end
+
+    def test_unary_parens
+      assert_equivalent("-(7)")
+      assert_equivalent("(-7)")
+      assert_equivalent("(-\n7)")
+    end
+
+    def test_binary_parens
+      assert_equivalent("(3 + 7) * 4")
+    end
+
+    def test_ident
+      assert_equivalent("foo")
+    end
+
+    def test_range
+      assert_equivalent("(...2)")
+      assert_equivalent("(..2)")
+      assert_equivalent("(1...2)")
+      assert_equivalent("(1..2)")
+      assert_equivalent("(foo..-7)")
+    end
+
     private
 
     def assert_equivalent(source)


### PR DESCRIPTION
Part of issue #2354

More support for operators. Add basic support for ranges, parentheses and negative integers. Tests for each of these.

Full Ripper compatibility will require a lot more, but it seems good to start simple.