### PR TITLE
Fix bug when `#!` ends with carriage return

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -21711,7 +21711,7 @@ pm_strnstr(const char *big, const char *little, size_t big_length) {
  */
 static void
 pm_parser_warn_shebang_carriage_return(pm_parser_t *parser, const uint8_t *start, size_t length) {
-    if (length > 2 && start[length - 1] == '\n' && start[length - 2] == '\r') {
+    if (length > 2 && start[length - 2] == '\r' && start[length - 1] == '\n') {
         pm_parser_warn(parser, start, start + length, PM_WARN_SHEBANG_CARRIAGE_RETURN);
     }
 }
@@ -21904,11 +21904,17 @@ pm_parser_init(pm_parser_t *parser, const uint8_t *source, size_t size, const pm
 
         const char *engine;
         if ((engine = pm_strnstr((const char *) parser->start, "ruby", length)) != NULL) {
-            pm_parser_warn_shebang_carriage_return(parser, parser->start, length);
-            if (newline != NULL) parser->encoding_comment_start = newline + 1;
+            if (newline != NULL) {
+                size_t length_including_newline = length + 1;
+                pm_parser_warn_shebang_carriage_return(parser, parser->start, length_including_newline);
+
+                parser->encoding_comment_start = newline + 1;
+            }
+
             if (options != NULL && options->shebang_callback != NULL) {
                 pm_parser_init_shebang(parser, options, engine, length - ((size_t) (engine - (const char *) parser->start)));
             }
+
             search_shebang = false;
         } else if (!parser->parsing_eval) {
             search_shebang = true;
@@ -21938,17 +21944,20 @@ pm_parser_init(pm_parser_t *parser, const uint8_t *source, size_t size, const pm
 
             size_t length = (size_t) ((newline != NULL ? newline : parser->end) - cursor);
             if (length > 2 && cursor[0] == '#' && cursor[1] == '!') {
-                if (parser->newline_list.size == 1) {
-                    pm_parser_warn_shebang_carriage_return(parser, cursor, length);
-                }
-
                 const char *engine;
                 if ((engine = pm_strnstr((const char *) cursor, "ruby", length)) != NULL) {
                     found_shebang = true;
-                    if (newline != NULL) parser->encoding_comment_start = newline + 1;
+                    if (newline != NULL) {
+                        size_t length_including_newline = length + 1;
+                        pm_parser_warn_shebang_carriage_return(parser, cursor, length_including_newline);
+
+                        parser->encoding_comment_start = newline + 1;
+                    }
+
                     if (options != NULL && options->shebang_callback != NULL) {
                         pm_parser_init_shebang(parser, options, engine, length - ((size_t) (engine - (const char *) cursor)));
                     }
+
                     break;
                 }
             }

--- a/test/prism/result/warnings_test.rb
+++ b/test/prism/result/warnings_test.rb
@@ -321,6 +321,44 @@ module Prism
       assert_warning("tap { redo; foo }", "statement not reached")
     end
 
+    def test_shebang_ending_with_carriage_return
+      msg = "shebang line ending with \\r may cause problems"
+
+      assert_warning(<<~RUBY, msg, compare: false)
+        #!ruby\r
+        p(123)
+      RUBY
+
+      assert_warning(<<~RUBY, msg, compare: false)
+        #!ruby \r
+        p(123)
+      RUBY
+
+      assert_warning(<<~RUBY, msg, compare: false)
+        #!ruby -Eutf-8\r
+        p(123)
+      RUBY
+
+      # Used with the `-x` object, to ignore the script up until the first shebang that mentioned "ruby".
+      assert_warning(<<~SCRIPT, msg, compare: false)
+        #!/usr/bin/env bash
+        # Some initial shell script or other content
+        # that Ruby should ignore
+        echo "This is shell script part"
+        exit 0
+
+        #! /usr/bin/env ruby -Eutf-8\r
+        # Ruby script starts here
+        puts "Hello from Ruby!"
+      SCRIPT
+
+      refute_warning("#ruby not_a_shebang\r\n", compare: false)
+
+      # CRuby doesn't emit the warning if a malformed file only has `\r` and not `\n`.
+      # https://bugs.ruby-lang.org/issues/20700
+      refute_warning("#!ruby\r", compare: false)
+    end
+
     def test_warnings_verbosity
       warning = Prism.parse("def foo; END { }; end").warnings.first
       assert_equal "END in method; use at_exit", warning.message
@@ -333,7 +371,7 @@ module Prism
 
     private
 
-    def assert_warning(source, *messages)
+    def assert_warning(source, *messages, compare: true)
       warnings = Prism.parse(source).warnings
       assert_equal messages.length, warnings.length, "Expected #{messages.length} warning(s) in #{source.inspect}, got #{warnings.map(&:message).inspect}"
 
@@ -341,7 +379,7 @@ module Prism
         assert_include warning.message, message
       end
 
-      if defined?(RubyVM::AbstractSyntaxTree)
+      if compare && defined?(RubyVM::AbstractSyntaxTree)
         stderr = capture_stderr { RubyVM::AbstractSyntaxTree.parse(source) }
         messages.each { |message| assert_include stderr, message }
       end


### PR DESCRIPTION
Related to #2996

Fixes the second of the two assertion failures here:

```
TestRubyOptions#test_shebang [/Users/alex/src/github.com/Ruby/ruby/test/ruby/test_rubyoptions.rb:514]:
pid 49518 exit 0.

1. [1/2] Assertion for "stdout"
   | <["\"あ\""]> expected but was
   | <["\"\\u3042\""]>.

2. [2/2] Assertion for "stderr"
   | Expected /shebang line ending with \\r/ to match "".

Finished tests in 0.030572s, 32.7097 tests/s, 359.8064 assertions/s.
1 tests, 11 assertions, 1 failures, 0 errors, 0 skips

ruby -v: ruby 3.4.0dev (2024-08-22T14:01:55Z master 56a34b5af5) +PRISM [arm64-darwin23]
make: *** [yes-test-all] Error 1
```

## Root cause

The "string" (pointer+length combo) given to `pm_parser_warn_shebang_carriage_return` ended on the `\r`, right before the `\n`. So the check for `\r\n` actually found `8\r` instead.

## Solution approach

When there _is_ a newline, bump the `length` by 1 to include it as part of the string passed to `pm_parser_warn_shebang_carriage_return`, which can then accurately detect the `\r\n`.