### PR TITLE
Render node comments into their `ast.h`

### DIFF
--- a/templates/include/prism/ast.h.erb
+++ b/templates/include/prism/ast.h.erb
@@ -151,12 +151,14 @@ typedef struct pm_node {
 <%- nodes.each do |node| -%>
 
 /**
+ * <%= node.name %>
+ *
 <%- node.each_comment_line do |line| -%>
  *<%= line %>
 <%- end -%>
- * <%= node.name %> (type: <%= node.type %>)
-<%- if (node_flags = node.flags) -%>
  *
+ * Type: <%= node.type %>
+<%- if (node_flags = node.flags) -%>
  * Flags:
 <%- node_flags.values.each do |value| -%>
  *    PM_<%= node_flags.human.upcase %>_<%= value.name %>

--- a/templates/include/prism/ast.h.erb
+++ b/templates/include/prism/ast.h.erb
@@ -151,10 +151,12 @@ typedef struct pm_node {
 <%- nodes.each do |node| -%>
 
 /**
- * <%= node.name %>
- *
- * Type: <%= node.type %>
+<%- node.each_comment_line do |line| -%>
+ *<%= line %>
+<%- end -%>
+ * <%= node.name %> (type: <%= node.type %>)
 <%- if (node_flags = node.flags) -%>
+ *
  * Flags:
 <%- node_flags.values.each do |value| -%>
  *    PM_<%= node_flags.human.upcase %>_<%= value.name %>


### PR DESCRIPTION
The `config.yml` file contains nodes with comments, but none of those are surfaced in the header docs `ast.h`, and thus don't get rendered into the doxygen site.

This PR fixes that, and greatly improves the quality of the docsite. Compare:


|          | Before | After |
|----------|--------|-------|
| Overview | <img width="475" alt="Before overview" src="https://github.com/user-attachments/assets/8b6f1760-47bf-44d7-b24b-90550173666c"> | <img width="460" alt="Before details" src="https://github.com/user-attachments/assets/a0948944-addb-495c-9dfe-3273c5393642"> |
| Details  | <img width="478" alt="After overview" src="https://github.com/user-attachments/assets/8a27610e-f3d3-4b1a-9b57-c45ae81bb355"> | <img width="479" alt="After detais" src="https://github.com/user-attachments/assets/cae9dd3f-63f5-43c3-8887-edd7d4100730"> |
        









