### PR TITLE
Avoid breaking code units offset on binary encoding

### DIFF
--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -90,7 +90,7 @@ module Prism
     # concept of code units that differs from the number of characters in other
     # encodings, it is not captured here.
     def code_units_offset(byte_offset, encoding)
-      byteslice = (source.byteslice(0, byte_offset) or raise).encode(encoding)
+      byteslice = (source.byteslice(0, byte_offset) or raise).encode(encoding, invalid: :replace, undef: :replace)
 
       if encoding == Encoding::UTF_16LE || encoding == Encoding::UTF_16BE
         byteslice.bytesize / 2

--- a/test/prism/ruby/location_test.rb
+++ b/test/prism/ruby/location_test.rb
@@ -140,6 +140,25 @@ module Prism
       assert_equal 7, location.end_code_units_column(Encoding::UTF_32LE)
     end
 
+    def test_code_units_handles_binary_encoding_with_multibyte_characters
+      # If the encoding is set to binary and the source contains multibyte
+      # characters, we avoid breaking the code unit offsets, but they will
+      # still be incorrect.
+
+      program = Prism.parse(<<~RUBY).value
+        # -*- encoding: binary -*-
+
+        😀 + 😀
+      RUBY
+
+      # first 😀
+      location = program.statements.body.first.receiver.location
+
+      assert_equal 4, location.end_code_units_column(Encoding::UTF_8)
+      assert_equal 4, location.end_code_units_column(Encoding::UTF_16LE)
+      assert_equal 4, location.end_code_units_column(Encoding::UTF_32LE)
+    end
+
     def test_chop
       location = Prism.parse("foo").value.location
 


### PR DESCRIPTION
When a file is using binary encoding and contains multibyte characters, trying to call `encode` with one of the accepted LSP encodings (UTF-8, UTF-16 or UTF-32) will fail because it's not a valid conversion.

In situations like these, we want to avoid breaking, even if we can't provide the correct locations for nodes. In the included test, you can see that the locations are all using the number of bytes, rather than the code units.