### PR TITLE
Fix cross-compile issue with newlib on Ubuntu 24.04

### DIFF
--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -23,6 +23,9 @@
  * some platforms they aren't included unless this is already defined.
  */
 #define __STDC_FORMAT_MACROS
+// Include sys/types.h before inttypes.h to work around issue with
+// certain versions of GCC and newlib which causes omission of PRIx64
+#include <sys/types.h>
 #include <inttypes.h>
 
 /**


### PR DESCRIPTION
This PR fixes a cross-compile issue of PicoRuby.


## Problem


I'm trying to build PicoRuby, which uses Prism, on Ubuntu 24.04. But it causes the following build error.

```
$ rake pico --trace

(snip)

CC    build/repos/r2p2-cortex-m0plus/mruby-compiler2/lib/prism/src/util/pm_integer.c -> build/r2p2-cortex-m0plus/mrbgems/mruby-compiler2/lib/pm_integer.o
/home/pocke/ghq/github.com/picoruby/R2P2/lib/picoruby/build/repos/r2p2-cortex-m0plus/mruby-compiler2/lib/prism/src/util/pm_integer.c: In function 'pm_integer_string':
/home/pocke/ghq/github.com/picoruby/R2P2/lib/picoruby/build/repos/r2p2-cortex-m0plus/mruby-compiler2/lib/prism/src/util/pm_integer.c:623:44: error: expected ')' before 'PRIu64'
  623 |         pm_buffer_append_format(buffer, "%" PRIu64, value);
      |                                ~           ^~~~~~~
      |                                            )
/home/pocke/ghq/github.com/picoruby/R2P2/lib/picoruby/build/repos/r2p2-cortex-m0plus/mruby-compiler2/lib/prism/src/util/pm_integer.c:2:1: note: 'PRIu64' is defined in header '<inttypes.h>'; did you forget to '#include <inttypes.h>'?
    1 | #include "prism/util/pm_integer.h"
  +++ |+#include <inttypes.h>
    2 | 
/home/pocke/ghq/github.com/picoruby/R2P2/lib/picoruby/build/repos/r2p2-cortex-m0plus/mruby-compiler2/lib/prism/src/util/pm_integer.c:622:24: warning: unused variable 'value' [-Wunused-variable]
  622 |         const uint64_t value = ((uint64_t) integer->values[0]) | ((uint64_t) integer->values[1] << 32);
      |                        ^~~~~
rake aborted!

(snip)
```


## Cause

The Raspberry Pi Pico SDK had the same problem. https://github.com/raspberrypi/pico-examples/issues/520
This issue describes the problem. In short, it looks like a bug of newlib.

## Reproduce

I reproduced it on the R2P2 repository, which is a .
https://github.com/picoruby/R2P2

```console
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 24.04.1 LTS
Release:        24.04
Codename:       noble

$ sudo apt install cmake python3 build-essential gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib

$ git clone https://github.com/picoruby/R2P2.git
$ cd R2P2
$ rake setup
$ rake pico --trace
# => It shows the error.
```

BTW, R2P2 requires setting `PICO_SDK_PATH` environment variable, but it is not necessary for this reproduction because it fails before using `PICO_SDK_PATH`.

Sorry for the lack of minimum reproduction. I'm not very familiar with PicoRuby and the building system, so I'm not sure how to minimize the reproduction process. 🙇 


## Solution

Add `#include <sys/types.h>` before `#include <inttypes.h>`.
This solution is based on https://github.com/raspberrypi/pico-sdk/pull/1863.

I've confirmed that this patch fixes the error in my environment.