### PR TITLE
Update rescue node doc

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3685,7 +3685,7 @@ nodes:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           end
 
-      `Foo, *splat, Bar` are in the `exceptions` field. `ex` is in the `exception` field.
+      `Foo, *splat, Bar` are in the `exceptions` field. `ex` is in the `reference` field.
   - name: RestParameterNode
     flags: ParameterFlags
     fields:


### PR DESCRIPTION
Its `exception` field was renamed to `reference` in #1204 but the documentation was not updated.