### PR TITLE
Add RDoc to development dependencies to use its new theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ platforms :mri, :mswin, :mingw, :x64_mingw do
   gem "parser"
   gem "ruby_memcheck"
   gem "ruby_parser"
-end  
+  gem "rdoc"
+end
 
 gem "onigmo", platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,16 +18,21 @@ GEM
       ast (~> 2.4.1)
       racc
     power_assert (2.0.3)
+    psych (5.2.0)
+      stringio
     racc (1.8.0)
     rake (13.2.1)
     rake-compiler (1.2.7)
       rake
+    rdoc (6.8.1)
+      psych (>= 4.0.0)
     ruby_memcheck (3.0.0)
       nokogiri
     ruby_parser (3.21.0)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
     sexp_processor (4.17.1)
+    stringio (3.1.2)
     test-unit (3.6.2)
       power_assert
 
@@ -42,6 +47,7 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
+  rdoc
   ruby_memcheck
   ruby_parser
   test-unit


### PR DESCRIPTION
RDoc has started receiving more updates, especially around the default theme. By having it as a development dependency, we can use the latest theme for Prism's Ruby documentation too.

### Before

<img width="90%" alt="Screenshot 2024-11-20 at 22 55 25" src="https://github.com/user-attachments/assets/6f6d00a0-6aa3-4fe5-a599-c9f4365bc31d">

### After

<img width="90%" alt="Screenshot 2024-11-20 at 22 54 56" src="https://github.com/user-attachments/assets/4174435d-0c5a-4480-8bd9-49441cdce434">
