### PR TITLE
GitHub Action that uploads builds as release artifacts

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,39 @@
+name: Build Library Artifacts
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler-cache: true
+
+    - name: Build library
+      run: bundle exec rake compile
+
+    - name: Upload to release
+      if: github.event_name == 'release'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          build/libprism.so
+          build/libprism.dylib


### PR DESCRIPTION
This GitHub Action builds Prism for Linux and MacOS and then uploads the builds to the latest release.

## Motivation
I am working on adopting Prism in a third-party library (Sorbet) where Ruby is not available during the build process. In order to avoid adding Ruby to the Sorbet build pipeline, I would like to have access to pre-built Prism binaries that Sorbet can pull and use in its build process.