### PR TITLE
Make Rake compile task a dependency of test task

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -8,7 +8,7 @@ config = lambda do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
-Rake::TestTask.new(:test, &config)
+Rake::TestTask.new(test: :compile, &config)
 
 # If we're on JRuby or TruffleRuby, we don't want to bother to configure
 # memcheck or debug tests.


### PR DESCRIPTION
We should make the compile task a dependency of the test task so that:

- On new clones of prism, running `rake test` will not fail with `'Kernel#require_relative': cannot load such file -- prism/lib/prism/node (LoadError)`.
- When a C file changes, it will be recompiled before the tests are ran.