### PR TITLE
Fix parsing keyword params

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -4524,7 +4524,10 @@ pm_local_variable_or_write_node_create(pm_parser_t *parser, pm_node_t *target, c
  */
 static pm_local_variable_read_node_t *
 pm_local_variable_read_node_create_constant_id(pm_parser_t *parser, const pm_token_t *name, pm_constant_id_t name_id, uint32_t depth) {
-    if (parser->current_param_name == name_id) {
+    if (
+        (parser->current_param_name == name_id) &&
+        ((parser->current_context->context != PM_CONTEXT_DEFAULT_PARAMS) || (parser->current.type != PM_TOKEN_EQUAL))
+    ) {
         pm_parser_err_token(parser, name, PM_ERR_PARAMETER_CIRCULAR);
     }
 

--- a/test/prism/fixtures/methods.txt
+++ b/test/prism/fixtures/methods.txt
@@ -181,3 +181,5 @@ end
 def foo(bar = (def baz(bar) = bar; 1)) = 2
 
 def (class Foo; end).foo(bar = 1) = 2
+
+def foo(bar: bar = 1); end

--- a/test/prism/snapshots/methods.txt
+++ b/test/prism/snapshots/methods.txt
@@ -1,8 +1,8 @@
-@ ProgramNode (location: (1,0)-(183,37))
+@ ProgramNode (location: (1,0)-(185,26))
 ├── locals: [:a, :c, :foo]
 └── statements:
-    @ StatementsNode (location: (1,0)-(183,37))
-    └── body: (length: 69)
+    @ StatementsNode (location: (1,0)-(185,26))
+    └── body: (length: 70)
         ├── @ DefNode (location: (1,0)-(2,3))
         │   ├── name: :foo
         │   ├── name_loc: (1,4)-(1,7) = "foo"
@@ -1999,53 +1999,88 @@
         │   ├── rparen_loc: (181,37)-(181,38) = ")"
         │   ├── equal_loc: (181,39)-(181,40) = "="
         │   └── end_keyword_loc: ∅
-        └── @ DefNode (location: (183,0)-(183,37))
+        ├── @ DefNode (location: (183,0)-(183,37))
+        │   ├── name: :foo
+        │   ├── name_loc: (183,21)-(183,24) = "foo"
+        │   ├── receiver:
+        │   │   @ ParenthesesNode (location: (183,4)-(183,20))
+        │   │   ├── body:
+        │   │   │   @ ClassNode (location: (183,5)-(183,19))
+        │   │   │   ├── locals: []
+        │   │   │   ├── class_keyword_loc: (183,5)-(183,10) = "class"
+        │   │   │   ├── constant_path:
+        │   │   │   │   @ ConstantReadNode (location: (183,11)-(183,14))
+        │   │   │   │   └── name: :Foo
+        │   │   │   ├── inheritance_operator_loc: ∅
+        │   │   │   ├── superclass: ∅
+        │   │   │   ├── body: ∅
+        │   │   │   ├── end_keyword_loc: (183,16)-(183,19) = "end"
+        │   │   │   └── name: :Foo
+        │   │   ├── opening_loc: (183,4)-(183,5) = "("
+        │   │   └── closing_loc: (183,19)-(183,20) = ")"
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (183,25)-(183,32))
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 1)
+        │   │   │   └── @ OptionalParameterNode (location: (183,25)-(183,32))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── name: :bar
+        │   │   │       ├── name_loc: (183,25)-(183,28) = "bar"
+        │   │   │       ├── operator_loc: (183,29)-(183,30) = "="
+        │   │   │       └── value:
+        │   │   │           @ IntegerNode (location: (183,31)-(183,32))
+        │   │   │           ├── flags: decimal
+        │   │   │           └── value: 1
+        │   │   ├── rest: ∅
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body:
+        │   │   @ StatementsNode (location: (183,36)-(183,37))
+        │   │   └── body: (length: 1)
+        │   │       └── @ IntegerNode (location: (183,36)-(183,37))
+        │   │           ├── flags: decimal
+        │   │           └── value: 2
+        │   ├── locals: [:bar]
+        │   ├── def_keyword_loc: (183,0)-(183,3) = "def"
+        │   ├── operator_loc: (183,20)-(183,21) = "."
+        │   ├── lparen_loc: (183,24)-(183,25) = "("
+        │   ├── rparen_loc: (183,32)-(183,33) = ")"
+        │   ├── equal_loc: (183,34)-(183,35) = "="
+        │   └── end_keyword_loc: ∅
+        └── @ DefNode (location: (185,0)-(185,26))
             ├── name: :foo
-            ├── name_loc: (183,21)-(183,24) = "foo"
-            ├── receiver:
-            │   @ ParenthesesNode (location: (183,4)-(183,20))
-            │   ├── body:
-            │   │   @ ClassNode (location: (183,5)-(183,19))
-            │   │   ├── locals: []
-            │   │   ├── class_keyword_loc: (183,5)-(183,10) = "class"
-            │   │   ├── constant_path:
-            │   │   │   @ ConstantReadNode (location: (183,11)-(183,14))
-            │   │   │   └── name: :Foo
-            │   │   ├── inheritance_operator_loc: ∅
-            │   │   ├── superclass: ∅
-            │   │   ├── body: ∅
-            │   │   ├── end_keyword_loc: (183,16)-(183,19) = "end"
-            │   │   └── name: :Foo
-            │   ├── opening_loc: (183,4)-(183,5) = "("
-            │   └── closing_loc: (183,19)-(183,20) = ")"
+            ├── name_loc: (185,4)-(185,7) = "foo"
+            ├── receiver: ∅
             ├── parameters:
-            │   @ ParametersNode (location: (183,25)-(183,32))
+            │   @ ParametersNode (location: (185,8)-(185,20))
             │   ├── requireds: (length: 0)
-            │   ├── optionals: (length: 1)
-            │   │   └── @ OptionalParameterNode (location: (183,25)-(183,32))
-            │   │       ├── flags: ∅
-            │   │       ├── name: :bar
-            │   │       ├── name_loc: (183,25)-(183,28) = "bar"
-            │   │       ├── operator_loc: (183,29)-(183,30) = "="
-            │   │       └── value:
-            │   │           @ IntegerNode (location: (183,31)-(183,32))
-            │   │           ├── flags: decimal
-            │   │           └── value: 1
+            │   ├── optionals: (length: 0)
             │   ├── rest: ∅
             │   ├── posts: (length: 0)
-            │   ├── keywords: (length: 0)
+            │   ├── keywords: (length: 1)
+            │   │   └── @ OptionalKeywordParameterNode (location: (185,8)-(185,20))
+            │   │       ├── flags: ∅
+            │   │       ├── name: :bar
+            │   │       ├── name_loc: (185,8)-(185,12) = "bar:"
+            │   │       └── value:
+            │   │           @ LocalVariableWriteNode (location: (185,13)-(185,20))
+            │   │           ├── name: :bar
+            │   │           ├── depth: 0
+            │   │           ├── name_loc: (185,13)-(185,16) = "bar"
+            │   │           ├── value:
+            │   │           │   @ IntegerNode (location: (185,19)-(185,20))
+            │   │           │   ├── flags: decimal
+            │   │           │   └── value: 1
+            │   │           └── operator_loc: (185,17)-(185,18) = "="
             │   ├── keyword_rest: ∅
             │   └── block: ∅
-            ├── body:
-            │   @ StatementsNode (location: (183,36)-(183,37))
-            │   └── body: (length: 1)
-            │       └── @ IntegerNode (location: (183,36)-(183,37))
-            │           ├── flags: decimal
-            │           └── value: 2
+            ├── body: ∅
             ├── locals: [:bar]
-            ├── def_keyword_loc: (183,0)-(183,3) = "def"
-            ├── operator_loc: (183,20)-(183,21) = "."
-            ├── lparen_loc: (183,24)-(183,25) = "("
-            ├── rparen_loc: (183,32)-(183,33) = ")"
-            ├── equal_loc: (183,34)-(183,35) = "="
-            └── end_keyword_loc: ∅
+            ├── def_keyword_loc: (185,0)-(185,3) = "def"
+            ├── operator_loc: ∅
+            ├── lparen_loc: (185,7)-(185,8) = "("
+            ├── rparen_loc: (185,20)-(185,21) = ")"
+            ├── equal_loc: ∅
+            └── end_keyword_loc: (185,23)-(185,26) = "end"


### PR DESCRIPTION
Fixes parsing code like:

```ruby
def foo(bar: bar = 1); end
```

@kddnewton I recall that there should be an issue for this, but I cannot find it now.