### PR TITLE
Support -p, -n, -a, and -l command line options

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -195,7 +195,10 @@ The final argument to `pm_serialize_parse` is an optional string that controls t
 | `4`     | the length the encoding    |
 | ...     | the encoding bytes         |
 | `1`     | frozen string literal      |
-| `1`     | suppress warnings          |
+| `1`     | `-p` command line flag     |
+| `1`     | `-n` command line flag     |
+| `1`     | `-l` command line flag     |
+| `1`     | `-a` command line flag     |
 | `1`     | syntax version, see [pm_options_version_t](https://github.com/ruby/prism/blob/main/include/prism/options.h) for valid values |
 | `4`     | the number of scopes       |
 | ...     | the scopes                 |

--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -29,6 +29,10 @@ ID rb_option_id_line;
 ID rb_option_id_frozen_string_literal;
 ID rb_option_id_version;
 ID rb_option_id_scopes;
+ID rb_option_id_command_line_p;
+ID rb_option_id_command_line_n;
+ID rb_option_id_command_line_l;
+ID rb_option_id_command_line_a;
 
 /******************************************************************************/
 /* IO of Ruby code                                                            */
@@ -149,6 +153,14 @@ build_options_i(VALUE key, VALUE value, VALUE argument) {
         }
     } else if (key_id == rb_option_id_scopes) {
         if (!NIL_P(value)) build_options_scopes(options, value);
+    } else if (key_id == rb_option_id_command_line_p) {
+        if (!NIL_P(value)) pm_options_command_line_p_set(options, value == Qtrue);
+    } else if (key_id == rb_option_id_command_line_n) {
+        if (!NIL_P(value)) pm_options_command_line_n_set(options, value == Qtrue);
+    } else if (key_id == rb_option_id_command_line_l) {
+        if (!NIL_P(value)) pm_options_command_line_l_set(options, value == Qtrue);
+    } else if (key_id == rb_option_id_command_line_a) {
+        if (!NIL_P(value)) pm_options_command_line_a_set(options, value == Qtrue);
     } else {
         rb_raise(rb_eArgError, "unknown keyword: %"PRIsVALUE, key);
     }
@@ -1232,6 +1244,10 @@ Init_prism(void) {
     rb_option_id_frozen_string_literal = rb_intern_const("frozen_string_literal");
     rb_option_id_version = rb_intern_const("version");
     rb_option_id_scopes = rb_intern_const("scopes");
+    rb_option_id_command_line_p = rb_intern_const("command_line_p");
+    rb_option_id_command_line_n = rb_intern_const("command_line_n");
+    rb_option_id_command_line_l = rb_intern_const("command_line_l");
+    rb_option_id_command_line_a = rb_intern_const("command_line_a");
 
     /**
      * The version of the prism library.

--- a/include/prism/node.h
+++ b/include/prism/node.h
@@ -30,6 +30,15 @@ bool pm_node_list_grow(pm_node_list_t *list);
 void pm_node_list_append(pm_node_list_t *list, pm_node_t *node);
 
 /**
+ * Prepend a new node onto the beginning of the node list.
+ *
+ * @param list The list to prepend to.
+ * @param node The node to prepend.
+ */
+void
+pm_node_list_prepend(pm_node_list_t *list, pm_node_t *node);
+
+/**
  * Free the internal memory associated with the given node list.
  *
  * @param list The list to free.

--- a/include/prism/options.h
+++ b/include/prism/options.h
@@ -78,6 +78,18 @@ typedef struct {
 
     /** Whether or not the frozen string literal option has been set. */
     bool frozen_string_literal;
+
+    /** Whether or not the -p command line option has been set. */
+    bool command_line_p;
+
+    /** Whether or not the -n command line option has been set. */
+    bool command_line_n;
+
+    /** Whether or not the -l command line option has been set. */
+    bool command_line_l;
+
+    /** Whether or not the -a command line option has been set. */
+    bool command_line_a;
 } pm_options_t;
 
 /**
@@ -111,6 +123,38 @@ PRISM_EXPORTED_FUNCTION void pm_options_encoding_set(pm_options_t *options, cons
  * @param frozen_string_literal The frozen string literal value to set.
  */
 PRISM_EXPORTED_FUNCTION void pm_options_frozen_string_literal_set(pm_options_t *options, bool frozen_string_literal);
