### PR TITLE
Use isinf on non-mingw windows

### DIFF
--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -138,10 +138,14 @@
 
 /**
  * isinf on POSIX systems it accepts a float, a double, or a long double.
- * But Windows didn't provide isinf, so we need to use _finite instead.
+ * But mingw didn't provide an isinf macro, only an isinf function that only
+ * accepts floats, so we need to use _finite instead.
  */
-#ifdef _WIN32
-#   include <float.h>
+#ifdef __MINGW64__
+    #include <float.h>
+    #define PRISM_ISINF(x) (!_finite(x))
+#else
+    #define PRISM_ISINF(x) isinf(x)
 #endif
 
 /**

--- a/src/prism.c
+++ b/src/prism.c
@@ -4142,14 +4142,7 @@ pm_double_parse(pm_parser_t *parser, const pm_token_t *token) {
 
     // If errno is set, then it should only be ERANGE. At this point we need to
     // check if it's infinity (it should be).
-    if (
-        errno == ERANGE &&
-#ifdef _WIN32
-        !_finite(value)
-#else
-        isinf(value)
-#endif
-    ) {
+    if (errno == ERANGE && PRISM_ISINF(value)) {
         int warn_width;
         const char *ellipsis;
 

--- a/src/static_literals.c
+++ b/src/static_literals.c
@@ -501,13 +501,7 @@ pm_static_literal_inspect_node(pm_buffer_t *buffer, const pm_static_literals_met
         case PM_FLOAT_NODE: {
             const double value = ((const pm_float_node_t *) node)->value;
 
-            if (
-#ifdef _WIN32
-                !_finite(value)
-#else
-                isinf(value)
-#endif
-            ) {
+            if (PRISM_ISINF(value)) {
                 if (*node->location.start == '-') {
                     pm_buffer_append_byte(buffer, '-');
                 }


### PR DESCRIPTION
Supersedes https://github.com/ruby/prism/pull/3274