### PR TITLE
[Doc] Update the required runtime Ruby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To compile the shared library, you will need:
 
 * C99 compiler
 * make
-* Ruby 3.0.0 or later
+* Ruby 2.7.0 or later
 
 Once you have these dependencies, run:
 


### PR DESCRIPTION
It seems that due to https://github.com/ruby/prism/pull/2364, Ruby 2.7.0 is now accepted as a runtime.

```ruby
$ gem i prism
$ ruby -rprism -ve "p Prism.parse_success?('42')"
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]
true
```

The requirements could be updated from Ruby 3.0.0 to Ruby 2.7.0.