+
+/**
+ * Sets the -p command line option on the given options struct.
+ *
+ * @param options The options struct to set the -p command line option on.
+ * @param command_line_p The -p command line option to set.
+ */
+PRISM_EXPORTED_FUNCTION void pm_options_command_line_p_set(pm_options_t *options, bool command_line_p);
+
+/**
+ * Sets the -n command line option on the given options struct.
+ *
+ * @param options The options struct to set the -n command line option on.
+ * @param command_line_n The -n command line option to set.
+ */
+PRISM_EXPORTED_FUNCTION void pm_options_command_line_n_set(pm_options_t *options, bool command_line_n);
+
+/**
+ * Sets the -l command line option on the given options struct.
+ *
+ * @param options The options struct to set the -l command line option on.
+ * @param command_line_l The -l command line option to set.
+ */
+PRISM_EXPORTED_FUNCTION void pm_options_command_line_l_set(pm_options_t *options, bool command_line_l);
+
+/**
+ * Sets the -a command line option on the given options struct.
+ *
+ * @param options The options struct to set the -a command line option on.
+ * @param command_line_a The -a command line option to set.
+ */
+PRISM_EXPORTED_FUNCTION void pm_options_command_line_a_set(pm_options_t *options, bool command_line_a);
 
 /**
  * Set the version option on the given options struct by parsing the given
@@ -186,7 +230,10 @@ PRISM_EXPORTED_FUNCTION void pm_options_free(pm_options_t *options);
  * | `4`     | the length the encoding    |
  * | ...     | the encoding bytes         |
  * | `1`     | frozen string literal      |
- * | `1`     | suppress warnings          |
+ * | `1`     | -p command line option     |
+ * | `1`     | -n command line option     |
+ * | `1`     | -l command line option     |
+ * | `1`     | -a command line option     |
  * | `1`     | the version                |
  * | `4`     | the number of scopes       |
  * | ...     | the scopes                 |

--- a/include/prism/parser.h
+++ b/include/prism/parser.h
@@ -736,6 +736,30 @@ struct pm_parser {
      * a true value.
      */
     bool frozen_string_literal;
+
+    /**
+     * Whether or not -p was present on the command line that invoked the
+     * parser. -p prints the value of $_ at the end of each loop.
+     */
+    bool command_line_p;
+
+    /**
+     * Whether or not -n was present on the command line that invoked the
+     * parser. -n wraps the script in a while gets loop.
+     */
+    bool command_line_n;
+
+    /**
+     * Whether or not -l was present on the command line that invoked the
+     * parser. -l chomps the input line by default.
+     */
+    bool command_line_l;
+
+    /**
+     * Whether or not -a was present on the command line that invoked the
+     * parser. -a splits the input line $_ into $F.
+     */
+    bool command_line_a;
 };
 
 #endif

