### PR TITLE
Allow failures for arm64/ppc64le/s390x due to infra errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,15 @@ matrix:
     - arch: arm64
     - arch: ppc64le
     - arch: s390x
+  allow_failures:
+    # Allow failures due to the following infra errors.
+    # The jobs are not starting.
+    - arch: arm64
+    # No output has been received in the last 10m0s, this potentially indicates
+    # a stalled build or something wrong with the build itself.
+    # https://app.travis-ci.com/github/ruby/prism/builds/271968231
+    - arch: ppc64le
+    - arch: s390x
   fast_finish: true
 
 before_install:


### PR DESCRIPTION
Allow failures for ppc64le/s390x due to the following infra errors.

https://app.travis-ci.com/github/ruby/prism/builds/271968231
> No output has been received in the last 10m0s, this potentially indicates
> a stalled build or something wrong with the build itself.