### PR TITLE
Run Sorbet type-checking with `typed: true`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,12 +49,12 @@ jobs:
       with:
         ruby-version: "3.3"
         bundler-cache: true
-    - name: Check annotations
-      run: |
-        bundle exec rake typecheck:tapioca typecheck:sorbet
-        bundle exec rake typecheck:steep
-        rm lib/prism/node.rb && CHECK_FIELD_KIND=true bundle exec rake
-
+    - name: Check Sorbet
+      run: bundle exec rake typecheck:tapioca typecheck:sorbet
+    - name: Check Steep
+      run: bundle exec rake typecheck:steep
+    - name: Check field kinds
+      run: rm lib/prism/node.rb && CHECK_FIELD_KIND=true bundle exec rake
   build:
     strategy:
       fail-fast: false

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ task default: [:compile, :test]
 require_relative "templates/template"
 
 desc "Generate all ERB template based files"
-task templates: Prism::TEMPLATES
+task templates: Prism::Template::TEMPLATES
 
 task make: [:templates] do
   sh(RUBY_PLATFORM.include?("openbsd") ? "gmake" : "make")
@@ -50,13 +50,13 @@ elsif RUBY_ENGINE == "jruby"
 end
 
 # So `rake clobber` will delete generated files
-CLOBBER.concat(Prism::TEMPLATES)
+CLOBBER.concat(Prism::Template::TEMPLATES)
 CLOBBER.concat(["build"])
 CLOBBER << "lib/prism/prism.#{RbConfig::CONFIG["DLEXT"]}"
 
-Prism::TEMPLATES.each do |filepath|
+Prism::Template::TEMPLATES.each do |filepath|
   desc "Generate #{filepath}"
   file filepath => ["templates/#{filepath}.erb", "templates/template.rb", "config.yml"] do |t|
-    Prism.template(t.name)
+    Prism::Template.render(t.name)
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ task make_no_debug: [:templates] do
 end
 
 # decorate the gem build task with prerequisites
-task build: [:check_manifest, :templates, :"typecheck:sorbet", :"typecheck:steep"]
+task build: [:check_manifest, :templates]
 
 # the C extension
 task "compile:prism" => ["templates"] # must be before the ExtensionTask is created

--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -276,13 +276,6 @@ module Prism
 
       Location.new(source, start_offset, other.end_offset - start_offset)
     end
-
-    # Returns a null location that does not correspond to a source and points to
-    # the beginning of the file. Useful for when you want a location object but
-    # do not care where it points.
-    def self.null
-      new(nil, 0, 0) # steep:ignore
-    end
   end
 
   # This represents a comment that was encountered during parsing. It is the

--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -87,9 +87,9 @@ module Prism
 
       while left <= right
         mid = left + (right - left) / 2
-        return mid if offsets[mid] == byte_offset
+        return mid if (offset = offsets[mid]) == byte_offset
 
-        if offsets[mid] < byte_offset
+        if offset < byte_offset
           left = mid + 1
         else
           right = mid - 1
@@ -262,7 +262,7 @@ module Prism
 
     # Returns true if the given other location is equal to this location.
     def ==(other)
-      other.is_a?(Location) &&
+      Location === other &&
         other.start_offset == start_offset &&
         other.end_offset == end_offset
     end
@@ -541,7 +541,7 @@ module Prism
 
     # Returns true if the given other token is equal to this token.
     def ==(other)
-      other.is_a?(Token) &&
+      Token === other &&
         other.type == type &&
         other.value == value
     end

--- a/lib/prism/parse_result/newlines.rb
+++ b/lib/prism/parse_result/newlines.rb
@@ -58,6 +58,8 @@ module Prism
 
     # Walk the tree and mark nodes that are on a new line.
     def mark_newlines!
+      value = self.value
+      raise "This method should only be called on a parse result that contains a node" unless Node === value
       value.accept(Newlines.new(Array.new(1 + source.offsets.size, false))) # steep:ignore
     end
   end

--- a/lib/prism/polyfill/string.rb
+++ b/lib/prism/polyfill/string.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Polyfill for String#unpack1 with the offset parameter.
+if String.instance_method(:unpack1).parameters.none? { |_, name| name == :offset }
+  String.prepend(
+    Module.new {
+      def unpack1(format, offset: 0) # :nodoc:
+        offset == 0 ? super(format) : self[offset..].unpack1(format) # steep:ignore
+      end
+    }
+  )
+end

--- a/lib/prism/translation/parser/compiler.rb
+++ b/lib/prism/translation/parser/compiler.rb
@@ -1799,7 +1799,7 @@ module Prism
 
         # Visit a heredoc that can be either a string or an xstring.
         def visit_heredoc(node)
-          children = []
+          children = Array.new
           node.parts.each do |part|
             pushing =
               if part.is_a?(StringNode) && part.unescaped.include?("\n")

--- a/lib/prism/translation/parser/lexer.rb
+++ b/lib/prism/translation/parser/lexer.rb
@@ -302,7 +302,7 @@ module Prism
                 index += 1
               end
             when :tFID
-              if !tokens.empty? && tokens[-1][0] == :kDEF
+              if !tokens.empty? && tokens.dig(-1, 0) == :kDEF
                 type = :tIDENTIFIER
               end
             end

--- a/lib/prism/translation/ripper.rb
+++ b/lib/prism/translation/ripper.rb
@@ -975,16 +975,16 @@ module Prism
 
             bounds(last_argument.location)
             on_assign(call, value)
-          when :-@, :+@, :~@
+          when :-@, :+@, :~
             receiver = visit(node.receiver)
 
             bounds(node.location)
             on_unary(node.name, receiver)
-          when :!@
+          when :!
             receiver = visit(node.receiver)
 
             bounds(node.location)
-            on_unary(node.message == "not" ? :not : :!@, receiver)
+            on_unary(node.message == "not" ? :not : :!, receiver)
           when *BINARY_OPERATORS
             receiver = visit(node.receiver)
             value = visit(node.arguments.arguments.first)

--- a/prism.gemspec
+++ b/prism.gemspec
@@ -87,6 +87,7 @@ Gem::Specification.new do |spec|
     "lib/prism/parse_result/comments.rb",
     "lib/prism/parse_result/newlines.rb",
     "lib/prism/pattern.rb",
+    "lib/prism/polyfill/string.rb",
     "lib/prism/serialize.rb",
     "lib/prism/translation.rb",
     "lib/prism/translation/parser.rb",

--- a/rakelib/typecheck.rake
+++ b/rakelib/typecheck.rake
@@ -24,7 +24,53 @@ namespace :typecheck do
 
   desc "Typecheck with Sorbet"
   task sorbet: :templates do
-    Process.wait(fork { exec Gem.bin_path("sorbet", "srb"), "typecheck" })
+    polyfills = Dir["lib/prism/polyfill/**/*.rb"]
+    gem_rbis = Dir["sorbet/rbi/**/*.rbi"]
+
+    File.write("sorbet/typed_overrides.yml", ERB.new(<<~YAML, trim_mode: "-").result(binding))
+      false:
+        - ./lib/prism/debug.rb
+        - ./lib/prism/lex_compat.rb
+        - ./lib/prism/node_ext.rb
+        - ./lib/prism/parse_result.rb
+        - ./lib/prism/visitor.rb
+        - ./lib/prism/translation/ripper.rb
+        - ./lib/prism/translation/ripper/ripper_compiler.rb
+        - ./lib/prism/translation/ripper/sexp.rb
+        - ./lib/prism/translation/ruby_parser.rb
+        # We want to treat all polyfill files as "typed: false"
+      <% polyfills.each do |file| -%>
+        - ./<%= file %>
+      <% end -%>
+        # We want to treat all RBI files as "typed: false"
+      <% gem_rbis.each do |file| -%>
+        - ./<%= file %>
+      <% end -%>
+    YAML
+
+    File.write("sorbet/config", <<~CONFIG)
+      --dir=.
+      --ignore=tmp/
+      --ignore=vendor/
+      --ignore=ext/
+      --ignore=test/
+      --ignore=rakelib/
+      --ignore=Rakefile
+      # Treat all files as "typed: true" by default
+      --typed=true
+      # Use the typed-override file to revert some files to "typed: false"
+      --typed-override=sorbet/typed_overrides.yml
+      # We want to permit initializing a class by constant assignment
+      --suppress-error-code=4022
+      # We want to permit redefining the existing method as a method alias
+      --suppress-error-code=5037
+      # We want to permit changing the type of a variable in a loop
+      --suppress-error-code=7001
+    CONFIG
+
+    Process.wait(fork do
+      exec "#{::Gem::Specification.find_by_name("sorbet-static").full_gem_path}/libexec/sorbet"
+    end)
   end
 
   desc "Typecheck with Steep"

--- a/rbi/prism/compiler.rbi
+++ b/rbi/prism/compiler.rbi
@@ -9,6 +9,6 @@ class Prism::Compiler
   sig { params(nodes: T::Array[T.nilable(Prism::Node)]).returns(T::Array[T.nilable(Result)]) }
   def visit_all(nodes); end
 
-  sig { params(node: T.nilable(Prism::Node)).returns(T::Array[T.nilable(Result)]) }
+  sig { params(node: Prism::Node).returns(T::Array[T.nilable(Result)]) }
   def visit_child_nodes(node); end
 end

--- a/rbi/prism/translation/ripper.rbi
+++ b/rbi/prism/translation/ripper.rbi
@@ -1,6 +1,6 @@
 # typed: strict
 
-class Prism::Translation::Ripper < Prism::Translation::RipperCompiler
+class Prism::Translation::Ripper < Prism::Compiler
   Result = type_member
 
   sig { returns(T::Boolean) }
@@ -9,11 +9,11 @@ class Prism::Translation::Ripper < Prism::Translation::RipperCompiler
   sig { returns(T.nilable(Result)) }
   def parse; end
 
-  sig { params(source: String).returns(T.untyped) }
-  def self.sexp_raw(source); end
+  sig { params(source: String, filename: String, lineno: Integer, raise_errors: T.untyped).returns(T.untyped) }
+  def self.sexp_raw(source, filename = "-", lineno = 1, raise_errors: false); end
 
-  sig { params(source: String).returns(T.untyped) }
-  def self.sexp(source); end
+  sig { params(source: String, filename: String, lineno: Integer, raise_errors: T.untyped).returns(T.untyped) }
+  def self.sexp(source, filename = "-", lineno = 1, raise_errors: false); end
 end
 
 class Prism::Translation::Ripper::SexpBuilder < Prism::Translation::Ripper

--- a/sig/prism/parse_result.rbs
+++ b/sig/prism/parse_result.rbs
@@ -43,8 +43,6 @@ module Prism
     def deconstruct_keys: (Array[Symbol] keys) -> { start_offset: Integer, end_offset: Integer }
     def pretty_print: (untyped q) -> untyped
     def join: (Location other) -> Location
-
-    def self.null: () -> Location
   end
 
   class Comment

