### PR TITLE
Split up comments between leading and trailing

### DIFF
--- a/test/prism/magic_comment_test.rb
+++ b/test/prism/magic_comment_test.rb
@@ -30,7 +30,7 @@ module Prism
 
     def assert_magic_comment(example)
       expected = Ripper.new(example).tap(&:parse).encoding
-      actual = Prism.parse(example).source.source.encoding
+      actual = Prism.parse(example).encoding
       assert_equal expected, actual
     end
   end


### PR DESCRIPTION
Also make them lazy to allocate the array, and also expose ParseResult#encoding.