### PR TITLE
Assume an eval context for `Prism::Translation::Parser`

### DIFF
--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -46,7 +46,7 @@ module Prism
         source = source_buffer.source
 
         offset_cache = build_offset_cache(source)
-        result = unwrap(Prism.parse(source, filepath: source_buffer.name, version: convert_for_prism(version)), offset_cache)
+        result = unwrap(Prism.parse(source, filepath: source_buffer.name, version: convert_for_prism(version), scopes: [[]]), offset_cache)
 
         build_ast(result.value, offset_cache)
       ensure
@@ -59,7 +59,7 @@ module Prism
         source = source_buffer.source
 
         offset_cache = build_offset_cache(source)
-        result = unwrap(Prism.parse(source, filepath: source_buffer.name, version: convert_for_prism(version)), offset_cache)
+        result = unwrap(Prism.parse(source, filepath: source_buffer.name, version: convert_for_prism(version), scopes: [[]]), offset_cache)
 
         [
           build_ast(result.value, offset_cache),
@@ -78,7 +78,7 @@ module Prism
         offset_cache = build_offset_cache(source)
         result =
           begin
-            unwrap(Prism.parse_lex(source, filepath: source_buffer.name, version: convert_for_prism(version)), offset_cache)
+            unwrap(Prism.parse_lex(source, filepath: source_buffer.name, version: convert_for_prism(version), scopes: [[]]), offset_cache)
           rescue ::Parser::SyntaxError
             raise if !recover
           end


### PR DESCRIPTION
This is similar to https://github.com/davidwessman/syntax_tree-erb/issues/81 but for RuboCop. The parser gem doesn't support these types of checks, see https://github.com/whitequark/parser?tab=readme-ov-file#syntax-check-of-block-exits

While this is technically a bug in the parser gem, it does increase compatibility and allows prism to be used when linting erb or haml through a RuboCop extension.