### PR TITLE
Fix an incorrect range of `Prism::Location` when `PM_ERR_RETURN_INVALID`

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -16330,7 +16330,7 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
                         (parser->current_context->context == PM_CONTEXT_CLASS) ||
                         (parser->current_context->context == PM_CONTEXT_MODULE)
                     ) {
-                        pm_parser_err_current(parser, PM_ERR_RETURN_INVALID);
+                        pm_parser_err_previous(parser, PM_ERR_RETURN_INVALID);
                     }
                     return (pm_node_t *) pm_return_node_create(parser, &keyword, arguments.arguments);
                 }

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -1091,7 +1091,7 @@ module Prism
       )
 
       assert_errors expected, "class A; return; end", [
-        ["invalid `return` in a class or module body", 15..16]
+        ["invalid `return` in a class or module body", 9..15]
       ]
     end
 
@@ -1106,7 +1106,7 @@ module Prism
       )
 
       assert_errors expected, "module A; return; end", [
-        ["invalid `return` in a class or module body", 16..17]
+        ["invalid `return` in a class or module body", 10..16]
       ]
     end
 


### PR DESCRIPTION
This PR fixes the following incorrect range of `Prism::Location` when `PM_ERR_RETURN_INVALID`.

It may be hard to tell from the text, but this Ruby error highlights `return`:

```console
$ ruby -e 'class Foo return end'
-e:1: Invalid return in class/module body
class Foo return end
-e: compile error (SyntaxError)
```

Previously, the error's `Prism::Location` pointed to `end`:

```console
$ bundle exec ruby -Ilib -rprism -ve 'p Prism.parse("class Foo return end").errors'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
[#<Prism::ParseError @type=:return_invalid @message="invalid `return` in a class or module body"
@location=#<Prism::Location @start_offset=17 @length=3 start_line=1> @level=:fatal>]

After this fix, it will indicate `return`.

```console
$ bundle exec ruby -Ilib -rprism -ve 'p Prism.parse("class Foo return end").errors' ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22] [#<Prism::ParseError @type=:return_invalid @message="invalid `return` in a class or module body" @location=#<Prism::Location @start_offset=10 @length=6 start_line=1> @level=:fatal>]
```

For reference, here are the before and after of `Prism::Translation::Parser`.

Before:

```console
$ bundle exec ruby -Ilib -rprism -rprism/translation/parser33 -ve 'p Prism::Translation::Parser33.parse("class Foo return end")' ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22] (string):1:18: error: invalid `return` in a class or module body (string):1: class Foo return end
(string):1:                  ^~~
/Users/koic/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/parser-3.3.0.5/lib/parser/diagnostic/engine.rb:72:in `process':
invalid `return` in a class or module body (Parser::SyntaxError)
        from /Users/koic/src/github.com/ruby/prism/lib/prism/translation/parser.rb:220:in `block in unwrap'
        from /Users/koic/src/github.com/ruby/prism/lib/prism/translation/parser.rb:218:in `each'
        from /Users/koic/src/github.com/ruby/prism/lib/prism/translation/parser.rb:218:in `unwrap'
        from /Users/koic/src/github.com/ruby/prism/lib/prism/translation/parser.rb:49:in `parse'
        from /Users/koic/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/parser-3.3.0.5/lib/parser/base.rb:33:in `parse'
        from -e:1:in `<main>'
```

After:

```console
$ bundle exec ruby -Ilib -rprism -rprism/translation/parser33 -ve 'p Prism::Translation::Parser33.parse("class Foo return end")'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin22]
(string):1:11: error: invalid `return` in a class or module body
(string):1: class Foo return end
(string):1:           ^~~~~~
/Users/koic/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/parser-3.3.0.5/lib/parser/diagnostic/engine.rb:72:in `process':
invalid `return` in a class or module body (Parser::SyntaxError)
        from /Users/koic/src/github.com/ruby/prism/lib/prism/translation/parser.rb:220:in `block in unwrap'
        from /Users/koic/src/github.com/ruby/prism/lib/prism/translation/parser.rb:218:in `each'
        from /Users/koic/src/github.com/ruby/prism/lib/prism/translation/parser.rb:218:in `unwrap'
        from /Users/koic/src/github.com/ruby/prism/lib/prism/translation/parser.rb:49:in `parse'
        from /Users/koic/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/parser-3.3.0.5/lib/parser/base.rb:33:in `parse'
        from -e:1:in `<main>'
```

This PR ensures that the originally intended `return` is highlighted as it should be.