### PR TITLE
Disallow dynamic patterns in labels at top level followed by pipes

### DIFF
--- a/test/prism/errors/dynamic_label_pattern.txt
+++ b/test/prism/errors/dynamic_label_pattern.txt
@@ -1,0 +1,3 @@
+:a => 'a': | 1
+           ^ expected a pattern expression after the key
+


### PR DESCRIPTION
Fixes https://github.com/ruby/prism/issues/3098