### PR TITLE
Follow #2579

### DIFF
--- a/test/prism/parser_test.rb
+++ b/test/prism/parser_test.rb
@@ -78,7 +78,6 @@ module Prism
       "heredocs_nested.txt",
       "indented_file_end.txt",
       "non_alphanumeric_methods.txt",
-      "range_begin_open_inclusive.txt",
       "strings.txt",
       "xstring.txt"
     ]


### PR DESCRIPTION
Due to #2579, the test case for range_begin_open_inclusive.txt has also been restored.