### PR TITLE
Fix parser translation's heredoc whitespace calculation

### DIFF
--- a/lib/prism/translation/parser/compiler.rb
+++ b/lib/prism/translation/parser/compiler.rb
@@ -953,8 +953,35 @@ module Prism
         def visit_interpolated_string_node(node)
           if node.heredoc?
             children, closing = visit_heredoc(node)
+            opening = token(node.opening_loc)
 
-            return builder.string_compose(token(node.opening_loc), children, closing)
+            start_offset = node.opening_loc.end_offset + 1
+            end_offset = node.parts.first.location.start_offset
+
+            # In the below case, the offsets should be the same:
+            #
+            # <<~HEREDOC
+            #   a #{b}
+            # HEREDOC
+            #
+            # But in this case, the end_offset would be greater than the start_offset:
+            #
+            # <<~HEREDOC
+            #   #{b}
+            # HEREDOC
+            #
+            # So we need to make sure the result node's heredoc range is correct, without updating the children
+            result = if start_offset < end_offset
+              # We need to add a padding string to ensure that the heredoc has correct range for its body
+              padding_string_node = builder.string_internal(["", srange_offsets(start_offset, end_offset)])
+              node_with_correct_location = builder.string_compose(opening, [padding_string_node, *children], closing)
+              # But the padding string should not be included in the final AST, so we need to update the result's children
+              node_with_correct_location.updated(:dstr, children)
+            else
+              builder.string_compose(opening, children, closing)
+            end
+
+            return result
           end
 
           parts = if node.parts.one? { |part| part.type == :string_node }

--- a/test/prism/parser_test.rb
+++ b/test/prism/parser_test.rb
@@ -59,7 +59,6 @@ module Prism
       "regex_char_width.txt",
       "spanning_heredoc.txt",
       "spanning_heredoc_newlines.txt",
-      "tilde_heredocs.txt",
       "unescaping.txt"
     ]
 
@@ -75,6 +74,7 @@ module Prism
       "heredoc_with_comment.txt",
       "indented_file_end.txt",
       "strings.txt",
+      "tilde_heredocs.txt",
       "xstring_with_backslash.txt"
     ]
 


### PR DESCRIPTION
Given this example:

```rb
<<~HEREDOC
  #{1} a
HEREDOC
```

Both the parser gem and Prism's translation layer would generate the following AST:

```
s(:dstr,
  s(:begin,
    s(:int, 1)),
  s(:str, " a\n"))
```

However, the parser gem inserts a empty string node into this node's location, like:

```
<Parser::Source::Map::Heredoc:0x0000000104ce73b8
 @expression=#<Parser::Source::Range (string) 0...10>,
 @heredoc_body=#<Parser::Source::Range (string) 11...20>,
 @heredoc_end=#<Parser::Source::Range (string) 20...27>,
 @node=s(:dstr,
  s(:str, ""),
  s(:begin,
    s(:int, 1)),
  s(:str, " a\n"))>
```

This is required to calculate the correct whitespace for the heredoc body.

We need to adjust the translation layer to account for this.

With this fix, we also won't need to ignore the tilde heredoc fixture anymore.

Closes #2374