### PR TITLE
Match CRuby interpolation semantics

### DIFF
--- a/test/prism/snapshots/heredocs_nested.txt
+++ b/test/prism/snapshots/heredocs_nested.txt
@@ -4,7 +4,7 @@
     @ StatementsNode (location: (1,0)-(12,4))
     └── body: (length: 2)
         ├── @ InterpolatedStringNode (location: (1,0)-(1,7))
-        │   ├── flags: ∅
+        │   ├── flags: mutable
         │   ├── opening_loc: (1,0)-(1,7) = "<<~RUBY"
         │   ├── parts: (length: 4)
         │   │   ├── @ StringNode (location: (2,0)-(3,0))
@@ -19,7 +19,7 @@
         │   │   │   │   @ StatementsNode (location: (4,0)-(4,6))
         │   │   │   │   └── body: (length: 1)
         │   │   │   │       └── @ StringNode (location: (4,0)-(4,6))
-        │   │   │   │           ├── flags: ∅
+        │   │   │   │           ├── flags: frozen
         │   │   │   │           ├── opening_loc: (4,0)-(4,6) = "<<RUBY"
         │   │   │   │           ├── content_loc: (5,0)-(6,0) = "  hello\n"
         │   │   │   │           ├── closing_loc: (6,0)-(7,0) = "RUBY\n"

--- a/test/prism/snapshots/seattlerb/dstr_evstr.txt
+++ b/test/prism/snapshots/seattlerb/dstr_evstr.txt
@@ -13,7 +13,7 @@
             │   │   │   @ StatementsNode (location: (1,3)-(1,6))
             │   │   │   └── body: (length: 1)
             │   │   │       └── @ StringNode (location: (1,3)-(1,6))
-            │   │   │           ├── flags: ∅
+            │   │   │           ├── flags: frozen
             │   │   │           ├── opening_loc: (1,3)-(1,4) = "'"
             │   │   │           ├── content_loc: (1,4)-(1,5) = "a"
             │   │   │           ├── closing_loc: (1,5)-(1,6) = "'"

--- a/test/prism/snapshots/seattlerb/dstr_str.txt
+++ b/test/prism/snapshots/seattlerb/dstr_str.txt
@@ -4,7 +4,7 @@
     @ StatementsNode (location: (1,0)-(1,10))
     └── body: (length: 1)
         └── @ InterpolatedStringNode (location: (1,0)-(1,10))
-            ├── flags: ∅
+            ├── flags: mutable
             ├── opening_loc: (1,0)-(1,1) = "\""
             ├── parts: (length: 2)
             │   ├── @ EmbeddedStatementsNode (location: (1,1)-(1,7))
@@ -13,7 +13,7 @@
             │   │   │   @ StatementsNode (location: (1,3)-(1,6))
             │   │   │   └── body: (length: 1)
             │   │   │       └── @ StringNode (location: (1,3)-(1,6))
-            │   │   │           ├── flags: ∅
+            │   │   │           ├── flags: frozen
             │   │   │           ├── opening_loc: (1,3)-(1,4) = "'"
             │   │   │           ├── content_loc: (1,4)-(1,5) = "a"
             │   │   │           ├── closing_loc: (1,5)-(1,6) = "'"

--- a/test/prism/snapshots/seattlerb/heredoc_nested.txt
+++ b/test/prism/snapshots/seattlerb/heredoc_nested.txt
@@ -7,7 +7,7 @@
             ├── flags: ∅
             ├── elements: (length: 2)
             │   ├── @ InterpolatedStringNode (location: (1,1)-(1,4))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: mutable
             │   │   ├── opening_loc: (1,1)-(1,4) = "<<A"
             │   │   ├── parts: (length: 3)
             │   │   │   ├── @ EmbeddedStatementsNode (location: (2,0)-(2,6))
@@ -16,7 +16,7 @@
             │   │   │   │   │   @ StatementsNode (location: (2,2)-(2,5))
             │   │   │   │   │   └── body: (length: 1)
             │   │   │   │   │       └── @ StringNode (location: (2,2)-(2,5))
-            │   │   │   │   │           ├── flags: ∅
+            │   │   │   │   │           ├── flags: frozen
             │   │   │   │   │           ├── opening_loc: (2,2)-(2,5) = "<<B"
             │   │   │   │   │           ├── content_loc: (3,0)-(4,0) = "b\n"
             │   │   │   │   │           ├── closing_loc: (4,0)-(5,0) = "B\n"

--- a/test/prism/snapshots/seattlerb/pct_w_heredoc_interp_nested.txt
+++ b/test/prism/snapshots/seattlerb/pct_w_heredoc_interp_nested.txt
@@ -13,7 +13,7 @@
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "1"
             │   ├── @ InterpolatedStringNode (location: (1,6)-(1,12))
-            │   │   ├── flags: ∅
+            │   │   ├── flags: mutable
             │   │   ├── opening_loc: ∅
             │   │   ├── parts: (length: 1)
             │   │   │   └── @ EmbeddedStatementsNode (location: (1,6)-(1,12))
@@ -22,7 +22,7 @@
             │   │   │       │   @ StatementsNode (location: (1,8)-(1,11))
             │   │   │       │   └── body: (length: 1)
             │   │   │       │       └── @ StringNode (location: (1,8)-(1,11))
