### PR TITLE
Fix 3112 - disallow commas after block arg

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -14127,9 +14127,6 @@ parse_arguments(pm_parser_t *parser, pm_arguments_t *arguments, bool accepts_for
     bool parsed_forwarding_arguments = false;
 
     while (!match1(parser, PM_TOKEN_EOF)) {
-        if (parsed_block_argument) {
-            pm_parser_err_current(parser, PM_ERR_ARGUMENT_AFTER_BLOCK);
-        }
         if (parsed_forwarding_arguments) {
             pm_parser_err_current(parser, PM_ERR_ARGUMENT_AFTER_FORWARDING_ELLIPSES);
         }
@@ -14176,6 +14173,10 @@ parse_arguments(pm_parser_t *parser, pm_arguments_t *arguments, bool accepts_for
                     parse_arguments_append(parser, arguments, argument);
                 } else {
                     arguments->block = argument;
+                }
+
+                if (parser->current.type == PM_TOKEN_COMMA) {
+                    pm_parser_err_current(parser, PM_ERR_ARGUMENT_AFTER_BLOCK);
                 }
 
                 parsed_block_argument = true;

--- a/test/prism/errors/arguments_after_block.txt
+++ b/test/prism/errors/arguments_after_block.txt
@@ -1,3 +1,17 @@
 a(&block, foo)
-          ^~~ unexpected argument after a block argument
+        ^ unexpected argument after a block argument
+a(&block,)
+        ^ unexpected argument after a block argument
+a.(&block,)
+         ^ unexpected argument after a block argument
+a[&block,]
+        ^ unexpected argument after a block argument
+def a(&block)
+  p(&block,)
+          ^ unexpected argument after a block argument
+  a.(&block,)
+           ^ unexpected argument after a block argument
+  a[&block,]
+          ^ unexpected argument after a block argument
+end
 


### PR DESCRIPTION
Prism was already disallowing arguments after block args, but in parse.y, any comma after a block arg is a syntax error. This moves the error handling into `PM_TOKEN_UAMPERSAND` where we can check if the current type is `PM_TOKEN_COMMA`then raise an error. I've also updated the tests to include the examplesfrom ruby/prism#3112.

Fixes: ruby/prism#3112