--- a/java-wasm/src/test/java/org/prism/DummyTest.java
+++ b/java-wasm/src/test/java/org/prism/DummyTest.java
@@ -32,7 +32,19 @@ public class DummyTest {
         var sourcePointer = calloc.apply(Value.i32(1), Value.i32(source.length()));
         memory.writeString(sourcePointer[0].asInt(), source);
 
-        var packedOptions = new byte[] {};
+        var packedOptions = ParsingOptions.serialize(
+            new byte[] {},
+            1,
+            new byte[] {},
+            false,
+            false,
+            false,
+            false,
+            false,
+            ParsingOptions.SyntaxVersion.LATEST,
+            new byte[][][] {}
+        );
+
         var optionsPointer = calloc.apply(Value.i32(1), Value.i32(packedOptions.length));
         memory.write(optionsPointer[0].asInt(), packedOptions);
 
@@ -74,7 +86,19 @@ public class DummyTest {
         var sourcePointer = calloc.apply(Value.i32(1), Value.i32(source.length()));
         memory.writeString(sourcePointer[0].asInt(), source);
 
-        var packedOptions = new byte[] {};
+        var packedOptions = ParsingOptions.serialize(
+            new byte[] {},
+            1,
+            new byte[] {},
+            false,
+            false,
+            false,
+            false,
+            false,
+            ParsingOptions.SyntaxVersion.LATEST,
+            new byte[][][] {}
+        );
+
         var optionsPointer = calloc.apply(Value.i32(1), Value.i32(packedOptions.length));
         memory.write(optionsPointer[0].asInt(), packedOptions);
 

--- a/java/org/prism/ParsingOptions.java
+++ b/java/org/prism/ParsingOptions.java
@@ -29,10 +29,14 @@ public abstract class ParsingOptions {
      * @param line the line within the file that the parser starts on. This value is 1-indexed
      * @param encoding the name of the encoding that the source file is in
      * @param frozenStringLiteral whether the frozen string literal option has been set
+     * @param commandLineP whether the -p command line option has been set
+     * @param commandLineN whether the -n command line option has been set
+     * @param commandLineL whether the -l command line option has been set
+     * @param commandLineA whether the -a command line option has been set
      * @param version code of Ruby version which syntax will be used to parse
      * @param scopes scopes surrounding the code that is being parsed with local variable names defined in every scope
      *            ordered from the outermost scope to the innermost one */
-    public static byte[] serialize(byte[] filepath, int line, byte[] encoding, boolean frozenStringLiteral, SyntaxVersion version, byte[][][] scopes) {
+    public static byte[] serialize(byte[] filepath, int line, byte[] encoding, boolean frozenStringLiteral, boolean commandLineP, boolean commandLineN, boolean commandLineL, boolean commandLineA, SyntaxVersion version, byte[][][] scopes) {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
 
         // filepath
@@ -47,11 +51,13 @@ public abstract class ParsingOptions {
         write(output, encoding);
 
         // frozenStringLiteral
-        if (frozenStringLiteral) {
-            output.write(1);
-        } else {
-            output.write(0);
-        }
+        output.write(frozenStringLiteral ? 1 : 0);
+
+        // command line flags
+        output.write(commandLineP ? 1 : 0);
+        output.write(commandLineN ? 1 : 0);
+        output.write(commandLineL ? 1 : 0);
+        output.write(commandLineA ? 1 : 0);
 
         // version
         output.write(version.getValue());

--- a/javascript/src/parsePrism.js
+++ b/javascript/src/parsePrism.js
@@ -68,6 +68,18 @@ function dumpOptions(options) {
   values.push(options.frozen_string_literal === undefined ? 0 : 1);
 
   template.push("C");
+  values.push(options.command_line_p === undefined ? 0 : 1);
+
+  template.push("C");
+  values.push(options.command_line_n === undefined ? 0 : 1);
+
+  template.push("C");
+  values.push(options.command_line_l === undefined ? 0 : 1);
+
+  template.push("C");
+  values.push(options.command_line_a === undefined ? 0 : 1);
+
+  template.push("C");
   if (!options.version || options.version === "latest" || options.version === "3.4.0") {
     values.push(0);
   } else if (options.version === "3.3.0") {

--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -343,6 +343,18 @@ module Prism
       values << (options.fetch(:frozen_string_literal, false) ? 1 : 0)
 
       template << "C"
+      values << (options.fetch(:command_line_p, false) ? 1 : 0)
+
+      template << "C"
+      values << (options.fetch(:command_line_n, false) ? 1 : 0)
+
+      template << "C"
+      values << (options.fetch(:command_line_l, false) ? 1 : 0)
+
+      template << "C"
+      values << (options.fetch(:command_line_a, false) ? 1 : 0)
+
+      template << "C"
       values << { nil => 0, "3.3.0" => 1, "3.4.0" => 0, "latest" => 0 }.fetch(options[:version])
 
       template << "L"

--- a/src/options.c
+++ b/src/options.c
@@ -33,6 +33,38 @@ pm_options_frozen_string_literal_set(pm_options_t *options, bool frozen_string_l
 }
 
 /**
+ * Sets the -p command line option on the given options struct.
+ */
+PRISM_EXPORTED_FUNCTION void
+pm_options_command_line_p_set(pm_options_t *options, bool command_line_p) {
+    options->command_line_p = command_line_p;
+}
+
+/**
+ * Sets the -n command line option on the given options struct.
+ */
+PRISM_EXPORTED_FUNCTION void
+pm_options_command_line_n_set(pm_options_t *options, bool command_line_n) {
+    options->command_line_n = command_line_n;
+}
+
+/**
+ * Sets the -l command line option on the given options struct.
+ */
+PRISM_EXPORTED_FUNCTION void
+pm_options_command_line_l_set(pm_options_t *options, bool command_line_l) {
+    options->command_line_l = command_line_l;
+}
+
+/**
+ * Sets the -a command line option on the given options struct.
+ */
+PRISM_EXPORTED_FUNCTION void
+pm_options_command_line_a_set(pm_options_t *options, bool command_line_a) {
+    options->command_line_a = command_line_a;
+}
+
+/**
  * Set the version option on the given options struct by parsing the given
  * string. If the string contains an invalid option, this returns false.
  * Otherwise, it returns true.
@@ -193,7 +225,11 @@ pm_options_read(pm_options_t *options, const char *data) {
         data += encoding_length;
     }
 
-    options->frozen_string_literal = *data++;
+    options->frozen_string_literal = (*data++) ? true : false;
+    options->command_line_p = (*data++) ? true : false;
+    options->command_line_n = (*data++) ? true : false;
+    options->command_line_l = (*data++) ? true : false;
+    options->command_line_a = (*data++) ? true : false;
     options->version = (pm_options_version_t) *data++;
 
     uint32_t scopes_count = pm_options_read_u32(data);

--- a/templates/src/node.c.erb
+++ b/templates/src/node.c.erb
@@ -43,6 +43,18 @@ pm_node_list_append(pm_node_list_t *list, pm_node_t *node) {
 }
 
 /**
+ * Prepend a new node onto the beginning of the node list.
+ */
+void
+pm_node_list_prepend(pm_node_list_t *list, pm_node_t *node) {
+    if (pm_node_list_grow(list)) {
+        memmove(list->nodes + 1, list->nodes, list->size * sizeof(pm_node_t *));
+        list->nodes[0] = node;
+        list->size++;
+    }
+}
+
+/**
  * Free the internal memory associated with the given node list.
  */
 void

--- a/test/prism/command_line_test.rb
+++ b/test/prism/command_line_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+module Prism
+  class CommandLineTest < TestCase
+    def test_command_line_p
+      program = Prism.parse("1", command_line_p: true).value
+      statements = program.statements.body
+
+      assert_equal 2, statements.length
+      assert_kind_of CallNode, statements.last
+      assert_equal :print, statements.last.name
+    end
+
+    def test_command_line_n
+      program = Prism.parse("1", command_line_n: true).value
+      statements = program.statements.body
+
+      assert_equal 1, statements.length
+      assert_kind_of WhileNode, statements.first
+
+      predicate = statements.first.predicate
+      assert_kind_of CallNode, predicate
+      assert_equal :gets, predicate.name
+
+      arguments = predicate.arguments.arguments
+      assert_equal 1, arguments.length
+      assert_equal :$/, arguments.first.name
+    end
+
+    def test_command_line_a
+      program = Prism.parse("1", command_line_n: true, command_line_a: true).value
+      statements = program.statements.body
+
+      assert_equal 1, statements.length
+      assert_kind_of WhileNode, statements.first
+
+      statement = statements.first.statements.body.first
+      assert_kind_of GlobalVariableWriteNode, statement
+      assert_equal :$F, statement.name
+    end
+
+    def test_command_line_l
+      program = Prism.parse("1", command_line_n: true, command_line_l: true).value
+      statements = program.statements.body
+
+      assert_equal 1, statements.length
+      assert_kind_of WhileNode, statements.first
+
+      predicate = statements.first.predicate
+      assert_kind_of CallNode, predicate
+      assert_equal :gets, predicate.name
+
+      arguments = predicate.arguments.arguments
+      assert_equal 2, arguments.length
+      assert_equal :$/, arguments.first.name
+      assert_equal "chomp", arguments.last.elements.first.key.unescaped
+    end
+  end
+end


### PR DESCRIPTION
The current CRuby parser supports these options by mutating the AST. I don't want to do that, and instead would prefer to do it in the compiler. But that work is for another day, and this will be far easier than wading into those waters. So instead, we now support the following options:

* `command_line_p`
* `command_line_n`
* `command_line_a`
* `command_line_l`

These correspond with the respective command line flags. They mutate the AST such that you get back what would be executed (this pretty much exactly matches what the current parser does).

cc @enebo, @eregon, @seven1m — you may want to use these or you may not. I'm assuming all of you currently have your own solutions for this. It's not that much code at the end of the day so entirely up to you.

Fixes https://github.com/ruby/prism/issues/2002