### PR TITLE
Reduce locals variables per CRuby

### DIFF
--- a/bin/prism
+++ b/bin/prism
@@ -399,7 +399,7 @@ module Prism
       case argv.first
       when "-e"
         argv.shift
-        Prism.parse(argv.shift)
+        Prism.parse(argv.shift, command_line: "e")
       when nil
         Prism.parse_file("test.rb")
       else

--- a/test/prism/warnings_test.rb
+++ b/test/prism/warnings_test.rb
@@ -24,7 +24,7 @@ module Prism
     end
 
     def test_equal_in_conditional
-      assert_warning("if a = 1; end", "should be ==")
+      assert_warning("if a = 1; end; a", "should be ==")
     end
 
     def test_dot_dot_dot_eol
@@ -88,6 +88,43 @@ module Prism
       assert_warning("if /foo\#{bar}/; end", "regex")
     end
 
+    def test_unused_local_variables
+      assert_warning("foo = 1", "unused")
+
+      refute_warning("foo = 1", compare: false, command_line: "e")
+      refute_warning("foo = 1", compare: false, scopes: [[]])
+
+      assert_warning("def foo; bar = 1; end", "unused")
+      assert_warning("def foo; bar, = 1; end", "unused")
+
+      refute_warning("def foo; bar &&= 1; end")
+      refute_warning("def foo; bar ||= 1; end")
+      refute_warning("def foo; bar += 1; end")
+
+      refute_warning("def foo; bar = bar; end")
+      refute_warning("def foo; bar = bar = 1; end")
+      refute_warning("def foo; bar = (bar = 1); end")
+      refute_warning("def foo; bar = begin; bar = 1; end; end")
+      refute_warning("def foo; bar = (qux; bar = 1); end")
+      refute_warning("def foo; bar, = bar = 1; end")
+      refute_warning("def foo; bar, = 1, bar = 1; end")
+
+      refute_warning("def foo(bar); end")
+      refute_warning("def foo(bar = 1); end")
+      refute_warning("def foo((bar)); end")
+      refute_warning("def foo(*bar); end")
+      refute_warning("def foo(*, bar); end")
+      refute_warning("def foo(*, (bar)); end")
+      refute_warning("def foo(bar:); end")
+      refute_warning("def foo(**bar); end")
+      refute_warning("def foo(&bar); end")
+      refute_warning("->(bar) {}")
+      refute_warning("->(; bar) {}", compare: false)
+
+      refute_warning("def foo; bar = 1; tap { bar }; end")
+      refute_warning("def foo; bar = 1; tap { baz = bar; baz }; end")
+    end
+
     private
 
     def assert_warning(source, message)
@@ -101,10 +138,10 @@ module Prism
       end
     end
 
-    def refute_warning(source)
-      assert_empty Prism.parse(source).warnings
+    def refute_warning(source, compare: true, **options)
+      assert_empty Prism.parse(source, **options).warnings
 
-      if defined?(RubyVM::AbstractSyntaxTree)
+      if compare && defined?(RubyVM::AbstractSyntaxTree)
         assert_empty capture_warning { RubyVM::AbstractSyntaxTree.parse(source) }
       end
     end


### PR DESCRIPTION
```ruby
a = a = 1
```

no longer warns.