### PR TITLE
Shareable constant nodes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -248,6 +248,7 @@ warnings:
   - INTEGER_IN_FLIP_FLOP
   - INVALID_CHARACTER
   - INVALID_NUMBERED_REFERENCE
+  - INVALID_SHAREABLE_CONSTANT_VALUE
   - KEYWORD_EOL
   - LITERAL_IN_CONDITION_DEFAULT
   - LITERAL_IN_CONDITION_VERBOSE
@@ -667,6 +668,15 @@ flags:
       - name: FORCED_US_ASCII_ENCODING
         comment: "internal bytes forced the encoding to US-ASCII"
     comment: Flags for regular expression and match last line nodes.
+  - name: ShareableConstantNodeFlags
+    values:
+      - name: LITERAL
+        comment: "constant writes that should be modified with shareable constant value literal"
+      - name: EXPERIMENTAL_EVERYTHING
+        comment: "constant writes that should be modified with shareable constant value experimental everything"
+      - name: EXPERIMENTAL_COPY
+        comment: "constant writes that should be modified with shareable constant value experimental copy"
+    comment: Flags for shareable constant nodes.
   - name: StringFlags
     values:
       - name: FORCED_UTF8_ENCODING
@@ -3063,6 +3073,29 @@ nodes:
 
           self
           ^^^^
+  - name: ShareableConstantNode
+    fields:
+      - name: flags
+        type: flags
+        kind: ShareableConstantNodeFlags
+      - name: write
+        type: node
+        kind:
+          - ConstantWriteNode
+          - ConstantAndWriteNode
+          - ConstantOrWriteNode
+          - ConstantOperatorWriteNode
+          - ConstantPathWriteNode
+          - ConstantPathAndWriteNode
+          - ConstantPathOrWriteNode
+          - ConstantPathOperatorWriteNode
+        comment: The constant write that should be modified with the shareability state.
+    comment: |
+      This node wraps a constant write to indicate that when the value is written, it should have its shareability state modified.
+
+          # shareable_constant_value: literal
+          C = { a: 1 }
+          ^^^^^^^^^^^^
   - name: SingletonClassNode
     fields:
       - name: locals

--- a/include/prism/parser.h
+++ b/include/prism/parser.h
@@ -448,6 +448,13 @@ typedef struct {
     void (*callback)(void *data, pm_parser_t *parser, pm_token_t *token);
 } pm_lex_callback_t;
 
+/** The type of shareable constant value that can be set. */
+typedef uint8_t pm_shareable_constant_value_t;
+static const pm_shareable_constant_value_t PM_SCOPE_SHAREABLE_CONSTANT_NONE = 0x0;
+static const pm_shareable_constant_value_t PM_SCOPE_SHAREABLE_CONSTANT_LITERAL = 0x1;
+static const pm_shareable_constant_value_t PM_SCOPE_SHAREABLE_CONSTANT_EXPERIMENTAL_EVERYTHING = 0x2;
+static const pm_shareable_constant_value_t PM_SCOPE_SHAREABLE_CONSTANT_EXPERIMENTAL_COPY = 0x4;
+
 /**
  * This struct represents a node in a linked list of scopes. Some scopes can see
  * into their parent scopes, while others cannot.
@@ -486,6 +493,12 @@ typedef struct pm_scope {
      * about how many numbered parameters exist.
      */
     int8_t numbered_parameters;
+
+    /**
+     * The current state of constant shareability for this scope. This is
+     * changed by magic shareable_constant_value comments.
+     */
+    pm_shareable_constant_value_t shareable_constant;
 
     /**
      * A boolean indicating whether or not this scope can see into its parent.

--- a/lib/prism/translation/parser/compiler.rb
+++ b/lib/prism/translation/parser/compiler.rb
@@ -1423,6 +1423,11 @@ module Prism
           builder.self(token(node.location))
         end
 
+        # A shareable constant.
+        def visit_shareable_constant_node(node)
+          visit(node.write)
+        end
+
         # class << self; end
         # ^^^^^^^^^^^^^^^^^^
         def visit_singleton_class_node(node)

--- a/lib/prism/translation/ripper.rb
+++ b/lib/prism/translation/ripper.rb
@@ -2858,6 +2858,11 @@ module Prism
         on_var_ref(on_kw("self"))
       end
 
+      # A shareable constant.
+      def visit_shareable_constant_node(node)
+        visit(node.write)
+      end
+
       # class << self; end
       # ^^^^^^^^^^^^^^^^^^
       def visit_singleton_class_node(node)

--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -1274,6 +1274,11 @@ module Prism
           s(node, :self)
         end
 
+        # A shareable constant.
+        def visit_shareable_constant_node(node)
+          visit(node.write)
+        end
+
         # class << self; end
         # ^^^^^^^^^^^^^^^^^^
         def visit_singleton_class_node(node)

--- a/templates/src/diagnostic.c.erb
+++ b/templates/src/diagnostic.c.erb
@@ -327,6 +327,7 @@ static const pm_diagnostic_data_t diagnostic_messages[PM_DIAGNOSTIC_ID_MAX] = {
     [PM_WARN_FLOAT_OUT_OF_RANGE]                = { "Float %.*s%s out of range", PM_WARNING_LEVEL_VERBOSE },
     [PM_WARN_INTEGER_IN_FLIP_FLOP]              = { "integer literal in flip-flop", PM_WARNING_LEVEL_DEFAULT },
     [PM_WARN_INVALID_CHARACTER]                 = { "invalid character syntax; use %s%s%s", PM_WARNING_LEVEL_DEFAULT },
+    [PM_WARN_INVALID_SHAREABLE_CONSTANT_VALUE]  = { "invalid value for shareable_constant_value: %.*s", PM_WARNING_LEVEL_VERBOSE },
     [PM_WARN_INVALID_NUMBERED_REFERENCE]        = { "'%.*s' is too big for a number variable, always nil", PM_WARNING_LEVEL_DEFAULT },
     [PM_WARN_KEYWORD_EOL]                       = { "`%.*s` at the end of line without an expression", PM_WARNING_LEVEL_VERBOSE },
     [PM_WARN_LITERAL_IN_CONDITION_DEFAULT]      = { "%sliteral in %s", PM_WARNING_LEVEL_DEFAULT },

--- a/test/prism/location_test.rb
+++ b/test/prism/location_test.rb
@@ -781,6 +781,15 @@ module Prism
       assert_location(SelfNode, "self")
     end
 
+    def test_ShareableConstantNode
+      source = <<~RUBY
+        # shareable_constant_value: literal
+        C = { foo: 1 }
+      RUBY
+
+      assert_location(ShareableConstantNode, source, 36...50)
+    end
+
     def test_SingletonClassNode
       assert_location(SingletonClassNode, "class << self; end")
     end
@@ -915,8 +924,7 @@ module Prism
 
     def assert_location(kind, source, expected = 0...source.length, **options)
       result = Prism.parse(source, **options)
-      assert_equal [], result.comments
-      assert_equal [], result.errors
+      assert result.success?
 
       node = result.value.statements.body.last
       node = yield node if block_given?


### PR DESCRIPTION
Needed to support the `# shareable_constant_value` magic comments that control ractors. Other implementations should probably just skip right past these nodes.