### PR TITLE
[rust] give node downcasts the proper lifetimes

### DIFF
--- a/rust/ruby-prism/build.rs
+++ b/rust/ruby-prism/build.rs
@@ -844,7 +844,7 @@ impl<'pr> Node<'pr> {{
     for node in &config.nodes {
         writeln!(file, "    /// Returns the node as a `{}`.", node.name)?;
         writeln!(file, "    #[must_use]")?;
-        writeln!(file, "    pub fn as{}(&self) -> Option<{}<'_>> {{", struct_name(&node.name), node.name)?;
+        writeln!(file, "    pub fn as{}(&self) -> Option<{}<'pr>> {{", struct_name(&node.name), node.name)?;
         writeln!(file, "        match *self {{")?;
         writeln!(file, "            Self::{} {{ parser, pointer, marker }} => Some({} {{ parser, pointer, marker }}),", node.name, node.name)?;
         writeln!(file, "            _ => None")?;


### PR DESCRIPTION
This PR is sort of the opposite of #1625: here, the code currently returns structures that are bound to the lifetime of `&self`.  But that's not correct; the structures are actually bound to `'pr`, the lifetime of the parse result.  There's no reason that they should be bound to the lifetime of `&self`; doing so makes some kinds of programs difficult to write.

e.g. The added test gets errors like:

```
error[E0597]: `path` does not live long enough
   --> ruby-prism/src/lib.rs:804:38
    |
802 |         impl<'pr> Extract<'pr> {
    |              --- lifetime `'pr` defined here
803 |             fn push_scope(&mut self, path: Node<'pr>) {
    |                                      ---- binding `path` declared here
804 |                 if let Some(cread) = path.as_constant_read_node() {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                                      |
    |                                      borrowed value does not live long enough
    |                                      argument requires that `path` is borrowed for `'pr`
...
811 |             }
    |              - `path` dropped here while still borrowed
```

cc @ngroman 