### PR TITLE
Parse huge integer faster

### DIFF
--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -992,30 +992,16 @@ integer_parse(VALUE self, VALUE source) {
     pm_integer_t integer = { 0 };
     pm_integer_parse(&integer, PM_INTEGER_BASE_UNKNOWN, start, start + length);
 
-    VALUE number;
-
-    if (integer.values == NULL) {
-        number = UINT2NUM(integer.value);
-    } else {
-        number = UINT2NUM(0);
-        for (size_t i = 0; i < integer.length; i++) {
-            VALUE receiver = rb_funcall(UINT2NUM(integer.values[i]), rb_intern("<<"), 1, ULONG2NUM(i * 32));
-            number = rb_funcall(receiver, rb_intern("|"), 1, number);
-        }
-    }
-
-    if (integer.negative) number = rb_funcall(number, rb_intern("-@"), 0);
-
     pm_buffer_t buffer = { 0 };
     pm_integer_string(&buffer, &integer);
 
     VALUE string = rb_str_new(pm_buffer_value(&buffer), pm_buffer_length(&buffer));
     pm_buffer_free(&buffer);
-    pm_integer_free(&integer);
 
     VALUE result = rb_ary_new_capa(2);
-    rb_ary_push(result, number);
+    rb_ary_push(result, pm_integer_new(&integer));
     rb_ary_push(result, string);
+    pm_integer_free(&integer);
 
     return result;
 }

