### PR TITLE
Refactor implicit "it" handling

### DIFF
--- a/bin/prism
+++ b/bin/prism
@@ -301,8 +301,6 @@ module Prism
 
       puts "Prism:"
       pp prism
-
-      puts "Output is #{ripper == prism ? "" : "not "}identical"
     end
 
     # bin/prism rubyparser [source]
@@ -311,7 +309,7 @@ module Prism
       source, filepath = read_source(argv)
 
       ruby_parser = RubyParser.new.parse(source, filepath)
-      prism = Prism::Translation::RubyParser.parse(source, filepath)
+      prism = Prism::Translation::RubyParser.new.parse(source, filepath)
 
       puts "RubyParser:"
       pp ruby_parser

--- a/config.yml
+++ b/config.yml
@@ -2552,6 +2552,12 @@ nodes:
 
           `foo #{bar} baz`
           ^^^^^^^^^^^^^^^^
+  - name: ItLocalVariableReadNode
+    comment: |
+      Represents reading the implicit `it` local variable.
+
+          -> { it }
+               ^^
   - name: ItParametersNode
     comment: |
       Represents an implicit set of parameters through the use of the `it` keyword within a block or lambda.
@@ -2676,10 +2682,6 @@ nodes:
           Note that this can also be an underscore followed by a number for the default block parameters.
 
               _1     # name `:_1`
-
-          Finally, for the default `it` block parameter, the name is `0it`. This is to distinguish it from an `it` local variable that is explicitly declared.
-
-              it     # name `:0it`
 
       - name: depth
         type: uint32

--- a/lib/prism/translation/parser/compiler.rb
+++ b/lib/prism/translation/parser/compiler.rb
@@ -1031,6 +1031,12 @@ module Prism
         end
 
         # -> { it }
+        #      ^^
+        def visit_it_local_variable_read_node(node)
+          builder.call_method(nil, nil, token(node.location), nil, [], nil)
+        end
+
+        # -> { it }
         # ^^^^^^^^^
         def visit_it_parameters_node(node)
           builder.args(nil, [], nil, false)
@@ -1083,14 +1089,7 @@ module Prism
         # foo
         # ^^^
         def visit_local_variable_read_node(node)
-          name = node.name
-
-          # This is just a guess. parser doesn't have support for the implicit
-          # `it` variable yet, so we'll probably have to visit this once it
-          # does.
-          name = :it if name == :"0it"
-
-          builder.ident([name, srange(node.location)]).updated(:lvar)
+          builder.ident([node.name, srange(node.location)]).updated(:lvar)
         end
 
         # foo = 1

--- a/lib/prism/translation/ripper.rb
+++ b/lib/prism/translation/ripper.rb
@@ -2218,6 +2218,13 @@ module Prism
       end
 
       # -> { it }
+      #      ^^
+      def visit_it_local_variable_read_node(node)
+        bounds(node.location)
+        on_vcall(on_ident(node.slice))
+      end
+
+      # -> { it }
       # ^^^^^^^^^
       def visit_it_parameters_node(node)
       end
@@ -2312,12 +2319,7 @@ module Prism
       # ^^^
       def visit_local_variable_read_node(node)
         bounds(node.location)
-
-        if node.name == :"0it"
-          on_vcall(on_ident(node.slice))
-        else
-          on_var_ref(on_ident(node.slice))
-        end
+        on_var_ref(on_ident(node.slice))
       end
 
       # foo = 1

--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -906,6 +906,18 @@ module Prism
           end
         end
 
+        # -> { it }
+        #      ^^
+        def visit_it_local_variable_read_node(node)
+          s(node, :call, nil, :it)
+        end
+
+        # -> { it }
+        # ^^^^^^^^^
+        def visit_it_parameters_node(node)
+          0
+        end
+
         # foo(bar: baz)
         #     ^^^^^^^^
         def visit_keyword_hash_node(node)
