### PR TITLE
Accept newlines before ) in patterns

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -11926,6 +11926,7 @@ parse_required_destructured_parameter(pm_parser_t *parser) {
         pm_multi_target_node_targets_append(parser, node, param);
     } while (accept1(parser, PM_TOKEN_COMMA));
 
+    accept1(parser, PM_TOKEN_NEWLINE);
     expect1(parser, PM_TOKEN_PARENTHESIS_RIGHT, PM_ERR_EXPECT_RPAREN_REQ_PARAMETER);
     pm_multi_target_node_closing_set(node, &parser->previous);
 
@@ -14070,6 +14071,7 @@ parse_pattern_primitives(pm_parser_t *parser, pm_diagnostic_id_t diag_id) {
                 }
                 node = parse_pattern(parser, false, PM_ERR_PATTERN_EXPRESSION_AFTER_PAREN);
 
+                accept1(parser, PM_TOKEN_NEWLINE);
                 expect1(parser, PM_TOKEN_PARENTHESIS_RIGHT, PM_ERR_PATTERN_TERM_PAREN);
                 break;
             }


### PR DESCRIPTION
And destructured required parameters.

Fixes https://github.com/ruby/prism/issues/2445