### PR TITLE
Use `Parser::Ruby34` for `bin/prism parser` command

### DIFF
--- a/bin/prism
+++ b/bin/prism
@@ -274,14 +274,14 @@ module Prism
 
     # bin/prism parser [source]
     def parser(argv)
-      require "parser/ruby33"
+      require "parser/ruby34"
       source, filepath = read_source(argv)
 
       buffer = Parser::Source::Buffer.new(filepath, 1)
       buffer.source = source
 
       puts "Parser:"
-      parser_parse(Parser::Ruby33.new, buffer)
+      parser_parse(Parser::Ruby34.new, buffer)
 
       puts "Prism:"
       parser_parse(Prism::Translation::Parser34.new, buffer)


### PR DESCRIPTION
Follow up https://github.com/ruby/prism/pull/2717.

This PR updates the `bin/prism parser` command to use `Parser::Ruby34`. This aligns both Parser gem and `Prism::Translation::Parser` with the same version, Ruby 3.4. Although Parser gem does not yet support Ruby 3.4's `it` parameter, it makes sense to align the versions since preparations for Ruby 3.4 have already begun.