### PR TITLE
Fix opening loc for an empty symbol

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -14205,7 +14205,6 @@ parse_strings(pm_parser_t *parser, pm_node_t *current) {
             // If we get here, then we have an end of a label immediately
             // after a start. In that case we'll create an empty symbol
             // node.
-            pm_token_t opening = not_provided(parser);
             pm_token_t content = parse_strings_empty_content(parser->previous.start);
             pm_symbol_node_t *symbol = pm_symbol_node_create(parser, &opening, &content, &parser->previous);
 

--- a/test/prism/location_test.rb
+++ b/test/prism/location_test.rb
@@ -43,6 +43,7 @@ module Prism
     end
 
     def test_AssocNode
+      assert_location(AssocNode, "{ '': 1 }", 2...7) { |node| node.elements.first }
       assert_location(AssocNode, "{ foo: :bar }", 2...11) { |node| node.elements.first }
       assert_location(AssocNode, "{ :foo => :bar }", 2...14) { |node| node.elements.first }
       assert_location(AssocNode, "foo(bar: :baz)", 4...13) { |node| node.arguments.arguments.first.elements.first }


### PR DESCRIPTION
Consider two examples: `{'a':1}` and `{'':1}` and let's run `parse` for them:

```
irb(test_parse(Prism::ParserTest)):001:0> p = Prism::Translation::Parser.parse("{'a':1}")
=>
s(:hash,
  s(:pair,
    s(:sym, :a),
    s(:int, 1)))
irb(test_parse(Prism::ParserTest)):002:0> p.children.first.children.first.loc.expression.source
=> "'a'"

# ---

irb(test_parse(Prism::ParserTest)):001:0> p = Prism::Translation::Parser.parse("{'':1}")
=>
s(:hash,
  s(:pair,
    s(:sym, :""),
    s(:int, 1)))
irb(test_parse(Prism::ParserTest)):002:0> p.children.first.children.first.loc.expression.source
=> "'"
```

I would expect the last result to be an empty string`"''"` instead of the single quote.

I'm not sure why in case of an empty symbol node the location was reset, but all the tests seems to be green ❇️ 

I also compared it to the output of `ruby --dump=parsetree -e "{'':1}"` and it matches now:

```
ruby --dump=parsetree -e "{'':1}"                                                                                                                                                        tmp-debug
###########################################################
## Do NOT use this node dump for any purpose other than  ##
## debug and research.  Compatibility is not guaranteed. ##
###########################################################

# @ NODE_SCOPE (line: 1, location: (1,0)-(1,6))
# +- nd_tbl: (empty)
# +- nd_args:
# |   (null node)
# +- nd_body:
#     @ NODE_HASH (line: 1, location: (1,0)-(1,6))*
#     +- nd_brace: 1 (hash literal)
#     +- nd_head:
#         @ NODE_LIST (line: 1, location: (1,1)-(1,5))
#         +- nd_alen: 2
#         +- nd_head:
#         |   @ NODE_LIT (line: 1, location: (1,1)-(1,4))
#         |   +- nd_lit: :""
#         +- nd_head:
#         |   @ NODE_LIT (line: 1, location: (1,4)-(1,5))
#         |   +- nd_lit: 1
#         +- nd_next:
#             (null node)
```

```
bin/parse -e "{'':1}"                                                                                                                                                                    tmp-debug
@ ProgramNode (location: (1,0)-(1,6))
├── locals: []
└── statements:
    @ StatementsNode (location: (1,0)-(1,6))
    └── body: (length: 1)
        └── @ HashNode (location: (1,0)-(1,6))
            ├── opening_loc: (1,0)-(1,1) = "{"
            ├── elements: (length: 1)
            │   └── @ AssocNode (location: (1,1)-(1,5))
            │       ├── key:
            │       │   @ SymbolNode (location: (1,1)-(1,4))
            │       │   ├── flags: ∅
            │       │   ├── opening_loc: (1,1)-(1,2) = "'"
            │       │   ├── value_loc: (1,2)-(1,2) = ""
            │       │   ├── closing_loc: (1,2)-(1,4) = "':"
            │       │   └── unescaped: ""
            │       ├── value:
            │       │   @ IntegerNode (location: (1,4)-(1,5))
            │       │   └── flags: decimal
            │       └── operator_loc: ∅
            └── closing_loc: (1,5)-(1,6) = "}"
```

and this is how it was before the fix (the locations of the `AssocNode` and `SymbolNode` are different):

```
@ ProgramNode (location: (1,0)-(1,6))
├── locals: []
└── statements:
    @ StatementsNode (location: (1,0)-(1,6))
    └── body: (length: 1)
        └── @ HashNode (location: (1,0)-(1,6))
            ├── opening_loc: (1,0)-(1,1) = "{"
            ├── elements: (length: 1)
            │   └── @ AssocNode (location: (1,2)-(1,5))
            │       ├── key:
            │       │   @ SymbolNode (location: (1,2)-(1,4))
            │       │   ├── flags: ∅
            │       │   ├── opening_loc: ∅
            │       │   ├── value_loc: (1,2)-(1,2) = ""
            │       │   ├── closing_loc: (1,2)-(1,4) = "':"
            │       │   └── unescaped: ""
            │       ├── value:
            │       │   @ IntegerNode (location: (1,4)-(1,5))
            │       │   └── flags: decimal
            │       └── operator_loc: ∅
            └── closing_loc: (1,5)-(1,6) = "}"
```