### PR TITLE
Handle single global variable character name

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -9051,6 +9051,10 @@ lex_global_variable(pm_parser_t *parser) {
         return PM_TOKEN_GLOBAL_VARIABLE;
     }
 
+    // True if multiple characters are allowed after the declaration of the
+    // global variable. Not true when it starts with "$-".
+    bool allow_multiple = true;
+
     switch (*parser->current.end) {
         case '~':  // $~: match-data
         case '*':  // $*: argv
@@ -9109,6 +9113,7 @@ lex_global_variable(pm_parser_t *parser) {
 
         case '-':
             parser->current.end++;
+            allow_multiple = false;
             /* fallthrough */
         default: {
             size_t width;
@@ -9116,7 +9121,7 @@ lex_global_variable(pm_parser_t *parser) {
             if ((width = char_is_identifier(parser, parser->current.end)) > 0) {
                 do {
                     parser->current.end += width;
-                } while (parser->current.end < parser->end && (width = char_is_identifier(parser, parser->current.end)) > 0);
+                } while (allow_multiple && parser->current.end < parser->end && (width = char_is_identifier(parser, parser->current.end)) > 0);
             } else if (pm_char_is_whitespace(peek(parser))) {
                 // If we get here, then we have a $ followed by whitespace,
                 // which is not allowed.

--- a/test/prism/magic_comment_test.rb
+++ b/test/prism/magic_comment_test.rb
@@ -87,7 +87,14 @@ module Prism
 
       # Compare against Ruby's expectation.
       if defined?(RubyVM::InstructionSequence)
-        expected = RubyVM::InstructionSequence.compile(source).eval.encoding
+        previous = $VERBOSE
+        expected =
+          begin
+            $VERBOSE = nil
+            RubyVM::InstructionSequence.compile(source).eval.encoding
+          ensure
+            $VERBOSE = previous
+          end
         assert_equal expected, actual
       end
     end


### PR DESCRIPTION
Fixes https://github.com/ruby/prism/issues/3129