### PR TITLE
Update the error message format for Ruby 3.4

### DIFF
--- a/include/prism/diagnostic.h
+++ b/include/prism/diagnostic.h
@@ -8,6 +8,7 @@
 
 #include "prism/ast.h"
 #include "prism/defines.h"
+#include "prism/options.h"
 #include "prism/util/pm_list.h"
 
 #include <stdbool.h>
@@ -314,7 +315,7 @@ typedef enum {
  * @param diag_id The diagnostic ID.
  * @return Whether the diagnostic was successfully appended.
  */
-bool pm_diagnostic_list_append(pm_list_t *list, const uint8_t *start, const uint8_t *end, pm_diagnostic_id_t diag_id);
+bool pm_diagnostic_list_append(pm_list_t *list, pm_options_version_t version, const uint8_t *start, const uint8_t *end, pm_diagnostic_id_t diag_id);
 
 /**
  * Append a diagnostic to the given list of diagnostics that is using a format
@@ -327,7 +328,7 @@ bool pm_diagnostic_list_append(pm_list_t *list, const uint8_t *start, const uint
  * @param ... The arguments to the format string for the message.
  * @return Whether the diagnostic was successfully appended.
  */
-bool pm_diagnostic_list_append_format(pm_list_t *list, const uint8_t *start, const uint8_t *end, pm_diagnostic_id_t diag_id, ...);
+bool pm_diagnostic_list_append_format(pm_list_t *list, pm_options_version_t version, const uint8_t *start, const uint8_t *end, pm_diagnostic_id_t diag_id, ...);
 
 /**
  * Deallocate the internal state of the given diagnostic list.

--- a/src/prism.c
+++ b/src/prism.c
@@ -486,14 +486,14 @@ debug_lex_state_set(pm_parser_t *parser, pm_lex_state_t state, char const * call
  */
 static inline void
 pm_parser_err(pm_parser_t *parser, const uint8_t *start, const uint8_t *end, pm_diagnostic_id_t diag_id) {
-    pm_diagnostic_list_append(&parser->error_list, start, end, diag_id);
+    pm_diagnostic_list_append(&parser->error_list, parser->version, start, end, diag_id);
 }
 
 /**
  * Append an error to the list of errors on the parser using a format string.
  */
 #define PM_PARSER_ERR_FORMAT(parser, start, end, diag_id, ...) \
-    pm_diagnostic_list_append_format(&parser->error_list, start, end, diag_id, __VA_ARGS__)
+    pm_diagnostic_list_append_format(&parser->error_list, parser->version, start, end, diag_id, __VA_ARGS__)
 
 /**
  * Append an error to the list of errors on the parser using the location of the
@@ -571,7 +571,7 @@ pm_parser_err_token(pm_parser_t *parser, const pm_token_t *token, pm_diagnostic_
  */
 static inline void
 pm_parser_warn(pm_parser_t *parser, const uint8_t *start, const uint8_t *end, pm_diagnostic_id_t diag_id) {
-    pm_diagnostic_list_append(&parser->warning_list, start, end, diag_id);
+    pm_diagnostic_list_append(&parser->warning_list, parser->version, start, end, diag_id);
 }
 
 /**

--- a/src/util/pm_strpbrk.c
+++ b/src/util/pm_strpbrk.c
@@ -5,7 +5,7 @@
  */
 static inline void
 pm_strpbrk_invalid_multibyte_character(pm_parser_t *parser, const uint8_t *start, const uint8_t *end) {
-    pm_diagnostic_list_append_format(&parser->error_list, start, end, PM_ERR_INVALID_MULTIBYTE_CHARACTER, *start);
+    pm_diagnostic_list_append_format(&parser->error_list, parser->version, start, end, PM_ERR_INVALID_MULTIBYTE_CHARACTER, *start);
 }
 
 /**

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -177,9 +177,14 @@ module Prism
 
     def test_incomplete_instance_var_string
       assert_errors expression('%@#@@#'), '%@#@@#', [
-        ["`@#' is not allowed as an instance variable name", 4..5],
+        ["'@#' is not allowed as an instance variable name", 4..5],
         ["unexpected instance variable, expecting end-of-input", 4..5]
       ]
+
+      assert_errors expression('%@#@@#'), '%@#@@#', [
+        ["`@#' is not allowed as an instance variable name", 4..5],
+        ["unexpected instance variable, expecting end-of-input", 4..5]
+      ], version: "3.3.0"
     end
 
     def test_unterminated_s_symbol
@@ -1258,8 +1263,12 @@ module Prism
 
     def test_unterminated_global_variable
       assert_errors expression("$"), "$", [
-        ["`$' is not allowed as a global variable name", 0..1]
+        ["'$' is not allowed as a global variable name", 0..1]
       ]
+
+      assert_errors expression("$"), "$", [
+        ["`$' is not allowed as a global variable name", 0..1]
+      ], version: "3.3.0"
     end
 
     def test_invalid_global_variable_write
@@ -2115,11 +2124,13 @@ module Prism
 
     private
 
-    def assert_errors(expected, source, errors, compare_ripper: RUBY_ENGINE == "ruby")
+    def assert_errors(expected, source, errors, version: nil, compare_ripper: RUBY_ENGINE == "ruby")
       # Ripper behaves differently on JRuby/TruffleRuby, so only check this on CRuby
       assert_nil Ripper.sexp_raw(source) if compare_ripper
 
-      result = Prism.parse(source)
+      opts = {}
+      opts[:version] = version if version
+      result = Prism.parse(source, **opts)
       node = result.value.statements.body.last
 
       assert_equal_nodes(expected, node, compare_location: false)


### PR DESCRIPTION
Ruby 3.4 will use a single quote instead of a backtick for a open quote.

https://bugs.ruby-lang.org/issues/16495

This is a draft PR because I don't know how to make the error message change between Ruby versions.