### PR TITLE
Follow RuboCop's parser engine support

### DIFF
--- a/lib/prism/translation/parser/rubocop.rb
+++ b/lib/prism/translation/parser/rubocop.rb
@@ -20,17 +20,34 @@ module Prism
 
       # This module gets prepended into RuboCop::AST::ProcessedSource.
       module ProcessedSource
-        # Redefine parser_class so that we can inject the prism parser into the
-        # list of known parsers.
-        def parser_class(ruby_version)
-          if ruby_version == Prism::Translation::Parser::VERSION_3_3
-            require "prism/translation/parser33"
-            Prism::Translation::Parser33
-          elsif ruby_version == Prism::Translation::Parser::VERSION_3_4
-            require "prism/translation/parser34"
-            Prism::Translation::Parser34
-          else
-            super
+        # This condition is compatible with rubocop-ast versions up to 1.30.0.
+        if RuboCop::AST::ProcessedSource.instance_method(:parser_class).arity == 1
+          # Redefine parser_class so that we can inject the prism parser into the
+          # list of known parsers.
+          def parser_class(ruby_version)
+            if ruby_version == Prism::Translation::Parser::VERSION_3_3
+              require "prism/translation/parser33"
+              Prism::Translation::Parser33
+            elsif ruby_version == Prism::Translation::Parser::VERSION_3_4
+              require "prism/translation/parser34"
+              Prism::Translation::Parser34
+            else
+              super
+            end
+          end
+        else
+          # Redefine parser_class so that we can inject the prism parser into the
+          # list of known parsers.
+          def parser_class(ruby_version, _parser_engine)
+            if ruby_version == Prism::Translation::Parser::VERSION_3_3
+              require "prism/translation/parser33"
+              Prism::Translation::Parser33
+            elsif ruby_version == Prism::Translation::Parser::VERSION_3_4
+              require "prism/translation/parser34"
+              Prism::Translation::Parser34
+            else
+              super
+            end
           end
         end
       end


### PR DESCRIPTION
With the introduction of `Prism::Translation::Parser` to RuboCop (RuboCop AST), the number of arguments for `RuboCop::AST::ProcessedSource#parser_class` internal API will be changed:
https://github.com/rubocop/rubocop-ast/pull/277

## Before

As a result, the following error will occur starting from the next release of RuboCop AST (< 1.30.0) :

```console
$ bundle exec ruby -rrubocop/ast -rprism -rprism/translation/parser/rubocop -ve "p RuboCop::AST::ProcessedSource.new('42', 80_82_73_83_77.33).ast"
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
/Users/koic/src/github.com/ruby/prism/lib/prism/translation/parser/rubocop.rb:25:in `parser_class':
wrong number of arguments (given 2, expected 1) (ArgumentError)
        from /Users/koic/src/github.com/rubocop/rubocop-ast/lib/rubocop/ast/processed_source.rb:309:in `create_parser'
        from /Users/koic/src/github.com/rubocop/rubocop-ast/lib/rubocop/ast/processed_source.rb:219:in `parse'
        from /Users/koic/src/github.com/rubocop/rubocop-ast/lib/rubocop/ast/processed_source.rb:47:in `initialize'
        from -e:1:in `new'
        from -e:1:in `<main>'
```

## After

This PR prevents the above error by updating the monkey patch to support the new argument:

```console
$ bundle exec ruby -rrubocop/ast -rprism -rprism/translation/parser/rubocop -ve "p RuboCop::AST::ProcessedSource.new('42', 80_82_73_83_77.33).ast"
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
s(:int, 42)
```

Moreover, to ensure compatibility with the existing RuboCop AST, conditional logic has been implemented to maintain backward compatibility.