### PR TITLE
Fix `it` lexing

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -11874,7 +11874,8 @@ parser_lex(pm_parser_t *parser) {
                         !(last_state & (PM_LEX_STATE_DOT | PM_LEX_STATE_FNAME)) &&
                         (type == PM_TOKEN_IDENTIFIER) &&
                         ((pm_parser_local_depth(parser, &parser->current) != -1) ||
-                         pm_token_is_numbered_parameter(parser->current.start, parser->current.end))
+                         pm_token_is_numbered_parameter(parser->current.start, parser->current.end) ||
+                         pm_token_is_it(parser->current.start, parser->current.end))
                     ) {
                         lex_state_set(parser, PM_LEX_STATE_END | PM_LEX_STATE_LABEL);
                     }

--- a/test/prism/lex_test.rb
+++ b/test/prism/lex_test.rb
@@ -74,6 +74,13 @@ module Prism
       end
     end
 
+    def test_lex_it_in_block
+      # `it` should be treated as a local so we have an "ambiguous regex"
+      # situation below
+      code = "i=2; 42.tap { it /1/i }"
+      assert_equal 2, Prism.lex(code).value.map(&:first).map(&:type).count(:SLASH)
+    end
+
     private
 
     def assert_lex(fixture)


### PR DESCRIPTION
Given the following code:

```ruby
i=2; 42.tap { it /1/i }
```

Before this commit, the tokenizer would treat `it /1/i` as a method call with a regular expression parameter.  `it` is to be treated as a local variable, so this needs to be tokenized as division rather than a regular expression.  In other words it should be tokenized as `it / 1 / i`

This commit fixes tokenization.

[Bug #20970]

Bug is here: https://bugs.ruby-lang.org/issues/20970#change-111104

This makes the AST correct, but I haven't tested it with `prism_compile.c`