### PR TITLE
Aliases for Ripper Translation

### DIFF
--- a/bin/prism
+++ b/bin/prism
@@ -220,7 +220,7 @@ module Prism
       source, filepath = read_source(argv)
 
       ripper = Ripper.sexp_raw(source)
-      prism = Prism::RipperCompat.sexp_raw(source)
+      prism = Prism::Translation::Ripper.sexp_raw(source) rescue :parse_error
 
       puts "Ripper:"
       pp ripper


### PR DESCRIPTION
Handle more aliases, including fully handling aliases.txt.

As part of handling more aliases, handle symbols that are keywords, constants or operations. Handle interpolated symbols. Handle global variable references.

<s>Better testing of prism ripper CLI and a test for it. I had broken it in renaming Translation::Ripper. Now it's tested.</s> It also prints better output when Prism or Ripper Translation gets an exception during parsing.