@@ -923,18 +935,19 @@ module Prism
 
         # -> {}
         def visit_lambda_node(node)
-          parameters =
-            case node.parameters
+          parameters = node.parameters
+          s_params =
+            case parameters
             when nil, NumberedParametersNode
               s(node, :args)
             else
-              visit(node.parameters)
+              visit(parameters)
             end
 
           if node.body.nil?
-            s(node, :iter, s(node, :lambda), parameters)
+            s(node, :iter, s(node, :lambda), s_params)
           else
-            s(node, :iter, s(node, :lambda), parameters, visit(node.body))
+            s(node, :iter, s(node, :lambda), s_params, visit(node.body))
           end
         end
 
@@ -950,9 +963,6 @@ module Prism
 
         # foo = 1
         # ^^^^^^^
-        #
-        # foo, bar = 1
-        # ^^^  ^^^
         def visit_local_variable_write_node(node)
           s(node, :lasgn, node.name, visit_write_value(node.value))
         end
@@ -1094,7 +1104,7 @@ module Prism
         # -> { _1 + _2 }
         # ^^^^^^^^^^^^^^
         def visit_numbered_parameters_node(node)
-          raise "Cannot visit numbered parameters directly"
+          0
         end
 
         # $1
@@ -1487,18 +1497,13 @@ module Prism
           if block.nil?
             sexp
           else
-            parameters =
-              case block.parameters
-              when nil, NumberedParametersNode
-                0
-              else
-                visit(block.parameters)
-              end
+            parameters = block.parameters
+            s_params = parameters.nil? ? 0 : visit(parameters)
 
             if block.body.nil?
-              s(node, :iter, sexp, parameters)
+              s(node, :iter, sexp, s_params)
             else
-              s(node, :iter, sexp, parameters, visit(block.body))
+              s(node, :iter, sexp, s_params, visit(block.body))
             end
           end
         end

--- a/test/prism/it_test.rb
+++ b/test/prism/it_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+module Prism
+  class ItTest < TestCase
+    def test_regular
+      lambda = parse("-> { it }")
+
+      assert_kind_of Prism::ItParametersNode, lambda.parameters
+      assert_kind_of Prism::ItLocalVariableReadNode, lambda.body.body.first
+    end
+
+    def test_write
+      lambda = parse("-> { it = 1 }")
+
+      refute_kind_of Prism::ItParametersNode, lambda.parameters
+      refute_kind_of Prism::ItLocalVariableReadNode, lambda.body.body.first
+    end
+
+    def test_target
+      lambda = parse("-> { (_, it) = 1 }")
+
+      refute_kind_of Prism::ItParametersNode, lambda.parameters
+      refute_kind_of Prism::ItLocalVariableReadNode, lambda.body.body.first.lefts.last
+    end
+
+    def test_def_receiver
+      lambda = parse("-> { def it.foo; end }")
+
+      assert_kind_of Prism::ItParametersNode, lambda.parameters
+      assert_kind_of Prism::ItLocalVariableReadNode, lambda.body.body.first.receiver
+    end
+
+    def test_pinned
+      lambda = parse("-> { foo in ^it }")
+
+      assert_kind_of Prism::ItParametersNode, lambda.parameters
+      assert_kind_of Prism::ItLocalVariableReadNode, lambda.body.body.first.pattern.variable
+    end
+
+    def test_error_ordinary
+      result = Prism.parse("-> (foo) { it }")
+
+      assert result.failure?
+      assert_includes result.errors.first.message, "ordinary parameter is defined"
+    end
+
+    def test_error_numbered
+      result = Prism.parse("-> { _1 + it }")
+
+      assert result.failure?
+      assert_includes result.errors.first.message, "numbered parameter is defined"
+    end
+
+    private
+
+    def parse(source)
+      Prism.parse(source).value.statements.body.first.tap do |lambda|
+        assert_kind_of Prism::LambdaNode, lambda
+      end
+    end
+  end
+end

