### PR TITLE
Reject extra comma in array after keyword argument

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -10874,6 +10874,10 @@ parser_lex(pm_parser_t *parser) {
 
                 // ,
                 case ',':
+                    if ((parser->previous.type == PM_TOKEN_COMMA) && (parser->enclosure_nesting > 0)) {
+                        PM_PARSER_ERR_TOKEN_FORMAT(parser, parser->current, PM_ERR_ARRAY_TERM, pm_token_type_human(parser->current.type));
+                    }
+
                     lex_state_set(parser, PM_LEX_STATE_BEG | PM_LEX_STATE_LABEL);
                     LEX(PM_TOKEN_COMMA);
 

--- a/test/prism/errors/array_with_double_commas.txt
+++ b/test/prism/errors/array_with_double_commas.txt
@@ -1,0 +1,3 @@
+[a:1,,]
+     ^ unexpected ','; expected a `]` to close the array
+

--- a/test/prism/errors/double_splat_with_double_commas.txt
+++ b/test/prism/errors/double_splat_with_double_commas.txt
@@ -1,0 +1,3 @@
+[**a,,]
+     ^ unexpected ','; expected a `]` to close the array
+


### PR DESCRIPTION
Fixes: https://github.com/ruby/prism/issues/3109