### PR TITLE
Disallow infix operators after label

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -21629,6 +21629,13 @@ parse_expression(pm_parser_t *parser, pm_binding_power_t binding_power, bool acc
                 return node;
             }
             break;
+        case PM_SYMBOL_NODE:
+            // If we have a symbol node that is being parsed as a label, then we
+            // need to immediately return, because there should never be an
+            // infix operator following this node.
+            if (pm_symbol_node_label_p(node)) {
+                return node;
+            }
         default:
             break;
     }

--- a/test/prism/errors/infix_after_label.txt
+++ b/test/prism/errors/infix_after_label.txt
@@ -1,0 +1,6 @@
+{ 'a':.upcase => 1 }
+      ^ unexpected '.'; expected a value in the hash literal
+      ^ expected a `}` to close the hash literal
+                   ^ unexpected '}', expecting end-of-input
+                   ^ unexpected '}', ignoring it
+


### PR DESCRIPTION
Partially addresses https://github.com/ruby/prism/issues/3098