### PR TITLE
Reject invalid dot method call after match predicate or after match required

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -21430,6 +21430,32 @@ parse_expression_infix(pm_parser_t *parser, pm_node_t *node, pm_binding_power_t 
                 return (pm_node_t *) pm_call_node_shorthand_create(parser, node, &operator, &arguments);
             }
 
+            switch (PM_NODE_TYPE(node)) {
+                case PM_RESCUE_MODIFIER_NODE: {
+                    pm_rescue_modifier_node_t *cast = (pm_rescue_modifier_node_t *) node;
+                    if (PM_NODE_TYPE_P(cast->rescue_expression, PM_MATCH_PREDICATE_NODE) || PM_NODE_TYPE_P(cast->rescue_expression, PM_MATCH_REQUIRED_NODE)) {
+                        PM_PARSER_ERR_TOKEN_FORMAT(parser, operator, PM_ERR_EXPECT_EOL_AFTER_STATEMENT, pm_token_type_human(operator.type));
+                    }
+                    break;
+                }
+                case PM_AND_NODE: {
+                    pm_and_node_t *cast = (pm_and_node_t *) node;
+                    if (PM_NODE_TYPE_P(cast->right, PM_MATCH_PREDICATE_NODE) || PM_NODE_TYPE_P(cast->right, PM_MATCH_REQUIRED_NODE)) {
+                        PM_PARSER_ERR_TOKEN_FORMAT(parser, operator, PM_ERR_EXPECT_EOL_AFTER_STATEMENT, pm_token_type_human(operator.type));
+                    }
+                    break;
+                }
+                case PM_OR_NODE: {
+                    pm_or_node_t *cast = (pm_or_node_t *) node;
+                    if (PM_NODE_TYPE_P(cast->right, PM_MATCH_PREDICATE_NODE) || PM_NODE_TYPE_P(cast->right, PM_MATCH_REQUIRED_NODE)) {
+                        PM_PARSER_ERR_TOKEN_FORMAT(parser, operator, PM_ERR_EXPECT_EOL_AFTER_STATEMENT, pm_token_type_human(operator.type));
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+
             pm_token_t message;
 
             switch (parser->current.type) {

--- a/test/prism/errors/match_predicate_after_and_with_dot_method_call.txt
+++ b/test/prism/errors/match_predicate_after_and_with_dot_method_call.txt
@@ -1,0 +1,3 @@
+1 and 2 in 3.inspect
+            ^ unexpected '.', expecting end-of-input
+

--- a/test/prism/errors/match_predicate_after_or_with_dot_method_call.txt
+++ b/test/prism/errors/match_predicate_after_or_with_dot_method_call.txt
@@ -1,0 +1,3 @@
+'a' or 1 in 1.upcase
+             ^ unexpected '.', expecting end-of-input
+

--- a/test/prism/errors/match_predicate_after_rescue_with_dot_method_call.txt
+++ b/test/prism/errors/match_predicate_after_rescue_with_dot_method_call.txt
@@ -1,0 +1,3 @@
+'a' rescue 2 in 3.upcase
+                 ^ unexpected '.', expecting end-of-input
+

--- a/test/prism/errors/match_required_after_and_with_dot_method_call.txt
+++ b/test/prism/errors/match_required_after_and_with_dot_method_call.txt
@@ -1,0 +1,3 @@
+1 and 2 => 3.inspect
+            ^ unexpected '.', expecting end-of-input
+

--- a/test/prism/errors/match_required_after_or_with_dot_method_call.txt
+++ b/test/prism/errors/match_required_after_or_with_dot_method_call.txt
@@ -1,0 +1,3 @@
+1 or 2 => 3.inspect
+           ^ unexpected '.', expecting end-of-input
+

--- a/test/prism/errors/match_required_after_rescue_with_dot_method_call.txt
+++ b/test/prism/errors/match_required_after_rescue_with_dot_method_call.txt
@@ -1,0 +1,3 @@
+1 rescue 2 => 3.inspect
+               ^ unexpected '.', expecting end-of-input
+


### PR DESCRIPTION
Partially fixes:  https://github.com/ruby/prism/issues/3171