### PR TITLE
When parsing an invalid write, still add to the local table

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -13695,7 +13695,7 @@ parse_unwriteable_write(pm_parser_t *parser, pm_node_t *target, const pm_token_t
         default: break;
     }
 
-    pm_constant_id_t name = pm_parser_constant_id_location(parser, target->location.start, target->location.end);
+    pm_constant_id_t name = pm_parser_local_add_location(parser, target->location.start, target->location.end, 1);
     pm_local_variable_write_node_t *result = pm_local_variable_write_node_create(parser, name, 0, value, &target->location, equals);
 
     pm_node_destroy(parser, target);

--- a/test/prism/locals_test.rb
+++ b/test/prism/locals_test.rb
@@ -9,6 +9,11 @@
 # to test on the most recent versions.
 return if !defined?(RubyVM::InstructionSequence) || RUBY_VERSION < "3.4.0"
 
+# In Ruby 3.4.0, the local table for method forwarding changed. But 3.4.0 can
+# refer to the dev version, so while 3.4.0 still isn't released, we need to
+# check if we have a high enough revision.
+return if RubyVM::InstructionSequence.compile("def foo(...); end").to_a[13][2][2][10].length != 1
+
 # Omit tests if running on a 32-bit machine because there is a bug with how
 # Ruby is handling large ISeqs on 32-bit machines
 return if RUBY_PLATFORM =~ /i686/


### PR DESCRIPTION
In the case that we're parsing invalid local variable writes, we still need to add the name to the local table, otherwise it could fail to find the local later when modifying it.