### PR TITLE
Fix build error for C99 and C23 CI matrix

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -1238,7 +1238,7 @@ pm_regular_expression_flags_create(pm_parser_t *parser, const pm_token_t *closin
 
         size_t unknown_flags_length = pm_buffer_length(&unknown_flags);
         if (unknown_flags_length != 0) {
-            char *word = unknown_flags_length >= 2 ? "options" : "option";
+            const char *word = unknown_flags_length >= 2 ? "options" : "option";
             PM_PARSER_ERR_TOKEN_FORMAT(parser, parser->previous, PM_ERR_REGEXP_UNKNOWN_OPTIONS, word, unknown_flags_length, pm_buffer_value(&unknown_flags));
         }
         pm_buffer_free(&unknown_flags);


### PR DESCRIPTION
This PR fixes the following build error for C99 and C23 Ruby's CI matrix:

```console
../src/prism/prism.c:1241:19: error: initializing 'char *' with an expression of
type 'const char *' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
1241 |             char *word = unknown_flags_length >= 2 ? "options" : "option";
     |                   ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
assembling ../src/coroutine/amd64/Context.S
```

- c99 ... https://github.com/ruby/ruby/actions/runs/8419905079/job/23053543994#step:10:249
- c23 ... https://github.com/ruby/ruby/actions/runs/8419905079/job/23053544274#step:10:257

This is my mistake. It is an incorrect code introduced in https://github.com/ruby/prism/pull/2618.