### PR TITLE
Only read from buffer if `size` is greater than 0

### DIFF
--- a/src/util/pm_char.c
+++ b/src/util/pm_char.c
@@ -185,7 +185,7 @@ pm_strspn_number_kind_underscores(const uint8_t *string, ptrdiff_t length, const
         size++;
     }
 
-    if (string[size - 1] == '_') *invalid = string + size - 1;
+    if (size > 0 && string[size - 1] == '_') *invalid = string + size - 1;
     return size;
 }
 


### PR DESCRIPTION
It looks like we can possibly do an out of bounds read if size is equal to 0.  This commit adds a conditional to ensure size is actually greater than 0 before looking backwards in the buffer