### PR TITLE
Add Prism::Node#deprecated method type

### DIFF
--- a/templates/sig/prism/node.rbs.erb
+++ b/templates/sig/prism/node.rbs.erb
@@ -19,6 +19,7 @@ module Prism
     def pretty_print: (untyped q) -> untyped
     def to_dot: () -> String
     def tunnel: (Integer line, Integer column) -> Array[Prism::node]
+    def deprecated: (*String) -> void
   end
 
   type node_singleton = singleton(Node) & _NodeSingleton


### PR DESCRIPTION
Add `Prism::Node#deprecated` method type and supress `deprecated` method type error.