### PR TITLE
Support node_id

### DIFF
--- a/include/prism/parser.h
+++ b/include/prism/parser.h
@@ -503,6 +503,9 @@ static const uint8_t PM_FORWARDING_ALL = 0x8;
  * it's considering.
  */
 struct pm_parser {
+    /** The current node ID that will be written to the next node. */
+    uint32_t node_id;
+
     /** The current state of the lexer. */
     pm_lex_state_t lex_state;
 

--- a/src/prism.c
+++ b/src/prism.c
@@ -1094,14 +1094,16 @@ pm_statements_node_body_length(pm_statements_node_t *node);
  * This function is here to allow us a place to extend in the future when we
  * implement our own arena allocation.
  */
-static inline void *
-pm_alloc_node(PRISM_ATTRIBUTE_UNUSED pm_parser_t *parser, size_t size) {
-    void *memory = calloc(1, size);
-    if (memory == NULL) {
+static void *
+pm_alloc_node(pm_parser_t *parser, size_t size) {
+    pm_node_t *node = calloc(1, size);
+    if (node == NULL) {
         fprintf(stderr, "Failed to allocate %d bytes\n", (int) size);
         abort();
     }
-    return memory;
+
+    node->id = ++parser->node_id;
+    return (void *) node;
 }
 
 #define PM_ALLOC_NODE(parser, type) (type *) pm_alloc_node(parser, sizeof(type))
@@ -17774,6 +17776,7 @@ pm_parser_init(pm_parser_t *parser, const uint8_t *source, size_t size, const pm
     assert(source != NULL);
 
     *parser = (pm_parser_t) {
+        .node_id = 0,
         .lex_state = PM_LEX_STATE_BEG,
         .enclosure_nesting = 0,
         .lambda_enclosure_nesting = -1,

--- a/templates/include/prism/ast.h.erb
+++ b/templates/include/prism/ast.h.erb
@@ -127,6 +127,13 @@ static const pm_node_flags_t PM_NODE_FLAG_COMMON_MASK = (1 << (PM_NODE_FLAG_BITS
  */
 typedef struct pm_node {
     /**
+     * A unique identifier for this node in the syntax tree. This will be the
+     * same integer for each parse of the same source, which makes it suitable
+     * for finding the node again based on the identifier.
+     */
+    uint32_t id;
+
+    /**
      * This represents the type of the node. It somewhat maps to the nodes that
      * existed in the original grammar and ripper, but it's not a 1:1 mapping.
      */


### PR DESCRIPTION
I did not want to support this, because I desperately did not want to have to add 4 bytes to every node. Unfortunately, in order to support all of the functionality of CRuby, this is a requirement. Hopefully we can mitigate this memory by reducing the size of our location fields at some point.

Fixes https://github.com/ruby/prism/issues/2383.