### PR TITLE
Add PM_STRING_FLAGS_FROZEN / PM_STRING_FLAGS_MUTABLE on PM_SOURCE_FILE_NODE

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3090,6 +3090,9 @@ nodes:
           ^^^^^^^^^^^^
   - name: SourceFileNode
     fields:
+      - name: flags
+        type: flags
+        kind: StringFlags
       - name: filepath
         type: string
     comment: |

--- a/src/prism.c
+++ b/src/prism.c
@@ -5782,10 +5782,21 @@ pm_source_file_node_create(pm_parser_t *parser, const pm_token_t *file_keyword) 
     pm_source_file_node_t *node = PM_ALLOC_NODE(parser, pm_source_file_node_t);
     assert(file_keyword->type == PM_TOKEN_KEYWORD___FILE__);
 
+    pm_node_flags_t flags = 0;
+
+    switch (parser->frozen_string_literal) {
+        case PM_OPTIONS_FROZEN_STRING_LITERAL_DISABLED:
+            flags |= PM_STRING_FLAGS_MUTABLE;
+            break;
+        case PM_OPTIONS_FROZEN_STRING_LITERAL_ENABLED:
+            flags |= PM_NODE_FLAG_STATIC_LITERAL | PM_STRING_FLAGS_FROZEN;
+            break;
+    }
+
     *node = (pm_source_file_node_t) {
         {
             .type = PM_SOURCE_FILE_NODE,
-            .flags = PM_NODE_FLAG_STATIC_LITERAL,
+            .flags = flags,
             .location = PM_LOCATION_TOKEN_VALUE(file_keyword),
         },
         .filepath = parser->filepath

--- a/test/prism/snapshots/keyword_method_names.txt
+++ b/test/prism/snapshots/keyword_method_names.txt
@@ -132,6 +132,7 @@
         │   ├── name_loc: (22,13)-(22,14) = "a"
         │   ├── receiver:
         │   │   @ SourceFileNode (location: (22,4)-(22,12))
+        │   │   ├── flags: ∅
         │   │   └── filepath: "keyword_method_names.txt"
         │   ├── parameters: ∅
         │   ├── body: ∅

--- a/test/prism/snapshots/keywords.txt
+++ b/test/prism/snapshots/keywords.txt
@@ -8,5 +8,6 @@
         ├── @ SelfNode (location: (5,0)-(5,4))
         ├── @ SourceEncodingNode (location: (7,0)-(7,12))
         ├── @ SourceFileNode (location: (9,0)-(9,8))
+        │   ├── flags: ∅
         │   └── filepath: "keywords.txt"
         └── @ SourceLineNode (location: (11,0)-(11,8))

--- a/test/prism/snapshots/patterns.txt
+++ b/test/prism/snapshots/patterns.txt
@@ -445,6 +445,7 @@
         │   │   └── block: ∅
         │   ├── pattern:
         │   │   @ SourceFileNode (location: (23,7)-(23,15))
+        │   │   ├── flags: ∅
         │   │   └── filepath: "patterns.txt"
         │   └── operator_loc: (23,4)-(23,6) = "=>"
         ├── @ MatchRequiredNode (location: (24,0)-(24,15))
@@ -1153,9 +1154,11 @@
         │   │   ├── flags: ∅
         │   │   ├── left:
         │   │   │   @ SourceFileNode (location: (49,7)-(49,15))
+        │   │   │   ├── flags: ∅
         │   │   │   └── filepath: "patterns.txt"
         │   │   ├── right:
         │   │   │   @ SourceFileNode (location: (49,19)-(49,27))
+        │   │   │   ├── flags: ∅
         │   │   │   └── filepath: "patterns.txt"
         │   │   └── operator_loc: (49,16)-(49,18) = ".."
         │   └── operator_loc: (49,4)-(49,6) = "=>"
@@ -2823,6 +2826,7 @@
         │   │   └── block: ∅
         │   ├── pattern:
         │   │   @ SourceFileNode (location: (126,7)-(126,15))
+        │   │   ├── flags: ∅
         │   │   └── filepath: "patterns.txt"
         │   └── operator_loc: (126,4)-(126,6) = "in"
         ├── @ MatchPredicateNode (location: (127,0)-(127,15))
@@ -3504,6 +3508,7 @@
         │   │   └── @ InNode (location: (157,10)-(157,26))
         │   │       ├── pattern:
         │   │       │   @ SourceFileNode (location: (157,13)-(157,21))
+        │   │       │   ├── flags: ∅
         │   │       │   └── filepath: "patterns.txt"
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (157,10)-(157,12) = "in"
@@ -4460,6 +4465,7 @@
         │   │       │   │   @ StatementsNode (location: (184,13)-(184,21))
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ SourceFileNode (location: (184,13)-(184,21))
+        │   │       │   │           ├── flags: ∅
         │   │       │   │           └── filepath: "patterns.txt"
         │   │       │   ├── consequent: ∅
         │   │       │   └── end_keyword_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/pragma.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/pragma.txt
@@ -5,6 +5,7 @@
     └── body: (length: 4)
         ├── @ SourceEncodingNode (location: (1,0)-(1,12))
         ├── @ SourceFileNode (location: (2,0)-(2,8))
+        │   ├── flags: ∅
         │   └── filepath: "unparser/corpus/literal/pragma.txt"
         ├── @ SourceLineNode (location: (3,0)-(3,8))
         └── @ CallNode (location: (4,0)-(4,7))

--- a/test/prism/snapshots/whitequark/pattern_matching__FILE__LINE_literals.txt
+++ b/test/prism/snapshots/whitequark/pattern_matching__FILE__LINE_literals.txt
@@ -9,6 +9,7 @@
             │   ├── flags: ∅
             │   ├── elements: (length: 3)
             │   │   ├── @ SourceFileNode (location: (1,14)-(1,22))
+            │   │   │   ├── flags: ∅
             │   │   │   └── filepath: "whitequark/pattern_matching__FILE__LINE_literals.txt"
             │   │   ├── @ CallNode (location: (1,24)-(1,36))
             │   │   │   ├── flags: ∅
@@ -37,6 +38,7 @@
             │       │   ├── constant: ∅
             │       │   ├── requireds: (length: 3)
             │       │   │   ├── @ SourceFileNode (location: (2,14)-(2,22))
+            │       │   │   │   ├── flags: ∅
             │       │   │   │   └── filepath: "whitequark/pattern_matching__FILE__LINE_literals.txt"
             │       │   │   ├── @ SourceLineNode (location: (2,24)-(2,32))
             │       │   │   └── @ SourceEncodingNode (location: (2,34)-(2,46))

--- a/test/prism/snapshots/whitequark/string___FILE__.txt
+++ b/test/prism/snapshots/whitequark/string___FILE__.txt
@@ -4,4 +4,5 @@
     @ StatementsNode (location: (1,0)-(1,8))
     └── body: (length: 1)
         └── @ SourceFileNode (location: (1,0)-(1,8))
+            ├── flags: ∅
             └── filepath: "whitequark/string___FILE__.txt"

--- a/test/prism/static_inspect_test.rb
+++ b/test/prism/static_inspect_test.rb
@@ -58,7 +58,7 @@ module Prism
     end
 
     def test_source_file
-      assert_equal __FILE__.inspect, static_inspect("__FILE__", filepath: __FILE__)
+      assert_equal __FILE__.inspect, static_inspect("__FILE__", filepath: __FILE__, frozen_string_literal: true)
     end
 
     def test_source_line

--- a/test/prism/static_literals_test.rb
+++ b/test/prism/static_literals_test.rb
@@ -34,7 +34,6 @@ module Prism
 
       assert_warning("\"#{__FILE__}\"")
       assert_warning("\"foo\"")
-      assert_warning("\"#{__FILE__}\"", "__FILE__")
 
       assert_warning("/foo/")
 


### PR DESCRIPTION
For all intent and purposes, `__FILE__` is a string literal subject to the `# frozen_string_literal: true/false` comment and to the global `--enable-frozen-string-literal / --disable-frozen-string-literal` CLI flags.