### PR TITLE
Replace . with decimal point for strtod

### DIFF
--- a/include/prism.h
+++ b/include/prism.h
@@ -26,6 +26,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <locale.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/src/prism.c
+++ b/src/prism.c
@@ -3424,6 +3424,15 @@ pm_double_parse(pm_parser_t *parser, const pm_token_t *token) {
     char *buffer = xmalloc(sizeof(char) * (length + 1));
     memcpy((void *) buffer, token->start, length);
 
+    // Next, determine if we need to replace the decimal point because of
+    // locale-specific options, and then normalize them if we have to.
+    char decimal_point = *localeconv()->decimal_point;
+    if (decimal_point != '.') {
+        for (size_t index = 0; index < length; index++) {
+            if (buffer[index] == '.') buffer[index] = decimal_point;
+        }
+    }
+
     // Next, handle underscores by removing them from the buffer.
     for (size_t index = 0; index < length; index++) {
         if (buffer[index] == '_') {


### PR DESCRIPTION
Fixes https://github.com/ruby/prism/issues/2638