### PR TITLE
Fix an error when specifying the parsing version `latest`

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -44,16 +44,14 @@ pm_options_version_set(pm_options_t *options, const char *version, size_t length
         return true;
     }
 
-    if (length == 5) {
-        if (strncmp(version, "3.3.0", 5) == 0) {
-            options->version = PM_OPTIONS_VERSION_CRUBY_3_3_0;
-            return true;
-        }
+    if (length == 5 && strncmp(version, "3.3.0", length) == 0) {
+        options->version = PM_OPTIONS_VERSION_CRUBY_3_3_0;
+        return true;
+    }
 
-        if (strncmp(version, "latest", 6) == 0) {
-            options->version = PM_OPTIONS_VERSION_LATEST;
-            return true;
-        }
+    if (length == 6 && strncmp(version, "latest", length) == 0) {
+        options->version = PM_OPTIONS_VERSION_LATEST;
+        return true;
     }
 
     return false;

--- a/test/prism/location_test.rb
+++ b/test/prism/location_test.rb
@@ -178,6 +178,11 @@ module Prism
       assert_location(CallNode, "-> { it }", 5...7, version: "3.3.0") do |node|
         node.body.body.first
       end
+
+      # TODO: Please consider using `version: 3.4.0` instead of `version: latest` in the future.
+      assert_location(LocalVariableReadNode, "-> { it }", 5...7, version: "latest") do |node|
+        node.body.body.first
+      end
     end
 
     def test_CallAndWriteNode


### PR DESCRIPTION
This PR fixes following error when using `version: latest` argument.

```console
$ ruby -rprism -e "p Prism.parse('-> { it }', version: 'latest')"
-e:1:in `parse': invalid version: latest (ArgumentError)

p Prism.parse('-> { it }', version: 'latest')
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        from -e:1:in `<main>'
```

The argument `version: latest` in the added test is commented as potentially being better replaced with `version: 3.4.0` in the future.