### PR TITLE
_finitef is unavailable on Windows x86

### DIFF
--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -137,17 +137,6 @@
 #endif
 
 /**
- * isinf on Windows is defined as accepting a float, but on POSIX systems it
- * accepts a float, a double, or a long double. We want to mirror this behavior
- * on windows.
- */
-#ifdef _WIN32
-#   include <float.h>
-#   undef isinf
-#   define isinf(x) (sizeof(x) == sizeof(float) ? !_finitef(x) : !_finite(x))
-#endif
-
-/**
  * If you build prism with a custom allocator, configure it with
  * "-D PRISM_XALLOCATOR" to use your own allocator that defines xmalloc,
  * xrealloc, xcalloc, and xfree.

--- a/src/prism.c
+++ b/src/prism.c
@@ -4142,7 +4142,14 @@ pm_double_parse(pm_parser_t *parser, const pm_token_t *token) {
 
     // If errno is set, then it should only be ERANGE. At this point we need to
     // check if it's infinity (it should be).
-    if (errno == ERANGE && isinf(value)) {
+    if (
+        errno == ERANGE &&
+#ifdef _WIN32
+        !_finite(value)
+#else
+        isinf(value)
+#endif
+    ) {
         int warn_width;
         const char *ellipsis;
 

--- a/src/static_literals.c
+++ b/src/static_literals.c
@@ -501,7 +501,13 @@ pm_static_literal_inspect_node(pm_buffer_t *buffer, const pm_static_literals_met
         case PM_FLOAT_NODE: {
             const double value = ((const pm_float_node_t *) node)->value;
 
-            if (isinf(value)) {
+            if (
+#ifdef _WIN32
+                !_finite(value)
+#else
+                isinf(value)
+#endif
+            ) {
                 if (*node->location.start == '-') {
                     pm_buffer_append_byte(buffer, '-');
                 }


### PR DESCRIPTION
Instead cast it inline to a double on Windows.

Fixes https://github.com/ruby/prism/issues/3260