### PR TITLE
Fix `full_name` for constant path targets

### DIFF
--- a/lib/prism/node_ext.rb
+++ b/lib/prism/node_ext.rb
@@ -94,7 +94,7 @@ module Prism
 
     # Returns the full name of this constant. For example: "Foo"
     def full_name
-      name.name
+      name.to_s
     end
   end
 
@@ -135,12 +135,35 @@ module Prism
     # Returns the list of parts for the full name of this constant path.
     # For example: [:Foo, :Bar]
     def full_name_parts
-      (parent&.full_name_parts || [:""]).push(child.name)
+      parts = case parent
+      when ConstantPathNode, ConstantReadNode
+        parent.full_name_parts
+      when nil
+        [:""]
+      else
+        raise ConstantPathNode::DynamicPartsInConstantPathError,
+          "Constant path target contains dynamic parts. Cannot compute full name"
+      end
+
+      parts.push(child.name)
     end
 
     # Returns the full name of this constant path. For example: "Foo::Bar"
     def full_name
       full_name_parts.join("::")
+    end
+  end
+
+  class ConstantTargetNode < Node
+    # Returns the list of parts for the full name of this constant.
+    # For example: [:Foo]
+    def full_name_parts
+      [name]
+    end
+
+    # Returns the full name of this constant. For example: "Foo"
+    def full_name
+      name.to_s
     end
   end
 

--- a/test/prism/constant_path_node_test.rb
+++ b/test/prism/constant_path_node_test.rb
@@ -63,5 +63,29 @@ module Prism
       node = Prism.parse(source).value.statements.body.first
       assert_equal("::Foo::Bar::Baz::Qux", node.lefts.first.full_name)
     end
+
+    def test_full_name_for_constant_path_target_with_non_constant_parent
+      source = <<~RUBY
+        self::Foo, Bar = [1, 2]
+      RUBY
+
+      constant_target = Prism.parse(source).value.statements.body.first
+      dynamic, static = constant_target.lefts
+
+      assert_raise(ConstantPathNode::DynamicPartsInConstantPathError) do
+        dynamic.full_name
+      end
+
+      assert_equal("Bar", static.full_name)
+    end
+
+    def test_full_name_for_constant_read_node
+      source = <<~RUBY
+        Bar
+      RUBY
+
+      constant = Prism.parse(source).value.statements.body.first
+      assert_equal("Bar", constant.full_name)
+    end
   end
 end


### PR DESCRIPTION
We noticed that `full_name` was not working for constant targets. We probably forgot to add handling for them in the original PR.