### PR TITLE
RipperCompat: support method calls with blocks

### DIFF
--- a/lib/prism/ripper_compat.rb
+++ b/lib/prism/ripper_compat.rb
@@ -352,7 +352,7 @@ module Prism
     def visit_binary_operator(node)
       left_val = visit(node.left)
       right_val = visit(node.right)
-      on_binary(left_val, node.operator_loc.slice.to_sym, right_val)
+      on_binary(left_val, node.operator.to_sym, right_val)
     end
 
     # This method is responsible for updating lineno and column information

--- a/test/prism/ripper_compat_test.rb
+++ b/test/prism/ripper_compat_test.rb
@@ -24,8 +24,30 @@ module Prism
       assert_equivalent("(3 + 7) * 4")
     end
 
-    def test_ident
+    def test_method_calls_with_variable_names
       assert_equivalent("foo")
+      assert_equivalent("foo()")
+      assert_equivalent("foo(-7)")
+      assert_equivalent("foo(1, 2, 3)")
+      assert_equivalent("foo 1")
+      assert_equivalent("foo bar")
+      assert_equivalent("foo 1, 2")
+      assert_equivalent("foo.bar")
+      assert_equivalent("🗻")
+      assert_equivalent("🗻.location")
+      assert_equivalent("foo.🗻")
+      assert_equivalent("🗻.😮!")
+      assert_equivalent("🗻 🗻,🗻,🗻")
+    end
+
+    def test_method_calls_on_immediate_values
+      assert_equivalent("7.even?")
+      assert_equivalent("!1")
+      assert_equivalent("7 && 7")
+      assert_equivalent("7 and 7")
+      assert_equivalent("7 || 7")
+      assert_equivalent("7 or 7")
+      #assert_equivalent("'racecar'.reverse")
     end
 
     def test_range
@@ -57,5 +79,26 @@ module Prism
       refute_nil expected
       assert_equal expected, RipperCompat.sexp_raw(source)
     end
+  end
+
+  class RipperCompatFixturesTest < TestCase
+    #base = File.join(__dir__, "fixtures")
+    #relatives = ENV["FOCUS"] ? [ENV["FOCUS"]] : Dir["**/*.txt", base: base]
+    relatives = ["arithmetic.txt", "integer_operations.txt"]
+
+    relatives.each do |relative|
+      define_method "test_ripper_filepath_#{relative}" do
+        path = File.join(__dir__, "fixtures", relative)
+
+        # First, read the source from the path. Use binmode to avoid converting CRLF on Windows,
+        # and explicitly set the external encoding to UTF-8 to override the binmode default.
+        source = File.read(path, binmode: true, external_encoding: Encoding::UTF_8)
+
+        expected = Ripper.sexp_raw(source)
+        refute_nil expected
+        assert_equal expected, RipperCompat.sexp_raw(source)
+      end
+    end
+
   end
 end

--- a/test/prism/ripper_compat_test.rb
+++ b/test/prism/ripper_compat_test.rb
@@ -38,6 +38,10 @@ module Prism
       assert_equivalent("foo.🗻")
       assert_equivalent("🗻.😮!")
       assert_equivalent("🗻 🗻,🗻,🗻")
+      assert_equivalent("foo&.bar")
+      assert_equivalent("foo { bar }")
+      assert_equivalent("foo.bar { 7 }")
+      assert_equivalent("foo(1) { bar }")
     end
 
     def test_method_calls_on_immediate_values
@@ -84,7 +88,11 @@ module Prism
   class RipperCompatFixturesTest < TestCase
     #base = File.join(__dir__, "fixtures")
     #relatives = ENV["FOCUS"] ? [ENV["FOCUS"]] : Dir["**/*.txt", base: base]
-    relatives = ["arithmetic.txt", "integer_operations.txt"]
+    relatives = [
+      "arithmetic.txt",
+      "comments.txt",
+      "integer_operations.txt",
+    ]
 
     relatives.each do |relative|
       define_method "test_ripper_filepath_#{relative}" do
@@ -95,6 +103,9 @@ module Prism
         source = File.read(path, binmode: true, external_encoding: Encoding::UTF_8)
 
         expected = Ripper.sexp_raw(source)
+        if expected.nil?
+          puts "Could not parse #{path.inspect}!"
+        end
         refute_nil expected
         assert_equal expected, RipperCompat.sexp_raw(source)
       end

--- a/test/prism/ripper_compat_test.rb
+++ b/test/prism/ripper_compat_test.rb
@@ -33,15 +33,25 @@ module Prism
       assert_equivalent("foo bar")
       assert_equivalent("foo 1, 2")
       assert_equivalent("foo.bar")
-      assert_equivalent("🗻")
-      assert_equivalent("🗻.location")
-      assert_equivalent("foo.🗻")
-      assert_equivalent("🗻.😮!")
-      assert_equivalent("🗻 🗻,🗻,🗻")
+
+      # TruffleRuby prints emoji symbols differently in a way that breaks here.
+      if RUBY_ENGINE != "truffleruby"
+        assert_equivalent("🗻")
+        assert_equivalent("🗻.location")
+        assert_equivalent("foo.🗻")
+        assert_equivalent("🗻.😮!")
+        assert_equivalent("🗻 🗻,🗻,🗻")
+      end
+
       assert_equivalent("foo&.bar")
       assert_equivalent("foo { bar }")
       assert_equivalent("foo.bar { 7 }")
       assert_equivalent("foo(1) { bar }")
+      assert_equivalent("foo(bar)")
+      assert_equivalent("foo(bar(1))")
+      assert_equivalent("foo bar(1)")
+      # assert_equivalent("foo(bar 1)") # This succeeds for me locally but fails on CI
+      # assert_equivalent("foo bar 1")
     end
 
     def test_method_calls_on_immediate_values


### PR DESCRIPTION
There are a few cases we don't correctly support yet ("foo bar 1") and the argument handling is messy here. I'm working on it. But we're supporting a few fixture files correctly now.

This is part of fixing issue #2354.