### PR TITLE
Fix up lex difference when ~ heredoc with 0 dedent and line continuation

### DIFF
--- a/lib/prism/lex_compat.rb
+++ b/lib/prism/lex_compat.rb
@@ -481,7 +481,7 @@ module Prism
                 embexpr_balance -= 1
               when :on_tstring_content
                 if embexpr_balance == 0
-                  while index < max_index && tokens[index].event == :on_tstring_content
+                  while index < max_index && tokens[index].event == :on_tstring_content && !token.value.match?(/\\\r?\n\z/)
                     token.value << tokens[index].value
                     index += 1
                   end


### PR DESCRIPTION
Fixes https://github.com/ruby/prism/issues/2842