### PR TITLE
Turn on heredocs nested test for `Prism::Translation::Parser`

### DIFF
--- a/test/prism/parser_test.rb
+++ b/test/prism/parser_test.rb
@@ -74,7 +74,6 @@ module Prism
       "comments.txt",
       "heredoc_with_comment.txt",
       "heredocs_leading_whitespace.txt",
-      "heredocs_nested.txt",
       "indented_file_end.txt",
       "strings.txt",
       "xstring_with_backslash.txt"


### PR DESCRIPTION
This PR enables the heredocs_nested.txt that was previously skipped testing.