-            │   │   │       │           ├── flags: ∅
+            │   │   │       │           ├── flags: frozen
             │   │   │       │           ├── opening_loc: (1,8)-(1,11) = "<<A"
             │   │   │       │           ├── content_loc: (2,0)-(3,0) = "2\n"
             │   │   │       │           ├── closing_loc: (3,0)-(4,0) = "A\n"

--- a/test/prism/snapshots/seattlerb/str_str.txt
+++ b/test/prism/snapshots/seattlerb/str_str.txt
@@ -4,7 +4,7 @@
     @ StatementsNode (location: (1,0)-(1,10))
     └── body: (length: 1)
         └── @ InterpolatedStringNode (location: (1,0)-(1,10))
-            ├── flags: ∅
+            ├── flags: mutable
             ├── opening_loc: (1,0)-(1,1) = "\""
             ├── parts: (length: 2)
             │   ├── @ StringNode (location: (1,1)-(1,3))
@@ -19,7 +19,7 @@
             │       │   @ StatementsNode (location: (1,5)-(1,8))
             │       │   └── body: (length: 1)
             │       │       └── @ StringNode (location: (1,5)-(1,8))
-            │       │           ├── flags: ∅
+            │       │           ├── flags: frozen
             │       │           ├── opening_loc: (1,5)-(1,6) = "'"
             │       │           ├── content_loc: (1,6)-(1,7) = "b"
             │       │           ├── closing_loc: (1,7)-(1,8) = "'"

--- a/test/prism/snapshots/seattlerb/str_str_str.txt
+++ b/test/prism/snapshots/seattlerb/str_str_str.txt
@@ -4,7 +4,7 @@
     @ StatementsNode (location: (1,0)-(1,12))
     └── body: (length: 1)
         └── @ InterpolatedStringNode (location: (1,0)-(1,12))
-            ├── flags: ∅
+            ├── flags: mutable
             ├── opening_loc: (1,0)-(1,1) = "\""
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (1,1)-(1,3))
@@ -19,7 +19,7 @@
             │   │   │   @ StatementsNode (location: (1,5)-(1,8))
             │   │   │   └── body: (length: 1)
             │   │   │       └── @ StringNode (location: (1,5)-(1,8))
-            │   │   │           ├── flags: ∅
+            │   │   │           ├── flags: frozen
             │   │   │           ├── opening_loc: (1,5)-(1,6) = "'"
             │   │   │           ├── content_loc: (1,6)-(1,7) = "b"
             │   │   │           ├── closing_loc: (1,7)-(1,8) = "'"

--- a/test/prism/snapshots/unparser/corpus/literal/literal.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/literal.txt
@@ -635,7 +635,7 @@
         │   │       │   @ StatementsNode (location: (53,3)-(53,11))
         │   │       │   └── body: (length: 1)
         │   │       │       └── @ StringNode (location: (53,3)-(53,11))
-        │   │       │           ├── flags: ∅
+        │   │       │           ├── flags: frozen
         │   │       │           ├── opening_loc: (53,3)-(53,4) = "\""
         │   │       │           ├── content_loc: (53,4)-(53,10) = "\\u0000"
         │   │       │           ├── closing_loc: (53,10)-(53,11) = "\""
@@ -707,7 +707,7 @@
         │   │       │   @ StatementsNode (location: (59,4)-(59,9))
         │   │       │   └── body: (length: 1)
         │   │       │       └── @ StringNode (location: (59,4)-(59,9))
-        │   │       │           ├── flags: ∅
+        │   │       │           ├── flags: frozen
         │   │       │           ├── opening_loc: (59,4)-(59,5) = "\""
         │   │       │           ├── content_loc: (59,5)-(59,8) = "foo"
         │   │       │           ├── closing_loc: (59,8)-(59,9) = "\""

--- a/test/prism/snapshots/whitequark/dedenting_heredoc.txt
+++ b/test/prism/snapshots/whitequark/dedenting_heredoc.txt
@@ -15,7 +15,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (1,2)-(1,8))
-        │   │           ├── flags: ∅
+        │   │           ├── flags: mutable
         │   │           ├── opening_loc: (1,2)-(1,8) = "<<~\"E\""
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (2,0)-(3,0))
@@ -30,7 +30,7 @@
         │   │           │   │   │   @ StatementsNode (location: (3,4)-(3,9))
         │   │           │   │   │   └── body: (length: 1)
         │   │           │   │   │       └── @ StringNode (location: (3,4)-(3,9))
-        │   │           │   │   │           ├── flags: ∅
+        │   │           │   │   │           ├── flags: frozen
         │   │           │   │   │           ├── opening_loc: (3,4)-(3,5) = "\""
         │   │           │   │   │           ├── content_loc: (3,5)-(3,8) = "  y"
         │   │           │   │   │           ├── closing_loc: (3,8)-(3,9) = "\""


### PR DESCRIPTION
If a single string that is a static literal is interpolated, it does not impact whether or not the parent is a static literal. In this way, if you have something like a regular expression that interpolates a string literal, it's possible that you will end up pushing just a single regexp onto the stack as opposed to calling out to toregexp.