### PR TITLE
Disable GNU `make` implicit variables and Quiet `ar` with `ARFLAGS` rather than `> null`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ CFLAGS := -g -O2 -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion 
 JAVA_WASM_CFLAGS := -g -Oz -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion -Wno-missing-braces -fPIC -fvisibility=hidden -Wimplicit-fallthrough $(JAVA_WASM_CFLAGS)
 CC ?= cc
 AR ?= ar
+ARFLAGS ?= -r$(V0:1=v)
 WASI_SDK_PATH := /opt/wasi-sdk
 
 MAKEDIRS ?= mkdir -p
@@ -38,7 +39,7 @@ build/libprism.$(SOEXT): $(SHARED_OBJECTS)
 
 build/libprism.a: $(STATIC_OBJECTS)
 	$(ECHO) "building $@ with $(AR)"
-	$(Q) $(AR) $(ARFLAGS) $@ $(STATIC_OBJECTS) $(Q1:0=>/dev/null)
+	$(Q) $(AR) $(ARFLAGS) $@ $(STATIC_OBJECTS)
 
 javascript/src/prism.wasm: Makefile $(SOURCES) $(HEADERS)
 	$(ECHO) "building $@"


### PR DESCRIPTION
`CC`, `AR` and `ARFLAGS` (and also `RM` and `CXX`) are all [implicit variables in GNU `make`](https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html).
* `CC` and `AR` already defaults to `cc` and `ar`, which means `CC ?= cc` does nothing *since before I started tinkering*.
* `ARFLAGS` defaults to `-rv`, where `v` stands for `v`erbose.
  * https://stackoverflow.com/a/40516532 hints that changing it to `r` avoids printing to `null`,
    and *printing to `/dev/null` was the final obstacle for me to build nightly Prism on my [MSYS-less Windows setup](https://github.com/ParadoxV5/ruby-mingw-make)!*

Rather than adapting the `Makefile` and `extconf.rb` around them, I disabled them with `--no-builtin-variables`. While this flag may be GNU-exclusive,  the `README` implies that we only support GNU `make`.
* `CURDIR` from #2706 is also possibly GNU-exclusive.
* The popularity of GNU means it’s a-okay to be toolset-specific rather than platform-specific.

---

* Previously conflicted with #2716