### PR TITLE
Introduce `PRISM_HAS_MMAP` macro

### DIFF
--- a/docs/build_system.md
+++ b/docs/build_system.md
@@ -73,6 +73,15 @@ and links to `libprism.a` (to avoid exporting symbols, so no conflict when insta
 
 TODO, similar to TruffleRuby.
 
+### Building prism for embedded system
+
+For instance, you can build a static library `libprism.a` targeting the Arm Cortex-M0+ embedded system by the commands below:
+
+* `templates/template.rb`
+* `CFLAGS="-mcpu=cortex-m0plus" make static CC=arm-none-eabi-gcc`
+
+The build process internally looks up `_POSIX_MAPPED_FILES` and `_WIN32` macros to determine whether the functions of the memory map are available on the target platform.
+
 ### Building prism from source as a C library
 
 All of the source files match `src/**/*.c` and all of the headers match `include/**/*.h`.

--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -99,4 +99,13 @@
 #   define PM_STATIC_ASSERT(line, condition, message) typedef char PM_CONCATENATE(static_assert_, line)[(condition) ? 1 : -1]
 #endif
 
+/**
+ * In general, libc for embedded systems does not support memory-mapped files.
+ * If the target platform is POSIX or Windows, we can map a file in memory and
+ * read it in a more efficient manner.
+ */
+#if defined(_POSIX_MAPPED_FILES) || defined(_WIN32)
+#   define PRISM_HAS_MMAP
+#endif
+
 #endif

--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 /**
  * We want to be able to use the PRI* macros for printing out integers, but on

--- a/include/prism/util/pm_string.h
+++ b/include/prism/util/pm_string.h
@@ -17,7 +17,7 @@
 // The following headers are necessary to read files using demand paging.
 #ifdef _WIN32
 #include <windows.h>
-#else
+#elif defined(_POSIX_MAPPED_FILES)
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -45,8 +45,10 @@ typedef struct {
         /** This string owns its memory, and should be freed using `pm_string_free`. */
         PM_STRING_OWNED,
 
+#ifdef PRISM_HAS_MMAP
         /** This string is a memory-mapped file, and should be freed using `pm_string_free`. */
         PM_STRING_MAPPED
+#endif
     } type;
 } pm_string_t;
 

--- a/include/prism/util/pm_string.h
+++ b/include/prism/util/pm_string.h
@@ -21,7 +21,6 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #endif
 
 /**

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -41,9 +41,11 @@ pm_serialize_string(pm_parser_t *parser, pm_string_t *string, pm_buffer_t *buffe
             pm_buffer_append_bytes(buffer, pm_string_source(string), length);
             break;
         }
+#ifdef PRISM_HAS_MMAP
         case PM_STRING_MAPPED:
             assert(false && "Cannot serialize mapped strings.");
             break;
+#endif
     }
 }
 


### PR DESCRIPTION
This is to know if the memory map interface is available in the target platform by using `_POSIX_MAPPED_FILES` and `_WIN32`

ref #2217