### PR TITLE
Lazily create Location objects in Prism::Serialize::Loader#load_location

### DIFF
--- a/lib/prism.rb
+++ b/lib/prism.rb
@@ -95,11 +95,11 @@ require_relative "prism/parse_result/newlines"
 if RUBY_ENGINE == "ruby" and !ENV["PRISM_FFI_BACKEND"]
   require "prism/prism"
 
-  # Using a C extension is the default backend for the parser.
+  # The C extension is the default backend on CRuby.
   Prism::BACKEND = :CEXT
 else
   require_relative "prism/ffi"
 
-  # On platforms that don't support C extensions, we use FFI.
+  # The FFI backend is used on other Ruby implementations.
   Prism::BACKEND = :FFI
 end

--- a/templates/lib/prism/serialize.rb.erb
+++ b/templates/lib/prism/serialize.rb.erb
@@ -89,18 +89,18 @@ module Prism
       def load_comments
         Array.new(load_varuint) do
           case load_varuint
-          when 0 then InlineComment.new(load_location)
-          when 1 then EmbDocComment.new(load_location)
+          when 0 then InlineComment.new(load_location_object)
+          when 1 then EmbDocComment.new(load_location_object)
           end
         end
       end
 
       def load_metadata
         comments = load_comments
-        magic_comments = Array.new(load_varuint) { MagicComment.new(load_location, load_location) }
-        data_loc = load_optional_location
-        errors = Array.new(load_varuint) { ParseError.new(load_embedded_string, load_location, load_error_level) }
-        warnings = Array.new(load_varuint) { ParseWarning.new(load_embedded_string, load_location, load_warning_level) }
+        magic_comments = Array.new(load_varuint) { MagicComment.new(load_location_object, load_location_object) }
+        data_loc = load_optional_location_object
+        errors = Array.new(load_varuint) { ParseError.new(load_embedded_string, load_location_object, load_error_level) }
+        warnings = Array.new(load_varuint) { ParseWarning.new(load_embedded_string, load_location_object, load_warning_level) }
         [comments, magic_comments, data_loc, errors, warnings]
       end
 
@@ -214,11 +214,19 @@ module Prism
       end
 
       def load_location
+        (load_varuint << 32) | load_varuint
+      end
+
+      def load_location_object
         Location.new(source, load_varuint, load_varuint)
       end
 
       def load_optional_location
         load_location if io.getbyte != 0
+      end
+
+      def load_optional_location_object
+        load_location_object if io.getbyte != 0
       end
 
       def load_constant(index)


### PR DESCRIPTION
* Following the changes in #2428.
* `PRISM_FFI_BACKEND=true ruby -v -Ilib -rprism -rbenchmark -e '10.times { p Benchmark.realtime { Dir.glob("lib/**/*.rb") { |f| Prism.parse_file(f) } } }'`
  ruby 3.3.0:      0.255 => 0.210
  ruby 3.3.0 YJIT: 0.150 => 0.120

From https://github.com/ruby/prism/issues/2402#issuecomment-1951376375