### PR TITLE
Draft: Parser heredocs

### DIFF
--- a/bin/prism
+++ b/bin/prism
@@ -225,13 +225,31 @@ module Prism
     # bin/prism parser [source]
     def parser(argv)
       require "parser/current"
+
+      with_locations = argv.delete("--source-locations")
+
       source, filepath = read_source(argv)
 
+      buffer = Parser::Source::Buffer.new(filepath, 1)
+      buffer.source = source
+
       puts "Parser:"
-      pp Parser::CurrentRuby.parse(source, filepath)
+      ast, _comments, _tokens = Parser::CurrentRuby.default_parser.tokenize(buffer)
+      pp with_locations ? parser_ast_with_locations(ast) : ast
 
       puts "Prism:"
-      pp Translation::Parser.parse(source, filepath)
+      ast, _comments, _tokens = Translation::Parser.new.tokenize(buffer)
+      pp with_locations ? parser_ast_with_locations(ast) : ast
+    end
+
+    def parser_ast_with_locations(a)
+      [a.type] + a.children.map do |elt|
+        if elt.is_a?(AST::Node)
+          parser_ast_with_locations(elt)
+        else
+          elt
+        end
+      end + [a.location.expression.begin_pos, a.location.expression.end_pos]
     end
 
     # bin/prism ripper [source]

--- a/lib/prism/translation/parser/lexer.rb
+++ b/lib/prism/translation/parser/lexer.rb
@@ -278,6 +278,9 @@ module Prism
               if token.type == :REGEXP_END
                 value = value[0]
                 location = Range.new(source_buffer, offset_cache[token.location.start_offset], offset_cache[token.location.start_offset + 1])
+              elsif token.type == :HEREDOC_END && value[-1] == "\n"
+                value.chomp!
+                location = Range.new(source_buffer, offset_cache[token.location.start_offset], offset_cache[token.location.end_offset - 1])
               end
             when :tSYMBEG
               if (next_token = lexed[index]) && next_token.type != :STRING_CONTENT && next_token.type != :EMBEXPR_BEGIN && next_token.type != :EMBVAR

--- a/test/prism/parser_test.rb
+++ b/test/prism/parser_test.rb
@@ -108,14 +108,14 @@ HEREDOC
       RUBY
     end
 
-#    def test_basic_squiggly_heredoc
-#      assert_equal_text_parses(<<~RUBY)
-#        <<~HEREDOC
-#          #{1}
-#        HEREDOC
-#      RUBY
-#    end
-#
+    def test_basic_tilde_heredoc
+      assert_equal_text_parses(<<~RUBY)
+        <<~HEREDOC
+          #{1}
+        HEREDOC
+      RUBY
+    end
+
 #    def test_basic_minus_heredoc
 #      assert_equal_text_parses(<<~RUBY)
 #        <<-HEREDOC


### PR DESCRIPTION
I started work on #2374. It's a small thing - the "source" location is a bit off on tilde-heredocs (a.k.a. squiggly heredocs). But it looks like we're also not lexing them quite like Parser does, and we do limited (or no) checks on some heredoc-related fixtures, especially for lexing (e.g. look at skip_all and skip_tokens in parser_test.rb). Our heredoc support for Translation::Parser is kind of limited and doesn't 100% match up.

I've been building better debugging support, such as unit tests on inline code and teaching "bin/prism parser" to emit source locations with its sexps. And I've improved the lexer a bit to match some source locations better. With tilde heredocs that means keeping a stack of string begin/ends, for instance, so that we can trim leading whitespace since Parser does that for lexing, not just parsing.

But I think maybe we don't care as much about the lexer. I had originally thought I'd need to fix that to fix the parser source locations. Now I think I was wrong about that.

This is a little rough. I'm just putting this up to show where I'm at and what I'm thinking for right now. Parser::Compiler#visit_heredoc is definitely going to need more work. I'm getting some basic tests working (various kinds of simple heredocs, nested heredocs, etc.) directly in parser_test.rb. And I can turn more fixtures on once more stuff works.