### PR TITLE
Same numbered param cannot be used in child blocks

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -16408,14 +16408,15 @@ static pm_node_t *
 parse_variable(pm_parser_t *parser) {
     pm_constant_id_t name_id = pm_parser_constant_id_token(parser, &parser->previous);
     int depth;
+    bool is_numbered_param = pm_token_is_numbered_parameter(parser->previous.start, parser->previous.end);
 
-    if ((depth = pm_parser_local_depth_constant_id(parser, name_id)) != -1) {
+    if (!is_numbered_param && ((depth = pm_parser_local_depth_constant_id(parser, name_id)) != -1)) {
         return (pm_node_t *) pm_local_variable_read_node_create_constant_id(parser, &parser->previous, name_id, (uint32_t) depth, false);
     }
 
     pm_scope_t *current_scope = parser->current_scope;
     if (!current_scope->closed && !(current_scope->parameters & PM_SCOPE_PARAMETERS_IMPLICIT_DISALLOWED)) {
-        if (pm_token_is_numbered_parameter(parser->previous.start, parser->previous.end)) {
+        if (is_numbered_param) {
             // When you use a numbered parameter, it implies the existence of
             // all of the locals that exist before it. For example, referencing
             // _2 means that _1 must exist. Therefore here we loop through all

--- a/test/prism/errors/double_scope_repeated_numbered_parameters.txt
+++ b/test/prism/errors/double_scope_repeated_numbered_parameters.txt
@@ -1,0 +1,3 @@
+-> { _1 + -> { _1 } }
+               ^~ numbered parameter is already used in outer block
+


### PR DESCRIPTION
Raise an exception when the same numbered param is used inside a child block.  For example, the following code should be a syntax error:

```ruby
-> { _1 + -> { _1 } }
```

Fixes #3291