--- a/test/prism/location_test.rb
+++ b/test/prism/location_test.rb
@@ -175,14 +175,6 @@ module Prism
 
       assert_location(CallNode, "foo bar baz")
       assert_location(CallNode, "foo bar('baz')")
-
-      assert_location(CallNode, "-> { it }", 5...7, version: "3.3.0") do |node|
-        node.body.body.first
-      end
-
-      assert_location(LocalVariableReadNode, "-> { it }", 5...7, version: "3.4.0") do |node|
-        node.body.body.first
-      end
     end
 
     def test_CallAndWriteNode
@@ -544,6 +536,32 @@ module Prism
       assert_location(InterpolatedXStringNode, '`foo #{bar} baz`')
     end
 
+    def test_ItLocalVariableReadNode
+      assert_location(ItLocalVariableReadNode, "-> { it }", 5...7) do |node|
+        node.body.body.first
+      end
+
+      assert_location(ItLocalVariableReadNode, "foo { it }", 6...8) do |node|
+        node.block.body.body.first
+      end
+
+      assert_location(CallNode, "-> { it }", 5...7, version: "3.3.0") do |node|
+        node.body.body.first
+      end
+
+      assert_location(ItLocalVariableReadNode, "-> { it }", 5...7, version: "3.4.0") do |node|
+        node.body.body.first
+      end
+
+      assert_location(ItLocalVariableReadNode, "-> { 1 in ^it }", 11...13) do |node|
+        node.body.body.first.pattern.variable
+      end
+
+      assert_location(ItLocalVariableReadNode, "-> { def it.foo; end }", 9...11) do |node|
+        node.body.body.first.receiver
+      end
+    end
+
     def test_ItParametersNode
       assert_location(ItParametersNode, "-> { it }", &:parameters)
     end
@@ -584,12 +602,6 @@ module Prism
 
     def test_LocalVariableReadNode
       assert_location(LocalVariableReadNode, "foo = 1; foo", 9...12)
-      assert_location(LocalVariableReadNode, "-> { it }", 5...7) do |node|
-        node.body.body.first
-      end
-      assert_location(LocalVariableReadNode, "foo { it }", 6...8) do |node|
-        node.block.body.body.first
-      end
     end
 
     def test_LocalVariableTargetNode

--- a/test/prism/ruby_parser_test.rb
+++ b/test/prism/ruby_parser_test.rb
@@ -113,17 +113,19 @@ module Prism
 
     def assert_parse_file(base, name, allowed_failure)
       filepath = File.join(base, name)
-      expected = ::RubyParser.new.parse(File.read(filepath), filepath)
-      actual = Prism::Translation::RubyParser.parse_file(filepath)
+      source = File.read(filepath)
+
+      expected = ::RubyParser.new.parse(source, filepath)
+      actual = Prism::Translation::RubyParser.new.parse(source, filepath)
 
       if !allowed_failure
-        assert_equal_nodes expected, actual
+        assert_equal_nodes expected, actual, expected, actual
       elsif expected == actual
         puts "#{name} now passes"
       end
     end
 
-    def assert_equal_nodes(left, right)
+    def assert_equal_nodes(original_left, original_right, left, right)
       return if left == right
 
       if left.is_a?(Sexp) && right.is_a?(Sexp)
@@ -134,10 +136,10 @@ module Prism
         elsif left.length != right.length
           assert_equal "(#{left.inspect} length=#{left.length})", "(#{right.inspect} length=#{right.length})"
         else
-          left.zip(right).each { |l, r| assert_equal_nodes(l, r) }
+          left.zip(right).each { |l, r| assert_equal_nodes(original_left, original_right, l, r) }
         end
       else
-        assert_equal left, right
+        assert_equal original_left, original_right
       end
     end
   end


### PR DESCRIPTION
Creating a special node for the implicit "it" local variable makes the handling of it much simpler, and fixes a couple of bugs with it as well. It also should make it easier on consumers as they won't have to check for the weird `0it` name anymore.