### PR TITLE
Fix typos

### DIFF
--- a/docs/cruby_compilation.md
+++ b/docs/cruby_compilation.md
@@ -10,7 +10,7 @@ ruby/ruby uses the Prism code to generate an AST from which it can generate inst
 
 1. Compute an AST
 
-Syncing over the Prism code allows ruby/ruby to compute the AST using Prism. It currently does this within [`iseq.c`](https://github.com/ruby/ruby/blob/master/iseq.c) using the `pm_parser_init` fuction.
+Syncing over the Prism code allows ruby/ruby to compute the AST using Prism. It currently does this within [`iseq.c`](https://github.com/ruby/ruby/blob/master/iseq.c) using the `pm_parser_init` function.
 
 2. Run a first pass of compilation
 

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -214,14 +214,14 @@ Command line flags are a bitset. By default every flag is `0`. It includes the f
 
 Scopes are ordered from the outermost scope to the innermost one.
 
-Each scope is layed out as follows:
+Each scope is laid out as follows:
 
 | # bytes | field                      |
 | ------- | -------------------------- |
 | `4`     | the number of locals       |
 | ...     | the locals                 |
 
-Each local is layed out as follows:
+Each local is laid out as follows:
 
 | # bytes | field                      |
 | ------- | -------------------------- |

--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -730,7 +730,7 @@ parse_input(pm_string_t *input, const pm_options_t *options) {
  *       parsed. This should be an array of arrays of symbols or nil. Scopes are
  *       ordered from the outermost scope to the innermost one.
  * * `version` - the version of Ruby syntax that prism should used to parse Ruby
- *       code. By default prism assumes you want to parse with the latest vesion
+ *       code. By default prism assumes you want to parse with the latest version
  *       of Ruby syntax (which you can trigger with `nil` or `"latest"`). You
  *       may also restrict the syntax to a specific version of Ruby. The
  *       supported values are `"3.3.0"` and `"3.4.0"`.

--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -151,7 +151,7 @@
 #else
     #ifndef xmalloc
         /**
-         * The malloc function that should be used. This can be overriden with
+         * The malloc function that should be used. This can be overridden with
          * the PRISM_XALLOCATOR define.
          */
         #define xmalloc malloc
@@ -159,7 +159,7 @@
 
     #ifndef xrealloc
         /**
-         * The realloc function that should be used. This can be overriden with
+         * The realloc function that should be used. This can be overridden with
          * the PRISM_XALLOCATOR define.
          */
         #define xrealloc realloc
@@ -167,7 +167,7 @@
 
     #ifndef xcalloc
         /**
-         * The calloc function that should be used. This can be overriden with
+         * The calloc function that should be used. This can be overridden with
          * the PRISM_XALLOCATOR define.
          */
         #define xcalloc calloc
@@ -175,7 +175,7 @@
 
     #ifndef xfree
         /**
-         * The free function that should be used. This can be overriden with the
+         * The free function that should be used. This can be overridden with the
          * PRISM_XALLOCATOR define.
          */
         #define xfree free

--- a/include/prism/options.h
+++ b/include/prism/options.h
@@ -286,14 +286,14 @@ PRISM_EXPORTED_FUNCTION void pm_options_free(pm_options_t *options);
  * | `0`   | use the latest version of prism |
  * | `1`   | use the version of prism that is vendored in CRuby 3.3.0 |
  *
- * Each scope is layed out as follows:
+ * Each scope is laid out as follows:
  *
  * | # bytes | field                      |
  * | ------- | -------------------------- |
  * | `4`     | the number of locals       |
  * | ...     | the locals                 |
  *
- * Each local is layed out as follows:
+ * Each local is laid out as follows:
  *
  * | # bytes | field                      |
  * | ------- | -------------------------- |

--- a/src/prism.c
+++ b/src/prism.c
@@ -5602,7 +5602,7 @@ pm_rescue_modifier_node_create(pm_parser_t *parser, pm_node_t *expression, const
 }
 
 /**
- * Allocate and initiliaze a new RescueNode node.
+ * Allocate and initialize a new RescueNode node.
  */
 static pm_rescue_node_t *
 pm_rescue_node_create(pm_parser_t *parser, const pm_token_t *keyword) {
@@ -10416,7 +10416,7 @@ parser_lex(pm_parser_t *parser) {
                             }
                             default:
                                 // If we get to this point, then we have a % that is completely
-                                // unparseable. In this case we'll just drop it from the parser
+                                // unparsable. In this case we'll just drop it from the parser
                                 // and skip past it and hope that the next token is something
                                 // that we can parse.
                                 pm_parser_err_current(parser, PM_ERR_INVALID_PERCENT);
@@ -14426,7 +14426,7 @@ parse_heredoc_dedent_string(pm_string_t *string, size_t common_whitespace) {
 static void
 parse_heredoc_dedent(pm_parser_t *parser, pm_node_list_t *nodes, size_t common_whitespace) {
     // The next node should be dedented if it's the first node in the list or if
-    // if follows a string node.
+    // it follows a string node.
     bool dedent_next = true;
 
     // Iterate over all nodes, and trim whitespace accordingly. We're going to
@@ -17949,7 +17949,7 @@ parse_regular_expression_named_captures(pm_parser_t *parser, const pm_string_t *
 
     if (pm_regexp_named_capture_group_names(pm_string_source(content), pm_string_length(content), &named_captures, parser->encoding_changed, parser->encoding) && (named_captures.length > 0)) {
         // Since we should not create a MatchWriteNode when all capture names
-        // are invalid, creating a MatchWriteNode is delayed here.
+        // are invalid, creating a MatchWriteNode is delaid here.
         pm_match_write_node_t *match = NULL;
         pm_constant_id_list_t names = { 0 };
 
@@ -19616,7 +19616,7 @@ pm_parser_errors_format(const pm_parser_t *parser, pm_buffer_t *buffer, bool col
 
     // Now we're going to determine how we're going to format line numbers and
     // blank lines based on the maximum number of digits in the line numbers
-    // that are going to be displayed.
+    // that are going to be displaid.
     pm_error_format_t error_format;
     int32_t max_line_number = errors[error_list->size - 1].line - start_line;
 
@@ -19707,7 +19707,7 @@ pm_parser_errors_format(const pm_parser_t *parser, pm_buffer_t *buffer, bool col
         pm_error_t *error = &errors[index];
 
         // Here we determine how many lines of padding of the source to display,
-        // based on the difference from the last line that was displayed.
+        // based on the difference from the last line that was displaid.
         if (error->line - last_line > 1) {
             if (error->line - last_line > 2) {
                 if ((index != 0) && (error->line - last_line > 3)) {
@@ -19739,7 +19739,7 @@ pm_parser_errors_format(const pm_parser_t *parser, pm_buffer_t *buffer, bool col
         // the width of the error, then the error message itself.
         //
         // Note that this doesn't take into account the width of the actual
-        // character when displayed in the terminal. For some east-asian
+        // character when displaid in the terminal. For some east-asian
         // languages or emoji, this means it can be thrown off pretty badly. We
         // will need to solve this eventually.
         pm_buffer_append_string(buffer, "  ", 2);

--- a/test/prism/parse_test.rb
+++ b/test/prism/parse_test.rb
@@ -204,7 +204,7 @@ module Prism
       # Additionally, Ripper cannot parse the %w[] fixture in this file, so set ripper_should_parse to false.
       ripper_should_parse = false if relative == "spanning_heredoc.txt"
 
-      # Ruby < 3.3.0 cannot parse heredocs where there are leading whitespace charactes in the heredoc start.
+      # Ruby < 3.3.0 cannot parse heredocs where there are leading whitespace characters in the heredoc start.
       # Example: <<~'   EOF' or <<-'  EOF'
       # https://bugs.ruby-lang.org/issues/19539
       ripper_should_parse = false if relative == "heredocs_leading_whitespace.txt" && RUBY_VERSION < "3.3.0"


### PR DESCRIPTION
After finding the "if if" typo, some additional typos identified by running `codespell` are also being corrected:
https://github.com/codespell-project/codespell