### PR TITLE
Provide options for reducing size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
       run: bundle exec rake typecheck:steep
     - name: Check field kinds
       run: rm lib/prism/node.rb && CHECK_FIELD_KIND=true bundle exec rake
+
   build:
     strategy:
       fail-fast: false
@@ -94,7 +95,23 @@ jobs:
       - name: Run Ruby tests
         run: bundle exec rake
 
-  build-debug-mode:
+  build-without-assertions:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: head
+        bundler-cache: true
+    - name: Run Ruby tests
+      run: bundle exec rake compile_no_debug && bundle exec rake test
+
+  build-debug:
     strategy:
       fail-fast: false
       matrix:
@@ -110,14 +127,10 @@ jobs:
     - name: Run Ruby tests
       run: bundle exec rake
       env:
-        PRISM_DEBUG_MODE_BUILD: "1"
+        PRISM_BUILD_DEBUG: "1"
 
-  build-without-assertions:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-    runs-on: ${{ matrix.os }}
+  build-minimal:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
@@ -126,7 +139,9 @@ jobs:
         ruby-version: head
         bundler-cache: true
     - name: Run Ruby tests
-      run: bundle exec rake compile_no_debug
+      run: bundle exec rake compile_minimal && bundle exec rake test
+      env:
+        PRISM_BUILD_MINIMAL: "1"
 
   build-java:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ all-no-debug: DEBUG_FLAGS := -DNDEBUG=1
 all-no-debug: OPTFLAGS := -O3
 all-no-debug: all
 
+minimal: CFLAGS := $(CFLAGS) -DPRISM_EXCLUDE_SERIALIZATION -DPRISM_EXCLUDE_JSON -DPRISM_EXCLUDE_PACK -DPRISM_EXCLUDE_PRETTYPRINT -DPRISM_ENCODING_EXCLUDE_FULL
+minimal: all
+
 run: Makefile $(STATIC_OBJECTS) $(HEADERS) test.c
 	$(ECHO) "compiling test.c"
 	$(Q) $(CC) $(CPPFLAGS) $(CFLAGS) $(STATIC_OBJECTS) test.c

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require "rake/clean"
 
 task compile: :make
 task compile_no_debug: :make_no_debug
+task compile_minimal: :make_minimal
 
 task default: [:compile, :test]
 
@@ -14,13 +15,10 @@ require_relative "templates/template"
 desc "Generate all ERB template based files"
 task templates: Prism::Template::TEMPLATES
 
-task make: [:templates] do
-  sh(RUBY_PLATFORM.include?("openbsd") ? "gmake" : "make")
-end
-
-task make_no_debug: [:templates] do
-  sh("#{RUBY_PLATFORM.include?("openbsd") ? "gmake" : "make"} all-no-debug")
-end
+make = RUBY_PLATFORM.include?("openbsd") ? "gmake" : "make"
+task(make: :templates) { sh(make) }
+task(make_no_debug: :templates) { sh("#{make} all-no-debug") }
+task(make_minimal: :templates) { sh("#{make} minimal") }
 
 # decorate the gem build task with prerequisites
 task build: [:check_manifest, :templates]

--- a/docs/build_system.md
+++ b/docs/build_system.md
@@ -108,3 +108,14 @@ If you want to build prism as a shared library and link against it, you should c
 ```
 MAKEFLAGS="-j10" bundle exec rake compile
 ```
+
+## Build options
+
+* `PRISM_BUILD_DEBUG` - Will cause all file reading to copy into its own allocation to allow easier tracking of reading off the end of the buffer. By default this is off.
+* `PRISM_ENCODING_EXCLUDE_FULL` - Will cause the library to exclude the full encoding API, and only include the minimal number of encodings to support parsing Ruby code without encoding comments. By default this is off.
+* `PRISM_EXPORT_SYMBOLS` - Will cause the shared library to export symbols. By default this is off.
+* `PRISM_EXCLUDE_JSON` - Will cause the library to exclude the JSON API. By default this is off.
+* `PRISM_EXCLUDE_PACK` - Will cause the library to exclude the pack API. By default this is off.
+* `PRISM_EXCLUDE_PRETTYPRINT` - Will cause the library to exclude the prettyprint API. By default this is off.
+* `PRISM_EXCLUDE_SERIALIZATION` - Will cause the library to exclude the serialization API. By default this is off.
+* `PRISM_XALLOCATOR` - Will cause the library to use the custom memory allocator. By default this is off.

