### PR TITLE
Fix serialization of a command line parsing option

### DIFF
--- a/java/org/prism/ParsingOptions.java
+++ b/java/org/prism/ParsingOptions.java
@@ -100,7 +100,8 @@ public abstract class ParsingOptions {
     private static <T extends Enum<T>> byte serializeEnumSet(EnumSet<T> set) {
         byte result = 0;
         for (T value : set) {
-            result |= 1 << value.ordinal();
+            assert (1 << value.ordinal()) <= Byte.MAX_VALUE;
+            result |= (byte) (1 << value.ordinal());
         }
         return result;
     }


### PR DESCRIPTION
Explicitly convert command line options `int` representation to `byte`.

Implicit convertion leads to the following error in TruffleRuby:

```
/b/b/e/main/src/yarp/java/org/prism/ParsingOptions.java:103: warning: [lossy-conversions] implicit cast from int to byte in compound assignment is possibly lossy
            result |= 1 << value.ordinal();
                        ^
error: warnings found and -Werror specified
1 error
```