### PR TITLE
Translation::Parser should process warnings, not just errors

### DIFF
--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -17,9 +17,9 @@ module Prism
         attr_reader :message
 
         # Initialize a new diagnostic with the given message and location.
-        def initialize(message, level, location)
+        def initialize(message, level, reason, location)
           @message = message
-          super(level, :prism_error, {}, location, [])
+          super(level, reason, {}, location, [])
         end
       end
 
@@ -106,6 +106,12 @@ module Prism
         true
       end
 
+      # This is a hook to allow consumers to disable some warnings if they don't
+      # want them to block creating the syntax tree.
+      def valid_warning?(warning)
+        true
+      end
+
       # If there was a error generated during the parse, then raise an
       # appropriate syntax error. Otherwise return the result.
       def unwrap(result, offset_cache)
@@ -113,13 +119,13 @@ module Prism
           next unless valid_error?(error)
 
           location = build_range(error.location, offset_cache)
-          diagnostics.process(Diagnostic.new(error.message, :error, location))
+          diagnostics.process(Diagnostic.new(error.message, :error, :prism_error, location))
         end
         result.warnings.each do |warning|
           next unless valid_warning?(warning)
 
           location = build_range(warning.location, offset_cache)
-          diagnostics.process(Diagnostic.new(warning.message, :warning, location))
+          diagnostics.process(Diagnostic.new(warning.message, :warning, :prism_warning, location))
         end
 
         result

--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -116,7 +116,7 @@ module Prism
           diagnostics.process(Diagnostic.new(error.message, :error, location))
         end
         result.warnings.each do |warning|
-          next unless valid_error?(warning)
+          next unless valid_warning?(warning)
 
           location = build_range(warning.location, offset_cache)
           diagnostics.process(Diagnostic.new(warning.message, :warning, location))

--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -17,9 +17,9 @@ module Prism
         attr_reader :message
 
         # Initialize a new diagnostic with the given message and location.
-        def initialize(message, location)
+        def initialize(message, level, location)
           @message = message
-          super(:error, :prism_error, {}, location, [])
+          super(level, :prism_error, {}, location, [])
         end
       end
 
@@ -113,7 +113,13 @@ module Prism
           next unless valid_error?(error)
 
           location = build_range(error.location, offset_cache)
-          diagnostics.process(Diagnostic.new(error.message, location))
+          diagnostics.process(Diagnostic.new(error.message, :error, location))
+        end
+        result.warnings.each do |warning|
+          next unless valid_error?(warning)
+
+          location = build_range(warning.location, offset_cache)
+          diagnostics.process(Diagnostic.new(warning.message, :warning, location))
         end
 
         result

--- a/test/prism/parser_test.rb
+++ b/test/prism/parser_test.rb
@@ -94,6 +94,19 @@ module Prism
       end
     end
 
+    def test_warnings
+      buffer = Parser::Source::Buffer.new("inline ruby with warning", 1)
+      buffer.source = "do_something *array"
+
+      parser = Prism::Translation::Parser.new
+      parser.diagnostics.all_errors_are_fatal = false
+      warning = nil
+      parser.diagnostics.consumer = ->(received) { warning = received }
+      parser.parse(buffer)
+      assert_equal :warning, warning.level
+      assert_includes warning.message, "has been interpreted as"
+    end
+
     private
 
     def assert_equal_parses(filepath, compare_tokens: true)


### PR DESCRIPTION
We weren't registering warnings, just errors.

As a side effect, this will cause "bin/prism parser" to die when it sees a warning because we're running the Parser gem in that mode. I think that's probably fine, but it seems worth mentioning.

Should fix #2454 
