### PR TITLE
Tweak inspect representation of `Prism::Location`

### DIFF
--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -711,5 +711,11 @@ module Prism
         other.type == type &&
         other.value == value
     end
+
+    # Returns a string representation of this token.
+    def inspect
+      location
+      super
+    end
   end
 end


### PR DESCRIPTION
This PR tweaks inspect representation of `Prism::Location`.

## Before

During debugging, the meaning of `@location=21474836481` was unclear:

```console
$ ruby -Ilib -rprism -e 'p Prism.lex("puts :hi").value.map(&:first)[1]'
#<Prism::Token:0x000000010cd74e40 @source=#<Prism::ASCIISource:0x000000010cb5f808 @source="puts :hi", @start_line=1, @offsets=[0]>,
@type=:SYMBOL_BEGIN, @value=":", @location=21474836481>
```

## After

This PR clarifies the contents of the location object, aligning with what I think user expects:

```console
$ ruby -Ilib -rprism -e 'p Prism.lex("puts :hi").value.map(&:first)[1]'
#<Prism::Token:0x000000010e174d50 @source=#<Prism::ASCIISource:0x000000010df5efe8 @source="puts :hi", @start_line=1, @offsets=[0]>,
@type=:SYMBOL_BEGIN, @value=":", @location=#<Prism::Location @start_offset=5 @length=1 start_line=1>>
```

Although it is uncertain whether Prism will accept this change in the inspect representation, it is submitted here as a suggestion.