### PR TITLE
Optimize serialized size for PRISM_SERIALIZE_ONLY_SEMANTICS_FIELDS=1

### DIFF
--- a/templates/java/org/prism/Loader.java.erb
+++ b/templates/java/org/prism/Loader.java.erb
@@ -363,7 +363,7 @@ public class Loader {
             <%-
             params = ["startOffset", "length"]
             params << "buffer.getInt()" if node.needs_serialized_length?
-            params << "loadFlags()"
+            params << "loadFlags()" if node.flags
             params.concat node.semantic_fields.map { |field|
               case field
               when Prism::Template::NodeField then "#{field.java_cast}loadNode()"

--- a/templates/java/org/prism/Loader.java.erb
+++ b/templates/java/org/prism/Loader.java.erb
@@ -353,7 +353,6 @@ public class Loader {
 
     private Nodes.Node loadNode() {
         int type = buffer.get() & 0xFF;
-        loadVarUInt(); // skip over node_id
         int startOffset = loadVarUInt();
         int length = loadVarUInt();
 

--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -94,13 +94,11 @@ public abstract class Nodes {
 
         public final int startOffset;
         public final int length;
-        protected final short flags;
         private boolean newLineFlag = false;
 
-        public Node(int startOffset, int length, short flags) {
+        public Node(int startOffset, int length) {
             this.startOffset = startOffset;
             this.length = length;
-            this.flags = flags;
         }
 
         public final int endOffset() {
@@ -202,6 +200,9 @@ public abstract class Nodes {
         <%- if node.needs_serialized_length? -%>
         public final int serializedLength;
         <%- end -%>
+        <%- if node.flags -%>
+        public final short flags;
+        <%- end -%>
         <%- node.semantic_fields.each do |field| -%>
         <%- if field.comment -%>
         /**
@@ -224,13 +225,16 @@ public abstract class Nodes {
         <%-
           params = ["int startOffset", "int length"]
           params << "int serializedLength" if node.needs_serialized_length?
-          params << "short flags"
+          params << "short flags" if node.flags
           params.concat(node.semantic_fields.map { |field| "#{field.java_type} #{field.name}" })
         -%>
         public <%= node.name -%>(<%= params.join(", ") %>) {
-            super(startOffset, length, flags);
+            super(startOffset, length);
         <%- if node.needs_serialized_length? -%>
             this.serializedLength = serializedLength;
+        <%- end -%>
+        <%- if node.flags -%>
+            this.flags = flags;
         <%- end -%>
         <%- node.semantic_fields.each do |field| -%>
             this.<%= field.name %> = <%= field.name %>;

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -74,7 +74,9 @@ pm_serialize_node(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
 
     size_t offset = buffer->length;
 
+    <%- unless Prism::Template::SERIALIZE_ONLY_SEMANTICS_FIELDS -%>
     pm_buffer_append_varuint(buffer, node->node_id);
+    <%- end -%>
     pm_serialize_location(parser, &node->location, buffer);
 
     switch (PM_NODE_TYPE(node)) {

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -92,7 +92,9 @@ pm_serialize_node(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
             size_t length_offset = buffer->length;
             pm_buffer_append_string(buffer, "\0\0\0\0", 4); /* consume 4 bytes, updated below */
             <%- end -%>
+            <%- unless Prism::Template::SERIALIZE_ONLY_SEMANTICS_FIELDS && !node.flags -%>
             pm_buffer_append_varuint(buffer, (uint32_t) node->flags);
+            <%- end -%>
             <%- node.fields.each do |field| -%>
             <%- case field -%>
             <%- when Prism::Template::NodeField -%>


### PR DESCRIPTION
From https://github.com/ruby/prism/pull/2924#issuecomment-2248749015, `average` went from 0.799 before #2924 to 0.950 after, with this PR it goes back to 0.800.

As an aside this makes the `flags` field public again, which is necessary as TruffleRuby uses it like that (the error can be seen at https://github.com/oracle/truffleruby/actions/workflows/prism.yml).