### PR TITLE
Add fields documentation for AliasMethodNode and AlternationPatternNode

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -821,6 +821,17 @@ nodes:
         kind:
           - SymbolNode
           - InterpolatedSymbolNode
+        comment: |
+          Represents the new name of the method that will be aliased.
+
+              alias foo bar
+                    ^^^
+
+              alias :foo :bar
+                    ^^^^
+
+              alias :"#{foo}" :"#{bar}"
+                    ^^^^^^^^^
       - name: old_name
         type: node
         kind:
@@ -828,6 +839,17 @@ nodes:
           - InterpolatedSymbolNode
           - on error: GlobalVariableReadNode # alias a $b
           - on error: MissingNode # alias a 42
+        comment: |
+          Represents the old name of the method that will be aliased.
+
+              alias foo bar
+                        ^^^
+
+              alias :foo :bar
+                         ^^^^
+
+              alias :"#{foo}" :"#{bar}"
+                              ^^^^^^^^^
       - name: keyword_loc
         type: location
     comment: |
@@ -840,11 +862,26 @@ nodes:
       - name: left
         type: node
         kind: pattern expression
+        comment: |
+          Represents the left side of the expression. It can be any [non-void expression](https://github.com/ruby/prism/blob/main/docs/parsing_rules.md#non-void-expression).
+
+              foo => bar | baz
+                     ^^^
       - name: right
         type: node
         kind: pattern expression
+        comment: |
+          Represents the right side of the expression. It can be any [non-void expression](https://github.com/ruby/prism/blob/main/docs/parsing_rules.md#non-void-expression).
+
+              foo => bar | baz
+                           ^^^
       - name: operator_loc
         type: location
+        comment: |
+          Represents the alternation operator location.
+
+              foo => bar | baz
+                         ^
     comment: |
       Represents an alternation pattern in pattern matching.
 

--- a/config.yml
+++ b/config.yml
@@ -863,7 +863,7 @@ nodes:
         type: node
         kind: pattern expression
         comment: |
-          Represents the left side of the expression. It can be any [non-void expression](https://github.com/ruby/prism/blob/main/docs/parsing_rules.md#non-void-expression).
+          Represents the left side of the expression.
 
               foo => bar | baz
                      ^^^
@@ -871,7 +871,7 @@ nodes:
         type: node
         kind: pattern expression
         comment: |
-          Represents the right side of the expression. It can be any [non-void expression](https://github.com/ruby/prism/blob/main/docs/parsing_rules.md#non-void-expression).
+          Represents the right side of the expression.
 
               foo => bar | baz
                            ^^^


### PR DESCRIPTION
This adds some documentation to the fields for `AliasMethodNode` and `AlternationPatternNode`. I was going to go through and do more, but wanted to get a pull-request up for review before moving forward with any others just incase. I'm trying to get more familiar with all of the node types and fields for a project that utilizes Prism, so this looks like a better (and more productive!) way to do it.

I also wanted to check if there was any other smaller intro issues/tickets where there might be an opportunity to jump in on. I took a brief look through and wasn't too sure on the scope of the existing ones on the issues board. If there was any other high-level ideas thrown around for more examples/guides for Prism I'd be happy to explore those too!