--- a/templates/ext/prism/api_node.c.erb
+++ b/templates/ext/prism/api_node.c.erb
@@ -130,15 +130,15 @@ pm_ast_new(const pm_parser_t *parser, const pm_node_t *node, rb_encoding *encodi
 
             switch (PM_NODE_TYPE(node)) {
                 <%- nodes.each do |node| -%>
-                <%- if node.fields.any? { |field| [Prism::NodeField, Prism::OptionalNodeField, Prism::NodeListField].include?(field.class) } -%>
+                <%- if node.fields.any? { |field| [Prism::Template::NodeField, Prism::Template::OptionalNodeField, Prism::Template::NodeListField].include?(field.class) } -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                 case <%= node.type %>: {
                     pm_<%= node.human %>_t *cast = (pm_<%= node.human %>_t *) node;
                     <%- node.fields.each do |field| -%>
                     <%- case field -%>
-                    <%- when Prism::NodeField, Prism::OptionalNodeField -%>
+                    <%- when Prism::Template::NodeField, Prism::Template::OptionalNodeField -%>
                     pm_node_stack_push(&node_stack, (pm_node_t *) cast-><%= field.name %>);
-                    <%- when Prism::NodeListField -%>
+                    <%- when Prism::Template::NodeListField -%>
                     for (size_t index = 0; index < cast-><%= field.name %>.size; index++) {
                         pm_node_stack_push(&node_stack, (pm_node_t *) cast-><%= field.name %>.nodes[index]);
                     }
@@ -159,7 +159,7 @@ pm_ast_new(const pm_parser_t *parser, const pm_node_t *node, rb_encoding *encodi
                 <%- nodes.each do |node| -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                 case <%= node.type %>: {
-                    <%- if node.fields.any? { |field| ![Prism::NodeField, Prism::OptionalNodeField, Prism::FlagsField].include?(field.class) } -%>
+                    <%- if node.fields.any? { |field| ![Prism::Template::NodeField, Prism::Template::OptionalNodeField, Prism::Template::FlagsField].include?(field.class) } -%>
                     pm_<%= node.human %>_t *cast = (pm_<%= node.human %>_t *) node;
                     <%- end -%>
                     VALUE argv[<%= node.fields.length + 2 %>];
@@ -170,50 +170,50 @@ pm_ast_new(const pm_parser_t *parser, const pm_node_t *node, rb_encoding *encodi
 
                     // <%= field.name %>
                     <%- case field -%>
-                    <%- when Prism::NodeField, Prism::OptionalNodeField -%>
+                    <%- when Prism::Template::NodeField, Prism::Template::OptionalNodeField -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = rb_ary_pop(value_stack);
-                    <%- when Prism::NodeListField -%>
+                    <%- when Prism::Template::NodeListField -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = rb_ary_new_capa(cast-><%= field.name %>.size);
                     for (size_t index = 0; index < cast-><%= field.name %>.size; index++) {
                         rb_ary_push(argv[<%= index %>], rb_ary_pop(value_stack));
                     }
-                    <%- when Prism::StringField -%>
+                    <%- when Prism::Template::StringField -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = pm_string_new(&cast-><%= field.name %>, encoding);
-                    <%- when Prism::ConstantField -%>
+                    <%- when Prism::Template::ConstantField -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     assert(cast-><%= field.name %> != 0);
                     argv[<%= index %>] = rb_id2sym(constants[cast-><%= field.name %> - 1]);
-                    <%- when Prism::OptionalConstantField -%>
+                    <%- when Prism::Template::OptionalConstantField -%>
                     argv[<%= index %>] = cast-><%= field.name %> == 0 ? Qnil : rb_id2sym(constants[cast-><%= field.name %> - 1]);
-                    <%- when Prism::ConstantListField -%>
+                    <%- when Prism::Template::ConstantListField -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = rb_ary_new_capa(cast-><%= field.name %>.size);
                     for (size_t index = 0; index < cast-><%= field.name %>.size; index++) {
                         assert(cast-><%= field.name %>.ids[index] != 0);
                         rb_ary_push(argv[<%= index %>], rb_id2sym(constants[cast-><%= field.name %>.ids[index] - 1]));
                     }
-                    <%- when Prism::LocationField -%>
+                    <%- when Prism::Template::LocationField -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = pm_location_new(parser, cast-><%= field.name %>.start, cast-><%= field.name %>.end);
-                    <%- when Prism::OptionalLocationField -%>
+                    <%- when Prism::Template::OptionalLocationField -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = cast-><%= field.name %>.start == NULL ? Qnil : pm_location_new(parser, cast-><%= field.name %>.start, cast-><%= field.name %>.end);
-                    <%- when Prism::UInt8Field -%>
+                    <%- when Prism::Template::UInt8Field -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = UINT2NUM(cast-><%= field.name %>);
-                    <%- when Prism::UInt32Field -%>
+                    <%- when Prism::Template::UInt32Field -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = ULONG2NUM(cast-><%= field.name %>);
-                    <%- when Prism::FlagsField -%>
+                    <%- when Prism::Template::FlagsField -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = ULONG2NUM(node->flags & ~PM_NODE_FLAG_COMMON_MASK);
-                    <%- when Prism::IntegerField -%>
+                    <%- when Prism::Template::IntegerField -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = pm_integer_new(&cast-><%= field.name %>);
-                    <%- when Prism::DoubleField -%>
+                    <%- when Prism::Template::DoubleField -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = DBL2NUM(cast-><%= field.name %>);
                     <%- else -%>

--- a/templates/include/prism/ast.h.erb
+++ b/templates/include/prism/ast.h.erb
@@ -151,7 +151,7 @@ typedef struct pm_node {
  * <%= node.name %>
  *
  * Type: <%= node.type %>
-<%- if (node_flags = node.fields.find { |field| field.is_a? Prism::FlagsField }) -%>
+<%- if (node_flags = node.fields.find { |field| field.is_a? Prism::Template::FlagsField }) -%>
  * Flags:
 <%- found = flags.find { |flag| flag.name == node_flags.kind }.tap { |found| raise "Expected to find #{field.kind}" unless found } -%>
 <%- found.values.each do |value| -%>
@@ -164,7 +164,7 @@ typedef struct pm_node {
 typedef struct pm_<%= node.human %> {
     /** The embedded base node. */
     pm_node_t base;
-<%- node.fields.grep_v(Prism::FlagsField).each do |field| -%>
+<%- node.fields.grep_v(Prism::Template::FlagsField).each do |field| -%>
 
     /**
      * <%= node.name %>#<%= field.name %>
@@ -176,16 +176,16 @@ typedef struct pm_<%= node.human %> {
     <%- end -%>
      */
     <%= case field
-    when Prism::NodeField, Prism::OptionalNodeField then "struct #{field.c_type} *#{field.name}"
-    when Prism::NodeListField then "struct pm_node_list #{field.name}"
-    when Prism::ConstantField, Prism::OptionalConstantField then "pm_constant_id_t #{field.name}"
-    when Prism::ConstantListField then "pm_constant_id_list_t #{field.name}"
-    when Prism::StringField then "pm_string_t #{field.name}"
-    when Prism::LocationField, Prism::OptionalLocationField then "pm_location_t #{field.name}"
-    when Prism::UInt8Field then "uint8_t #{field.name}"
-    when Prism::UInt32Field then "uint32_t #{field.name}"
-    when Prism::IntegerField then "pm_integer_t #{field.name}"
-    when Prism::DoubleField then "double #{field.name}"
+    when Prism::Template::NodeField, Prism::Template::OptionalNodeField then "struct #{field.c_type} *#{field.name}"
+    when Prism::Template::NodeListField then "struct pm_node_list #{field.name}"
+    when Prism::Template::ConstantField, Prism::Template::OptionalConstantField then "pm_constant_id_t #{field.name}"
+    when Prism::Template::ConstantListField then "pm_constant_id_list_t #{field.name}"
+    when Prism::Template::StringField then "pm_string_t #{field.name}"
+    when Prism::Template::LocationField, Prism::Template::OptionalLocationField then "pm_location_t #{field.name}"
+    when Prism::Template::UInt8Field then "uint8_t #{field.name}"
+    when Prism::Template::UInt32Field then "uint32_t #{field.name}"
+    when Prism::Template::IntegerField then "pm_integer_t #{field.name}"
+    when Prism::Template::DoubleField then "double #{field.name}"
     else raise field.class.name
     end
     %>;
@@ -212,6 +212,6 @@ typedef enum pm_<%= flag.human %> {
  * to specify that through the environment. It will never be true except for in
  * those build systems.
  */
-#define PRISM_SERIALIZE_ONLY_SEMANTICS_FIELDS <%= Prism::SERIALIZE_ONLY_SEMANTICS_FIELDS %>
+#define PRISM_SERIALIZE_ONLY_SEMANTICS_FIELDS <%= Prism::Template::SERIALIZE_ONLY_SEMANTICS_FIELDS %>
 
 #endif

--- a/templates/java/org/prism/Loader.java.erb
+++ b/templates/java/org/prism/Loader.java.erb
@@ -1,4 +1,4 @@
-<%- string_type = Prism::JAVA_STRING_TYPE -%>
+<%- string_type = Prism::Template::JAVA_STRING_TYPE -%>
 package org.prism;
 
 import org.prism.Nodes;
@@ -362,23 +362,23 @@ public class Loader {
             params = node.needs_serialized_length? ? ["buffer.getInt()"] : []
             params.concat node.semantic_fields.map { |field|
               case field
-              when Prism::NodeField then "#{field.java_cast}loadNode()"
-              when Prism::OptionalNodeField then "#{field.java_cast}loadOptionalNode()"
-              when Prism::StringField then "loadString()"
-              when Prism::NodeListField then
+              when Prism::Template::NodeField then "#{field.java_cast}loadNode()"
+              when Prism::Template::OptionalNodeField then "#{field.java_cast}loadOptionalNode()"
+              when Prism::Template::StringField then "loadString()"
+              when Prism::Template::NodeListField then
                 element_type = field.java_type.sub('[]', '')
                 array_types << element_type
                 "load#{element_type}s()"
-              when Prism::ConstantField then "loadConstant()"
-              when Prism::OptionalConstantField then "loadOptionalConstant()"
-              when Prism::ConstantListField then "loadConstants()"
-              when Prism::LocationField then "loadLocation()"
-              when Prism::OptionalLocationField then "loadOptionalLocation()"
-              when Prism::UInt8Field then "buffer.get()"
-              when Prism::UInt32Field then "loadVarUInt()"
-              when Prism::FlagsField then "loadFlags()"
-              when Prism::IntegerField then "loadInteger()"
-              when Prism::DoubleField then "buffer.getDouble()"
+              when Prism::Template::ConstantField then "loadConstant()"
+              when Prism::Template::OptionalConstantField then "loadOptionalConstant()"
+              when Prism::Template::ConstantListField then "loadConstants()"
+              when Prism::Template::LocationField then "loadLocation()"
+              when Prism::Template::OptionalLocationField then "loadOptionalLocation()"
+              when Prism::Template::UInt8Field then "buffer.get()"
+              when Prism::Template::UInt32Field then "loadVarUInt()"
+              when Prism::Template::FlagsField then "loadFlags()"
+              when Prism::Template::IntegerField then "loadInteger()"
+              when Prism::Template::DoubleField then "buffer.getDouble()"
               else raise
               end
             }

--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -1,4 +1,4 @@
-<%- string_type = Prism::JAVA_STRING_TYPE -%>
+<%- string_type = Prism::Template::JAVA_STRING_TYPE -%>
 package org.prism;
 
 import java.lang.Override;
@@ -138,7 +138,7 @@ public abstract class Nodes {
     <%- flags.each do |group| -%>
 
     /**
-     * <%= Prism::JavaDoc.escape(group.comment) %>
+     * <%= Prism::Template::JavaDoc.escape(group.comment) %>
      */
     public static final class <%= group.name %> implements Comparable<<%= group.name %>> {
         <%- group.values.each_with_index do |value, index| -%>
@@ -234,7 +234,7 @@ public abstract class Nodes {
         <%- end -%>
         }
         <%# methods for flags -%>
-        <%- node.semantic_fields.grep(Prism::FlagsField).each do |field| -%>
+        <%- node.semantic_fields.grep(Prism::Template::FlagsField).each do |field| -%>
         <%- flags.find { |flag| flag.name == field.kind }.tap { |flag| raise "Expected to find #{field.kind}" unless flag }.values.each do |value| -%>
 
         public boolean is<%= value.camelcase %>() {
@@ -255,9 +255,9 @@ public abstract class Nodes {
         public void setNewLineFlag(Source source, boolean[] newlineMarked) {
           <%- field = node.semantic_fields.find { |f| f.name == node.newline } or raise node.newline -%>
           <%- case field -%>
-          <%- when Prism::NodeField -%>
+          <%- when Prism::Template::NodeField -%>
             this.<%= field.name %>.setNewLineFlag(source, newlineMarked);
-          <%- when Prism::NodeListField -%>
+          <%- when Prism::Template::NodeListField -%>
             Node first = this.<%= field.name %>.length > 0 ? this.<%= field.name %>[0] : null;
             if (first != null) {
                 first.setNewLineFlag(source, newlineMarked);
@@ -270,13 +270,13 @@ public abstract class Nodes {
         public <T> void visitChildNodes(AbstractNodeVisitor<T> visitor) {
           <%- node.semantic_fields.each do |field| -%>
             <%- case field -%>
-            <%- when Prism::NodeListField -%>
+            <%- when Prism::Template::NodeListField -%>
             for (Nodes.Node child : this.<%= field.name %>) {
                 child.accept(visitor);
             }
-            <%- when Prism::NodeField -%>
+            <%- when Prism::Template::NodeField -%>
             this.<%= field.name %>.accept(visitor);
-            <%- when Prism::OptionalNodeField -%>
+            <%- when Prism::Template::OptionalNodeField -%>
             if (this.<%= field.name %> != null) {
                 this.<%= field.name %>.accept(visitor);
             }
@@ -285,19 +285,19 @@ public abstract class Nodes {
         }
 
         public Node[] childNodes() {
-          <%- if node.semantic_fields.none?(Prism::NodeListField) and node.semantic_fields.none?(Prism::NodeKindField) -%>
+          <%- if node.semantic_fields.none?(Prism::Template::NodeListField) and node.semantic_fields.none?(Prism::Template::NodeKindField) -%>
             return EMPTY_ARRAY;
-          <%- elsif node.semantic_fields.one?(Prism::NodeListField) and node.semantic_fields.none?(Prism::NodeKindField) -%>
-            return this.<%= node.semantic_fields.grep(Prism::NodeListField).first.name %>;
-          <%- elsif node.semantic_fields.none?(Prism::NodeListField) -%>
-            return new Node[] { <%= node.semantic_fields.grep(Prism::NodeKindField).map { |field| "this.#{field.name}" }.join(', ') %> };
+          <%- elsif node.semantic_fields.one?(Prism::Template::NodeListField) and node.semantic_fields.none?(Prism::Template::NodeKindField) -%>
+            return this.<%= node.semantic_fields.grep(Prism::Template::NodeListField).first.name %>;
+          <%- elsif node.semantic_fields.none?(Prism::Template::NodeListField) -%>
+            return new Node[] { <%= node.semantic_fields.grep(Prism::Template::NodeKindField).map { |field| "this.#{field.name}" }.join(', ') %> };
           <%- else -%>
             ArrayList<Node> childNodes = new ArrayList<>();
             <%- node.semantic_fields.each do |field| -%>
               <%- case field -%>
-              <%- when Prism::NodeField, Prism::OptionalNodeField -%>
+              <%- when Prism::Template::NodeField, Prism::Template::OptionalNodeField -%>
             childNodes.add(this.<%= field.name %>);
-              <%- when Prism::NodeListField -%>
+              <%- when Prism::Template::NodeListField -%>
             childNodes.addAll(Arrays.asList(this.<%= field.name %>));
               <%- end -%>
             <%- end -%>
@@ -318,37 +318,37 @@ public abstract class Nodes {
             }
             builder.append('\n');
             String nextIndent = indent + "  ";
-            <%- if node.fields.any?(Prism::NodeListField) or node.fields.any?(Prism::ConstantListField) -%>
+            <%- if node.fields.any?(Prism::Template::NodeListField) or node.fields.any?(Prism::Template::ConstantListField) -%>
             String nextNextIndent = nextIndent + "  ";
             <%- end -%>
-            <%- node.fields.grep_v(Prism::LocationField).grep_v(Prism::OptionalLocationField).each do |field| -%>
+            <%- node.fields.grep_v(Prism::Template::LocationField).grep_v(Prism::Template::OptionalLocationField).each do |field| -%>
             builder.append(nextIndent);
             builder.append("<%= field.name %>: ");
             <%- case field -%>
-            <%- when Prism::NodeField -%>
+            <%- when Prism::Template::NodeField -%>
             builder.append(this.<%= field.name %>.toString(nextIndent));
-            <%- when Prism::OptionalNodeField -%>
+            <%- when Prism::Template::OptionalNodeField -%>
             builder.append(this.<%= field.name %> == null ? "null\n" : this.<%= field.name %>.toString(nextIndent));
-            <%- when Prism::NodeListField -%>
+            <%- when Prism::Template::NodeListField -%>
             builder.append('\n');
             for (Node child : this.<%= field.name %>) {
                 builder.append(nextNextIndent).append(child.toString(nextNextIndent));
             }
-            <%- when Prism::StringField -%>
+            <%- when Prism::Template::StringField -%>
             builder.append('"' + new String(this.<%= field.name %>, StandardCharsets.UTF_8) + '"');
             builder.append('\n');
-            <%- when Prism::ConstantField -%>
+            <%- when Prism::Template::ConstantField -%>
             builder.append('"').append(this.<%= field.name %>).append('"');
             builder.append('\n');
-            <%- when Prism::OptionalConstantField -%>
+            <%- when Prism::Template::OptionalConstantField -%>
             builder.append(this.<%= field.name %> == null ? "null" : "\"" + this.<%= field.name %> + "\"");
             builder.append('\n');
-            <%- when Prism::ConstantListField -%>
+            <%- when Prism::Template::ConstantListField -%>
             builder.append('\n');
             for (<%= string_type %> constant : this.<%= field.name %>) {
                 builder.append(nextNextIndent).append('"').append(constant).append('"').append('\n');
             }
-            <%- when Prism::UInt8Field, Prism::UInt32Field, Prism::FlagsField, Prism::IntegerField, Prism::DoubleField -%>
+            <%- when Prism::Template::UInt8Field, Prism::Template::UInt32Field, Prism::Template::FlagsField, Prism::Template::IntegerField, Prism::Template::DoubleField -%>
             builder.append(this.<%= field.name %>);
             builder.append('\n');
             <%- else -%>

--- a/templates/javascript/src/deserialize.js.erb
+++ b/templates/javascript/src/deserialize.js.erb
@@ -292,19 +292,19 @@ export function deserialize(source, array) {
         <%- end -%>
         return new nodes.<%= node.name %>(<%= (node.fields.map { |field|
           case field
-          when Prism::NodeField then "readRequiredNode()"
-          when Prism::OptionalNodeField then "readOptionalNode()"
-          when Prism::StringField then "buffer.readStringField()"
-          when Prism::NodeListField then "Array.from({ length: buffer.readVarInt() }, readRequiredNode)"
-          when Prism::ConstantField then "readRequiredConstant()"
-          when Prism::OptionalConstantField then "readOptionalConstant()"
-          when Prism::ConstantListField then "Array.from({ length: buffer.readVarInt() }, readRequiredConstant)"
-          when Prism::LocationField then "buffer.readLocation()"
-          when Prism::OptionalLocationField then "buffer.readOptionalLocation()"
-          when Prism::UInt8Field then "buffer.readByte()"
-          when Prism::UInt32Field, Prism::FlagsField then "buffer.readVarInt()"
-          when Prism::IntegerField then "readInteger()"
-          when Prism::DoubleField then "buffer.readDouble()"
+          when Prism::Template::NodeField then "readRequiredNode()"
+          when Prism::Template::OptionalNodeField then "readOptionalNode()"
+          when Prism::Template::StringField then "buffer.readStringField()"
+          when Prism::Template::NodeListField then "Array.from({ length: buffer.readVarInt() }, readRequiredNode)"
+          when Prism::Template::ConstantField then "readRequiredConstant()"
+          when Prism::Template::OptionalConstantField then "readOptionalConstant()"
+          when Prism::Template::ConstantListField then "Array.from({ length: buffer.readVarInt() }, readRequiredConstant)"
+          when Prism::Template::LocationField then "buffer.readLocation()"
+          when Prism::Template::OptionalLocationField then "buffer.readOptionalLocation()"
+          when Prism::Template::UInt8Field then "buffer.readByte()"
+          when Prism::Template::UInt32Field, Prism::Template::FlagsField then "buffer.readVarInt()"
+          when Prism::Template::IntegerField then "readInteger()"
+          when Prism::Template::DoubleField then "buffer.readDouble()"
           else raise
           end
         } + ["location"]).join(", ") -%>);

--- a/templates/javascript/src/nodes.js.erb
+++ b/templates/javascript/src/nodes.js.erb
@@ -10,16 +10,16 @@ end
 
 def jstype(field)
   case field
-  when Prism::NodeField then field.ruby_type
-  when Prism::OptionalNodeField then "#{field.ruby_type} | null"
-  when Prism::NodeListField then "Node[]"
-  when Prism::StringField then "string"
-  when Prism::ConstantField then "string"
-  when Prism::OptionalConstantField then "string | null"
-  when Prism::ConstantListField then "string[]"
-  when Prism::LocationField then "Location"
-  when Prism::OptionalLocationField then "Location | null"
-  when Prism::UInt8Field, Prism::UInt32Field, Prism::FlagsField, Prism::IntegerField, Prism::DoubleField then "number"
+  when Prism::Template::NodeField then field.ruby_type
+  when Prism::Template::OptionalNodeField then "#{field.ruby_type} | null"
+  when Prism::Template::NodeListField then "Node[]"
+  when Prism::Template::StringField then "string"
+  when Prism::Template::ConstantField then "string"
+  when Prism::Template::OptionalConstantField then "string | null"
+  when Prism::Template::ConstantListField then "string[]"
+  when Prism::Template::LocationField then "Location"
+  when Prism::Template::OptionalLocationField then "Location | null"
+  when Prism::Template::UInt8Field, Prism::Template::UInt32Field, Prism::Template::FlagsField, Prism::Template::IntegerField, Prism::Template::DoubleField then "number"
   else raise
   end
 end
@@ -61,7 +61,7 @@ export class <%= node.name -%> {
   /**
    * @type <%= jstype(field) %>
    */
-  <%= field.is_a?(Prism::FlagsField) ? "#flags" : prop(field) %>;
+  <%= field.is_a?(Prism::Template::FlagsField) ? "#flags" : prop(field) %>;
 
   <%- end -%>
   /**
@@ -79,7 +79,7 @@ export class <%= node.name -%> {
    */
   constructor(<%= (node.fields.map { |field| prop(field) } + ["location"]).join(", ") %>) {
     <%- node.fields.each do |field| -%>
-    <%- if field.is_a?(Prism::FlagsField) -%>
+    <%- if field.is_a?(Prism::Template::FlagsField) -%>
     this.#flags = flags;
     <%- else -%>
     this.<%= prop(field) %> = <%= prop(field) %>;
@@ -87,7 +87,7 @@ export class <%= node.name -%> {
     <%- end -%>
     this.location = location;
   }
-  <%- if (flags_field = node.fields.find { |field| field.is_a?(Prism::FlagsField) }) -%>
+  <%- if (flags_field = node.fields.find { |field| field.is_a?(Prism::Template::FlagsField) }) -%>
   <%- flag = flags.find { |flag| flag.name == flags_field.kind }.tap { |flag| raise "Expected to find #{field.kind}" unless flag } -%>
   <%- flag.values.each do |value| -%>
 
@@ -119,8 +119,8 @@ export class <%= node.name -%> {
   childNodes() {
     return [<%= node.fields.map { |field|
     case field
-    when Prism::NodeField, Prism::OptionalNodeField then "this.#{prop(field)}"
-    when Prism::NodeListField then "...this.#{prop(field)}"
+    when Prism::Template::NodeField, Prism::Template::OptionalNodeField then "this.#{prop(field)}"
+    when Prism::Template::NodeListField then "...this.#{prop(field)}"
     end
     }.compact.join(", ") %>]
   }
@@ -131,19 +131,19 @@ export class <%= node.name -%> {
    * @returns {Node[]} An array of compacted child nodes.
    */
   compactChildNodes() {
-    <%- if node.fields.any? { |field| field.is_a?(Prism::OptionalNodeField) } -%>
+    <%- if node.fields.any? { |field| field.is_a?(Prism::Template::OptionalNodeField) } -%>
     const compact = [];
 
     <%- node.fields.each do |field| -%>
     <%- case field -%>
-    <%- when Prism::NodeField -%>
+    <%- when Prism::Template::NodeField -%>
     compact.push(this.<%= prop(field) %>);
 
-    <%- when Prism::OptionalNodeField -%>
+    <%- when Prism::Template::OptionalNodeField -%>
     if (this.<%= prop(field) %>) {
       compact.push(this.<%= prop(field) %>);
     }
-    <%- when Prism::NodeListField -%>
+    <%- when Prism::Template::NodeListField -%>
     compact.concat(this.<%= prop(field) %>);
     <%- end -%>
     <%- end -%>
@@ -152,8 +152,8 @@ export class <%= node.name -%> {
     <%- else -%>
     return [<%= node.fields.map { |field|
     case field
-    when Prism::NodeField then "this.#{prop(field)}"
-    when Prism::NodeListField then "...this.#{prop(field)}"
+    when Prism::Template::NodeField then "this.#{prop(field)}"
+    when Prism::Template::NodeListField then "...this.#{prop(field)}"
     end
     }.compact.join(", ") %>];
     <%- end -%>
@@ -168,7 +168,7 @@ export class <%= node.name -%> {
     return {
       type: "<%= node.name %>",
       <%- node.fields.each do |field| -%>
-      <%- if field.is_a?(Prism::FlagsField) -%>
+      <%- if field.is_a?(Prism::Template::FlagsField) -%>
       flags: this.#flags,
       <%- elsif field.name == "arguments" -%>
       arguments: this.<%= prop(field) %>,

--- a/templates/lib/prism/compiler.rb.erb
+++ b/templates/lib/prism/compiler.rb.erb
@@ -16,7 +16,7 @@ module Prism
   #     Prism.parse("1 + 2").value.accept(SExpressions.new)
   #     # => [:program, [[[:call, [[:integer], [:arguments, [[:integer]]]]]]]]
   #
-  class Compiler
+  class Compiler < Visitor
     # Visit an individual node.
     def visit(node)
       node&.accept(self)

--- a/templates/lib/prism/dot_visitor.rb.erb
+++ b/templates/lib/prism/dot_visitor.rb.erb
@@ -113,15 +113,15 @@ module Prism
 
       # <%= field.name %>
       <%- case field -%>
-      <%- when Prism::NodeField -%>
+      <%- when Prism::Template::NodeField -%>
       table.field("<%= field.name %>", port: true)
       digraph.edge("#{id}:<%= field.name %> -> #{node_id(node.<%= field.name %>)};")
-      <%- when Prism::OptionalNodeField -%>
+      <%- when Prism::Template::OptionalNodeField -%>
       unless (<%= field.name %> = node.<%= field.name %>).nil?
         table.field("<%= field.name %>", port: true)
         digraph.edge("#{id}:<%= field.name %> -> #{node_id(<%= field.name %>)};")
       end
-      <%- when Prism::NodeListField -%>
+      <%- when Prism::Template::NodeListField -%>
       if node.<%= field.name %>.any?
         table.field("<%= field.name %>", port: true)
 
@@ -133,15 +133,15 @@ module Prism
       else
         table.field("<%= field.name %>", "[]")
       end
-      <%- when Prism::StringField, Prism::ConstantField, Prism::OptionalConstantField, Prism::UInt8Field, Prism::UInt32Field, Prism::ConstantListField, Prism::IntegerField, Prism::DoubleField -%>
+      <%- when Prism::Template::StringField, Prism::Template::ConstantField, Prism::Template::OptionalConstantField, Prism::Template::UInt8Field, Prism::Template::UInt32Field, Prism::Template::ConstantListField, Prism::Template::IntegerField, Prism::Template::DoubleField -%>
       table.field("<%= field.name %>", node.<%= field.name %>.inspect)
-      <%- when Prism::LocationField -%>
+      <%- when Prism::Template::LocationField -%>
       table.field("<%= field.name %>", location_inspect(node.<%= field.name %>))
-      <%- when Prism::OptionalLocationField -%>
+      <%- when Prism::Template::OptionalLocationField -%>
       unless (<%= field.name %> = node.<%= field.name %>).nil?
         table.field("<%= field.name %>", location_inspect(<%= field.name %>))
       end
-      <%- when Prism::FlagsField -%>
+      <%- when Prism::Template::FlagsField -%>
       <%- flag = flags.find { |flag| flag.name == field.kind }.tap { |flag| raise "Expected to find #{field.kind}" unless flag } -%>
       table.field("<%= field.name %>", <%= flag.human %>_inspect(node))
       <%- else -%>

--- a/templates/lib/prism/mutation_compiler.rb.erb
+++ b/templates/lib/prism/mutation_compiler.rb.erb
@@ -7,9 +7,9 @@ module Prism
 <%= "\n" if index != 0 -%>
     # Copy a <%= node.name %> node
     def visit_<%= node.human %>(node)
-      <%- fields = node.fields.select { |field| [Prism::NodeField, Prism::OptionalNodeField, Prism::NodeListField].include?(field.class) } -%>
+      <%- fields = node.fields.select { |field| [Prism::Template::NodeField, Prism::Template::OptionalNodeField, Prism::Template::NodeListField].include?(field.class) } -%>
       <%- if fields.any? -%>
-      node.copy(<%= fields.map { |field| "#{field.name}: #{field.is_a?(Prism::NodeListField) ? "visit_all" : "visit"}(node.#{field.name})" }.join(", ") %>)
+      node.copy(<%= fields.map { |field| "#{field.name}: #{field.is_a?(Prism::Template::NodeListField) ? "visit_all" : "visit"}(node.#{field.name})" }.join(", ") %>)
       <%- else -%>
       node.copy
       <%- end -%>

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -110,7 +110,7 @@ module Prism
       @newline = false
       @location = location
       <%- node.fields.each do |field| -%>
-      <%- if Prism::CHECK_FIELD_KIND && field.respond_to?(:check_field_kind) -%>
+      <%- if Prism::Template::CHECK_FIELD_KIND && field.respond_to?(:check_field_kind) -%>
       raise <%= field.name %>.inspect unless <%= field.check_field_kind %>
       <%- end -%>
       @<%= field.name %> = <%= field.name %>
@@ -131,9 +131,9 @@ module Prism
     def set_newline_flag(newline_marked) # :nodoc:
       <%- field = node.fields.find { |f| f.name == node.newline } or raise node.newline -%>
       <%- case field -%>
-      <%- when Prism::NodeField -%>
+      <%- when Prism::Template::NodeField -%>
       <%= field.name %>.set_newline_flag(newline_marked)
-      <%- when Prism::NodeListField -%>
+      <%- when Prism::Template::NodeListField -%>
       first = <%= field.name %>.first
       first.set_newline_flag(newline_marked) if first
       <%- else raise field.class.name -%>
@@ -145,23 +145,23 @@ module Prism
     def child_nodes
       [<%= node.fields.map { |field|
         case field
-        when Prism::NodeField, Prism::OptionalNodeField then field.name
-        when Prism::NodeListField then "*#{field.name}"
+        when Prism::Template::NodeField, Prism::Template::OptionalNodeField then field.name
+        when Prism::Template::NodeListField then "*#{field.name}"
         end
       }.compact.join(", ") %>]
     end
 
     # def compact_child_nodes: () -> Array[Node]
     def compact_child_nodes
-      <%- if node.fields.any? { |field| field.is_a?(Prism::OptionalNodeField) } -%>
+      <%- if node.fields.any? { |field| field.is_a?(Prism::Template::OptionalNodeField) } -%>
       compact = [] #: Array[Prism::node]
       <%- node.fields.each do |field| -%>
       <%- case field -%>
-      <%- when Prism::NodeField -%>
+      <%- when Prism::Template::NodeField -%>
       compact << <%= field.name %>
-      <%- when Prism::OptionalNodeField -%>
+      <%- when Prism::Template::OptionalNodeField -%>
       compact << <%= field.name %> if <%= field.name %>
-      <%- when Prism::NodeListField -%>
+      <%- when Prism::Template::NodeListField -%>
       compact.concat(<%= field.name %>)
       <%- end -%>
       <%- end -%>
@@ -169,8 +169,8 @@ module Prism
       <%- else -%>
       [<%= node.fields.map { |field|
         case field
-        when Prism::NodeField then field.name
-        when Prism::NodeListField then "*#{field.name}"
+        when Prism::Template::NodeField then field.name
+        when Prism::Template::NodeListField then "*#{field.name}"
         end
       }.compact.join(", ") %>]
       <%- end -%>
@@ -180,8 +180,8 @@ module Prism
     def comment_targets
       [<%= node.fields.map { |field|
         case field
-        when Prism::NodeField, Prism::LocationField then field.name
-        when Prism::OptionalNodeField, Prism::NodeListField, Prism::OptionalLocationField then "*#{field.name}"
+        when Prism::Template::NodeField, Prism::Template::LocationField then field.name
+        when Prism::Template::OptionalNodeField, Prism::Template::NodeListField, Prism::Template::OptionalLocationField then "*#{field.name}"
         end
       }.compact.join(", ") %>] #: Array[Prism::node | Location]
     end
@@ -201,20 +201,20 @@ module Prism
 
     <%- node.fields.each do |field| -%>
     <%- if field.comment.nil? -%>
-    # <%= "private " if field.is_a?(Prism::FlagsField) %>attr_reader <%= field.name %>: <%= field.rbs_class %>
+    # <%= "private " if field.is_a?(Prism::Template::FlagsField) %>attr_reader <%= field.name %>: <%= field.rbs_class %>
     <%- else -%>
     <%- field.each_comment_line do |line| -%>
     #<%= line %>
     <%- end -%>
     <%- end -%>
     <%- case field -%>
-    <%- when Prism::LocationField -%>
+    <%- when Prism::Template::LocationField -%>
     def <%= field.name %>
       location = @<%= field.name %>
       return location if location.is_a?(Location)
       @<%= field.name %> = Location.new(source, location >> 32, location & 0xFFFFFFFF)
     end
-    <%- when Prism::OptionalLocationField -%>
+    <%- when Prism::Template::OptionalLocationField -%>
     def <%= field.name %>
       location = @<%= field.name %>
       case location
@@ -227,13 +227,13 @@ module Prism
       end
     end
     <%- else -%>
-    attr_reader :<%= field.name -%><%= "\n    private :#{field.name}" if field.is_a?(Prism::FlagsField) %>
+    attr_reader :<%= field.name -%><%= "\n    private :#{field.name}" if field.is_a?(Prism::Template::FlagsField) %>
     <%- end -%>
 
     <%- end -%>
     <%- node.fields.each do |field| -%>
     <%- case field -%>
-    <%- when Prism::LocationField -%>
+    <%- when Prism::Template::LocationField -%>
     <%- raise unless field.name.end_with?("_loc") -%>
     <%- next if node.fields.any? { |other| other.name == field.name.delete_suffix("_loc") } -%>
 
@@ -241,7 +241,7 @@ module Prism
     def <%= field.name.delete_suffix("_loc") %>
       <%= field.name %>.slice
     end
-    <%- when Prism::OptionalLocationField -%>
+    <%- when Prism::Template::OptionalLocationField -%>
     <%- raise unless field.name.end_with?("_loc") -%>
     <%- next if node.fields.any? { |other| other.name == field.name.delete_suffix("_loc") } -%>
 
@@ -249,7 +249,7 @@ module Prism
     def <%= field.name.delete_suffix("_loc") %>
       <%= field.name %>&.slice
     end
-    <%- when Prism::FlagsField -%>
+    <%- when Prism::Template::FlagsField -%>
     <%- flags.find { |flag| flag.name == field.kind }.tap { |flag| raise "Expected to find #{field.kind}" unless flag }.values.each do |value| -%>
 
     # def <%= value.name.downcase %>?: () -> bool
@@ -266,33 +266,33 @@ module Prism
       <%- node.fields.each_with_index do |field, index| -%>
       <%- pointer, preadd = index == node.fields.length - 1 ? ["└── ", "    "] : ["├── ", "│   "] -%>
       <%- case field -%>
-      <%- when Prism::NodeListField -%>
+      <%- when Prism::Template::NodeListField -%>
       inspector << "<%= pointer %><%= field.name %>: #{inspector.list("#{inspector.prefix}<%= preadd %>", <%= field.name %>)}"
-      <%- when Prism::ConstantListField -%>
+      <%- when Prism::Template::ConstantListField -%>
       inspector << "<%= pointer %><%= field.name %>: #{<%= field.name %>.inspect}\n"
-      <%- when Prism::NodeField -%>
+      <%- when Prism::Template::NodeField -%>
       inspector << "<%= pointer %><%= field.name %>:\n"
       inspector << inspector.child_node(<%= field.name %>, "<%= preadd %>")
-      <%- when Prism::OptionalNodeField -%>
+      <%- when Prism::Template::OptionalNodeField -%>
       if (<%= field.name %> = self.<%= field.name %>).nil?
         inspector << "<%= pointer %><%= field.name %>: ∅\n"
       else
         inspector << "<%= pointer %><%= field.name %>:\n"
         inspector << <%= field.name %>.inspect(inspector.child_inspector("<%= preadd %>")).delete_prefix(inspector.prefix)
       end
-      <%- when Prism::ConstantField, Prism::StringField, Prism::UInt8Field, Prism::UInt32Field, Prism::IntegerField, Prism::DoubleField -%>
+      <%- when Prism::Template::ConstantField, Prism::Template::StringField, Prism::Template::UInt8Field, Prism::Template::UInt32Field, Prism::Template::IntegerField, Prism::Template::DoubleField -%>
       inspector << "<%= pointer %><%= field.name %>: #{<%= field.name %>.inspect}\n"
-      <%- when Prism::OptionalConstantField -%>
+      <%- when Prism::Template::OptionalConstantField -%>
       if (<%= field.name %> = self.<%= field.name %>).nil?
         inspector << "<%= pointer %><%= field.name %>: ∅\n"
       else
         inspector << "<%= pointer %><%= field.name %>: #{<%= field.name %>.inspect}\n"
       end
-      <%- when Prism::FlagsField -%>
+      <%- when Prism::Template::FlagsField -%>
       <%- flag = flags.find { |flag| flag.name == field.kind }.tap { |flag| raise unless flag } -%>
       flags = [<%= flag.values.map { |value| "(\"#{value.name.downcase}\" if #{value.name.downcase}?)" }.join(", ") %>].compact
       inspector << "<%= pointer %><%= field.name %>: #{flags.empty? ? "∅" : flags.join(", ")}\n"
-      <%- when Prism::LocationField, Prism::OptionalLocationField -%>
+      <%- when Prism::Template::LocationField, Prism::Template::OptionalLocationField -%>
       inspector << "<%= pointer %><%= field.name %>: #{inspector.location(<%= field.name %>)}\n"
       <%- else -%>
       <%- raise -%>

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -97,6 +97,11 @@ module Prism
     def type
       raise NoMethodError, "undefined method `type' for #{inspect}"
     end
+
+    # Returns a string representation of the node.
+    def inspect(inspector = NodeInspector.new)
+      raise NoMethodError, "undefined method `inspect' for #{inspect}"
+    end
   end
   <%- nodes.each do |node| -%>
 

--- a/templates/lib/prism/serialize.rb.erb
+++ b/templates/lib/prism/serialize.rb.erb
@@ -330,19 +330,19 @@ module Prism
             <%= node.name %>.new(
               source, <%= (node.fields.map { |field|
               case field
-              when Prism::NodeField then "load_node"
-              when Prism::OptionalNodeField then "load_optional_node"
-              when Prism::StringField then "load_string"
-              when Prism::NodeListField then "Array.new(load_varuint) { load_node }"
-              when Prism::ConstantField then "load_required_constant"
-              when Prism::OptionalConstantField then "load_optional_constant"
-              when Prism::ConstantListField then "Array.new(load_varuint) { load_required_constant }"
-              when Prism::LocationField then "load_location"
-              when Prism::OptionalLocationField then "load_optional_location"
-              when Prism::UInt8Field then "io.getbyte"
-              when Prism::UInt32Field, Prism::FlagsField then "load_varuint"
-              when Prism::IntegerField then "load_integer"
-              when Prism::DoubleField then "load_double"
+              when Prism::Template::NodeField then "load_node"
+              when Prism::Template::OptionalNodeField then "load_optional_node"
+              when Prism::Template::StringField then "load_string"
+              when Prism::Template::NodeListField then "Array.new(load_varuint) { load_node }"
+              when Prism::Template::ConstantField then "load_required_constant"
+              when Prism::Template::OptionalConstantField then "load_optional_constant"
+              when Prism::Template::ConstantListField then "Array.new(load_varuint) { load_required_constant }"
+              when Prism::Template::LocationField then "load_location"
+              when Prism::Template::OptionalLocationField then "load_optional_location"
+              when Prism::Template::UInt8Field then "io.getbyte"
+              when Prism::Template::UInt32Field, Prism::Template::FlagsField then "load_varuint"
+              when Prism::Template::IntegerField then "load_integer"
+              when Prism::Template::DoubleField then "load_double"
               else raise
               end
             } + ["location"]).join(", ") -%>)
@@ -367,19 +367,19 @@ module Prism
               <%= node.name %>.new(
                 source, <%= (node.fields.map { |field|
                 case field
-                when Prism::NodeField then "load_node"
-                when Prism::OptionalNodeField then "load_optional_node"
-                when Prism::StringField then "load_string"
-                when Prism::NodeListField then "Array.new(load_varuint) { load_node }"
-                when Prism::ConstantField then "load_required_constant"
-                when Prism::OptionalConstantField then "load_optional_constant"
-                when Prism::ConstantListField then "Array.new(load_varuint) { load_required_constant }"
-                when Prism::LocationField then "load_location"
-                when Prism::OptionalLocationField then "load_optional_location"
-                when Prism::UInt8Field then "io.getbyte"
-                when Prism::UInt32Field, Prism::FlagsField then "load_varuint"
-                when Prism::IntegerField then "load_integer"
-                when Prism::DoubleField then "load_double"
+                when Prism::Template::NodeField then "load_node"
+                when Prism::Template::OptionalNodeField then "load_optional_node"
+                when Prism::Template::StringField then "load_string"
+                when Prism::Template::NodeListField then "Array.new(load_varuint) { load_node }"
+                when Prism::Template::ConstantField then "load_required_constant"
+                when Prism::Template::OptionalConstantField then "load_optional_constant"
+                when Prism::Template::ConstantListField then "Array.new(load_varuint) { load_required_constant }"
+                when Prism::Template::LocationField then "load_location"
+                when Prism::Template::OptionalLocationField then "load_optional_location"
+                when Prism::Template::UInt8Field then "io.getbyte"
+                when Prism::Template::UInt32Field, Prism::Template::FlagsField then "load_varuint"
+                when Prism::Template::IntegerField then "load_integer"
+                when Prism::Template::DoubleField then "load_double"
                 else raise
                 end
               } + ["location"]).join(", ") -%>)

--- a/templates/lib/prism/serialize.rb.erb
+++ b/templates/lib/prism/serialize.rb.erb
@@ -1,15 +1,5 @@
 require "stringio"
-
-# Polyfill for String#unpack1 with the offset parameter.
-if String.instance_method(:unpack1).parameters.none? { |_, name| name == :offset }
-  String.prepend(
-    Module.new {
-      def unpack1(format, offset: 0) # :nodoc:
-        offset == 0 ? super(format) : self[offset..].unpack1(format)
-      end
-    }
-  )
-end
+require "prism/polyfill/string"
 
 module Prism
   # A module responsible for deserializing parse results.

--- a/templates/rbi/prism/node.rbi.erb
+++ b/templates/rbi/prism/node.rbi.erb
@@ -76,19 +76,19 @@ class Prism::<%= node.name -%> < Prism::Node
   def deconstruct_keys(keys); end
   <%- node.fields.each do |field| -%>
   <%- case field -%>
-  <%- when Prism::LocationField -%>
+  <%- when Prism::Template::LocationField -%>
   <%- raise unless field.name.end_with?("_loc") -%>
   <%- next if node.fields.any? { |other| other.name == field.name.delete_suffix("_loc") } -%>
 
   sig { returns(String) }
   def <%= field.name.delete_suffix("_loc") %>; end
-  <%- when Prism::OptionalLocationField -%>
+  <%- when Prism::Template::OptionalLocationField -%>
   <%- raise unless field.name.end_with?("_loc") -%>
   <%- next if node.fields.any? { |other| other.name == field.name.delete_suffix("_loc") } -%>
 
   sig { returns(T.nilable(String)) }
   def <%= field.name.delete_suffix("_loc") %>; end
-  <%- when Prism::FlagsField -%>
+  <%- when Prism::Template::FlagsField -%>
   <%- flags.find { |flag| flag.name == field.kind }.tap { |flag| raise "Expected to find #{field.kind}" unless flag }.values.each do |value| -%>
 
   sig { returns(T::Boolean) }

--- a/templates/rbi/prism/node.rbi.erb
+++ b/templates/rbi/prism/node.rbi.erb
@@ -22,7 +22,7 @@ class Prism::Node
   sig { returns(String) }
   def to_dot; end
 
-  sig { abstract.params(visitor: Prism::Visitor).void }
+  sig { abstract.params(visitor: Prism::Visitor).returns(T.untyped) }
   def accept(visitor); end
 
   sig { abstract.returns(T::Array[T.nilable(Prism::Node)]) }
@@ -39,6 +39,9 @@ class Prism::Node
 
   sig { abstract.returns(Symbol) }
   def type; end
+
+  sig { abstract.params(inspector: Prism::NodeInspector).returns(String) }
+  def inspect(inspector = Prism::NodeInspector.new); end
 end
 <%- nodes.each do |node| -%>
 
@@ -54,7 +57,7 @@ class Prism::<%= node.name -%> < Prism::Node
   sig { params(<%= ["source: Prism::Source", *node.fields.map { |field| "#{field.name}: #{field.rbi_class}" }, "location: Prism::Location"].join(", ") %>).void }
   def initialize(<%= ["source", *node.fields.map(&:name), "location"].join(", ") %>); end
 
-  sig { override.params(visitor: Prism::Visitor).void }
+  sig { override.params(visitor: Prism::Visitor).returns(T.untyped) }
   def accept(visitor); end
 
   sig { override.returns(T::Array[T.nilable(Prism::Node)]) }

--- a/templates/sig/prism/_private/dot_visitor.rbs.erb
+++ b/templates/sig/prism/_private/dot_visitor.rbs.erb
@@ -39,7 +39,7 @@ module Prism
     def location_inspect: (Location location) -> String
 
     <%- flags.each do |flag| -%>
-    def <%= flag.human %>_inspect: (<%= nodes.map { |node| node.name if node.fields.any? { |field| field.is_a?(Prism::FlagsField) && field.kind == flag.name } }.compact.join(" | ") %> node) -> String
+    def <%= flag.human %>_inspect: (<%= nodes.map { |node| node.name if node.fields.any? { |field| field.is_a?(Prism::Template::FlagsField) && field.kind == flag.name } }.compact.join(" | ") %> node) -> String
     <%- end -%>
   end
 end

--- a/templates/sig/prism/node.rbs.erb
+++ b/templates/sig/prism/node.rbs.erb
@@ -33,7 +33,7 @@ module Prism
     include _Node
 
     <%- node.fields.each do |field| -%>
-    <%= "private " if field.is_a?(Prism::FlagsField) %>attr_reader <%= field.name %>: <%= field.rbs_class %>
+    <%= "private " if field.is_a?(Prism::Template::FlagsField) %>attr_reader <%= field.name %>: <%= field.rbs_class %>
     <%- end -%>
 
     def initialize: (<%= ["Source source", *node.fields.map { |field| "#{field.rbs_class} #{field.name}" }, "Location location"].join(", ") %>) -> void
@@ -41,15 +41,15 @@ module Prism
     def deconstruct_keys: (Array[Symbol] keys) -> { <%= (node.fields.map { |field| "#{field.name}: #{field.rbs_class}" } + ["location: Location"]).join(", ") %> }
     <%- node.fields.each do |field| -%>
     <%- case field -%>
-    <%- when Prism::LocationField -%>
+    <%- when Prism::Template::LocationField -%>
     <%- raise unless field.name.end_with?("_loc") -%>
     <%- next if node.fields.any? { |other| other.name == field.name.delete_suffix("_loc") } -%>
     def <%= field.name.delete_suffix("_loc") %>: () -> String
-    <%- when Prism::OptionalLocationField -%>
+    <%- when Prism::Template::OptionalLocationField -%>
     <%- raise unless field.name.end_with?("_loc") -%>
     <%- next if node.fields.any? { |other| other.name == field.name.delete_suffix("_loc") } -%>
     def <%= field.name.delete_suffix("_loc") %>: () -> String?
-    <%- when Prism::FlagsField -%>
+    <%- when Prism::Template::FlagsField -%>
     <%- flags.find { |flag| flag.name == field.kind }.tap { |flag| raise "Expected to find #{field.kind}" unless flag }.values.each do |value| -%>
     def <%= value.name.downcase %>?: () -> bool
     <%- end -%>

--- a/templates/src/node.c.erb
+++ b/templates/src/node.c.erb
@@ -91,25 +91,25 @@ pm_node_destroy(pm_parser_t *parser, pm_node_t *node) {
         <%- nodes.each do |node| -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
         case <%= node.type %>: {
-            <%- if node.fields.any? { |field| ![Prism::LocationField, Prism::OptionalLocationField, Prism::UInt8Field, Prism::UInt32Field, Prism::FlagsField, Prism::ConstantField, Prism::OptionalConstantField, Prism::DoubleField].include?(field.class) } -%>
+            <%- if node.fields.any? { |field| ![Prism::Template::LocationField, Prism::Template::OptionalLocationField, Prism::Template::UInt8Field, Prism::Template::UInt32Field, Prism::Template::FlagsField, Prism::Template::ConstantField, Prism::Template::OptionalConstantField, Prism::Template::DoubleField].include?(field.class) } -%>
             pm_<%= node.human %>_t *cast = (pm_<%= node.human %>_t *) node;
             <%- end -%>
             <%- node.fields.each do |field| -%>
             <%- case field -%>
-            <%- when Prism::LocationField, Prism::OptionalLocationField, Prism::UInt8Field, Prism::UInt32Field, Prism::FlagsField, Prism::ConstantField, Prism::OptionalConstantField, Prism::DoubleField -%>
-            <%- when Prism::NodeField -%>
+            <%- when Prism::Template::LocationField, Prism::Template::OptionalLocationField, Prism::Template::UInt8Field, Prism::Template::UInt32Field, Prism::Template::FlagsField, Prism::Template::ConstantField, Prism::Template::OptionalConstantField, Prism::Template::DoubleField -%>
+            <%- when Prism::Template::NodeField -%>
             pm_node_destroy(parser, (pm_node_t *)cast-><%= field.name %>);
-            <%- when Prism::OptionalNodeField -%>
+            <%- when Prism::Template::OptionalNodeField -%>
             if (cast-><%= field.name %> != NULL) {
                 pm_node_destroy(parser, (pm_node_t *)cast-><%= field.name %>);
             }
-            <%- when Prism::StringField -%>
+            <%- when Prism::Template::StringField -%>
             pm_string_free(&cast-><%= field.name %>);
-            <%- when Prism::NodeListField -%>
+            <%- when Prism::Template::NodeListField -%>
             pm_node_list_destroy(parser, &cast-><%= field.name %>);
-            <%- when Prism::ConstantListField -%>
+            <%- when Prism::Template::ConstantListField -%>
             pm_constant_id_list_free(&cast-><%= field.name %>);
-            <%- when Prism::IntegerField -%>
+            <%- when Prism::Template::IntegerField -%>
             pm_integer_free(&cast-><%= field.name %>);
             <%- else -%>
             <%- raise -%>
@@ -142,20 +142,20 @@ pm_node_memsize_node(pm_node_t *node, pm_memsize_t *memsize) {
             memsize->memsize += sizeof(*cast);
             <%- node.fields.each do |field| -%>
             <%- case field -%>
-            <%- when Prism::ConstantField, Prism::OptionalConstantField, Prism::UInt8Field, Prism::UInt32Field, Prism::FlagsField, Prism::LocationField, Prism::OptionalLocationField, Prism::DoubleField -%>
-            <%- when Prism::NodeField -%>
+            <%- when Prism::Template::ConstantField, Prism::Template::OptionalConstantField, Prism::Template::UInt8Field, Prism::Template::UInt32Field, Prism::Template::FlagsField, Prism::Template::LocationField, Prism::Template::OptionalLocationField, Prism::Template::DoubleField -%>
+            <%- when Prism::Template::NodeField -%>
             pm_node_memsize_node((pm_node_t *)cast-><%= field.name %>, memsize);
-            <%- when Prism::OptionalNodeField -%>
+            <%- when Prism::Template::OptionalNodeField -%>
             if (cast-><%= field.name %> != NULL) {
                 pm_node_memsize_node((pm_node_t *)cast-><%= field.name %>, memsize);
             }
-            <%- when Prism::StringField -%>
+            <%- when Prism::Template::StringField -%>
             memsize->memsize += (pm_string_memsize(&cast-><%= field.name %>) - sizeof(pm_string_t));
-            <%- when Prism::NodeListField -%>
+            <%- when Prism::Template::NodeListField -%>
             memsize->memsize += (pm_node_list_memsize(&cast-><%= field.name %>, memsize) - sizeof(pm_node_list_t));
-            <%- when Prism::ConstantListField -%>
+            <%- when Prism::Template::ConstantListField -%>
             memsize->memsize += (pm_constant_id_list_memsize(&cast-><%= field.name %>) - sizeof(pm_constant_id_list_t));
-            <%- when Prism::IntegerField -%>
+            <%- when Prism::Template::IntegerField -%>
             memsize->memsize += (pm_integer_memsize(&cast-><%= field.name %>) - sizeof(pm_integer_t));
             <%- else -%>
             <%- raise -%>
@@ -214,20 +214,20 @@ PRISM_EXPORTED_FUNCTION void
 pm_visit_child_nodes(const pm_node_t *node, bool (*visitor)(const pm_node_t *node, void *data), void *data) {
     switch (PM_NODE_TYPE(node)) {
         <%- nodes.each do |node| -%>
-        <%- if (fields = node.fields.select { |field| field.is_a?(Prism::NodeField) || field.is_a?(Prism::OptionalNodeField) || field.is_a?(Prism::NodeListField) }).any? -%>
+        <%- if (fields = node.fields.select { |field| field.is_a?(Prism::Template::NodeField) || field.is_a?(Prism::Template::OptionalNodeField) || field.is_a?(Prism::Template::NodeListField) }).any? -%>
         case <%= node.type %>: {
             const pm_<%= node.human %>_t *cast = (const pm_<%= node.human %>_t *) node;
             <%- fields.each do |field| -%>
 
             // Visit the <%= field.name %> field
             <%- case field -%>
-            <%- when Prism::NodeField -%>
+            <%- when Prism::Template::NodeField -%>
             pm_visit_node((const pm_node_t *) cast-><%= field.name %>, visitor, data);
-            <%- when Prism::OptionalNodeField -%>
+            <%- when Prism::Template::OptionalNodeField -%>
             if (cast-><%= field.name %> != NULL) {
                 pm_visit_node((const pm_node_t *) cast-><%= field.name %>, visitor, data);
             }
-            <%- when Prism::NodeListField -%>
+            <%- when Prism::Template::NodeListField -%>
             const pm_node_list_t *<%= field.name %> = &cast-><%= field.name %>;
             for (size_t index = 0; index < <%= field.name %>->size; index++) {
                 pm_visit_node(<%= field.name %>->nodes[index], visitor, data);
@@ -280,15 +280,15 @@ pm_dump_json(pm_buffer_t *buffer, const pm_parser_t *parser, const pm_node_t *no
             pm_buffer_append_byte(buffer, ',');
             pm_buffer_append_string(buffer, "\"<%= field.name %>\":", <%= field.name.bytesize + 3 %>);
             <%- case field -%>
-            <%- when Prism::NodeField -%>
+            <%- when Prism::Template::NodeField -%>
             pm_dump_json(buffer, parser, (const pm_node_t *) cast-><%= field.name %>);
-            <%- when Prism::OptionalNodeField -%>
+            <%- when Prism::Template::OptionalNodeField -%>
             if (cast-><%= field.name %> != NULL) {
                 pm_dump_json(buffer, parser, (const pm_node_t *) cast-><%= field.name %>);
             } else {
                 pm_buffer_append_string(buffer, "null", 4);
             }
-            <%- when Prism::NodeListField -%>
+            <%- when Prism::Template::NodeListField -%>
             const pm_node_list_t *<%= field.name %> = &cast-><%= field.name %>;
             pm_buffer_append_byte(buffer, '[');
 
@@ -297,20 +297,20 @@ pm_dump_json(pm_buffer_t *buffer, const pm_parser_t *parser, const pm_node_t *no
                 pm_dump_json(buffer, parser, <%= field.name %>->nodes[index]);
             }
             pm_buffer_append_byte(buffer, ']');
-            <%- when Prism::StringField -%>
+            <%- when Prism::Template::StringField -%>
             const pm_string_t *<%= field.name %> = &cast-><%= field.name %>;
             pm_buffer_append_byte(buffer, '"');
             pm_buffer_append_source(buffer, pm_string_source(<%= field.name %>), pm_string_length(<%= field.name %>), PM_BUFFER_ESCAPING_JSON);
             pm_buffer_append_byte(buffer, '"');
-            <%- when Prism::ConstantField -%>
+            <%- when Prism::Template::ConstantField -%>
             pm_dump_json_constant(buffer, parser, cast-><%= field.name %>);
-            <%- when Prism::OptionalConstantField -%>
+            <%- when Prism::Template::OptionalConstantField -%>
             if (cast-><%= field.name %> != PM_CONSTANT_ID_UNSET) {
                 pm_dump_json_constant(buffer, parser, cast-><%= field.name %>);
             } else {
                 pm_buffer_append_string(buffer, "null", 4);
             }
-            <%- when Prism::ConstantListField -%>
+            <%- when Prism::Template::ConstantListField -%>
             const pm_constant_id_list_t *<%= field.name %> = &cast-><%= field.name %>;
             pm_buffer_append_byte(buffer, '[');
 
@@ -319,19 +319,19 @@ pm_dump_json(pm_buffer_t *buffer, const pm_parser_t *parser, const pm_node_t *no
                 pm_dump_json_constant(buffer, parser, <%= field.name %>->ids[index]);
             }
             pm_buffer_append_byte(buffer, ']');
-            <%- when Prism::LocationField -%>
+            <%- when Prism::Template::LocationField -%>
             pm_dump_json_location(buffer, parser, &cast-><%= field.name %>);
-            <%- when Prism::OptionalLocationField -%>
+            <%- when Prism::Template::OptionalLocationField -%>
             if (cast-><%= field.name %>.start != NULL) {
                 pm_dump_json_location(buffer, parser, &cast-><%= field.name %>);
             } else {
                 pm_buffer_append_string(buffer, "null", 4);
             }
-            <%- when Prism::UInt8Field -%>
+            <%- when Prism::Template::UInt8Field -%>
             pm_buffer_append_format(buffer, "%" PRIu8, cast-><%= field.name %>);
-            <%- when Prism::UInt32Field -%>
+            <%- when Prism::Template::UInt32Field -%>
             pm_buffer_append_format(buffer, "%" PRIu32, cast-><%= field.name %>);
-            <%- when Prism::FlagsField -%>
+            <%- when Prism::Template::FlagsField -%>
             size_t flags = 0;
             pm_buffer_append_byte(buffer, '[');
             <%- found = flags.find { |flag| flag.name == field.kind }.tap { |found| raise "Expected to find #{field.kind}" unless found } -%>
@@ -343,9 +343,9 @@ pm_dump_json(pm_buffer_t *buffer, const pm_parser_t *parser, const pm_node_t *no
             }
             <%- end -%>
             pm_buffer_append_byte(buffer, ']');
-            <%- when Prism::IntegerField -%>
+            <%- when Prism::Template::IntegerField -%>
             pm_integer_string(buffer, &cast-><%= field.name %>);
-            <%- when Prism::DoubleField -%>
+            <%- when Prism::Template::DoubleField -%>
             pm_buffer_append_format(buffer, "%f", cast-><%= field.name %>);
             <%- else -%>
             <%- raise %>

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -36,7 +36,7 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
                 pm_buffer_concat(output_buffer, prefix_buffer);
                 pm_buffer_append_string(output_buffer, "+-- <%= field.name %>:", <%= 4 + field.name.length + 1 %>);
             <%- case field -%>
-            <%- when Prism::NodeField -%>
+            <%- when Prism::Template::NodeField -%>
                 pm_buffer_append_byte(output_buffer, '\n');
 
                 size_t prefix_length = prefix_buffer->length;
@@ -44,7 +44,7 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
                 pm_buffer_concat(output_buffer, prefix_buffer);
                 prettyprint_node(output_buffer, parser, (pm_node_t *) cast-><%= field.name %>, prefix_buffer);
                 prefix_buffer->length = prefix_length;
-            <%- when Prism::OptionalNodeField -%>
+            <%- when Prism::Template::OptionalNodeField -%>
                 if (cast-><%= field.name %> == NULL) {
                     pm_buffer_append_string(output_buffer, " nil\n", 5);
                 } else {
@@ -56,11 +56,11 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
                     prettyprint_node(output_buffer, parser, (pm_node_t *) cast-><%= field.name %>, prefix_buffer);
                     prefix_buffer->length = prefix_length;
                 }
-            <%- when Prism::StringField -%>
+            <%- when Prism::Template::StringField -%>
                 pm_buffer_append_string(output_buffer, " \"", 2);
                 pm_buffer_append_source(output_buffer, pm_string_source(&cast-><%= field.name %>), pm_string_length(&cast-><%= field.name %>), PM_BUFFER_ESCAPING_RUBY);
                 pm_buffer_append_string(output_buffer, "\"\n", 2);
-            <%- when Prism::NodeListField -%>
+            <%- when Prism::Template::NodeListField -%>
                 pm_buffer_append_format(output_buffer, " (length: %lu)\n", (unsigned long) (cast-><%= field.name %>.size));
 
                 size_t last_index = cast-><%= field.name %>.size;
@@ -73,11 +73,11 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
                     prettyprint_node(output_buffer, parser, (pm_node_t *) cast-><%= field.name %>.nodes[index], prefix_buffer);
                     prefix_buffer->length = prefix_length;
                 }
-            <%- when Prism::ConstantField -%>
+            <%- when Prism::Template::ConstantField -%>
                 pm_buffer_append_byte(output_buffer, ' ');
                 prettyprint_constant(output_buffer, parser, cast-><%= field.name %>);
                 pm_buffer_append_byte(output_buffer, '\n');
-            <%- when Prism::OptionalConstantField -%>
+            <%- when Prism::Template::OptionalConstantField -%>
                 if (cast-><%= field.name %> == 0) {
                     pm_buffer_append_string(output_buffer, " nil\n", 5);
                 } else {
@@ -85,21 +85,21 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
                     prettyprint_constant(output_buffer, parser, cast-><%= field.name %>);
                     pm_buffer_append_byte(output_buffer, '\n');
                 }
-            <%- when Prism::ConstantListField -%>
+            <%- when Prism::Template::ConstantListField -%>
                 pm_buffer_append_string(output_buffer, " [", 2);
                 for (uint32_t index = 0; index < cast-><%= field.name %>.size; index++) {
                     if (index != 0) pm_buffer_append_string(output_buffer, ", ", 2);
                     prettyprint_constant(output_buffer, parser, cast-><%= field.name %>.ids[index]);
                 }
                 pm_buffer_append_string(output_buffer, "]\n", 2);
-            <%- when Prism::LocationField -%>
+            <%- when Prism::Template::LocationField -%>
                 pm_location_t *location = &cast-><%= field.name %>;
                 pm_buffer_append_byte(output_buffer, ' ');
                 prettyprint_location(output_buffer, parser, location);
                 pm_buffer_append_string(output_buffer, " = \"", 4);
                 pm_buffer_append_source(output_buffer, location->start, (size_t) (location->end - location->start), PM_BUFFER_ESCAPING_RUBY);
                 pm_buffer_append_string(output_buffer, "\"\n", 2);
-            <%- when Prism::OptionalLocationField -%>
+            <%- when Prism::Template::OptionalLocationField -%>
                 pm_location_t *location = &cast-><%= field.name %>;
                 if (location->start == NULL) {
                     pm_buffer_append_string(output_buffer, " nil\n", 5);
@@ -110,11 +110,11 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
                     pm_buffer_append_source(output_buffer, location->start, (size_t) (location->end - location->start), PM_BUFFER_ESCAPING_RUBY);
                     pm_buffer_append_string(output_buffer, "\"\n", 2);
                 }
-            <%- when Prism::UInt8Field -%>
+            <%- when Prism::Template::UInt8Field -%>
                 pm_buffer_append_format(output_buffer, " %" PRIu8 "\n", cast-><%= field.name %>);
-            <%- when Prism::UInt32Field -%>
+            <%- when Prism::Template::UInt32Field -%>
                 pm_buffer_append_format(output_buffer, " %" PRIu32 "\n", cast-><%= field.name %>);
-            <%- when Prism::FlagsField -%>
+            <%- when Prism::Template::FlagsField -%>
                 bool found = false;
                 <%- found = flags.find { |flag| flag.name == field.kind }.tap { |found| raise "Expected to find #{field.kind}" unless found } -%>
                 <%- found.values.each do |value| -%>
@@ -126,12 +126,12 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
                 <%- end -%>
                 if (!found) pm_buffer_append_string(output_buffer, " nil", 4);
                 pm_buffer_append_byte(output_buffer, '\n');
-            <%- when Prism::IntegerField -%>
+            <%- when Prism::Template::IntegerField -%>
                 const pm_integer_t *integer = &cast-><%= field.name %>;
                 pm_buffer_append_byte(output_buffer, ' ');
                 pm_integer_string(output_buffer, integer);
                 pm_buffer_append_byte(output_buffer, '\n');
-            <%- when Prism::DoubleField -%>
+            <%- when Prism::Template::DoubleField -%>
                 pm_buffer_append_format(output_buffer, " %f\n", cast-><%= field.name %>);
             <%- else -%>
             <%- raise -%>

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -82,35 +82,35 @@ pm_serialize_node(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
             <%- end -%>
             <%- node.fields.each do |field| -%>
             <%- case field -%>
-            <%- when Prism::NodeField -%>
+            <%- when Prism::Template::NodeField -%>
             pm_serialize_node(parser, (pm_node_t *)((pm_<%= node.human %>_t *)node)-><%= field.name %>, buffer);
-            <%- when Prism::OptionalNodeField -%>
+            <%- when Prism::Template::OptionalNodeField -%>
             if (((pm_<%= node.human %>_t *)node)-><%= field.name %> == NULL) {
                 pm_buffer_append_byte(buffer, 0);
             } else {
                 pm_serialize_node(parser, (pm_node_t *)((pm_<%= node.human %>_t *)node)-><%= field.name %>, buffer);
             }
-            <%- when Prism::StringField -%>
+            <%- when Prism::Template::StringField -%>
             pm_serialize_string(parser, &((pm_<%= node.human %>_t *)node)-><%= field.name %>, buffer);
-            <%- when Prism::NodeListField -%>
+            <%- when Prism::Template::NodeListField -%>
             uint32_t <%= field.name %>_size = pm_sizet_to_u32(((pm_<%= node.human %>_t *)node)-><%= field.name %>.size);
             pm_buffer_append_varuint(buffer, <%= field.name %>_size);
             for (uint32_t index = 0; index < <%= field.name %>_size; index++) {
                 pm_serialize_node(parser, (pm_node_t *) ((pm_<%= node.human %>_t *)node)-><%= field.name %>.nodes[index], buffer);
             }
-            <%- when Prism::ConstantField, Prism::OptionalConstantField -%>
+            <%- when Prism::Template::ConstantField, Prism::Template::OptionalConstantField -%>
             pm_buffer_append_varuint(buffer, pm_sizet_to_u32(((pm_<%= node.human %>_t *)node)-><%= field.name %>));
-            <%- when Prism::ConstantListField -%>
+            <%- when Prism::Template::ConstantListField -%>
             uint32_t <%= field.name %>_size = pm_sizet_to_u32(((pm_<%= node.human %>_t *)node)-><%= field.name %>.size);
             pm_buffer_append_varuint(buffer, <%= field.name %>_size);
             for (uint32_t index = 0; index < <%= field.name %>_size; index++) {
                 pm_buffer_append_varuint(buffer, pm_sizet_to_u32(((pm_<%= node.human %>_t *)node)-><%= field.name %>.ids[index]));
             }
-            <%- when Prism::LocationField -%>
+            <%- when Prism::Template::LocationField -%>
             <%- if field.should_be_serialized? -%>
             pm_serialize_location(parser, &((pm_<%= node.human %>_t *)node)-><%= field.name %>, buffer);
             <%- end -%>
-            <%- when Prism::OptionalLocationField -%>
+            <%- when Prism::Template::OptionalLocationField -%>
             <%- if field.should_be_serialized? -%>
             if (((pm_<%= node.human %>_t *)node)-><%= field.name %>.start == NULL) {
                 pm_buffer_append_byte(buffer, 0);
@@ -119,15 +119,15 @@ pm_serialize_node(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
                 pm_serialize_location(parser, &((pm_<%= node.human %>_t *)node)-><%= field.name %>, buffer);
             }
             <%- end -%>
-            <%- when Prism::UInt8Field -%>
+            <%- when Prism::Template::UInt8Field -%>
             pm_buffer_append_byte(buffer, ((pm_<%= node.human %>_t *)node)-><%= field.name %>);
-            <%- when Prism::UInt32Field -%>
+            <%- when Prism::Template::UInt32Field -%>
             pm_buffer_append_varuint(buffer, ((pm_<%= node.human %>_t *)node)-><%= field.name %>);
-            <%- when Prism::FlagsField -%>
+            <%- when Prism::Template::FlagsField -%>
             pm_buffer_append_varuint(buffer, (uint32_t)(node->flags & ~PM_NODE_FLAG_COMMON_MASK));
-            <%- when Prism::IntegerField -%>
+            <%- when Prism::Template::IntegerField -%>
             pm_serialize_integer(&((pm_<%= node.human %>_t *)node)-><%= field.name %>, buffer);
-            <%- when Prism::DoubleField -%>
+            <%- when Prism::Template::DoubleField -%>
             pm_buffer_append_double(buffer, ((pm_<%= node.human %>_t *)node)-><%= field.name %>);
             <%- else -%>
             <%- raise -%>
@@ -246,7 +246,7 @@ pm_serialize_metadata(pm_parser_t *parser, pm_buffer_t *buffer) {
     pm_serialize_encoding(parser->encoding, buffer);
     pm_buffer_append_varsint(buffer, parser->start_line);
     pm_serialize_newline_list(&parser->newline_list, buffer);
-<%- unless Prism::SERIALIZE_ONLY_SEMANTICS_FIELDS -%>
+<%- unless Prism::Template::SERIALIZE_ONLY_SEMANTICS_FIELDS -%>
     pm_serialize_comment_list(parser, &parser->comment_list, buffer);
 <%- end -%>
     pm_serialize_magic_comment_list(parser, &parser->magic_comment_list, buffer);

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -6,632 +6,634 @@ require "fileutils"
 require "yaml"
 
 module Prism
-  SERIALIZE_ONLY_SEMANTICS_FIELDS = ENV.fetch("PRISM_SERIALIZE_ONLY_SEMANTICS_FIELDS", false)
-  CHECK_FIELD_KIND = ENV.fetch("CHECK_FIELD_KIND", false)
+  module Template
+    SERIALIZE_ONLY_SEMANTICS_FIELDS = ENV.fetch("PRISM_SERIALIZE_ONLY_SEMANTICS_FIELDS", false)
+    CHECK_FIELD_KIND = ENV.fetch("CHECK_FIELD_KIND", false)
 
-  JAVA_BACKEND = ENV["PRISM_JAVA_BACKEND"] || "truffleruby"
-  JAVA_STRING_TYPE = JAVA_BACKEND == "jruby" ? "org.jruby.RubySymbol" : "String"
+    JAVA_BACKEND = ENV["PRISM_JAVA_BACKEND"] || "truffleruby"
+    JAVA_STRING_TYPE = JAVA_BACKEND == "jruby" ? "org.jruby.RubySymbol" : "String"
 
-  # This module contains methods for escaping characters in JavaDoc comments.
-  module JavaDoc
-    ESCAPES = {
-      "'" => "&#39;",
-      "\"" => "&quot;",
-      "@" => "&#64;",
-      "&" => "&amp;",
-      "<" => "&lt;",
-      ">" => "&gt;"
-    }.freeze
+    # This module contains methods for escaping characters in JavaDoc comments.
+    module JavaDoc
+      ESCAPES = {
+        "'" => "&#39;",
+        "\"" => "&quot;",
+        "@" => "&#64;",
+        "&" => "&amp;",
+        "<" => "&lt;",
+        ">" => "&gt;"
+      }.freeze
 
-    def self.escape(value)
-      value.gsub(/['&"<>@]/, ESCAPES)
-    end
-  end
-
-  # A comment attached to a field or node.
-  class ConfigComment
-    attr_reader :value
-
-    def initialize(value)
-      @value = value
-    end
-
-    def each_line(&block)
-      value.each_line { |line| yield line.prepend(" ").rstrip }
-    end
-
-    def each_java_line(&block)
-      ConfigComment.new(JavaDoc.escape(value)).each_line(&block)
-    end
-  end
-
-  # This represents a field on a node. It contains all of the necessary
-  # information to template out the code for that field.
-  class Field
-    attr_reader :name, :comment, :options
-
-    def initialize(name:, comment: nil, **options)
-      @name = name
-      @comment = comment
-      @options = options
-    end
-
-    def each_comment_line(&block)
-      ConfigComment.new(comment).each_line(&block) if comment
-    end
-
-    def each_comment_java_line(&block)
-      ConfigComment.new(comment).each_java_line(&block) if comment
-    end
-
-    def semantic_field?
-      true
-    end
-
-    def should_be_serialized?
-      SERIALIZE_ONLY_SEMANTICS_FIELDS ? semantic_field? : true
-    end
-  end
-
-  # Some node fields can be specialized if they point to a specific kind of
-  # node and not just a generic node.
-  class NodeKindField < Field
-    def c_type
-      if specific_kind
-        "pm_#{specific_kind.gsub(/(?<=.)[A-Z]/, "_\\0").downcase}"
-      else
-        "pm_node"
+      def self.escape(value)
+        value.gsub(/['&"<>@]/, ESCAPES)
       end
     end
 
-    def ruby_type
-      specific_kind || "Node"
-    end
+    # A comment attached to a field or node.
+    class ConfigComment
+      attr_reader :value
 
-    def java_type
-      specific_kind || "Node"
-    end
+      def initialize(value)
+        @value = value
+      end
 
-    def java_cast
-      if specific_kind
-        "(Nodes.#{options[:kind]}) "
-      else
-        ""
+      def each_line(&block)
+        value.each_line { |line| yield line.prepend(" ").rstrip }
+      end
+
+      def each_java_line(&block)
+        ConfigComment.new(JavaDoc.escape(value)).each_line(&block)
       end
     end
 
-    def specific_kind
-      options[:kind] unless options[:kind].is_a?(Array)
-    end
+    # This represents a field on a node. It contains all of the necessary
+    # information to template out the code for that field.
+    class Field
+      attr_reader :name, :comment, :options
 
-    def union_kind
-      options[:kind] if options[:kind].is_a?(Array)
-    end
-  end
+      def initialize(name:, comment: nil, **options)
+        @name = name
+        @comment = comment
+        @options = options
+      end
 
-  # This represents a field on a node that is itself a node. We pass them as
-  # references and store them as references.
-  class NodeField < NodeKindField
-    def rbs_class
-      if specific_kind
-        specific_kind
-      elsif union_kind
-        union_kind.join(" | ")
-      else
-        "Prism::node"
+      def each_comment_line(&block)
+        ConfigComment.new(comment).each_line(&block) if comment
+      end
+
+      def each_comment_java_line(&block)
+        ConfigComment.new(comment).each_java_line(&block) if comment
+      end
+
+      def semantic_field?
+        true
+      end
+
+      def should_be_serialized?
+        SERIALIZE_ONLY_SEMANTICS_FIELDS ? semantic_field? : true
       end
     end
 
-    def rbi_class
-      if specific_kind
-        "Prism::#{specific_kind}"
-      elsif union_kind
-        "T.any(#{union_kind.map { |kind| "Prism::#{kind}" }.join(", ")})"
-      else
-        "Prism::Node"
-      end
-    end
-
-    def check_field_kind
-      if union_kind
-        "[#{union_kind.join(', ')}].include?(#{name}.class)"
-      else
-        "#{name}.is_a?(#{ruby_type})"
-      end
-    end
-  end
-
-  # This represents a field on a node that is itself a node and can be
-  # optionally null. We pass them as references and store them as references.
-  class OptionalNodeField < NodeKindField
-    def rbs_class
-      if specific_kind
-        "#{specific_kind}?"
-      elsif union_kind
-        [*union_kind, "nil"].join(" | ")
-      else
-        "Prism::node?"
-      end
-    end
-
-    def rbi_class
-      if specific_kind
-        "T.nilable(Prism::#{specific_kind})"
-      elsif union_kind
-        "T.nilable(T.any(#{union_kind.map { |kind| "Prism::#{kind}" }.join(", ")}))"
-      else
-        "T.nilable(Prism::Node)"
-      end
-    end
-
-    def check_field_kind
-      if union_kind
-        "[#{union_kind.join(', ')}, NilClass].include?(#{name}.class)"
-      else
-        "#{name}.nil? || #{name}.is_a?(#{ruby_type})"
-      end
-    end
-  end
-
-  # This represents a field on a node that is a list of nodes. We pass them as
-  # references and store them directly on the struct.
-  class NodeListField < NodeKindField
-    def rbs_class
-      if specific_kind
-        "Array[#{specific_kind}]"
-      elsif union_kind
-        "Array[#{union_kind.join(" | ")}]"
-      else
-        "Array[Prism::node]"
-      end
-    end
-
-    def rbi_class
-      if specific_kind
-        "T::Array[Prism::#{specific_kind}]"
-      elsif union_kind
-        "T::Array[T.any(#{union_kind.map { |kind| "Prism::#{kind}" }.join(", ")})]"
-      else
-        "T::Array[Prism::Node]"
-      end
-    end
-
-    def java_type
-      "#{super}[]"
-    end
-
-    def check_field_kind
-      if union_kind
-        "#{name}.all? { |n| [#{union_kind.join(', ')}].include?(n.class) }"
-      else
-        "#{name}.all? { |n| n.is_a?(#{ruby_type}) }"
-      end
-    end
-  end
-
-  # This represents a field on a node that is the ID of a string interned
-  # through the parser's constant pool.
-  class ConstantField < Field
-    def rbs_class
-      "Symbol"
-    end
-
-    def rbi_class
-      "Symbol"
-    end
-
-    def java_type
-      JAVA_STRING_TYPE
-    end
-  end
-
-  # This represents a field on a node that is the ID of a string interned
-  # through the parser's constant pool and can be optionally null.
-  class OptionalConstantField < Field
-    def rbs_class
-      "Symbol?"
-    end
-
-    def rbi_class
-      "T.nilable(Symbol)"
-    end
-
-    def java_type
-      JAVA_STRING_TYPE
-    end
-  end
-
-  # This represents a field on a node that is a list of IDs that are associated
-  # with strings interned through the parser's constant pool.
-  class ConstantListField < Field
-    def rbs_class
-      "Array[Symbol]"
-    end
-
-    def rbi_class
-      "T::Array[Symbol]"
-    end
-
-    def java_type
-      "#{JAVA_STRING_TYPE}[]"
-    end
-  end
-
-  # This represents a field on a node that is a string.
-  class StringField < Field
-    def rbs_class
-      "String"
-    end
-
-    def rbi_class
-      "String"
-    end
-
-    def java_type
-      "byte[]"
-    end
-  end
-
-  # This represents a field on a node that is a location.
-  class LocationField < Field
-    def semantic_field?
-      false
-    end
-
-    def rbs_class
-      "Location"
-    end
-
-    def rbi_class
-      "Prism::Location"
-    end
-
-    def java_type
-      "Location"
-    end
-  end
-
-  # This represents a field on a node that is a location that is optional.
-  class OptionalLocationField < Field
-    def semantic_field?
-      false
-    end
-
-    def rbs_class
-      "Location?"
-    end
-
-    def rbi_class
-      "T.nilable(Prism::Location)"
-    end
-
-    def java_type
-      "Location"
-    end
-  end
-
-  # This represents an integer field.
-  class UInt8Field < Field
-    def rbs_class
-      "Integer"
-    end
-
-    def rbi_class
-      "Integer"
-    end
-
-    def java_type
-      "int"
-    end
-  end
-
-  # This represents an integer field.
-  class UInt32Field < Field
-    def rbs_class
-      "Integer"
-    end
-
-    def rbi_class
-      "Integer"
-    end
-
-    def java_type
-      "int"
-    end
-  end
-
-  # This represents a set of flags. It is very similar to the UInt32Field, but
-  # can be directly embedded into the flags field on the struct and provides
-  # convenient methods for checking if a flag is set.
-  class FlagsField < Field
-    def rbs_class
-      "Integer"
-    end
-
-    def rbi_class
-      "Integer"
-    end
-
-    def java_type
-      "short"
-    end
-
-    def kind
-      options.fetch(:kind)
-    end
-  end
-
-  # This represents an arbitrarily-sized integer. When it gets to Ruby it will
-  # be an Integer.
-  class IntegerField < Field
-    def rbs_class
-      "Integer"
-    end
-
-    def rbi_class
-      "Integer"
-    end
-
-    def java_type
-      "Object"
-    end
-  end
-
-  # This represents a double-precision floating point number. When it gets to
-  # Ruby it will be a Float.
-  class DoubleField < Field
-    def rbs_class
-      "Float"
-    end
-
-    def rbi_class
-      "Float"
-    end
-
-    def java_type
-      "double"
-    end
-  end
-
-  # This class represents a node in the tree, configured by the config.yml file
-  # in YAML format. It contains information about the name of the node and the
-  # various child nodes it contains.
-  class NodeType
-    attr_reader :name, :type, :human, :fields, :newline, :comment
-
-    def initialize(config)
-      @name = config.fetch("name")
-
-      type = @name.gsub(/(?<=.)[A-Z]/, "_\\0")
-      @type = "PM_#{type.upcase}"
-      @human = type.downcase
-
-      @fields =
-        config.fetch("fields", []).map do |field|
-          type = field_type_for(field.fetch("type"))
-
-          options = field.transform_keys(&:to_sym)
-          options.delete(:type)
-
-          # If/when we have documentation on every field, this should be changed
-          # to use fetch instead of delete.
-          comment = options.delete(:comment)
-
-          type.new(comment: comment, **options)
+    # Some node fields can be specialized if they point to a specific kind of
+    # node and not just a generic node.
+    class NodeKindField < Field
+      def c_type
+        if specific_kind
+          "pm_#{specific_kind.gsub(/(?<=.)[A-Z]/, "_\\0").downcase}"
+        else
+          "pm_node"
         end
+      end
 
-      @newline = config.fetch("newline", true)
-      @comment = config.fetch("comment")
-    end
+      def ruby_type
+        specific_kind || "Node"
+      end
 
-    def each_comment_line(&block)
-      ConfigComment.new(comment).each_line(&block)
-    end
+      def java_type
+        specific_kind || "Node"
+      end
 
-    def each_comment_java_line(&block)
-      ConfigComment.new(comment).each_java_line(&block)
-    end
+      def java_cast
+        if specific_kind
+          "(Nodes.#{options[:kind]}) "
+        else
+          ""
+        end
+      end
 
-    def semantic_fields
-      @semantic_fields ||= @fields.select(&:semantic_field?)
-    end
+      def specific_kind
+        options[:kind] unless options[:kind].is_a?(Array)
+      end
 
-    # Should emit serialized length of node so implementations can skip
-    # the node to enable lazy parsing.
-    def needs_serialized_length?
-      name == "DefNode"
-    end
-
-    private
-
-    def field_type_for(name)
-      case name
-      when "node"       then NodeField
-      when "node?"      then OptionalNodeField
-      when "node[]"     then NodeListField
-      when "string"     then StringField
-      when "constant"   then ConstantField
-      when "constant?"  then OptionalConstantField
-      when "constant[]" then ConstantListField
-      when "location"   then LocationField
-      when "location?"  then OptionalLocationField
-      when "uint8"      then UInt8Field
-      when "uint32"     then UInt32Field
-      when "flags"      then FlagsField
-      when "integer"    then IntegerField
-      when "double"     then DoubleField
-      else raise("Unknown field type: #{name.inspect}")
+      def union_kind
+        options[:kind] if options[:kind].is_a?(Array)
       end
     end
-  end
 
-  # This represents a token in the lexer.
-  class Token
-    attr_reader :name, :value, :comment
+    # This represents a field on a node that is itself a node. We pass them as
+    # references and store them as references.
+    class NodeField < NodeKindField
+      def rbs_class
+        if specific_kind
+          specific_kind
+        elsif union_kind
+          union_kind.join(" | ")
+        else
+          "Prism::node"
+        end
+      end
 
-    def initialize(config)
-      @name = config.fetch("name")
-      @value = config["value"]
-      @comment = config.fetch("comment")
+      def rbi_class
+        if specific_kind
+          "Prism::#{specific_kind}"
+        elsif union_kind
+          "T.any(#{union_kind.map { |kind| "Prism::#{kind}" }.join(", ")})"
+        else
+          "Prism::Node"
+        end
+      end
+
+      def check_field_kind
+        if union_kind
+          "[#{union_kind.join(', ')}].include?(#{name}.class)"
+        else
+          "#{name}.is_a?(#{ruby_type})"
+        end
+      end
     end
-  end
 
-  # Represents a set of flags that should be internally represented with an enum.
-  class Flags
-    # Represents an individual flag within a set of flags.
-    class Flag
-      attr_reader :name, :camelcase, :comment
+    # This represents a field on a node that is itself a node and can be
+    # optionally null. We pass them as references and store them as references.
+    class OptionalNodeField < NodeKindField
+      def rbs_class
+        if specific_kind
+          "#{specific_kind}?"
+        elsif union_kind
+          [*union_kind, "nil"].join(" | ")
+        else
+          "Prism::node?"
+        end
+      end
+
+      def rbi_class
+        if specific_kind
+          "T.nilable(Prism::#{specific_kind})"
+        elsif union_kind
+          "T.nilable(T.any(#{union_kind.map { |kind| "Prism::#{kind}" }.join(", ")}))"
+        else
+          "T.nilable(Prism::Node)"
+        end
+      end
+
+      def check_field_kind
+        if union_kind
+          "[#{union_kind.join(', ')}, NilClass].include?(#{name}.class)"
+        else
+          "#{name}.nil? || #{name}.is_a?(#{ruby_type})"
+        end
+      end
+    end
+
+    # This represents a field on a node that is a list of nodes. We pass them as
+    # references and store them directly on the struct.
+    class NodeListField < NodeKindField
+      def rbs_class
+        if specific_kind
+          "Array[#{specific_kind}]"
+        elsif union_kind
+          "Array[#{union_kind.join(" | ")}]"
+        else
+          "Array[Prism::node]"
+        end
+      end
+
+      def rbi_class
+        if specific_kind
+          "T::Array[Prism::#{specific_kind}]"
+        elsif union_kind
+          "T::Array[T.any(#{union_kind.map { |kind| "Prism::#{kind}" }.join(", ")})]"
+        else
+          "T::Array[Prism::Node]"
+        end
+      end
+
+      def java_type
+        "#{super}[]"
+      end
+
+      def check_field_kind
+        if union_kind
+          "#{name}.all? { |n| [#{union_kind.join(', ')}].include?(n.class) }"
+        else
+          "#{name}.all? { |n| n.is_a?(#{ruby_type}) }"
+        end
+      end
+    end
+
+    # This represents a field on a node that is the ID of a string interned
+    # through the parser's constant pool.
+    class ConstantField < Field
+      def rbs_class
+        "Symbol"
+      end
+
+      def rbi_class
+        "Symbol"
+      end
+
+      def java_type
+        JAVA_STRING_TYPE
+      end
+    end
+
+    # This represents a field on a node that is the ID of a string interned
+    # through the parser's constant pool and can be optionally null.
+    class OptionalConstantField < Field
+      def rbs_class
+        "Symbol?"
+      end
+
+      def rbi_class
+        "T.nilable(Symbol)"
+      end
+
+      def java_type
+        JAVA_STRING_TYPE
+      end
+    end
+
+    # This represents a field on a node that is a list of IDs that are associated
+    # with strings interned through the parser's constant pool.
+    class ConstantListField < Field
+      def rbs_class
+        "Array[Symbol]"
+      end
+
+      def rbi_class
+        "T::Array[Symbol]"
+      end
+
+      def java_type
+        "#{JAVA_STRING_TYPE}[]"
+      end
+    end
+
+    # This represents a field on a node that is a string.
+    class StringField < Field
+      def rbs_class
+        "String"
+      end
+
+      def rbi_class
+        "String"
+      end
+
+      def java_type
+        "byte[]"
+      end
+    end
+
+    # This represents a field on a node that is a location.
+    class LocationField < Field
+      def semantic_field?
+        false
+      end
+
+      def rbs_class
+        "Location"
+      end
+
+      def rbi_class
+        "Prism::Location"
+      end
+
+      def java_type
+        "Location"
+      end
+    end
+
+    # This represents a field on a node that is a location that is optional.
+    class OptionalLocationField < Field
+      def semantic_field?
+        false
+      end
+
+      def rbs_class
+        "Location?"
+      end
+
+      def rbi_class
+        "T.nilable(Prism::Location)"
+      end
+
+      def java_type
+        "Location"
+      end
+    end
+
+    # This represents an integer field.
+    class UInt8Field < Field
+      def rbs_class
+        "Integer"
+      end
+
+      def rbi_class
+        "Integer"
+      end
+
+      def java_type
+        "int"
+      end
+    end
+
+    # This represents an integer field.
+    class UInt32Field < Field
+      def rbs_class
+        "Integer"
+      end
+
+      def rbi_class
+        "Integer"
+      end
+
+      def java_type
+        "int"
+      end
+    end
+
+    # This represents a set of flags. It is very similar to the UInt32Field, but
+    # can be directly embedded into the flags field on the struct and provides
+    # convenient methods for checking if a flag is set.
+    class FlagsField < Field
+      def rbs_class
+        "Integer"
+      end
+
+      def rbi_class
+        "Integer"
+      end
+
+      def java_type
+        "short"
+      end
+
+      def kind
+        options.fetch(:kind)
+      end
+    end
+
+    # This represents an arbitrarily-sized integer. When it gets to Ruby it will
+    # be an Integer.
+    class IntegerField < Field
+      def rbs_class
+        "Integer"
+      end
+
+      def rbi_class
+        "Integer"
+      end
+
+      def java_type
+        "Object"
+      end
+    end
+
+    # This represents a double-precision floating point number. When it gets to
+    # Ruby it will be a Float.
+    class DoubleField < Field
+      def rbs_class
+        "Float"
+      end
+
+      def rbi_class
+        "Float"
+      end
+
+      def java_type
+        "double"
+      end
+    end
+
+    # This class represents a node in the tree, configured by the config.yml file
+    # in YAML format. It contains information about the name of the node and the
+    # various child nodes it contains.
+    class NodeType
+      attr_reader :name, :type, :human, :fields, :newline, :comment
 
       def initialize(config)
         @name = config.fetch("name")
-        @camelcase = @name.split("_").map(&:capitalize).join
+
+        type = @name.gsub(/(?<=.)[A-Z]/, "_\\0")
+        @type = "PM_#{type.upcase}"
+        @human = type.downcase
+
+        @fields =
+          config.fetch("fields", []).map do |field|
+            type = field_type_for(field.fetch("type"))
+
+            options = field.transform_keys(&:to_sym)
+            options.delete(:type)
+
+            # If/when we have documentation on every field, this should be changed
+            # to use fetch instead of delete.
+            comment = options.delete(:comment)
+
+            type.new(comment: comment, **options)
+          end
+
+        @newline = config.fetch("newline", true)
+        @comment = config.fetch("comment")
+      end
+
+      def each_comment_line(&block)
+        ConfigComment.new(comment).each_line(&block)
+      end
+
+      def each_comment_java_line(&block)
+        ConfigComment.new(comment).each_java_line(&block)
+      end
+
+      def semantic_fields
+        @semantic_fields ||= @fields.select(&:semantic_field?)
+      end
+
+      # Should emit serialized length of node so implementations can skip
+      # the node to enable lazy parsing.
+      def needs_serialized_length?
+        name == "DefNode"
+      end
+
+      private
+
+      def field_type_for(name)
+        case name
+        when "node"       then NodeField
+        when "node?"      then OptionalNodeField
+        when "node[]"     then NodeListField
+        when "string"     then StringField
+        when "constant"   then ConstantField
+        when "constant?"  then OptionalConstantField
+        when "constant[]" then ConstantListField
+        when "location"   then LocationField
+        when "location?"  then OptionalLocationField
+        when "uint8"      then UInt8Field
+        when "uint32"     then UInt32Field
+        when "flags"      then FlagsField
+        when "integer"    then IntegerField
+        when "double"     then DoubleField
+        else raise("Unknown field type: #{name.inspect}")
+        end
+      end
+    end
+
+    # This represents a token in the lexer.
+    class Token
+      attr_reader :name, :value, :comment
+
+      def initialize(config)
+        @name = config.fetch("name")
+        @value = config["value"]
         @comment = config.fetch("comment")
       end
     end
 
-    attr_reader :name, :human, :values, :comment
+    # Represents a set of flags that should be internally represented with an enum.
+    class Flags
+      # Represents an individual flag within a set of flags.
+      class Flag
+        attr_reader :name, :camelcase, :comment
 
-    def initialize(config)
-      @name = config.fetch("name")
-      @human = @name.gsub(/(?<=.)[A-Z]/, "_\\0").downcase
-      @values = config.fetch("values").map { |flag| Flag.new(flag) }
-      @comment = config.fetch("comment")
-    end
-  end
-
-  class << self
-    # This templates out a file using ERB with the given locals. The locals are
-    # derived from the config.yml file.
-    def template(name, write_to: nil)
-      filepath = "templates/#{name}.erb"
-      template = File.expand_path("../#{filepath}", __dir__)
-
-      erb = read_template(template)
-      extension = File.extname(filepath.gsub(".erb", ""))
-
-      heading = case extension
-      when ".rb"
-        <<~HEADING
-        # frozen_string_literal: true
-
-        =begin
-        This file is generated by the templates/template.rb script and should not be
-        modified manually. See #{filepath}
-        if you are looking to modify the template
-        =end
-
-        HEADING
-      when ".rbs"
-        <<~HEADING
-        # This file is generated by the templates/template.rb script and should not be
-        # modified manually. See #{filepath}
-        # if you are looking to modify the template
-
-        HEADING
-      when ".rbi"
-        <<~HEADING
-        # typed: strict
-
-        =begin
-        This file is generated by the templates/template.rb script and should not be
-        modified manually. See #{filepath}
-        if you are looking to modify the template
-        =end
-
-        HEADING
-      else
-        <<~HEADING
-        /******************************************************************************/
-        /* This file is generated by the templates/template.rb script and should not  */
-        /* be modified manually. See                                                  */
-        /* #{filepath + " " * (74 - filepath.size) } */
-        /* if you are looking to modify the                                           */
-        /* template                                                                   */
-        /******************************************************************************/
-
-        HEADING
-      end
-
-      write_to ||= File.expand_path("../#{name}", __dir__)
-      contents = heading + erb.result_with_hash(locals)
-
-      if (extension == ".c" || extension == ".h") && !contents.ascii_only?
-        # Enforce that we only have ASCII characters here. This is necessary
-        # for non-UTF-8 locales that only allow ASCII characters in C source
-        # files.
-        contents.each_line.with_index(1) do |line, line_number|
-          raise "Non-ASCII character on line #{line_number} of #{write_to}" unless line.ascii_only?
+        def initialize(config)
+          @name = config.fetch("name")
+          @camelcase = @name.split("_").map(&:capitalize).join
+          @comment = config.fetch("comment")
         end
       end
 
-      FileUtils.mkdir_p(File.dirname(write_to))
-      File.write(write_to, contents)
+      attr_reader :name, :human, :values, :comment
+
+      def initialize(config)
+        @name = config.fetch("name")
+        @human = @name.gsub(/(?<=.)[A-Z]/, "_\\0").downcase
+        @values = config.fetch("values").map { |flag| Flag.new(flag) }
+        @comment = config.fetch("comment")
+      end
     end
 
-    private
+    class << self
+      # This templates out a file using ERB with the given locals. The locals are
+      # derived from the config.yml file.
+      def render(name, write_to: nil)
+        filepath = "templates/#{name}.erb"
+        template = File.expand_path("../#{filepath}", __dir__)
 
-    def read_template(filepath)
-      template = File.read(filepath, encoding: Encoding::UTF_8)
-      erb = erb(template)
-      erb.filename = filepath
-      erb
-    end
+        erb = read_template(template)
+        extension = File.extname(filepath.gsub(".erb", ""))
 
-    def erb(template)
-      ERB.new(template, trim_mode: "-")
-    end
+        heading = case extension
+        when ".rb"
+          <<~HEADING
+          # frozen_string_literal: true
 
-    def locals
-      @locals ||=
-        begin
-          config = YAML.load_file(File.expand_path("../config.yml", __dir__))
+          =begin
+          This file is generated by the templates/template.rb script and should not be
+          modified manually. See #{filepath}
+          if you are looking to modify the template
+          =end
 
-          {
-            nodes: config.fetch("nodes").map { |node| NodeType.new(node) }.sort_by(&:name),
-            tokens: config.fetch("tokens").map { |token| Token.new(token) },
-            flags: config.fetch("flags").map { |flags| Flags.new(flags) }
-          }
+          HEADING
+        when ".rbs"
+          <<~HEADING
+          # This file is generated by the templates/template.rb script and should not be
+          # modified manually. See #{filepath}
+          # if you are looking to modify the template
+
+          HEADING
+        when ".rbi"
+          <<~HEADING
+          # typed: strict
+
+          =begin
+          This file is generated by the templates/template.rb script and should not be
+          modified manually. See #{filepath}
+          if you are looking to modify the template
+          =end
+
+          HEADING
+        else
+          <<~HEADING
+          /******************************************************************************/
+          /* This file is generated by the templates/template.rb script and should not  */
+          /* be modified manually. See                                                  */
+          /* #{filepath + " " * (74 - filepath.size) } */
+          /* if you are looking to modify the                                           */
+          /* template                                                                   */
+          /******************************************************************************/
+
+          HEADING
         end
-    end
-  end
 
-  TEMPLATES = [
-    "ext/prism/api_node.c",
-    "include/prism/ast.h",
-    "javascript/src/deserialize.js",
-    "javascript/src/nodes.js",
-    "javascript/src/visitor.js",
-    "java/org/prism/Loader.java",
-    "java/org/prism/Nodes.java",
-    "java/org/prism/AbstractNodeVisitor.java",
-    "lib/prism/compiler.rb",
-    "lib/prism/dispatcher.rb",
-    "lib/prism/dot_visitor.rb",
-    "lib/prism/dsl.rb",
-    "lib/prism/mutation_compiler.rb",
-    "lib/prism/node.rb",
-    "lib/prism/serialize.rb",
-    "lib/prism/visitor.rb",
-    "src/node.c",
-    "src/prettyprint.c",
-    "src/serialize.c",
-    "src/token_type.c",
-    "rbi/prism/node.rbi",
-    "rbi/prism/visitor.rbi",
-    "sig/prism.rbs",
-    "sig/prism/dsl.rbs",
-    "sig/prism/mutation_compiler.rbs",
-    "sig/prism/node.rbs",
-    "sig/prism/visitor.rbs",
-    "sig/prism/_private/dot_visitor.rbs"
-  ]
+        write_to ||= File.expand_path("../#{name}", __dir__)
+        contents = heading + erb.result_with_hash(locals)
+
+        if (extension == ".c" || extension == ".h") && !contents.ascii_only?
+          # Enforce that we only have ASCII characters here. This is necessary
+          # for non-UTF-8 locales that only allow ASCII characters in C source
+          # files.
+          contents.each_line.with_index(1) do |line, line_number|
+            raise "Non-ASCII character on line #{line_number} of #{write_to}" unless line.ascii_only?
+          end
+        end
+
+        FileUtils.mkdir_p(File.dirname(write_to))
+        File.write(write_to, contents)
+      end
+
+      private
+
+      def read_template(filepath)
+        template = File.read(filepath, encoding: Encoding::UTF_8)
+        erb = erb(template)
+        erb.filename = filepath
+        erb
+      end
+
+      def erb(template)
+        ERB.new(template, trim_mode: "-")
+      end
+
+      def locals
+        @locals ||=
+          begin
+            config = YAML.load_file(File.expand_path("../config.yml", __dir__))
+
+            {
+              nodes: config.fetch("nodes").map { |node| NodeType.new(node) }.sort_by(&:name),
+              tokens: config.fetch("tokens").map { |token| Token.new(token) },
+              flags: config.fetch("flags").map { |flags| Flags.new(flags) }
+            }
+          end
+      end
+    end
+
+    TEMPLATES = [
+      "ext/prism/api_node.c",
+      "include/prism/ast.h",
+      "javascript/src/deserialize.js",
+      "javascript/src/nodes.js",
+      "javascript/src/visitor.js",
+      "java/org/prism/Loader.java",
+      "java/org/prism/Nodes.java",
+      "java/org/prism/AbstractNodeVisitor.java",
+      "lib/prism/compiler.rb",
+      "lib/prism/dispatcher.rb",
+      "lib/prism/dot_visitor.rb",
+      "lib/prism/dsl.rb",
+      "lib/prism/mutation_compiler.rb",
+      "lib/prism/node.rb",
+      "lib/prism/serialize.rb",
+      "lib/prism/visitor.rb",
+      "src/node.c",
+      "src/prettyprint.c",
+      "src/serialize.c",
+      "src/token_type.c",
+      "rbi/prism/node.rbi",
+      "rbi/prism/visitor.rbi",
+      "sig/prism.rbs",
+      "sig/prism/dsl.rbs",
+      "sig/prism/mutation_compiler.rbs",
+      "sig/prism/node.rbs",
+      "sig/prism/visitor.rbs",
+      "sig/prism/_private/dot_visitor.rbs"
+    ]
+  end
 end
 
 if __FILE__ == $0
   if ARGV.empty?
-    Prism::TEMPLATES.each { |filepath| Prism.template(filepath) }
+    Prism::Template::TEMPLATES.each { |filepath| Prism::Template.render(filepath) }
   else # ruby/ruby
     name, write_to = ARGV
-    Prism.template(name, write_to: write_to)
+    Prism::Template.render(name, write_to: write_to)
   end
 end


### PR DESCRIPTION
This PR makes the Sorbet type-checking task work with `typed: true` for all files by default, except for a few files that we revert back to `typed: false`. We also suppress a handful of classes of errors that are hard to solve without inline type assertions and are not essential errors for what we are trying to do here.

I've also had to make some code changes to get type-checking to work at this level. The major refactor was to move all template related methods and classes under the `Prism::Template` namespace, so that there is no name collision with types under the `Prism` namespace.