### PR TITLE
[Doc] Tweak example of `Prism::Dispatcher`

### DIFF
--- a/templates/lib/prism/dispatcher.rb.erb
+++ b/templates/lib/prism/dispatcher.rb.erb
@@ -14,7 +14,8 @@ module Prism
   #       end
   #     end
   #
-  #     dispatcher = Dispatcher.new
+  #     listener = OctalListener.new
+  #     dispatcher = Prism::Dispatcher.new
   #     dispatcher.register(listener, :on_integer_node_enter)
   #
   # Then, you can walk any number of trees and dispatch events to the listeners:


### PR DESCRIPTION
This PR tweaked the documentation to correct an error encountered when running the example code of `Prism::Dispatcher`. This aims to make understanding the example smoother.