### PR TITLE
[Compatibility] Improve printf format

### DIFF
--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -49,7 +49,11 @@
  * compiler-agnostic way.
  */
 #if defined(__GNUC__)
-#   define PRISM_ATTRIBUTE_FORMAT(string_index, argument_index) __attribute__((format(printf, string_index, argument_index)))
+#   if defined(__MINGW_PRINTF_FORMAT)
+#       define PRISM_ATTRIBUTE_FORMAT(string_index, argument_index) __attribute__((format(__MINGW_PRINTF_FORMAT, string_index, argument_index)))
+#   else
+#       define PRISM_ATTRIBUTE_FORMAT(string_index, argument_index) __attribute__((format(printf, string_index, argument_index)))
+#   endif
 #elif defined(__clang__)
 #   define PRISM_ATTRIBUTE_FORMAT(string_index, argument_index) __attribute__((__format__(__printf__, string_index, argument_index)))
 #else


### PR DESCRIPTION
For better compatibility, this patch suggests using __MINGW_PRINTF_FORMAT that GCC provides for MinGW environment.