### PR TITLE
all constant nodes should have full_name and full_name_parts methods

### DIFF
--- a/lib/prism/node_ext.rb
+++ b/lib/prism/node_ext.rb
@@ -98,6 +98,19 @@ module Prism
     end
   end
 
+  class ConstantWriteNode < Node
+    # Returns the list of parts for the full name of this constant.
+    # For example: [:Foo]
+    def full_name_parts
+      [name]
+    end
+
+    # Returns the full name of this constant. For example: "Foo"
+    def full_name
+      name.to_s
+    end
+  end
+
   class ConstantPathNode < Node
     # An error class raised when dynamic parts are found while computing a
     # constant path's full name. For example:


### PR DESCRIPTION
In reference to https://github.com/ruby/prism/discussions/2434#discussioncomment-8549837

There's no specific test for node extensions, it seems? Not sure where I'd add a test for this.