--- a/ext/prism/extconf.rb
+++ b/ext/prism/extconf.rb
@@ -8,14 +8,14 @@ if ARGV.delete("--help")
 
           --enable-debug-mode-build
               Enable debug mode build.
-              You may also use set PRISM_DEBUG_MODE_BUILD environment variable.
+              You may also use set PRISM_BUILD_DEBUG environment variable.
 
           --help
               Display this message.
 
       Environment variables used:
 
-          PRISM_DEBUG_MODE_BUILD
+          PRISM_BUILD_DEBUG
               Equivalent to `--enable-debug-mode-build` when set, even if nil or blank.
 
   TEXT
@@ -72,12 +72,12 @@ unless find_header("prism/extension.h", File.expand_path("..", __dir__))
 end
 
 # If `--enable-debug-mode-build` is passed to this script or the
-# `PRISM_DEBUG_MODE_BUILD` environment variable is defined, we'll build with the
-# `PRISM_DEBUG_MODE_BUILD` macro defined. This causes parse functions to
+# `PRISM_BUILD_DEBUG` environment variable is defined, we'll build with the
+# `PRISM_BUILD_DEBUG` macro defined. This causes parse functions to
 # duplicate their input so that they have clearly set bounds, which is useful
 # for finding bugs that cause the parser to read off the end of the input.
-if enable_config("debug-mode-build", ENV["PRISM_DEBUG_MODE_BUILD"] || false)
-  append_cflags("-DPRISM_DEBUG_MODE_BUILD")
+if enable_config("debug-mode-build", ENV["PRISM_BUILD_DEBUG"] || false)
+  append_cflags("-DPRISM_BUILD_DEBUG")
 end
 
 # By default, all symbols are hidden in the shared library.

