### PR TITLE
Add `data_loc` method to Rust bindings

### DIFF
--- a/rust/ruby-prism/src/lib.rs
+++ b/rust/ruby-prism/src/lib.rs
@@ -198,6 +198,18 @@ impl<'pr> ParseResult<'pr> {
         }
     }
 
+    /// Returns an optional location of the __END__ marker and the rest of the content of the file.
+    #[must_use]
+    pub fn data_loc(&self) -> Option<Location<'_>> {
+        let root = self.source.as_ptr();
+        let location = unsafe { &(*self.parser.as_ptr()).data_loc };
+        if location.start >= root {
+            Some(Location::new(self.parser, location))
+        } else {
+            None
+        }
+    }
+
     /// Returns the root node of the parse result.
     #[must_use]
     pub fn node(&self) -> Node<'_> {
@@ -252,6 +264,26 @@ mod tests {
             let text = std::str::from_utf8(comment.text()).unwrap();
             assert!(text.starts_with("# comment"));
         }
+    }
+
+    #[test]
+    fn data_loc_test() {
+        let source = "1";
+        let result = parse(source.as_ref());
+        let data_loc = result.data_loc();
+        assert!(data_loc.is_none());
+
+        let source = "__END__\nabc\n";
+        let result = parse(source.as_ref());
+        let data_loc = result.data_loc().unwrap();
+        let slice = std::str::from_utf8(result.as_slice(&data_loc)).unwrap();
+        assert_eq!(slice, "__END__\nabc\n");
+
+        let source = "1\n2\n3\n__END__\nabc\ndef\n";
+        let result = parse(source.as_ref());
+        let data_loc = result.data_loc().unwrap();
+        let slice = std::str::from_utf8(result.as_slice(&data_loc)).unwrap();
+        assert_eq!(slice, "__END__\nabc\ndef\n");
     }
 
     #[test]

--- a/rust/ruby-prism/src/lib.rs
+++ b/rust/ruby-prism/src/lib.rs
@@ -201,12 +201,11 @@ impl<'pr> ParseResult<'pr> {
     /// Returns an optional location of the __END__ marker and the rest of the content of the file.
     #[must_use]
     pub fn data_loc(&self) -> Option<Location<'_>> {
-        let root = self.source.as_ptr();
         let location = unsafe { &(*self.parser.as_ptr()).data_loc };
-        if location.start >= root {
-            Some(Location::new(self.parser, location))
-        } else {
+        if location.start.is_null() {
             None
+        } else {
+            Some(Location::new(self.parser, location))
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/ruby/prism/discussions/2621

Currently Prism recognizes the `__END__` content and provides a way to access it in Ruby, C, and Java APIs, but Rust bindings does not have it. This PR adds the `data_loc` method to Rust API.