### PR TITLE
Do not warn for unused variables on negative lines

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -962,17 +962,19 @@ pm_locals_order(PRISM_ATTRIBUTE_UNUSED pm_parser_t *parser, pm_locals_t *locals,
             pm_constant_id_list_insert(list, (size_t) local->index, local->name);
 
             if (warn_unused && local->reads == 0) {
-                pm_constant_t *constant = pm_constant_pool_id_to_constant(&parser->constant_pool, local->name);
+                if (pm_newline_list_line(&parser->newline_list, local->location.start, parser->start_line) >= 0) {
+                    pm_constant_t *constant = pm_constant_pool_id_to_constant(&parser->constant_pool, local->name);
 
-                if (constant->length >= 1 && *constant->start != '_') {
-                    PM_PARSER_WARN_FORMAT(
-                        parser,
-                        local->location.start,
-                        local->location.end,
-                        PM_WARN_UNUSED_LOCAL_VARIABLE,
-                        (int) constant->length,
-                        (const char *) constant->start
-                    );
+                    if (constant->length >= 1 && *constant->start != '_') {
+                        PM_PARSER_WARN_FORMAT(
+                            parser,
+                            local->location.start,
+                            local->location.end,
+                            PM_WARN_UNUSED_LOCAL_VARIABLE,
+                            (int) constant->length,
+                            (const char *) constant->start
+                        );
+                    }
                 }
             }
         }

--- a/test/prism/result/warnings_test.rb
+++ b/test/prism/result/warnings_test.rb
@@ -259,6 +259,8 @@ module Prism
 
       refute_warning("def foo; bar = 1; tap { bar }; end")
       refute_warning("def foo; bar = 1; tap { baz = bar; baz }; end")
+
+      refute_warning("def foo; bar = 1; end", line: -2, compare: false)
     end
 
     def test_void_statements


### PR DESCRIPTION
Fixes [Bug #20788]