### PR TITLE
Significantly faster offset cache for parser translation with multibyte characters

### DIFF
--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -124,20 +124,21 @@ module Prism
       # build the parser gem AST.
       #
       # If the bytesize of the source is the same as the length, then we can
-      # just use the offset directly. Otherwise, we build a hash that functions
-      # as a cache for the conversion.
-      #
-      # This is a good opportunity for some optimizations. If the source file
-      # has any multi-byte characters, this can tank the performance of the
-      # translator. We could make this significantly faster by using a
-      # different data structure for the cache.
+      # just use the offset directly. Otherwise, we build an array where the
+      # index is the byte offset and the value is the character offset.
       def build_offset_cache(source)
         if source.bytesize == source.length
           -> (offset) { offset }
         else
-          Hash.new do |hash, offset|
-            hash[offset] = source.byteslice(0, offset).length
+          offset_cache = []
+          offset = 0
+
+          source.each_char do |char|
+            char.bytesize.times { offset_cache << offset }
+            offset += 1
           end
+
+          offset_cache << offset
         end
       end
 


### PR DESCRIPTION
Before:

```
ruby 3.4.0dev (2024-02-07T11:34:48Z master 9ebaf7a8ef) [arm64-darwin23]
Warming up --------------------------------------
 Parser::CurrentRuby     1.000 i/100ms
Prism::Translation::Parser
                         1.000 i/100ms
Calculating -------------------------------------
 Parser::CurrentRuby      1.203 (± 0.0%) i/s -      7.000 in   5.821395s
Prism::Translation::Parser
                          0.245 (± 0.0%) i/s -      2.000 in   8.219212s

Comparison:
 Parser::CurrentRuby:        1.2 i/s
Prism::Translation::Parser:        0.2 i/s - 4.91x  slower
```

after:

```
ruby 3.4.0dev (2024-02-07T11:34:48Z master 9ebaf7a8ef) [arm64-darwin23]
Warming up --------------------------------------
 Parser::CurrentRuby     1.000 i/100ms
Prism::Translation::Parser
                         1.000 i/100ms
Calculating -------------------------------------
 Parser::CurrentRuby      1.167 (± 0.0%) i/s -      6.000 in   5.140792s
Prism::Translation::Parser
                          2.224 (± 0.0%) i/s -     12.000 in   5.401231s

Comparison:
Prism::Translation::Parser:        2.2 i/s
 Parser::CurrentRuby:        1.2 i/s - 1.90x  slower
```