### PR TITLE
Fix an incompatible behavior for `Prism::Translation::Parser`

### DIFF
--- a/lib/prism/translation/parser/compiler.rb
+++ b/lib/prism/translation/parser/compiler.rb
@@ -1607,11 +1607,7 @@ module Prism
           builder.when(
             token(node.keyword_loc),
             visit_all(node.conditions),
-            if node.then_keyword_loc
-              token(node.then_keyword_loc)
-            else
-              srange_find(node.conditions.last.location.end_offset, node.statements&.location&.start_offset || (node.conditions.last.location.end_offset + 1), [";"])
-            end,
+            srange_find(node.conditions.last.location.end_offset, node.statements&.location&.start_offset || node.statements&.then_keyword_loc, [";", "then"]),
             visit(node.statements)
           )
         end


### PR DESCRIPTION
This PR fixes the following incompatible behavior for `Prism::Translation::Parser` when using `case`/`when`/`end` with `;` expression.

## Expected

It returns the range of the semicolon even if there is a space before the semicolon:

```console
$ bundle exec ruby -Ilib -rprism -rprism/translation/parser33 -ve \
'p Prism::Translation::Parser33.parse("case foo when x; end").children.to_a[1].loc.begin'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
#<Parser::Source::Range (string) 15...16>
$ bundle exec ruby -Ilib -rprism -rprism/translation/parser33 -ve \
'p Prism::Translation::Parser33.parse("case foo when x; end").children.to_a[1].loc.begin.source'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
";"

$ bundle exec ruby -Ilib -rprism -rprism/translation/parser33 -ve \
'p Prism::Translation::Parser33.parse("case foo when x ; end").children.to_a[1].loc.begin'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
#<Parser::Source::Range (string) 16...17>
$ bundle exec ruby -Ilib -rprism -rprism/translation/parser33 -ve \
'p Prism::Translation::Parser33.parse("case foo when x ; end").children.to_a[1].loc.begin.source'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
";"
```

## Actual

It returns `nil` if there is a space before the semicolon:

```console
$ bundle exec ruby -Ilib -rprism -rprism/translation/parser33 -ve \
'p Prism::Translation::Parser33.parse("case foo when x; end").children.to_a[1].loc.begin'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
#<Parser::Source::Range (string) 15...16>
$ bundle exec ruby -Ilib -rprism -rprism/translation/parser33 -ve \
'p Prism::Translation::Parser33.parse("case foo when x; end").children.to_a[1].loc.begin.source'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
";"

$ bundle exec ruby -Ilib -rprism -rprism/translation/parser33 -ve \
'p Prism::Translation::Parser33.parse("case foo when x ; end").children.to_a[1].loc.begin'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
nil
$ bundle exec ruby -Ilib -rprism -rprism/translation/parser33 -ve \
'p Prism::Translation::Parser33.parse("case foo when x ; end").children.to_a[1].loc.begin.source'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
-e:1:in `<main>': undefined method `source' for nil (NoMethodError)

p Prism::Translation::Parser33.parse("case foo when x ; end").children.to_a[1].loc.begin.source
                                                                                        ^^^^^^^
```
