### PR TITLE
Blocks & kwargs are not valid in index assignments

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -13745,6 +13745,9 @@ parse_write(pm_parser_t *parser, pm_node_t *target, pm_token_t *operator, pm_nod
 
                 // Replace the name with "[]=".
                 call->name = pm_parser_constant_id_constant(parser, "[]=", 3);
+
+                // Ensure that the arguments for []= don't contain keywords
+                pm_index_arguments_check(parser, call->arguments, call->block);
                 pm_node_flag_set((pm_node_t *) call, PM_CALL_NODE_FLAGS_ATTRIBUTE_WRITE | pm_implicit_array_write_flags(value, PM_CALL_NODE_FLAGS_IMPLICIT_ARRAY));
 
                 return target;

--- a/test/prism/errors/block_args_in_array_assignment.txt
+++ b/test/prism/errors/block_args_in_array_assignment.txt
@@ -1,0 +1,3 @@
+matrix[5, &block] = 8
+          ^~~~~~ unexpected block arg given in index assignment; blocks are not allowed in index assignment expressions
+

--- a/test/prism/errors/keyword_args_in_array_assignment.txt
+++ b/test/prism/errors/keyword_args_in_array_assignment.txt
@@ -1,0 +1,3 @@
+matrix[5, axis: :y] = 8
+          ^~~~~~~~ unexpected keyword arg given in index assignment; keywords are not allowed in index assignment expressions
+

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -19,7 +19,11 @@ module Prism
     end
 
     if RUBY_VERSION < "3.4"
-      filepaths -= ["it_with_ordinary_parameter.txt"]
+      filepaths -= [
+        "it_with_ordinary_parameter.txt",
+        "block_args_in_array_assignment.txt",
+        "keyword_args_in_array_assignment.txt"
+      ]
     end
 
     if RUBY_VERSION < "3.4" || RUBY_RELEASE_DATE < "2024-07-24"


### PR DESCRIPTION
This PR is replicating the changes made in ruby/ruby#12343 and ruby/ruby#12342 in order to sync them to the upstream Prism repo.

I was under the impression that Prism was set up with a bi-directional sync, so that changes made to Prism inside the ruby repo would be mirrored here - but that doesn't seem to be the case?