### PR TITLE
Reject assigning command call without parentheses

### DIFF
--- a/test/prism/errors/assignment_in_and_operator_without_parentheses.txt
+++ b/test/prism/errors/assignment_in_and_operator_without_parentheses.txt
@@ -1,0 +1,4 @@
+1 and a = p 2
+            ^ expected a `do` keyword or a `{` to open the lambda block
+            ^ expected a `(` to start a required parameter
+

--- a/test/prism/errors/assignment_in_if_condition_without_parentheses.txt
+++ b/test/prism/errors/assignment_in_if_condition_without_parentheses.txt
@@ -1,0 +1,4 @@
+1 if a = p 2
+           ^ expected a `do` keyword or a `{` to open the lambda block
+           ^ expected a `(` to start a required parameter
+

--- a/test/prism/errors/assignment_in_or_operator_without_parentheses.txt
+++ b/test/prism/errors/assignment_in_or_operator_without_parentheses.txt
@@ -1,0 +1,4 @@
+1 or a = p 2
+           ^ expected a `do` keyword or a `{` to open the lambda block
+           ^ expected a `(` to start a required parameter
+

--- a/test/prism/errors/assignment_in_unless_condition_without_parentheses.txt
+++ b/test/prism/errors/assignment_in_unless_condition_without_parentheses.txt
@@ -1,0 +1,4 @@
+1 unless a = p 2
+               ^ expected a `do` keyword or a `{` to open the lambda block
+               ^ expected a `(` to start a required parameter
+

--- a/test/prism/errors/assignment_with_method_call_without_parentheses_and_and_operator.txt
+++ b/test/prism/errors/assignment_with_method_call_without_parentheses_and_and_operator.txt
@@ -1,0 +1,4 @@
+a = p 1 and 2
+      ^ expected a `do` keyword or a `{` to open the lambda block
+      ^ expected a `(` to start a required parameter
+

--- a/test/prism/errors/assignment_with_method_call_without_parentheses_and_or_operator.txt
+++ b/test/prism/errors/assignment_with_method_call_without_parentheses_and_or_operator.txt
@@ -1,0 +1,4 @@
+a = p 1 or 2
+      ^ expected a `do` keyword or a `{` to open the lambda block
+      ^ expected a `(` to start a required parameter
+


### PR DESCRIPTION
Fixes: https://github.com/ruby/prism/issues/3106