### PR TITLE
Use regular method to alias behavior of `visit_child_nodes`

### DIFF
--- a/templates/lib/prism/visitor.rb.erb
+++ b/templates/lib/prism/visitor.rb.erb
@@ -47,7 +47,9 @@ module Prism
     <%- nodes.each_with_index do |node, index| -%>
 <%= "\n" if index != 0 -%>
     # Visit a <%= node.name %> node
-    alias visit_<%= node.human %> visit_child_nodes
+    def visit_<%= node.human %>(node)
+      visit_child_nodes(node)
+    end
     <%- end -%>
   end
 end


### PR DESCRIPTION
The way the `visit_` methods are aliased to the base visitor makes it hard to override the behavior of `visit`:

```rb
module Prism
  class Visitor
    def visit(node)
      puts "BaseVisitor"
    end

    alias :visit_foo :visit
  end
end

class MyVisitor < Prism::Visitor
  def visit(node)
    puts "MyVisitor"
  end
end

v = Prism::Visitor.new
v.visit_foo(42) # => BaseVisitor

v = MyVisitor.new
v.visit_foo(42) # => BaseVisitor :(
```

One would need to also override each alias to `visit` so the call resolves to `MyVisitor#visitor`:

```rb
class MyVisitor < Prism::Visitor
  def visit(node)
    puts "MyVisitor"
  end

  def visit_foo(node)
    visit(node)
  end

  # ... all the other nodes
end

v = MyVisitor.new
v.visit_foo(42) # => MyVisitor :)
```

We can fix this with using normal methods rather than aliases:

```rb
module Prism
  class Visitor
    def visit(node)
      puts "BaseVisitor"
    end

    def visit_foo(node)
      visit(node)
    end
  end
end

class MyVisitor < Prism::Visitor
  def visit(node)
    puts "MyVisitor"
  end
end

v = MyVisitor.new
v.visit_foo(42) # => MyVisitor :)
```