### PR TITLE
`isinf` is available on MSVC

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -4142,14 +4142,7 @@ pm_double_parse(pm_parser_t *parser, const pm_token_t *token) {
 
     // If errno is set, then it should only be ERANGE. At this point we need to
     // check if it's infinity (it should be).
-    if (
-        errno == ERANGE &&
-#ifdef _WIN32
-        !_finite(value)
-#else
-        isinf(value)
-#endif
-    ) {
+    if (errno == ERANGE && isinf(value)) {
         int warn_width;
         const char *ellipsis;
 

--- a/src/static_literals.c
+++ b/src/static_literals.c
@@ -501,13 +501,7 @@ pm_static_literal_inspect_node(pm_buffer_t *buffer, const pm_static_literals_met
         case PM_FLOAT_NODE: {
             const double value = ((const pm_float_node_t *) node)->value;
 
-            if (
-#ifdef _WIN32
-                !_finite(value)
-#else
-                isinf(value)
-#endif
-            ) {
+            if (isinf(value)) {
                 if (*node->location.start == '-') {
                     pm_buffer_append_byte(buffer, '-');
                 }


### PR DESCRIPTION
At least Visual Studio 2015 (MSVC 14.0) provides the macro conforming to C99.
And, float.h is necessary to use `_finite()` like the current code.
