### PR TITLE
Warn for maximum number variables

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -247,6 +247,7 @@ warnings:
   - FLOAT_OUT_OF_RANGE
   - INTEGER_IN_FLIP_FLOP
   - INVALID_CHARACTER
+  - INVALID_NUMBERED_REFERENCE
   - KEYWORD_EOL
   - LITERAL_IN_CONDITION_DEFAULT
   - LITERAL_IN_CONDITION_VERBOSE
@@ -2677,13 +2678,13 @@ nodes:
       - name: number
         type: uint32
         comment: |
-          The (1-indexed, from the left) number of the capture group. Numbered references that would overflow a `uint32`  result in a `number` of exactly `2**32 - 1`.
+          The (1-indexed, from the left) number of the capture group. Numbered references that are too large result in this value being `0`.
 
               $1          # number `1`
 
               $5432       # number `5432`
 
-              $4294967296 # number `4294967295`
+              $4294967296 # number `0`
     comment: |
       Represents reading a numbered reference to a capture in the previous match.
 

--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -10,6 +10,7 @@
 #define PRISM_DEFINES_H
 
 #include <ctype.h>
+#include <limits.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -22,7 +23,6 @@
  * some platforms they aren't included unless this is already defined.
  */
 #define __STDC_FORMAT_MACROS
-
 #include <inttypes.h>
 
 /**

--- a/templates/src/diagnostic.c.erb
+++ b/templates/src/diagnostic.c.erb
@@ -327,6 +327,7 @@ static const pm_diagnostic_data_t diagnostic_messages[PM_DIAGNOSTIC_ID_MAX] = {
     [PM_WARN_FLOAT_OUT_OF_RANGE]                = { "Float %.*s%s out of range", PM_WARNING_LEVEL_VERBOSE },
     [PM_WARN_INTEGER_IN_FLIP_FLOP]              = { "integer literal in flip-flop", PM_WARNING_LEVEL_DEFAULT },
     [PM_WARN_INVALID_CHARACTER]                 = { "invalid character syntax; use %s%s%s", PM_WARNING_LEVEL_DEFAULT },
+    [PM_WARN_INVALID_NUMBERED_REFERENCE]        = { "'%.*s' is too big for a number variable, always nil", PM_WARNING_LEVEL_DEFAULT },
     [PM_WARN_KEYWORD_EOL]                       = { "`%.*s` at the end of line without an expression", PM_WARNING_LEVEL_VERBOSE },
     [PM_WARN_LITERAL_IN_CONDITION_DEFAULT]      = { "%sliteral in %s", PM_WARNING_LEVEL_DEFAULT },
     [PM_WARN_LITERAL_IN_CONDITION_VERBOSE]      = { "%sliteral in %s", PM_WARNING_LEVEL_VERBOSE },


### PR DESCRIPTION
This one will impact implementations. Now `NumberedReferenceReadNode` has `0` as the number if the value is too large. This matches CRuby's expectations. We also use this for adding an appropriate warning.

cc @enebo @eregon @seven1m 