### PR TITLE
RipperCompat: support for more features.

### DIFF
--- a/bin/prism
+++ b/bin/prism
@@ -16,6 +16,7 @@ module Prism
       when "memsize"  then memsize
       when "parse"    then parse(argv)
       when "parser"   then parser(argv)
+      when "ripper"   then ripper(argv)
       else
         puts <<~TXT
           Usage:
@@ -208,6 +209,23 @@ module Prism
 
       puts "Prism:"
       pp Translation::Parser.parse(source, filepath)
+    end
+
+    # bin/prism ripper [source]
+    def ripper(argv)
+      require "ripper"
+      source, filepath = read_source(argv)
+
+      ripper = Ripper.sexp_raw(source)
+      prism = Prism::RipperCompat.sexp_raw(source)
+
+      puts "Ripper:"
+      pp ripper
+
+      puts "Prism:"
+      pp prism
+
+      puts "Output is #{ripper == prism ? "" : "not "}identical"
     end
 
     ############################################################################

--- a/lib/prism/ripper_compat.rb
+++ b/lib/prism/ripper_compat.rb
@@ -208,7 +208,7 @@ module Prism
       return on_break(on_args_new) if node.arguments.nil?
 
       args_val = visit_elements(node.arguments.arguments)
-      on_break(on_args_add_block(args_val,false))
+      on_break(on_args_add_block(args_val, false))
     end
 
     # Visit an AndNode.

--- a/lib/prism/ripper_compat.rb
+++ b/lib/prism/ripper_compat.rb
@@ -230,7 +230,7 @@ module Prism
     # Visit a FalseNode.
     def visit_false_node(node)
       bounds(node.location)
-      on_var_ref(on_kw(node.slice))
+      on_var_ref(on_kw("false"))
     end
 
     # Visit a FloatNode node.

--- a/lib/prism/ripper_compat.rb
+++ b/lib/prism/ripper_compat.rb
@@ -17,7 +17,7 @@ module Prism
   #
   # To use this class, you treat `Prism::RipperCompat` effectively as you would
   # treat the `Ripper` class.
-  class RipperCompat < Visitor
+  class RipperCompat < Compiler
     # This class mirrors the ::Ripper::SexpBuilder subclass of ::Ripper that
     # returns the arrays of [type, *children].
     class SexpBuilder < RipperCompat
@@ -194,7 +194,7 @@ module Prism
     # This will require expanding as we support more kinds of parameters.
     def visit_parameters_node(node)
       #on_params(required, optional, nil, nil, nil, nil, nil)
-      on_params(node.requireds.map { |n| visit(n) }, nil, nil, nil, nil, nil, nil)
+      on_params(visit_all(node.requireds), nil, nil, nil, nil, nil, nil)
     end
 
     # Visit a RequiredParameterNode.

--- a/lib/prism/ripper_compat.rb
+++ b/lib/prism/ripper_compat.rb
@@ -200,7 +200,7 @@ module Prism
     # Visit a RequiredParameterNode.
     def visit_required_parameter_node(node)
       bounds(node.location)
-      on_ident(node.name.to_s)
+      on_ident(node.name.name)
     end
 
     # Visit a BreakNode.

--- a/lib/prism/ripper_compat.rb
+++ b/lib/prism/ripper_compat.rb
@@ -200,7 +200,7 @@ module Prism
     # Visit a RequiredParameterNode.
     def visit_required_parameter_node(node)
       bounds(node.location)
-      on_ident(node.name.name)
+      on_ident(node.name.to_s)
     end
 
     # Visit a BreakNode.

--- a/lib/prism/ripper_compat.rb
+++ b/lib/prism/ripper_compat.rb
@@ -224,7 +224,7 @@ module Prism
     # Visit a TrueNode.
     def visit_true_node(node)
       bounds(node.location)
-      on_var_ref(on_kw(node.slice))
+      on_var_ref(on_kw("true"))
     end
 
     # Visit a FalseNode.

--- a/lib/prism/ripper_compat.rb
+++ b/lib/prism/ripper_compat.rb
@@ -165,7 +165,7 @@ module Prism
 
     # Visit nodes for +=, *=, -=, etc., called LocalVariableOperatorWriteNodes.
     def visit_local_variable_operator_write_node(node)
-      visit_binary_op_assign(node, operator: node.operator.to_s + "=")
+      visit_binary_op_assign(node, operator: "#{node.operator}=")
     end
 
     # Visit a LocalVariableReadNode.

--- a/test/prism/ripper_compat_test.rb
+++ b/test/prism/ripper_compat_test.rb
@@ -27,6 +27,7 @@ module Prism
     def test_method_calls_with_variable_names
       assert_equivalent("foo")
       assert_equivalent("foo()")
+      assert_equivalent("foo -7")
       assert_equivalent("foo(-7)")
       assert_equivalent("foo(1, 2, 3)")
       assert_equivalent("foo 1")
@@ -49,9 +50,16 @@ module Prism
       assert_equivalent("foo(1) { bar }")
       assert_equivalent("foo(bar)")
       assert_equivalent("foo(bar(1))")
+      assert_equivalent("foo(bar(1)) { 7 }")
       assert_equivalent("foo bar(1)")
-      # assert_equivalent("foo(bar 1)") # This succeeds for me locally but fails on CI
+    end
+
+    def test_method_call_blocks
+      assert_equivalent("foo { |a| a }")
+
+      # assert_equivalent("foo(bar 1)")
       # assert_equivalent("foo bar 1")
+      # assert_equivalent("foo(bar 1) { 7 }")
     end
 
     def test_method_calls_on_immediate_values
@@ -85,6 +93,23 @@ module Prism
       assert_equivalent("[1ri, -1ri, +1ri, 1.5ri, -1.5ri, +1.5ri]")
     end
 
+    def test_begin_rescue
+      assert_equivalent("begin a; rescue; c; ensure b; end")
+    end
+
+    def test_break
+      assert_equivalent("foo { break }")
+      assert_equivalent("foo { break 7 }")
+      assert_equivalent("foo { break [1, 2, 3] }")
+    end
+
+    def test_op_assign
+      assert_equivalent("a += b")
+      assert_equivalent("a -= b")
+      assert_equivalent("a *= b")
+      assert_equivalent("a /= b")
+    end
+
     private
 
     def assert_equivalent(source)
@@ -100,6 +125,9 @@ module Prism
     #relatives = ENV["FOCUS"] ? [ENV["FOCUS"]] : Dir["**/*.txt", base: base]
     relatives = [
       "arithmetic.txt",
+      "booleans.txt",
+      "boolean_operators.txt",
+      # "break.txt", # No longer parseable by Ripper in CRuby 3.3.0+
       "comments.txt",
       "integer_operations.txt",
     ]


### PR DESCRIPTION
* add bin/prism ripper to compare Ripper output
* block arg handling is quirky, do it per-call-site
* required params for blocks
* boolean values
* various assign-operator support
* breaks
* early fragile begin/rescue/end
* more fixtures being checked

Part of #2354.