### PR TITLE
Introduce `version: "3.4.0"`

### DIFF
--- a/javascript/src/parsePrism.js
+++ b/javascript/src/parsePrism.js
@@ -68,7 +68,7 @@ function dumpOptions(options) {
   values.push(options.frozen_string_literal === undefined ? 0 : 1);
 
   template.push("C");
-  if (!options.version || options.version === "latest") {
+  if (!options.version || options.version === "latest" || options.version === "3.4.0") {
     values.push(0);
   } else if (options.version === "3.3.0") {
     values.push(1);

--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -317,7 +317,7 @@ module Prism
       values << (options.fetch(:frozen_string_literal, false) ? 1 : 0)
 
       template << "C"
-      values << { nil => 0, "3.3.0" => 1, "latest" => 0 }.fetch(options[:version])
+      values << { nil => 0, "3.3.0" => 1, "3.4.0" => 0, "latest" => 0 }.fetch(options[:version])
 
       template << "L"
       if (scopes = options[:scopes])

--- a/src/options.c
+++ b/src/options.c
@@ -44,9 +44,16 @@ pm_options_version_set(pm_options_t *options, const char *version, size_t length
         return true;
     }
 
-    if (length == 5 && strncmp(version, "3.3.0", length) == 0) {
-        options->version = PM_OPTIONS_VERSION_CRUBY_3_3_0;
-        return true;
+    if (length == 5) {
+        if (strncmp(version, "3.3.0", length) == 0) {
+            options->version = PM_OPTIONS_VERSION_CRUBY_3_3_0;
+            return true;
+        }
+
+        if (strncmp(version, "3.4.0", length) == 0) {
+            options->version = PM_OPTIONS_VERSION_LATEST;
+            return true;
+        }
     }
 
     if (length == 6 && strncmp(version, "latest", length) == 0) {

--- a/test/prism/location_test.rb
+++ b/test/prism/location_test.rb
@@ -179,8 +179,7 @@ module Prism
         node.body.body.first
       end
 
-      # TODO: Please consider using `version: 3.4.0` instead of `version: latest` in the future.
-      assert_location(LocalVariableReadNode, "-> { it }", 5...7, version: "latest") do |node|
+      assert_location(LocalVariableReadNode, "-> { it }", 5...7, version: "3.4.0") do |node|
         node.body.body.first
       end
     end


### PR DESCRIPTION
This is effectively an alias for "latest" right now. In the future it will change to be its own enum value.