### PR TITLE
Fallback to pm_string_file_init on platforms without memory-mapped files

### DIFF
--- a/src/util/pm_string.c
+++ b/src/util/pm_string.c
@@ -143,10 +143,7 @@ pm_string_mapped_init(pm_string_t *string, const char *filepath) {
     *string = (pm_string_t) { .type = PM_STRING_MAPPED, .source = source, .length = size };
     return true;
 #else
-    (void) string;
-    (void) filepath;
-    perror("pm_string_mapped_init is not implemented for this platform");
-    return false;
+    return pm_string_file_init(string, filepath);
 #endif
 }
 
@@ -205,7 +202,7 @@ pm_string_file_init(pm_string_t *string, const char *filepath) {
     CloseHandle(file);
     *string = (pm_string_t) { .type = PM_STRING_OWNED, .source = source, .length = (size_t) file_size };
     return true;
-#elif defined(_POSIX_MAPPED_FILES)
+#else
     FILE *file = fopen(filepath, "rb");
     if (file == NULL) {
         return false;
@@ -244,11 +241,6 @@ pm_string_file_init(pm_string_t *string, const char *filepath) {
 
     *string = (pm_string_t) { .type = PM_STRING_OWNED, .source = source, .length = length };
     return true;
-#else
-    (void) string;
-    (void) filepath;
-    perror("pm_string_file_init is not implemented for this platform");
-    return false;
 #endif
 }
 


### PR DESCRIPTION
> ..., and on other POSIX systems we'll use `read`.

As `pm_string_mapped_init`'s doc comment says, it should fall back to `read(2)`-based implementation on platforms without memory-mapped files like WASI, but it didn't. This commit fixes it by calling `pm_string_file_init` in the fallback case.
Also `defined(_POSIX_MAPPED_FILES)` check for `read(2)`-based path is unnecessary, and it prevents the fallback from being executed, so this change removes it.