### PR TITLE
Fix `types` path in `package.json` for NPM package

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -4,7 +4,7 @@
   "description": "Prism Ruby parser",
   "type": "module",
   "main": "src/index.js",
-  "types": "types/index.d.ts",
+  "types": "src/index.d.ts",
   "scripts": {
     "prepublishOnly": "npm run type",
     "test": "node test.js",


### PR DESCRIPTION
It looks like the types for the NPM package were rearranged in https://github.com/ruby/prism/pull/2117.

The `types` field in the `package.json` is currently pointing to a non-existing file resulting in an error like:

```
❯ tsc -w
[5:10:39 PM] Starting compilation in watch mode...

src/importmap_file.ts:1:107 - error TS7016: Could not find a declaration file for module '@ruby/prism'. '/Users/marcoroth/Development/stimulus-parser/node_modules/@ruby/prism/src/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/ruby__prism` if it exists or add a new declaration (.d.ts) file containing `declare module '@ruby/prism';`

1 import { loadPrism, Visitor, CallNode, KeywordHashNode, TrueNode, FalseNode, StringNode, AssocNode } from "@ruby/prism";
                                                                                                            ~~~~~~~~~~~~~

[5:10:42 PM] Found 1 error. Watching for file changes.
```

This pull request fixes the `types` field to the correct `index.d.ts` file in `src/`.