### PR TITLE
Use `Sexp#line_max` not `Sexp#max_line` for RubyParser translator

### DIFF
--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -192,19 +192,19 @@ module Prism
 
           if node.opening == "("
             result.line = node.opening_loc.start_line
-            result.max_line = node.closing_loc.end_line
+            result.line_max = node.closing_loc.end_line
             shadow_loc = false
           end
 
           if node.locals.any?
             shadow = s(node, :shadow).concat(visit_all(node.locals))
             shadow.line = node.locals.first.location.start_line
-            shadow.max_line = node.locals.last.location.end_line
+            shadow.line_max = node.locals.last.location.end_line
             result << shadow
 
             if shadow_loc
               result.line = shadow.line
-              result.max_line = shadow.max_line
+              result.line_max = shadow.line_max
             end
           end
 
@@ -1412,7 +1412,7 @@ module Prism
 
           if node.heredoc?
             result.line = node.content_loc.start_line
-            result.max_line = node.content_loc.end_line
+            result.line_max = node.content_loc.end_line
           end
 
           result
@@ -1439,7 +1439,7 @@ module Prism
           result = Sexp.new(*arguments)
           result.file = file
           result.line = node.location.start_line
-          result.max_line = node.location.end_line
+          result.line_max = node.location.end_line
           result
         end
 

--- a/test/prism/ruby_parser_test.rb
+++ b/test/prism/ruby_parser_test.rb
@@ -18,7 +18,7 @@ end
 Sexp.prepend(
   Module.new do
     def ==(other)
-      super && line == other.line && max_line == other.max_line && file == other.file
+      super && line == other.line && line_max == other.line_max && file == other.file
     end
   end
 )


### PR DESCRIPTION
Because RubyParser's `Sexp` uses `method_missing` for [search/delete](https://github.com/seattlerb/sexp_processor/blob/4081209706e81317fde170b327b73f2a69df4507/lib/sexp.rb#L253-L255), it swallows up calls to non-existent methods. That makes it harder to catch issues like this.

Took me a little while to convince myself that all the tests were actually running and passing, but `max_line` really was `nil` the whole time.

Happily, the tests still pass with `line_max` being set appropriately.