### PR TITLE
Disable use_only_ruby_free_at_exit in ruby_memcheck

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -26,6 +26,7 @@ end
 
 namespace :test do
   if have_memcheck
+    RubyMemcheck.config(use_only_ruby_free_at_exit: false)
     RubyMemcheck::TestTask.new(valgrind_internal: :compile, &config)
 
     # Hide test:valgrind_internal from rake -T


### PR DESCRIPTION
After upgrading to ruby_memcheck 3.0.0, on Ruby >= 3.4.0, it disables the heuristics in favor of using RUBY_FREE_AT_EXIT. This caused the issues below to start showing up on CI. This commit changes it to use the original heuristics even for versions that support RUBY_FREE_AT_EXIT.

    2,712 bytes in 1 blocks are definitely lost in loss record 1 of 3
      malloc (vg_replace_malloc.c:446)
      bfd_simple_get_relocated_section_contents (at /usr/lib/x86_64-linux-gnu/libbfd-2.38-system.so)
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      (below main) (libc_start_call_main.h:58)

    8,192 bytes in 1 blocks are definitely lost in loss record 3 of 3
      malloc (vg_replace_malloc.c:446)
      xrealloc (at /usr/lib/x86_64-linux-gnu/libbfd-2.38-system.so)
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      (below main) (libc_start_call_main.h:58)

    2,712 bytes in 1 blocks are definitely lost in loss record 1 of 3
      malloc (vg_replace_malloc.c:446)
      bfd_simple_get_relocated_section_contents (at /usr/lib/x86_64-linux-gnu/libbfd-2.38-system.so)
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      (below main) (libc_start_call_main.h:58)

    8,192 bytes in 1 blocks are definitely lost in loss record 3 of 3
      malloc (vg_replace_malloc.c:446)
      xrealloc (at /usr/lib/x86_64-linux-gnu/libbfd-2.38-system.so)
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      <unknown stack frame>
      (below main) (libc_start_call_main.h:58)