### PR TITLE
Fix a token incompatibility for `Prism::Translation::Parser`

### DIFF
--- a/lib/prism/translation/parser/lexer.rb
+++ b/lib/prism/translation/parser/lexer.rb
@@ -304,7 +304,11 @@ module Prism
             when :tSTRING_DVAR
               value = nil
             when :tSTRING_END
-              if token.type == :REGEXP_END
+              if token.type == :HEREDOC_END && value.end_with?("\n")
+                newline_length = value.end_with?("\r\n") ? 2 : 1
+                value = value.sub(/\r?\n\z/, '')
+                location = Range.new(source_buffer, offset_cache[token.location.start_offset], offset_cache[token.location.end_offset - newline_length])
+              elsif token.type == :REGEXP_END
                 value = value[0]
                 location = Range.new(source_buffer, offset_cache[token.location.start_offset], offset_cache[token.location.start_offset + 1])
               end

--- a/test/prism/fixtures/heredoc.txt
+++ b/test/prism/fixtures/heredoc.txt
@@ -1,0 +1,2 @@
+<<TEXT
+TEXT

--- a/test/prism/fixtures/heredoc_with_carriage_returns.txt
+++ b/test/prism/fixtures/heredoc_with_carriage_returns.txt
@@ -1,0 +1,2 @@
+<<TEXT
+TEXT

--- a/test/prism/snapshots/heredoc.txt
+++ b/test/prism/snapshots/heredoc.txt
@@ -1,0 +1,11 @@
+@ ProgramNode (location: (1,0)-(1,6))
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (1,0)-(1,6))
+    └── body: (length: 1)
+        └── @ StringNode (location: (1,0)-(1,6))
+            ├── flags: ∅
+            ├── opening_loc: (1,0)-(1,6) = "<<TEXT"
+            ├── content_loc: (2,0)-(2,0) = ""
+            ├── closing_loc: (2,0)-(3,0) = "TEXT\n"
+            └── unescaped: ""

--- a/test/prism/snapshots/heredoc_with_carriage_returns.txt
+++ b/test/prism/snapshots/heredoc_with_carriage_returns.txt
@@ -1,0 +1,11 @@
+@ ProgramNode (location: (1,0)-(1,6))
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (1,0)-(1,6))
+    └── body: (length: 1)
+        └── @ StringNode (location: (1,0)-(1,6))
+            ├── flags: ∅
+            ├── opening_loc: (1,0)-(1,6) = "<<TEXT"
+            ├── content_loc: (2,0)-(2,0) = ""
+            ├── closing_loc: (2,0)-(3,0) = "TEXT\r\n"
+            └── unescaped: ""


### PR DESCRIPTION
Fixes #2512.

This PR fixes a token incompatibility between Parser gem and `Prism::Translation::Parser` for `HEREDOC_END` with a newline.