### PR TITLE
UTF-8 characters in file name

### DIFF
--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -254,14 +254,14 @@ string_options(int argc, VALUE *argv, pm_string_t *input, pm_options_t *options)
  * Read options for methods that look like (filepath, **options).
  */
 static void
-file_options(int argc, VALUE *argv, pm_string_t *input, pm_options_t *options) {
+file_options(int argc, VALUE *argv, pm_string_t *input, pm_options_t *options, VALUE *encoded_filepath) {
     VALUE filepath;
     VALUE keywords;
     rb_scan_args(argc, argv, "1:", &filepath, &keywords);
 
     Check_Type(filepath, T_STRING);
-
-    extract_options(options, filepath, keywords);
+    *encoded_filepath = rb_str_encode_ospath(filepath);
+    extract_options(options, *encoded_filepath, keywords);
 
     const char * string_source = (const char *) pm_string_source(&options->filepath);
 
@@ -352,7 +352,8 @@ dump_file(int argc, VALUE *argv, VALUE self) {
     pm_string_t input;
     pm_options_t options = { 0 };
 
-    file_options(argc, argv, &input, &options);
+    VALUE encoded_filepath;
+    file_options(argc, argv, &input, &options, &encoded_filepath);
 
     VALUE value = dump_input(&input, &options);
     pm_string_free(&input);
@@ -685,7 +686,8 @@ lex_file(int argc, VALUE *argv, VALUE self) {
     pm_string_t input;
     pm_options_t options = { 0 };
 
-    file_options(argc, argv, &input, &options);
+    VALUE encoded_filepath;
+    file_options(argc, argv, &input, &options, &encoded_filepath);
 
     VALUE value = parse_lex_input(&input, &options, false);
     pm_string_free(&input);
@@ -782,7 +784,8 @@ parse_file(int argc, VALUE *argv, VALUE self) {
     pm_string_t input;
     pm_options_t options = { 0 };
 
-    file_options(argc, argv, &input, &options);
+    VALUE encoded_filepath;
+    file_options(argc, argv, &input, &options, &encoded_filepath);
 
     VALUE value = parse_input(&input, &options);
     pm_string_free(&input);
@@ -838,7 +841,9 @@ profile_file(int argc, VALUE *argv, VALUE self) {
     pm_string_t input;
     pm_options_t options = { 0 };
 
-    file_options(argc, argv, &input, &options);
+    VALUE encoded_filepath;
+    file_options(argc, argv, &input, &options, &encoded_filepath);
+
     profile_input(&input, &options);
     pm_string_free(&input);
     pm_options_free(&options);
@@ -952,7 +957,8 @@ parse_file_comments(int argc, VALUE *argv, VALUE self) {
     pm_string_t input;
     pm_options_t options = { 0 };
 
-    file_options(argc, argv, &input, &options);
+    VALUE encoded_filepath;
+    file_options(argc, argv, &input, &options, &encoded_filepath);
 
     VALUE value = parse_input_comments(&input, &options);
     pm_string_free(&input);
@@ -1007,7 +1013,8 @@ parse_lex_file(int argc, VALUE *argv, VALUE self) {
     pm_string_t input;
     pm_options_t options = { 0 };
 
-    file_options(argc, argv, &input, &options);
+    VALUE encoded_filepath;
+    file_options(argc, argv, &input, &options, &encoded_filepath);
 
     VALUE value = parse_lex_input(&input, &options, true);
     pm_string_free(&input);
@@ -1077,7 +1084,8 @@ parse_file_success_p(int argc, VALUE *argv, VALUE self) {
     pm_string_t input;
     pm_options_t options = { 0 };
 
-    file_options(argc, argv, &input, &options);
+    VALUE encoded_filepath;
+    file_options(argc, argv, &input, &options, &encoded_filepath);
 
     VALUE result = parse_input_success_p(&input, &options);
     pm_string_free(&input);

--- a/test/prism/api/parse_test.rb
+++ b/test/prism/api/parse_test.rb
@@ -69,6 +69,16 @@ module Prism
       end
     end
 
+    if RUBY_ENGINE != "truffleruby"
+      def test_parse_nonascii
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, "\u{3042 3044 3046 3048 304a}.rb".encode(Encoding::Windows_31J))
+          File.write(path, "ok")
+          Prism.parse_file(path)
+        end
+      end
+    end
+
     private
 
     def find_source_file_node(program)


### PR DESCRIPTION
@eregon just as a heads up, I needed to ignore truffleruby for this test I'm adding. It gave this:

```
Error: test_parse_nonascii(Prism::ParseTest): Errno::EILSEQ: Invalid or incomplete multibyte or wide character - /var/folders/py/lcjn3y352g1106vf1rqk521r0000gn/T/d20240911-3081-pppkms/����������.rb
<internal:core> core/errno.rb:48:in `handle'
<internal:core> core/io.rb:808:in `sysopen'
<internal:core> core/file.rb:1186:in `initialize'
<internal:core> core/io.rb:571:in `open'
<internal:core> core/io.rb:512:in `write'
/Users/runner/work/prism/prism/test/prism/api/parse_test.rb:75:in `block in test_parse_nonascii'
     72:     def test_parse_nonascii
     73:       Dir.mktmpdir do |dir|
     74:         path = File.join(dir, "\u{3042 3044 3046 3048 304a}.rb".encode(Encoding::Windows_31J))
  => 75:         File.write(path, "ok")
     76:         Prism.parse_file(path)
     77:       end
     78:     end
/Users/runner/.rubies/truffleruby-24.0.2/lib/mri/tmpdir.rb:94:in `mktmpdir'
/Users/runner/work/prism/prism/test/prism/api/parse_test.rb:73:in `test_parse_nonascii'
<internal:core> core/throw_catch.rb:36:in `catch'
<internal:core> core/throw_catch.rb:36:in `catch'
```

it's no rush or anything, I just figured I'd mention it.