### PR TITLE
Increment cursor to breakpoint + 2

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -12401,7 +12401,7 @@ parser_lex(pm_parser_t *parser) {
                         breakpoint++;
                         parser->current.end = breakpoint;
                         pm_token_buffer_escape(parser, &token_buffer);
-                        token_buffer.cursor = breakpoint;
+                        token_buffer.cursor = breakpoint + 2;
 
                         /* fallthrough */
                     case '\n':


### PR DESCRIPTION
When there is a `\r\n` in the following example: `p eval "%\n1\r\n \n"` Prism was returning `"1\n "` whereas parse.y returns `"1"`. In this case the cursor needs to be set to the breakpoint (which is `\r`) plus 2 to ignore the new line and the space.

I'm having trouble figuring out how to test this but locally here is the before and after output:

Parse.y

```
$ ./miniruby --parser=parse.y test.rb
"1"
```

Prism Before:

```
$ ./miniruby --parser=prism test.rb
"1\n "
```

Prism after:

```
$ ./miniruby --parser=prism test.rb
"1"
```

Fixed example 2 from https://github.com/ruby/prism/issues/3230