### PR TITLE
Accept all 3.3.x and 3.4.x Ruby versions for Prism.parse

### DIFF
--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -42,17 +42,11 @@ ID rb_id_source_for;
 /******************************************************************************/
 
 /**
- * Check if the given VALUE is a string. If it's nil, then return NULL. If it's
- * not a string, then raise a type error. Otherwise return the VALUE as a C
- * string.
+ * Check if the given VALUE is a string. If it's not a string, then raise a
+ * TypeError. Otherwise return the VALUE as a C string.
  */
 static const char *
 check_string(VALUE value) {
-    // If the value is nil, then we don't need to do anything.
-    if (NIL_P(value)) {
-        return NULL;
-    }
-
     // Check if the value is a string. If it's not, then raise a type error.
     if (!RB_TYPE_P(value, T_STRING)) {
         rb_raise(rb_eTypeError, "wrong argument type %" PRIsVALUE " (expected String)", rb_obj_class(value));

--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -770,8 +770,10 @@ parse_input(pm_string_t *input, const pm_options_t *options) {
  * * `version` - the version of Ruby syntax that prism should used to parse Ruby
  *       code. By default prism assumes you want to parse with the latest version
  *       of Ruby syntax (which you can trigger with `nil` or `"latest"`). You
- *       may also restrict the syntax to a specific version of Ruby. The
- *       supported values are `"3.3.0"` and `"3.4.0"`.
+ *       may also restrict the syntax to a specific version of Ruby, e.g., with `"3.3.0"`.
+ *       To parse with the same syntax version that the current Ruby is running
+ *       use `version: RUBY_VERSION`. Raises ArgumentError if the version is not
+ *       currently supported by Prism.
  */
 static VALUE
 parse(int argc, VALUE *argv, VALUE self) {

--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -411,6 +411,20 @@ module Prism
       end
     end
 
+    # Return the value that should be dumped for the version option.
+    def dump_options_version(version)
+      case version
+      when nil, "latest"
+        0
+      when /\A3\.3\.\d+\z/
+        1
+      when /\A3\.4\.\d+\z/
+        0
+      else
+        raise ArgumentError, "invalid version: #{version}"
+      end
+    end
+
     # Convert the given options into a serialized options string.
     def dump_options(options)
       template = +""
@@ -443,7 +457,7 @@ module Prism
       values << dump_options_command_line(options)
 
       template << "C"
-      values << { nil => 0, "3.3.0" => 1, "3.3.1" => 1, "3.4.0" => 0, "latest" => 0 }.fetch(options[:version])
+      values << dump_options_version(options[:version])
 
       template << "C"
       values << (options[:encoding] == false ? 1 : 0)

--- a/test/prism/version_test.rb
+++ b/test/prism/version_test.rb
@@ -4,8 +4,46 @@ require_relative "test_helper"
 
 module Prism
   class VersionTest < TestCase
-    def test_version_is_set
+    def test_prism_version_is_set
       refute_nil VERSION
+    end
+
+    def test_syntax_versions
+      assert Prism.parse("1 + 1", version: "3.3.0").success?
+      assert Prism.parse("1 + 1", version: "3.3.1").success?
+      assert Prism.parse("1 + 1", version: "3.3.9").success?
+      assert Prism.parse("1 + 1", version: "3.3.10").success?
+
+      assert Prism.parse("1 + 1", version: "3.4.0").success?
+      assert Prism.parse("1 + 1", version: "3.4.9").success?
+      assert Prism.parse("1 + 1", version: "3.4.10").success?
+
+      assert Prism.parse("1 + 1", version: "latest").success?
+
+      # Test edge case
+      error = assert_raise ArgumentError do
+        Prism.parse("1 + 1", version: "latest2")
+      end
+      assert_equal "invalid version: latest2", error.message
+
+      assert_raise ArgumentError do
+        Prism.parse("1 + 1", version: "3.3.a")
+      end
+
+      # Not supported version syntax
+      assert_raise ArgumentError do
+        Prism.parse("1 + 1", version: "3.3")
+      end
+
+      # Not supported version (too old)
+      assert_raise ArgumentError do
+        Prism.parse("1 + 1", version: "3.2.0")
+      end
+
+      # Not supported version (too new)
+      assert_raise ArgumentError do
+        Prism.parse("1 + 1", version: "3.5.0")
+      end
     end
   end
 end


### PR DESCRIPTION
As discussed with @mame