### PR TITLE
Follow ruby/prism#2581

### DIFF
--- a/test/prism/parser_test.rb
+++ b/test/prism/parser_test.rb
@@ -76,7 +76,6 @@ module Prism
       "heredocs_leading_whitespace.txt",
       "heredocs_nested.txt",
       "indented_file_end.txt",
-      "non_alphanumeric_methods.txt",
       "strings.txt",
       "xstring.txt"
     ]


### PR DESCRIPTION
Due to ruby/prism#2581, the test case for non_alphanumeric_methods.txt has also been restored. It also solved issues with `def self.`' not limited to constants for `tBACK_REF2` token.

```console
$ bundle exec ruby -Ilib -rprism -rprism/translation/parser33 -ve \
'buf = Parser::Source::Buffer.new("example.rb"); buf.source = "def self.`; end"; p Prism::Translation::Parser33.new.tokenize(buf)[2]'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
[[:kDEF, ["def", #<Parser::Source::Range example.rb 0...3>]], [:kSELF, ["self", #<Parser::Source::Range example.rb 4...8>]],
[:tDOT, [".", #<Parser::Source::Range example.rb 8...9>]], [:tBACK_REF2, ["`", #<Parser::Source::Range example.rb 9...10>]],
[:tSEMI, [";", #<Parser::Source::Range example.rb 10...11>]], [:kEND, ["end", #<Parser::Source::Range example.rb 12...15>]]]
```