### PR TITLE
Use gmake on FreeBSD

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ require_relative "templates/template"
 desc "Generate all ERB template based files"
 task templates: Prism::Template::TEMPLATES
 
-make = RUBY_PLATFORM.include?("openbsd") ? "gmake" : "make"
+make = RUBY_PLATFORM.match?(/openbsd|freebsd/) ? "gmake" : "make"
 task(make: :templates) { sh(make) }
 task(make_no_debug: :templates) { sh("#{make} all-no-debug") }
 task(make_minimal: :templates) { sh("#{make} minimal") }

--- a/ext/prism/extconf.rb
+++ b/ext/prism/extconf.rb
@@ -50,7 +50,7 @@ def make(env, target)
   Dir.chdir(File.expand_path("../..", __dir__)) do
     system(
       env,
-      RUBY_PLATFORM.include?("openbsd") ? "gmake" : "make",
+      RUBY_PLATFORM.match?(/openbsd|freebsd/) ? "gmake" : "make",
       target,
       exception: true
     )


### PR DESCRIPTION
This is similar to #2550, fixing the same issue as #2527 but on FreeBSD.

I feel like there should be a better way to handle this, or maybe change the Makefile to not use gmake-specific features, but this changes fixed the issue for now.

Tested on FreeBSD 14 with gmake, the gem builds correctly.