### PR TITLE
Do not abort `bundle exec rake` if there are extra files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require "rake/clean"
 task compile: :make
 task compile_no_debug: :make_no_debug
 
-task default: [:check_manifest, :compile, :test]
+task default: [:compile, :test]
 
 require_relative "templates/template"
 
@@ -32,7 +32,7 @@ task make_no_debug: [:templates] do
 end
 
 # decorate the gem build task with prerequisites
-task build: [:templates, :check_annotations, :check_manifest]
+task build: [:check_manifest, :templates, :check_annotations]
 
 # the C extension
 task "compile:prism" => ["templates"] # must be before the ExtensionTask is created


### PR DESCRIPTION
This check turns out to be annoying in practice, I think it's fine it just prints/warns without exiting.
Not being able to run the test suite just because there are extra files seems rather extreme.

FWIW my extra files are flamegraphs and profile data from optimizing Prism (#2402).