### PR TITLE
Supress string_query function warning

### DIFF
--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -1153,6 +1153,7 @@ string_query(pm_string_query_t result) {
         case PM_STRING_QUERY_TRUE:
             return Qtrue;
     }
+    return Qfalse;
 }
 
 /**


### PR DESCRIPTION
Supress this warning for string_query function.

```console
compiling ../../../../ext/prism/extension.c
../../../../ext/prism/extension.c: In function ‘string_query’:
../../../../ext/prism/extension.c:1156:1: warning: control reaches end of non-void function [-Wreturn-type]
 1156 | }
      | ^
../../../../ext/prism/extension.c: At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
```