### PR TITLE
Suppress restricted warnings from JDK 24

### DIFF
--- a/java/org/prism/Parser.java
+++ b/java/org/prism/Parser.java
@@ -2,6 +2,7 @@ package org.prism;
 
 public abstract class Parser {
 
+    @SuppressWarnings("restricted")
     public static void loadLibrary(String path) {
         System.load(path);
     }


### PR DESCRIPTION
* We intentionally load a native library here and need it.
* I also tried `@SuppressWarnings("all")` but that still emitted the warning.