--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -992,12 +992,16 @@ integer_parse(VALUE self, VALUE source) {
     pm_integer_t integer = { 0 };
     pm_integer_parse(&integer, PM_INTEGER_BASE_UNKNOWN, start, start + length);
 
-    VALUE number = UINT2NUM(integer.head.value);
-    size_t shift = 0;
+    VALUE number;
 
-    for (pm_integer_word_t *node = integer.head.next; node != NULL; node = node->next) {
-        VALUE receiver = rb_funcall(UINT2NUM(node->value), rb_intern("<<"), 1, ULONG2NUM(++shift * 32));
-        number = rb_funcall(receiver, rb_intern("|"), 1, number);
+    if (integer.values == NULL) {
+        number = UINT2NUM(integer.value);
+    } else {
+        number = UINT2NUM(0);
+        for (size_t i = 0; i < integer.length; i++) {
+            VALUE receiver = rb_funcall(UINT2NUM(integer.values[i]), rb_intern("<<"), 1, ULONG2NUM(i * 32));
+            number = rb_funcall(receiver, rb_intern("|"), 1, number);
+        }
     }
 
     if (integer.negative) number = rb_funcall(number, rb_intern("-@"), 0);

--- a/ext/prism/extension.h
+++ b/ext/prism/extension.h
@@ -10,6 +10,7 @@
 VALUE pm_source_new(const pm_parser_t *parser, rb_encoding *encoding);
 VALUE pm_token_new(const pm_parser_t *parser, const pm_token_t *token, rb_encoding *encoding, VALUE source);
 VALUE pm_ast_new(const pm_parser_t *parser, const pm_node_t *node, rb_encoding *encoding, VALUE source);
+VALUE pm_integer_new(const pm_integer_t *integer);
 
 void Init_prism_api_node(void);
 void Init_prism_pack(void);

--- a/include/prism/util/pm_integer.h
+++ b/include/prism/util/pm_integer.h
@@ -15,30 +15,25 @@
 #include <stdlib.h>
 
 /**
- * A node in the linked list of a pm_integer_t.
- */
-typedef struct pm_integer_word {
-    /** A pointer to the next node in the list. */
-    struct pm_integer_word *next;
-
-    /** The value of the node. */
-    uint32_t value;
-} pm_integer_word_t;
-
-/**
- * This structure represents an arbitrary-sized integer. It is implemented as a
- * linked list of 32-bit integers, with the least significant digit at the head
- * of the list.
+ * A structure represents an arbitrary-sized integer.
  */
 typedef struct {
-    /** The number of nodes in the linked list that have been allocated. */
+    /**
+     * Embedded value for small integer. This value is set to 0 if the value
+     * does not fit into uint32_t.
+     */
+    uint32_t value;
+
+    /**
+     * The number of allocated values. length is set to 0 if the integer fits
+     * into uint32_t.
+     */
     size_t length;
 
     /**
-     * The head of the linked list, embedded directly so that allocations do not
-     * need to be performed for small integers.
+     * List of 32-bit integers. Set to NULL if the integer fits into uint32_t.
      */
-    pm_integer_word_t head;
+    uint32_t *values;
 
     /**
      * Whether or not the integer is negative. It is stored this way so that a

--- a/rust/ruby-prism/build.rs
+++ b/rust/ruby-prism/build.rs
@@ -758,7 +758,7 @@ impl TryInto<i32> for Integer<'_> {{
         let length = unsafe {{ (*self.pointer).length }};
 
         if length == 0 {{
-            i32::try_from(unsafe {{ (*self.pointer).head.value }}).map_or(Err(()), |value| 
+            i32::try_from(unsafe {{ (*self.pointer).value }}).map_or(Err(()), |value| 
                 if negative {{
                     Ok(-value)
                 }} else {{

--- a/src/prism.c
+++ b/src/prism.c
@@ -16626,7 +16626,7 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
                             pm_interpolated_symbol_node_append(interpolated, first_string);
                             pm_interpolated_symbol_node_append(interpolated, second_string);
 
-                            free(current);
+                            xfree(current);
                             current = (pm_node_t *) interpolated;
                         } else {
                             assert(false && "unreachable");

--- a/src/static_literals.c
+++ b/src/static_literals.c
@@ -53,12 +53,11 @@ node_hash(const pm_parser_t *parser, const pm_node_t *node) {
         case PM_INTEGER_NODE: {
             // Integers hash their value.
             const pm_integer_t *integer = &((const pm_integer_node_t *) node)->value;
-            const uint32_t *value = &integer->head.value;
-
-            uint32_t hash = murmur_hash((const uint8_t *) value, sizeof(uint32_t));
-            for (const pm_integer_word_t *word = integer->head.next; word != NULL; word = word->next) {
-                value = &word->value;
-                hash ^= murmur_hash((const uint8_t *) value, sizeof(uint32_t));
+            uint32_t hash;
+            if (integer->values) {
+                hash = murmur_hash((const uint8_t *) integer->values, sizeof(uint32_t) * integer->length);
+            } else {
+                hash = murmur_hash((const uint8_t *) &integer->value, sizeof(uint32_t));
             }
 
             if (integer->negative) {
@@ -204,9 +203,9 @@ pm_int64_value(const pm_parser_t *parser, const pm_node_t *node) {
     switch (PM_NODE_TYPE(node)) {
         case PM_INTEGER_NODE: {
             const pm_integer_t *integer = &((const pm_integer_node_t *) node)->value;
-            if (integer->length > 0) return integer->negative ? INT64_MIN : INT64_MAX;
+            if (integer->values) return integer->negative ? INT64_MIN : INT64_MAX;
 
-            int64_t value = (int64_t) integer->head.value;
+            int64_t value = (int64_t) integer->value;
             return integer->negative ? -value : value;
         }
         case PM_SOURCE_LINE_NODE:

--- a/src/util/pm_integer.c
+++ b/src/util/pm_integer.c
@@ -29,8 +29,9 @@ big_add(pm_integer_t *destination, pm_integer_t *left, pm_integer_t *right, uint
 
     size_t length = left_length < right_length ? right_length : left_length;
     uint32_t *values = (uint32_t *) xmalloc(sizeof(uint32_t) * (length + 1));
-    uint64_t carry = 0;
+    if (values == NULL) return;
 
+    uint64_t carry = 0;
     for (size_t index = 0; index < length; index++) {
         uint64_t sum = carry + (index < left_length ? left_values[index] : 0) + (index < right_length ? right_values[index] : 0);
         values[index] = (uint32_t) (sum % base);
@@ -54,36 +55,15 @@ static void
 big_sub2(pm_integer_t *destination, pm_integer_t *a, pm_integer_t *b, pm_integer_t *c, uint64_t base) {
     size_t a_length;
     uint32_t *a_values;
-
-    if (a->values == NULL) {
-        a_length = 1;
-        a_values = &a->value;
-    } else {
-        a_length = a->length;
-        a_values = a->values;
-    }
+    INTEGER_EXTRACT(a, a_length, a_values)
 
     size_t b_length;
     uint32_t *b_values;
-
-    if (b->values == NULL) {
-        b_length = 1;
-        b_values = &b->value;
-    } else {
-        b_length = b->length;
-        b_values = b->values;
-    }
+    INTEGER_EXTRACT(b, b_length, b_values)
 
     size_t c_length;
     uint32_t *c_values;
-
-    if (c->values == NULL) {
-        c_length = 1;
-        c_values = &c->value;
-    } else {
-        c_length = c->length;
-        c_values = c->values;
-    }
+    INTEGER_EXTRACT(c, c_length, c_values)
 
     uint32_t *values = (uint32_t*) xmalloc(sizeof(uint32_t) * a_length);
     int64_t carry = 0;
@@ -137,6 +117,7 @@ karatsuba_multiply(pm_integer_t *destination, pm_integer_t *left, pm_integer_t *
     if (left_length <= 10) {
         size_t length = left_length + right_length;
         uint32_t *values = (uint32_t *) xcalloc(length, sizeof(uint32_t));
+        if (values == NULL) return;
 
         for (size_t left_index = 0; left_index < left_length; left_index++) {
             uint32_t carry = 0;
@@ -293,6 +274,8 @@ pm_integer_from_uint64(pm_integer_t *integer, uint64_t value, uint64_t base) {
     }
 
     uint32_t *values = (uint32_t *) xmalloc(sizeof(uint32_t) * length);
+    if (values == NULL) return;
+
     for (size_t value_index = 0; value_index < length; value_index++) {
         values[value_index] = (uint32_t) (value % base);
         value /= base;
@@ -340,6 +323,7 @@ pm_integer_convert_base(pm_integer_t *destination, const pm_integer_t *source, u
 
     size_t bigints_length = (source_length + 1) / 2;
     pm_integer_t *bigints = (pm_integer_t *) xcalloc(bigints_length, sizeof(pm_integer_t));
+    if (bigints == NULL) return;
 
     for (size_t index = 0; index < source_length; index += 2) {
         uint64_t value = source_values[index] + base_from * (index + 1 < source_length ? source_values[index + 1] : 0);
@@ -516,7 +500,7 @@ pm_integer_parse(pm_integer_t *integer, pm_integer_base_t base, const uint8_t *s
 
     const uint8_t *cursor = start;
     uint64_t value = (uint64_t) pm_integer_parse_digit(*cursor++);
- 
+
     for (; cursor < end; cursor++) {
         if (*cursor == '_') continue;
         value = value * multiplier + (uint64_t) pm_integer_parse_digit(*cursor);
@@ -528,7 +512,7 @@ pm_integer_parse(pm_integer_t *integer, pm_integer_base_t base, const uint8_t *s
             return;
         }
     }
- 
+
     integer->value = (uint32_t) value;
 }
 

--- a/src/util/pm_string.c
+++ b/src/util/pm_string.c
@@ -175,7 +175,7 @@ pm_string_file_init(pm_string_t *string, const char *filepath) {
     }
 
     // Create a buffer to read the file into.
-    uint8_t *source = malloc(file_size);
+    uint8_t *source = xmalloc(file_size);
     if (source == NULL) {
         CloseHandle(file);
         return false;
@@ -190,7 +190,7 @@ pm_string_file_init(pm_string_t *string, const char *filepath) {
 
     // Check the number of bytes read
     if (bytes_read != file_size) {
-        free(source);
+        xfree(source);
         CloseHandle(file);
         return false;
     }
@@ -220,7 +220,7 @@ pm_string_file_init(pm_string_t *string, const char *filepath) {
     }
 
     size_t length = (size_t) file_size;
-    uint8_t *source = malloc(length);
+    uint8_t *source = xmalloc(length);
     if (source == NULL) {
         fclose(file);
         return false;
@@ -231,7 +231,7 @@ pm_string_file_init(pm_string_t *string, const char *filepath) {
     fclose(file);
 
     if (bytes_read != 1) {
-        free(source);
+        xfree(source);
         return false;
     }
 

--- a/templates/ext/prism/api_node.c.erb
+++ b/templates/ext/prism/api_node.c.erb
@@ -40,20 +40,20 @@ pm_string_new(const pm_string_t *string, rb_encoding *encoding) {
 static VALUE
 pm_integer_new(const pm_integer_t *integer) {
     VALUE result;
-    if (integer->head.next) {
-        size_t length = integer->length + 1;
-        VALUE str = rb_str_new(NULL, length * 8);
+    if (integer->values) {
+        VALUE str = rb_str_new(NULL, integer->length * 8);
         unsigned char *buf = (unsigned char *)RSTRING_PTR(str);
-        size_t offset = length * 8;
-        for (const pm_integer_word_t *node = &integer->head; node != NULL; node = node->next) {
+        size_t offset = integer->length * 8;
+        for (size_t i = 0; i < integer->length; i++) {
+            uint32_t value = integer->values[i];
             for (int i = 0; i < 8; i++) {
-                int n = (node->value >> (4 * i)) & 0xf;
+                int n = (value >> (4 * i)) & 0xf;
                 buf[--offset] = n < 10 ? n + '0' : n - 10 + 'a';
             }
         }
         result = rb_funcall(str, rb_intern("to_i"), 1, UINT2NUM(16));
     } else {
-        result = UINT2NUM(integer->head.value);
+        result = UINT2NUM(integer->value);
     }
 
     if (integer->negative) {

--- a/templates/ext/prism/api_node.c.erb
+++ b/templates/ext/prism/api_node.c.erb
@@ -37,23 +37,26 @@ pm_string_new(const pm_string_t *string, rb_encoding *encoding) {
     return rb_enc_str_new((const char *) pm_string_source(string), pm_string_length(string), encoding);
 }
 
-static VALUE
+VALUE
 pm_integer_new(const pm_integer_t *integer) {
     VALUE result;
-    if (integer->values) {
-        VALUE str = rb_str_new(NULL, integer->length * 8);
-        unsigned char *buf = (unsigned char *)RSTRING_PTR(str);
+    if (integer->values == NULL) {
+        result = UINT2NUM(integer->value);
+    } else {
+        VALUE string = rb_str_new(NULL, integer->length * 8);
+        unsigned char *bytes = (unsigned char *) RSTRING_PTR(string);
+
         size_t offset = integer->length * 8;
-        for (size_t i = 0; i < integer->length; i++) {
-            uint32_t value = integer->values[i];
-            for (int i = 0; i < 8; i++) {
-                int n = (value >> (4 * i)) & 0xf;
-                buf[--offset] = n < 10 ? n + '0' : n - 10 + 'a';
+        for (size_t value_index = 0; value_index < integer->length; value_index++) {
+            uint32_t value = integer->values[value_index];
+
+            for (int index = 0; index < 8; index++) {
+                int byte = (value >> (4 * index)) & 0xf;
+                bytes[--offset] = byte < 10 ? byte + '0' : byte - 10 + 'a';
             }
         }
-        result = rb_funcall(str, rb_intern("to_i"), 1, UINT2NUM(16));
-    } else {
-        result = UINT2NUM(integer->value);
+
+        result = rb_funcall(string, rb_intern("to_i"), 1, UINT2NUM(16));
     }
 
     if (integer->negative) {

--- a/templates/ext/prism/api_node.c.erb
+++ b/templates/ext/prism/api_node.c.erb
@@ -39,12 +39,21 @@ pm_string_new(const pm_string_t *string, rb_encoding *encoding) {
 
 static VALUE
 pm_integer_new(const pm_integer_t *integer) {
-    VALUE result = UINT2NUM(integer->head.value);
-    size_t shift = 0;
-
-    for (const pm_integer_word_t *node = integer->head.next; node != NULL; node = node->next) {
-        VALUE receiver = rb_funcall(UINT2NUM(node->value), rb_intern("<<"), 1, ULONG2NUM(++shift * 32));
-        result = rb_funcall(receiver, rb_intern("|"), 1, result);
+    VALUE result;
+    if (integer->head.next) {
+        size_t length = integer->length + 1;
+        VALUE str = rb_str_new(NULL, length * 8);
+        unsigned char *buf = (unsigned char *)RSTRING_PTR(str);
+        size_t offset = length * 8;
+        for (const pm_integer_word_t *node = &integer->head; node != NULL; node = node->next) {
+            for (int i = 0; i < 8; i++) {
+                int n = (node->value >> (4 * i)) & 0xf;
+                buf[--offset] = n < 10 ? n + '0' : n - 10 + 'a';
+            }
+        }
+        result = rb_funcall(str, rb_intern("to_i"), 1, UINT2NUM(16));
+    } else {
+        result = UINT2NUM(integer->head.value);
     }
 
     if (integer->negative) {

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -52,10 +52,14 @@ pm_serialize_string(const pm_parser_t *parser, const pm_string_t *string, pm_buf
 static void
 pm_serialize_integer(const pm_integer_t *integer, pm_buffer_t *buffer) {
     pm_buffer_append_byte(buffer, integer->negative ? 1 : 0);
-    pm_buffer_append_varuint(buffer, pm_sizet_to_u32(integer->length + 1));
-
-    for (const pm_integer_word_t *node = &integer->head; node != NULL; node = node->next) {
-        pm_buffer_append_varuint(buffer, node->value);
+    if (integer->values == NULL) {
+        pm_buffer_append_varuint(buffer, pm_sizet_to_u32(1));
+        pm_buffer_append_varuint(buffer, integer->value);
+    } else {
+        pm_buffer_append_varuint(buffer, pm_sizet_to_u32(integer->length));
+        for (size_t i = 0; i < integer->length; i++) {
+            pm_buffer_append_varuint(buffer, integer->values[i]);
+        }
     }
 }
 

--- a/test/prism/integer_parse_test.rb
+++ b/test/prism/integer_parse_test.rb
@@ -26,6 +26,12 @@ module Prism
       assert_integer_parse(2**32)
       assert_integer_parse(2**64 + 2**32)
       assert_integer_parse(2**128 + 2**64 + 2**32)
+
+      num = 99 ** 99
+      assert_integer_parse(num, "0b#{num.to_s(2)}")
+      assert_integer_parse(num, "0o#{num.to_s(8)}")
+      assert_integer_parse(num, "0d#{num.to_s(10)}")
+      assert_integer_parse(num, "0x#{num.to_s(16)}")
     end
 
     private


### PR DESCRIPTION
Parsing huge integer literal is a bit slow.
`Prism.parse('1'*1000000)` takes about 67.8s, `eval('1'*1000000)` takes only 0.32s. This pull request improves it to 1.46s.

Constructing a bigint with `digits.each{v=v*10+_1}` is `O(n^2)`.
To make it faster, I think we need a fast bigint multiplication algorithm.
(I'm not sure this is worth introducing complexity)

### Bigint and multiplication
Implement karatsuba algorithm that ruby's Bignum uses internally.
Implement radix conversion using fast multiplication.

### Parse digits
If base is power of two, just pack bits to bigint.
If base is 10, peform radix conversion.

### pm_integer_t to ::Integer
`"0x...".to_i`  is  faster than `|` `<<` for large integer.

### pm_intger_t to string
Use radix conversion

### Comparison

| Prism.parse(code) | before | after | ratio |
| --- | --- | --- | --- |
| '1'*1000000 | 67.798872s | 1.462340s | x46.3 |
| '1'*100000 | 0.723387s | 0.061709s | x11.7 |
| '0x'+'1'*100000 | 0.908699s | 0.002813s | x323 |
| (['1'*100]*100000).join(';') | 0.322435s | 0.189371s | x1.70 |
| (['1'*20]*100000).join(';') | 0.084510s | 0.088816s | x0.95 slower |
