### PR TITLE
Use gcc-11 to align with the ruby/ruby Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ matrix:
     - arch: s390x
   fast_finish: true
 
+before_install:
+  - sudo apt update -yq
+  - sudo apt -yq install gcc-11
+  - gcc-11 --version
+
 before_script:
   # Enable the verbose option in mkmf.rb to print the compiling commands.
-  - export MAKEFLAGS="V=1"
+  - export MAKEFLAGS="V=1 CC=gcc-11"


### PR DESCRIPTION
This PR is to use the same version of GCC with the ruby/ruby's one in Travis CI.

The used gcc-11 version is 11.4.0, the same as the one used in ruby/ruby.

https://app.travis-ci.com/github/junaruga/ruby-prism/jobs/617607554#L172
> gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0

---

However in the `rake compile`, the `cc` is used in the actual command line. That is not expected. I don't know why.
https://app.travis-ci.com/github/junaruga/ruby-prism/jobs/617607554#L219

Edit: solved the issue.
