### PR TITLE
Set contains_keywords flag for implicit gets($/, chomp: true) method to handle -l CLI option

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -21905,6 +21905,7 @@ wrap_statements(pm_parser_t *parser, pm_statements_node_t *statements) {
             ));
 
             pm_arguments_node_arguments_append(arguments, (pm_node_t *) keywords);
+            pm_node_flag_set((pm_node_t *) arguments, PM_ARGUMENTS_NODE_FLAGS_CONTAINS_KEYWORDS);
         }
 
         pm_statements_node_t *wrapped_statements = pm_statements_node_create(parser);

--- a/test/prism/api/command_line_test.rb
+++ b/test/prism/api/command_line_test.rb
@@ -52,6 +52,9 @@ module Prism
       assert_kind_of CallNode, predicate
       assert_equal :gets, predicate.name
 
+      arguments = predicate.arguments
+      assert arguments.contains_keywords?
+
       arguments = predicate.arguments.arguments
       assert_equal 2, arguments.length
       assert_equal :$/, arguments.first.name


### PR DESCRIPTION
I suppose the `contains_keywords` flag is missing here because arguments contain keyword arguments `chomp: true` .

Examples before and after:

```shell
bin/prism parse -n -l -e 'puts $_.end_with?("\n")'
```

AST before:

```
@ ProgramNode (location: (1,0)-(1,0))
├── flags: ∅
├── locals: []
└── statements:
    @ StatementsNode (location: (1,0)-(1,0))
    ├── flags: ∅
    └── body: (length: 1)
        └── @ WhileNode (location: (1,0)-(1,0))
            ├── flags: newline
            ├── keyword_loc: (1,0)-(1,0) = ""
            ├── closing_loc: (1,0)-(1,0) = ""
            ├── predicate:
            │   @ CallNode (location: (1,0)-(1,0))
            │   ├── flags: ignore_visibility
            │   ├── receiver: ∅
            │   ├── call_operator_loc: ∅
            │   ├── name: :gets
            │   ├── message_loc: ∅
            │   ├── opening_loc: ∅
            │   ├── arguments:
            │   │   @ ArgumentsNode (location: (1,0)-(1,23))
            │   │   ├── flags: ∅
            │   │   └── arguments: (length: 2)
...
```

AST after:

```
@ ProgramNode (location: (1,0)-(1,0))
├── flags: ∅
├── locals: []
└── statements:
    @ StatementsNode (location: (1,0)-(1,0))
    ├── flags: ∅
    └── body: (length: 1)
        └── @ WhileNode (location: (1,0)-(1,0))
            ├── flags: newline
            ├── keyword_loc: (1,0)-(1,0) = ""
            ├── closing_loc: (1,0)-(1,0) = ""
            ├── predicate:
            │   @ CallNode (location: (1,0)-(1,0))
            │   ├── flags: ignore_visibility
            │   ├── receiver: ∅
            │   ├── call_operator_loc: ∅
            │   ├── name: :gets
            │   ├── message_loc: ∅
            │   ├── opening_loc: ∅
            │   ├── arguments:
            │   │   @ ArgumentsNode (location: (1,0)-(1,23))
            │   │   ├── flags: contains_keywords
```