### PR TITLE
Fix node flags values for Java

### DIFF
--- a/templates/include/prism/ast.h.erb
+++ b/templates/include/prism/ast.h.erb
@@ -207,7 +207,7 @@ typedef enum pm_<%= flag.human %> {
     <%- flag.values.each_with_index do |value, index| -%>
 <%= "\n" if index > 0 -%>
     /** <%= value.comment %> */
-    PM_<%= flag.human.upcase %>_<%= value.name %> = <%= 1 << (index + 2) %>,
+    PM_<%= flag.human.upcase %>_<%= value.name %> = <%= 1 << (index + Prism::Template::COMMON_FLAGS_COUNT) %>,
     <%- end -%>
 } pm_<%= flag.human %>_t;
 <%- end -%>

--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -135,19 +135,19 @@ public abstract class Nodes {
         protected abstract String toString(String indent);
     }
 <%# FLAGS -%>
-    <%- flags.each do |group| -%>
+    <%- flags.each do |flag| -%>
 
     /**
-     * <%= Prism::Template::JavaDoc.escape(group.comment) %>
+     * <%= Prism::Template::JavaDoc.escape(flag.comment) %>
      */
-    public static final class <%= group.name %> implements Comparable<<%= group.name %>> {
-        <%- group.values.each_with_index do |value, index| -%>
+    public static final class <%= flag.name %> implements Comparable<<%= flag.name %>> {
+        <%- flag.values.each_with_index do |value, index| -%>
 
         // <%= value.comment %>
         public static final short <%= value.name %> = 1 << <%= index + 2 %>;
         <%- end -%>
 
-        <%- group.values.each do |value| -%>
+        <%- flag.values.each do |value| -%>
         public static boolean is<%= value.camelcase %>(short flags) {
             return (flags & <%= value.name %>) != 0;
         }
@@ -155,7 +155,7 @@ public abstract class Nodes {
         <%- end -%>
         private final short flags;
 
-        public <%= group.name %>(short flags) {
+        public <%= flag.name %>(short flags) {
             this.flags = flags;
         }
 
@@ -166,19 +166,19 @@ public abstract class Nodes {
 
         @Override
         public boolean equals(Object other) {
-            if (!(other instanceof <%= group.name %>)) {
+            if (!(other instanceof <%= flag.name %>)) {
                 return false;
             }
 
-            return flags == ((<%= group.name %>) other).flags;
+            return flags == ((<%= flag.name %>) other).flags;
         }
 
         @Override
-        public int compareTo(<%= group.name %> other) {
+        public int compareTo(<%= flag.name %> other) {
             return flags - other.flags;
         }
 
-        <%- group.values.each do |value| -%>
+        <%- flag.values.each do |value| -%>
         public boolean is<%= value.camelcase %>() {
             return (flags & <%= value.name %>) != 0;
         }

--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -144,7 +144,7 @@ public abstract class Nodes {
         <%- group.values.each_with_index do |value, index| -%>
 
         // <%= value.comment %>
-        public static final short <%= value.name %> = 1 << <%= index %>;
+        public static final short <%= value.name %> = 1 << <%= index + 2 %>;
         <%- end -%>
 
         <%- group.values.each do |value| -%>

--- a/templates/java/org/prism/Nodes.java.erb
+++ b/templates/java/org/prism/Nodes.java.erb
@@ -144,7 +144,7 @@ public abstract class Nodes {
         <%- flag.values.each_with_index do |value, index| -%>
 
         // <%= value.comment %>
-        public static final short <%= value.name %> = 1 << <%= index + 2 %>;
+        public static final short <%= value.name %> = 1 << <%= index + Prism::Template::COMMON_FLAGS_COUNT %>;
         <%- end -%>
 
         <%- flag.values.each do |value| -%>

--- a/templates/javascript/src/nodes.js.erb
+++ b/templates/javascript/src/nodes.js.erb
@@ -32,8 +32,8 @@ import * as visitors from "./visitor.js"
  * <%= flag.comment %>
  */
 const <%= flag.name %> = {
-<%- flag.values.each.with_index(2) do |value, index| -%>
-  <%= value.name %>: 1 << <%= index %>,
+<%- flag.values.each_with_index do |value, index| -%>
+  <%= value.name %>: 1 << <%= index + 2 %>,
 <%- end -%>
 };
 <%- end -%>

--- a/templates/javascript/src/nodes.js.erb
+++ b/templates/javascript/src/nodes.js.erb
@@ -33,7 +33,7 @@ import * as visitors from "./visitor.js"
  */
 const <%= flag.name %> = {
 <%- flag.values.each_with_index do |value, index| -%>
-  <%= value.name %>: 1 << <%= index + 2 %>,
+  <%= value.name %>: 1 << <%= index + Prism::Template::COMMON_FLAGS_COUNT %>,
 <%- end -%>
 };
 <%- end -%>

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -395,7 +395,7 @@ module Prism
   module <%= flag.name %>
     <%- flag.values.each_with_index do |value, index| -%>
     # <%= value.comment %>
-    <%= value.name %> = 1 << <%= index + 2 %>
+    <%= value.name %> = 1 << <%= index + Prism::Template::COMMON_FLAGS_COUNT %>
 <%= "\n" if value != flag.values.last -%>
     <%- end -%>
   end

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -389,13 +389,13 @@ module Prism
     end
   end
   <%- end -%>
-  <%- flags.each_with_index do |flag, flag_index| -%>
+  <%- flags.each do |flag| -%>
 
   # <%= flag.comment %>
   module <%= flag.name %>
     <%- flag.values.each_with_index do |value, index| -%>
     # <%= value.comment %>
-    <%= value.name %> = 1 << <%= (index + 2) %>
+    <%= value.name %> = 1 << <%= index + 2 %>
 <%= "\n" if value != flag.values.last -%>
     <%- end -%>
   end

--- a/templates/rbi/prism/node.rbi.erb
+++ b/templates/rbi/prism/node.rbi.erb
@@ -148,7 +148,7 @@ end
 module Prism::<%= flag.name %>
   <%- flag.values.each_with_index do |value, index| -%>
   # <%= value.comment %>
-  <%= value.name %> = T.let(1 << <%= index %>, Integer)
+  <%= value.name %> = T.let(1 << <%= index + 2 %>, Integer)
   <%- end -%>
 end
 <%- end -%>

--- a/templates/rbi/prism/node.rbi.erb
+++ b/templates/rbi/prism/node.rbi.erb
@@ -148,7 +148,7 @@ end
 module Prism::<%= flag.name %>
   <%- flag.values.each_with_index do |value, index| -%>
   # <%= value.comment %>
-  <%= value.name %> = T.let(1 << <%= index + 2 %>, Integer)
+  <%= value.name %> = T.let(1 << <%= index + Prism::Template::COMMON_FLAGS_COUNT %>, Integer)
   <%- end -%>
 end
 <%- end -%>

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -13,6 +13,8 @@ module Prism
     JAVA_BACKEND = ENV["PRISM_JAVA_BACKEND"] || "truffleruby"
     JAVA_STRING_TYPE = JAVA_BACKEND == "jruby" ? "org.jruby.RubySymbol" : "String"
 
+    COMMON_FLAGS_COUNT = 2
+
     class Error
       attr_reader :name
 


### PR DESCRIPTION
Recently common flags were added for every node in #2924. So each flag value was increased by 2. There were changes for Ruby and JS but not for Java.

Also I have found helpful to have similar formatting/code style in templates (at least for the code to generate flags) to easily find difference. So I changed it a bit in several templates what is quite subjective.