--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -311,7 +311,7 @@ dump(int argc, VALUE *argv, VALUE self) {
     pm_options_t options = { 0 };
     string_options(argc, argv, &input, &options);
 
-#ifdef PRISM_DEBUG_MODE_BUILD
+#ifdef PRISM_BUILD_DEBUG
     size_t length = pm_string_length(&input);
     char* dup = xmalloc(length);
     memcpy(dup, pm_string_source(&input), length);
@@ -320,7 +320,7 @@ dump(int argc, VALUE *argv, VALUE self) {
 
     VALUE value = dump_input(&input, &options);
 
-#ifdef PRISM_DEBUG_MODE_BUILD
+#ifdef PRISM_BUILD_DEBUG
     xfree(dup);
 #endif
 
@@ -737,7 +737,7 @@ parse(int argc, VALUE *argv, VALUE self) {
     pm_options_t options = { 0 };
     string_options(argc, argv, &input, &options);
 
-#ifdef PRISM_DEBUG_MODE_BUILD
+#ifdef PRISM_BUILD_DEBUG
     size_t length = pm_string_length(&input);
     char* dup = xmalloc(length);
     memcpy(dup, pm_string_source(&input), length);
@@ -746,7 +746,7 @@ parse(int argc, VALUE *argv, VALUE self) {
 
     VALUE value = parse_input(&input, &options);
 
-#ifdef PRISM_DEBUG_MODE_BUILD
+#ifdef PRISM_BUILD_DEBUG
     xfree(dup);
 #endif
 

--- a/gemfiles/truffleruby/Gemfile
+++ b/gemfiles/truffleruby/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-ruby "~> 3.2.2", engine: "truffleruby", engine_version: "~> 23.1.2"
+ruby "~> 3.2.2", engine: "truffleruby", engine_version: "~> 24.0.0"
 
 gemspec path: "../.."
 

--- a/gemfiles/truffleruby/Gemfile.lock
+++ b/gemfiles/truffleruby/Gemfile.lock
@@ -29,7 +29,7 @@ DEPENDENCIES
   test-unit
 
 RUBY VERSION
-   ruby 3.2.2p0 (truffleruby 23.1.2)
+   ruby 3.2.2p0 (truffleruby 24.0.0)
 
 BUNDLED WITH
    2.2.32

--- a/include/prism.h
+++ b/include/prism.h
@@ -98,6 +98,11 @@ typedef char * (pm_parse_stream_fgets_t)(char *string, int size, void *stream);
  */
 PRISM_EXPORTED_FUNCTION pm_node_t * pm_parse_stream(pm_parser_t *parser, pm_buffer_t *buffer, void *stream, pm_parse_stream_fgets_t *fgets, const pm_options_t *options);
 
+// We optionally support serializing to a binary string. For systems that don't
+// want or need this functionality, it can be turned off with the
+// PRISM_EXCLUDE_SERIALIZATION define.
+#ifndef PRISM_EXCLUDE_SERIALIZATION
+
 /**
  * Parse and serialize the AST represented by the source that is read out of the
  * given stream into to the given buffer.
@@ -185,6 +190,8 @@ PRISM_EXPORTED_FUNCTION void pm_serialize_lex(pm_buffer_t *buffer, const uint8_t
  */
 PRISM_EXPORTED_FUNCTION void pm_serialize_parse_lex(pm_buffer_t *buffer, const uint8_t *source, size_t size, const char *data);
 
+#endif
+
 /**
  * Parse the source and return true if it parses without errors or warnings.
  *
@@ -220,6 +227,10 @@ const char * pm_token_type_human(pm_token_type_t token_type);
  */
 PRISM_EXPORTED_FUNCTION void pm_parser_errors_format(const pm_parser_t *parser, pm_buffer_t *buffer, bool colorize);
 
+// We optionally support dumping to JSON. For systems that don't want or need
+// this functionality, it can be turned off with the PRISM_EXCLUDE_JSON define.
+#ifndef PRISM_EXCLUDE_JSON
+
 /**
  * Dump JSON to the given buffer.
  *
@@ -228,6 +239,8 @@ PRISM_EXPORTED_FUNCTION void pm_parser_errors_format(const pm_parser_t *parser, 
  * @param node The node to serialize.
  */
 PRISM_EXPORTED_FUNCTION void pm_dump_json(pm_buffer_t *buffer, const pm_parser_t *parser, const pm_node_t *node);
+
+#endif
 
 /**
  * @mainpage

--- a/include/prism/encoding.h
+++ b/include/prism/encoding.h
@@ -135,7 +135,14 @@ extern const uint8_t pm_encoding_unicode_table[256];
  */
 typedef enum {
     PM_ENCODING_UTF_8 = 0,
+    PM_ENCODING_US_ASCII,
     PM_ENCODING_ASCII_8BIT,
+    PM_ENCODING_EUC_JP,
+    PM_ENCODING_WINDOWS_31J,
+
+// We optionally support excluding the full set of encodings to only support the
+// minimum necessary to process Ruby code without encoding comments.
+#ifndef PRISM_ENCODING_EXCLUDE_FULL
     PM_ENCODING_BIG5,
     PM_ENCODING_BIG5_HKSCS,
     PM_ENCODING_BIG5_UAO,
@@ -148,7 +155,6 @@ typedef enum {
     PM_ENCODING_CP950,
     PM_ENCODING_CP951,
     PM_ENCODING_EMACS_MULE,
-    PM_ENCODING_EUC_JP,
     PM_ENCODING_EUC_JP_MS,
     PM_ENCODING_EUC_JIS_2004,
     PM_ENCODING_EUC_KR,
@@ -208,7 +214,6 @@ typedef enum {
     PM_ENCODING_STATELESS_ISO_2022_JP,
     PM_ENCODING_STATELESS_ISO_2022_JP_KDDI,
     PM_ENCODING_TIS_620,
-    PM_ENCODING_US_ASCII,
     PM_ENCODING_UTF8_MAC,
     PM_ENCODING_UTF8_DOCOMO,
     PM_ENCODING_UTF8_KDDI,
@@ -222,8 +227,9 @@ typedef enum {
     PM_ENCODING_WINDOWS_1256,
     PM_ENCODING_WINDOWS_1257,
     PM_ENCODING_WINDOWS_1258,
-    PM_ENCODING_WINDOWS_31J,
     PM_ENCODING_WINDOWS_874,
+#endif
+
     PM_ENCODING_MAXIMUM
 } pm_encoding_type_t;
 

--- a/include/prism/pack.h
+++ b/include/prism/pack.h
@@ -6,6 +6,15 @@
 #ifndef PRISM_PACK_H
 #define PRISM_PACK_H
 
+// We optionally support parsing String#pack templates. For systems that don't
+// want or need this functionality, it can be turned off with the
+// PRISM_EXCLUDE_PACK define.
+#ifdef PRISM_EXCLUDE_PACK
+
+void pm_pack_parse(void);
+
+#else
+
 #include "prism/defines.h"
 
 #include <stdint.h>
@@ -148,5 +157,7 @@ pm_pack_parse(
  * @return The native size.
  */
 PRISM_EXPORTED_FUNCTION size_t pm_size_to_native(pm_pack_size size);
+
+#endif
 
 #endif

--- a/include/prism/prettyprint.h
+++ b/include/prism/prettyprint.h
@@ -6,6 +6,12 @@
 #ifndef PRISM_PRETTYPRINT_H
 #define PRISM_PRETTYPRINT_H
 
+#ifdef PRISM_EXCLUDE_PRETTYPRINT
+
+void pm_prettyprint(void);
+
+#else
+
 #include "prism/defines.h"
 
 #include <stdio.h>
@@ -22,5 +28,7 @@
  * @param node The root node of the AST to pretty-print.
  */
 PRISM_EXPORTED_FUNCTION void pm_prettyprint(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm_node_t *node);
+
+#endif
 
 #endif

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -33,8 +33,8 @@ namespace :test do
 
     desc "Run tests under valgrind"
     task :valgrind do
-      # Recompile with PRISM_DEBUG_MODE_BUILD=1
-      ENV["PRISM_DEBUG_MODE_BUILD"] = "1"
+      # Recompile with PRISM_BUILD_DEBUG=1
+      ENV["PRISM_BUILD_DEBUG"] = "1"
       Rake::Task["clobber"].invoke
       Rake::Task["test:valgrind_internal"].invoke
     end

--- a/src/prism.c
+++ b/src/prism.c
@@ -19316,6 +19316,41 @@ pm_parse_stream(pm_parser_t *parser, pm_buffer_t *buffer, void *stream, pm_parse
     return node;
 }
 
+/**
+ * Parse the source and return true if it parses without errors or warnings.
+ */
+PRISM_EXPORTED_FUNCTION bool
+pm_parse_success_p(const uint8_t *source, size_t size, const char *data) {
+    pm_options_t options = { 0 };
+    pm_options_read(&options, data);
+
+    pm_parser_t parser;
+    pm_parser_init(&parser, source, size, &options);
+
+    pm_node_t *node = pm_parse(&parser);
+    pm_node_destroy(&parser, node);
+
+    bool result = parser.error_list.size == 0 && parser.warning_list.size == 0;
+    pm_parser_free(&parser);
+    pm_options_free(&options);
+
+    return result;
+}
+
+#undef PM_CASE_KEYWORD
+#undef PM_CASE_OPERATOR
+#undef PM_CASE_WRITABLE
+#undef PM_STRING_EMPTY
+#undef PM_LOCATION_NODE_BASE_VALUE
+#undef PM_LOCATION_NODE_VALUE
+#undef PM_LOCATION_NULL_VALUE
+#undef PM_LOCATION_TOKEN_VALUE
+
+// We optionally support serializing to a binary string. For systems that don't
+// want or need this functionality, it can be turned off with the
+// PRISM_EXCLUDE_SERIALIZATION define.
+#ifndef PRISM_EXCLUDE_SERIALIZATION
+
 static inline void
 pm_serialize_header(pm_buffer_t *buffer) {
     pm_buffer_append_string(buffer, "PRISM", 5);
@@ -19402,14 +19437,7 @@ pm_serialize_parse_comments(pm_buffer_t *buffer, const uint8_t *source, size_t s
     pm_options_free(&options);
 }
 
-#undef PM_CASE_KEYWORD
-#undef PM_CASE_OPERATOR
-#undef PM_CASE_WRITABLE
-#undef PM_STRING_EMPTY
-#undef PM_LOCATION_NODE_BASE_VALUE
-#undef PM_LOCATION_NODE_VALUE
-#undef PM_LOCATION_NULL_VALUE
-#undef PM_LOCATION_TOKEN_VALUE
+#endif
 
 /** An error that is going to be formatted into the output. */
 typedef struct {

--- a/templates/src/node.c.erb
+++ b/templates/src/node.c.erb
@@ -247,6 +247,10 @@ pm_visit_child_nodes(const pm_node_t *node, bool (*visitor)(const pm_node_t *nod
     }
 }
 
+// We optionally support dumping to JSON. For systems that don't want or need
+// this functionality, it can be turned off with the PRISM_EXCLUDE_JSON define.
+#ifndef PRISM_EXCLUDE_JSON
+
 static void
 pm_dump_json_constant(pm_buffer_t *buffer, const pm_parser_t *parser, pm_constant_id_t constant_id) {
     const pm_constant_t *constant = pm_constant_pool_id_to_constant(&parser->constant_pool, constant_id);
@@ -360,3 +364,5 @@ pm_dump_json(pm_buffer_t *buffer, const pm_parser_t *parser, const pm_node_t *no
             break;
     }
 }
+
+#endif

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -1,6 +1,15 @@
 <%# encoding: ASCII -%>
 #include "prism/prettyprint.h"
 
+// We optionally support pretty printing nodes. For systems that don't want or
+// need this functionality, it can be turned off with the
+// PRISM_EXCLUDE_PRETTYPRINT define.
+#ifdef PRISM_EXCLUDE_PRETTYPRINT
+
+void pm_prettyprint(void) {}
+
+#else
+
 static inline void
 prettyprint_location(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm_location_t *location) {
     pm_line_column_t start = pm_newline_list_line_column(&parser->newline_list, location->start, parser->start_line);
@@ -154,3 +163,5 @@ pm_prettyprint(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm_n
     prettyprint_node(output_buffer, parser, node, &prefix_buffer);
     pm_buffer_free(&prefix_buffer);
 }
+
+#endif

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -1,5 +1,10 @@
 #include "prism.h"
 
+// We optionally support serializing to a binary string. For systems that don't
+// want or need this functionality, it can be turned off with the
+// PRISM_EXCLUDE_SERIALIZATION define.
+#ifndef PRISM_EXCLUDE_SERIALIZATION
+
 #include <stdio.h>
 
 static inline uint32_t
@@ -394,23 +399,4 @@ pm_serialize_parse_lex(pm_buffer_t *buffer, const uint8_t *source, size_t size, 
     pm_options_free(&options);
 }
 
-/**
- * Parse the source and return true if it parses without errors or warnings.
- */
-PRISM_EXPORTED_FUNCTION bool
-pm_parse_success_p(const uint8_t *source, size_t size, const char *data) {
-    pm_options_t options = { 0 };
-    pm_options_read(&options, data);
-
-    pm_parser_t parser;
-    pm_parser_init(&parser, source, size, &options);
-
-    pm_node_t *node = pm_parse(&parser);
-    pm_node_destroy(&parser, node);
-
-    bool result = parser.error_list.size == 0 && parser.warning_list.size == 0;
-    pm_parser_free(&parser);
-    pm_options_free(&options);
-
-    return result;
-}
+#endif

--- a/test/prism/fuzzer_test.rb
+++ b/test/prism/fuzzer_test.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+return if ENV["PRISM_BUILD_MINIMAL"]
+
 require_relative "test_helper"
 
 module Prism
-  # These tests are simply to exercise snippets found by the fuzzer that caused invalid memory access.
+  # These tests are simply to exercise snippets found by the fuzzer that caused
+  # invalid memory access.
   class FuzzerTest < TestCase
     def self.snippet(name, source)
       define_method(:"test_fuzzer_#{name}") { Prism.dump(source) }

--- a/test/prism/magic_comment_test.rb
+++ b/test/prism/magic_comment_test.rb
@@ -17,11 +17,11 @@ module Prism
       "# -*- \s\t\v encoding \s\t\v : \s\t\v ascii \s\t\v -*-",
       "# -*- foo: bar; encoding: ascii -*-",
       "# coding \t \r  \v   :     \t \v    \r   ascii-8bit",
-      "# vim: filetype=ruby, fileencoding=big5, tabsize=3, shiftwidth=3"
+      "# vim: filetype=ruby, fileencoding=windows-31j, tabsize=3, shiftwidth=3"
     ]
 
-    examples.each do |example|
-      define_method(:"test_magic_comment_#{example}") do
+    examples.each.with_index(1) do |example, index|
+      define_method(:"test_magic_comment_#{index}") do
         assert_magic_comment(example)
       end
     end

--- a/test/prism/parse_test.rb
+++ b/test/prism/parse_test.rb
@@ -75,19 +75,21 @@ module Prism
       assert_equal 5, tokens.length
     end
 
-    def test_dump_file
-      assert_nothing_raised do
-        Prism.dump_file(__FILE__)
-      end
+    if !ENV["PRISM_BUILD_MINIMAL"]
+      def test_dump_file
+        assert_nothing_raised do
+          Prism.dump_file(__FILE__)
+        end
 
-      error = assert_raise Errno::ENOENT do
-        Prism.dump_file("idontexist.rb")
-      end
+        error = assert_raise Errno::ENOENT do
+          Prism.dump_file("idontexist.rb")
+        end
 
-      assert_equal "No such file or directory - idontexist.rb", error.message
+        assert_equal "No such file or directory - idontexist.rb", error.message
 
-      assert_raise TypeError do
-        Prism.dump_file(nil)
+        assert_raise TypeError do
+          Prism.dump_file(nil)
+        end
       end
     end
 
@@ -259,9 +261,11 @@ module Prism
           warn("Created snapshot at #{snapshot}.")
         end
 
-        # Next, assert that the value can be serialized and deserialized without
-        # changing the shape of the tree.
-        assert_equal_nodes(result.value, Prism.load(source, Prism.dump(source, filepath: relative)).value)
+        if !ENV["PRISM_BUILD_MINIMAL"]
+          # Next, assert that the value can be serialized and deserialized
+          # without changing the shape of the tree.
+          assert_equal_nodes(result.value, Prism.load(source, Prism.dump(source, filepath: relative)).value)
+        end
 
         # Next, check that the location ranges of each node in the tree are a
         # superset of their respective child nodes.
@@ -318,7 +322,9 @@ module Prism
           result = Prism.parse(snippet, filepath: relative)
           assert_empty result.errors
 
-          assert_equal_nodes(result.value, Prism.load(snippet, Prism.dump(snippet, filepath: relative)).value)
+          if !ENV["PRISM_BUILD_MINIMAL"]
+            assert_equal_nodes(result.value, Prism.load(snippet, Prism.dump(snippet, filepath: relative)).value)
+          end
         end
       end
     end

--- a/test/prism/ruby_api_test.rb
+++ b/test/prism/ruby_api_test.rb
@@ -4,20 +4,22 @@ require_relative "test_helper"
 
 module Prism
   class RubyAPITest < TestCase
-    def test_ruby_api
-      filepath = __FILE__
-      source = File.read(filepath, binmode: true, external_encoding: Encoding::UTF_8)
+    if !ENV["PRISM_BUILD_MINIMAL"]
+      def test_ruby_api
+        filepath = __FILE__
+        source = File.read(filepath, binmode: true, external_encoding: Encoding::UTF_8)
 
-      assert_equal Prism.lex(source, filepath: filepath).value, Prism.lex_file(filepath).value
-      assert_equal Prism.dump(source, filepath: filepath), Prism.dump_file(filepath)
+        assert_equal Prism.lex(source, filepath: filepath).value, Prism.lex_file(filepath).value
+        assert_equal Prism.dump(source, filepath: filepath), Prism.dump_file(filepath)
 
-      serialized = Prism.dump(source, filepath: filepath)
-      ast1 = Prism.load(source, serialized).value
-      ast2 = Prism.parse(source, filepath: filepath).value
-      ast3 = Prism.parse_file(filepath).value
+        serialized = Prism.dump(source, filepath: filepath)
+        ast1 = Prism.load(source, serialized).value
+        ast2 = Prism.parse(source, filepath: filepath).value
+        ast3 = Prism.parse_file(filepath).value
 
-      assert_equal_nodes ast1, ast2
-      assert_equal_nodes ast2, ast3
+        assert_equal_nodes ast1, ast2
+        assert_equal_nodes ast2, ast3
+      end
     end
 
     def test_parse_success?

--- a/test/prism/static_inspect_test.rb
+++ b/test/prism/static_inspect_test.rb
@@ -54,7 +54,7 @@ module Prism
 
     def test_source_encoding
       assert_equal "#<Encoding:UTF-8>", static_inspect("__ENCODING__")
-      assert_equal "#<Encoding:Shift_JIS>", static_inspect("__ENCODING__", encoding: "Shift_JIS")
+      assert_equal "#<Encoding:Windows-31J>", static_inspect("__ENCODING__", encoding: "Windows-31J")
     end
 
     def test_source_file


### PR DESCRIPTION
This PR introduces a couple of defines that control what gets compiled into the final binary. These are:

* `PRISM_ENCODING_EXCLUDE_FULL` - Will cause the library to exclude the full encoding API, and only include the minimal number of encodings to support parsing Ruby code without encoding comments. By default this is off.
* `PRISM_EXCLUDE_JSON` - Will cause the library to exclude the JSON API. By default this is off.
* `PRISM_EXCLUDE_PACK` - Will cause the library to exclude the pack API. By default this is off.
* `PRISM_EXCLUDE_PRETTYPRINT` - Will cause the library to exclude the prettyprint API. By default this is off.
* `PRISM_EXCLUDE_SERIALIZATION` - Will cause the library to exclude the serialization API. By default this is off.

Including all of these options results in a pretty drastic cut in size of the final binary:

```
$ make static
building build/libprism.a
ar: creating archive build/libprism.a
$ ls -l build/libprism.a 
-rw-r--r--  1 kddnewton  staff  2484312 Mar 20 11:25 build/libprism.a
$ size build/libprism.a
__TEXT	__DATA	__OBJC	others	dec	hex
18038	6120	0	15901	40059	9c7b	build/libprism.a(diagnostic.o)
9188	0	0	9091	18279	4767	build/libprism.a(token_type.o)
60607	0	0	173718	234325	39355	build/libprism.a(prettyprint.o)
676	0	0	28436	29112	71b8	build/libprism.a(pm_strpbrk.o)
1636	0	0	10301	11937	2ea1	build/libprism.a(pm_char.o)
164	0	0	2864	3028	bd4	build/libprism.a(pm_memchr.o)
5289	0	0	23930	29219	7223	build/libprism.a(pm_integer.o)
120	0	0	2367	2487	9b7	build/libprism.a(pm_list.o)
116	0	0	2272	2388	954	build/libprism.a(pm_strncasecmp.o)
44	0	0	1534	1578	62a	build/libprism.a(pm_state_stack.o)
866	0	0	10760	11626	2d6a	build/libprism.a(pm_string.o)
757	0	0	4527	5284	14a4	build/libprism.a(pm_newline_list.o)
144	0	0	2385	2529	9e1	build/libprism.a(pm_string_list.o)
4149	0	0	27573	31722	7bea	build/libprism.a(pm_buffer.o)
1842	0	0	11102	12944	3290	build/libprism.a(pm_constant_pool.o)
19080	0	0	131454	150534	24c06	build/libprism.a(serialize.o)
5489	0	0	43378	48867	bee3	build/libprism.a(static_literals.o)
2296	0	0	11219	13515	34cb	build/libprism.a(regexp.o)
2172	0	0	6313	8485	2125	build/libprism.a(pack.o)
167941	2052	0	816518	986511	f0d8f	build/libprism.a(prism.o)
1027	0	0	9039	10066	2752	build/libprism.a(options.o)
58905	1200	0	180374	240479	3ab5f	build/libprism.a(node.o)
38869	4320	0	70406	113595	1bbbb	build/libprism.a(encoding.o)
$ make static CFLAGS="-DPRISM_EXCLUDE_SERIALIZATION -DPRISM_EXCLUDE_JSON -DPRISM_EXCLUDE_PACK -DPRISM_EXCLUDE_PRETTYPRINT -DPRISM_ENCODING_EXCLUDE_FULL"
building build/libprism.a
ar: creating archive build/libprism.a
$ ls -l build/libprism.a 
-rw-r--r--  1 kddnewton  staff  567328 Mar 20 11:26 build/libprism.a
$ size build/libprism.a
__TEXT	__DATA	__OBJC	others	dec	hex
23614	4080	0	192	27886	6cee	build/libprism.a(diagnostic.o)
10232	0	0	64	10296	2838	build/libprism.a(token_type.o)
0	0	0	0	0	0	build/libprism.a(prettyprint.o)
1924	0	0	192	2116	844	build/libprism.a(pm_strpbrk.o)
2332	0	0	672	3004	bbc	build/libprism.a(pm_char.o)
316	0	0	32	348	15c	build/libprism.a(pm_memchr.o)
9425	0	0	480	9905	26b1	build/libprism.a(pm_integer.o)
272	0	0	128	400	190	build/libprism.a(pm_list.o)
280	0	0	32	312	138	build/libprism.a(pm_strncasecmp.o)
124	0	0	96	220	dc	build/libprism.a(pm_state_stack.o)
1858	0	0	384	2242	8c2	build/libprism.a(pm_string.o)
1373	0	0	128	1501	5dd	build/libprism.a(pm_newline_list.o)
292	0	0	64	356	164	build/libprism.a(pm_string_list.o)
3470	0	0	736	4206	106e	build/libprism.a(pm_buffer.o)
3658	0	0	544	4202	106a	build/libprism.a(pm_constant_pool.o)
0	0	0	0	0	0	build/libprism.a(serialize.o)
8391	0	0	544	8935	22e7	build/libprism.a(static_literals.o)
6264	0	0	608	6872	1ad8	build/libprism.a(regexp.o)
0	0	0	0	0	0	build/libprism.a(pack.o)
233328	2968	0	15584	251880	3d7e8	build/libprism.a(prism.o)
2083	0	0	480	2563	a03	build/libprism.a(options.o)
37112	0	0	384	37496	9278	build/libprism.a(node.o)
24077	240	0	640	24957	617d	build/libprism.a(encoding.o)
```

Looks like it's about 22% of the original size. @hasumikin this isn't quite what we talked about because I haven't provided an option to exclude UTF-8 yet. I'll keep working on that. In the meantime, this should help.