### PR TITLE
Use `version: 3.3.1` against `Translation::Parser`

### DIFF
--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -408,7 +408,7 @@ module Prism
       values << dump_options_command_line(options)
 
       template << "C"
-      values << { nil => 0, "3.3.0" => 1, "3.4.0" => 0, "latest" => 0 }.fetch(options[:version])
+      values << { nil => 0, "3.3.0" => 1, "3.3.1" => 1, "3.4.0" => 0, "latest" => 0 }.fetch(options[:version])
 
       template << "L"
       if (scopes = options[:scopes])

--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -284,7 +284,7 @@ module Prism
       def convert_for_prism(version)
         case version
         when 33
-          "3.3.0"
+          "3.3.1"
         when 34
           "3.4.0"
         else


### PR DESCRIPTION
Follow up https://github.com/ruby/prism/pull/2760.

This PR updates the `Translation::Parser` to use version 3.3.1 when the version 3.3 is specified. The Parser gem is structured to support the latest patch versions, hence this aligns with Parser-compatible versioning. As noted in https://github.com/ruby/prism/pull/2760, the behavior remains unchanged with this switch from 3.3.0 to 3.3.1.