### PR TITLE
Visitor#visit should be called for every node

### DIFF
--- a/templates/lib/prism/visitor.rb.erb
+++ b/templates/lib/prism/visitor.rb.erb
@@ -12,12 +12,12 @@ module Prism
 
     # Visits each node in `nodes` by calling `accept` on each one.
     def visit_all(nodes)
-      nodes.each { |node| node&.accept(self) }
+      nodes.each { |node| visit(self) }
     end
 
     # Visits the child nodes of `node` by calling `accept` on each one.
     def visit_child_nodes(node)
-      node.compact_child_nodes.each { |node| node.accept(self) }
+      node.compact_child_nodes.each { |node| visit(node) }
     end
   end
 
@@ -40,6 +40,8 @@ module Prism
   #       end
   #     end
   #
+  #     ast = Prism.parse(code).value
+  #     FooCalls.new.visit(ast)
   class Visitor < BasicVisitor
     <%- nodes.each_with_index do |node, index| -%>
 <%= "\n" if index != 0 -%>

--- a/test/prism/desugar_compiler_test.rb
+++ b/test/prism/desugar_compiler_test.rb
@@ -75,7 +75,7 @@ module Prism
       ast = Prism.parse(source).value.accept(DesugarCompiler.new)
       assert_equal expected, ast_inspect(ast.statements.body.last)
 
-      ast.accept(EnsureEveryNodeOnceInAST.new)
+      EnsureEveryNodeOnceInAST.new.visit(ast)
     end
 
     def assert_not_desugared(source, reason)

--- a/test/prism/visitor_test.rb
+++ b/test/prism/visitor_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+module Prism
+  class VisitorTest < TestCase
+    def test_visitor_visit_method_called_for_every_node
+      visited = []
+      visitor = Class.new(Visitor) {
+        define_method :visit do |node|
+          visited << node
+          super(node)
+        end
+      }.new
+      tree = Prism.parse("1 + 2").value
+
+      all_nodes = []
+      collect_all_children = -> node {
+        all_nodes << node
+        node.compact_child_nodes.each { |child| collect_all_children.call(child) }
+      }
+      collect_all_children.call(tree)
+
+      visitor.visit(tree)
+      assert_equal all_nodes.map(&:class), visited.map(&:class)
+      assert_equal_nodes all_nodes, visited
+    end
+  end
+end


### PR DESCRIPTION
* This way #visit is the "default visit" method and sees every node.
* This was no longer the case since 2e6baa3f19ab7d82c9980b5398cd3467fc26bf22.
* As a consequence EnsureEveryNodeOnceInAST was only visiting ProgramNode for `visitor.visit(ast)` and no nodes at all for `ast.accept(visitor)`.