### PR TITLE
Fix parser translator ast when using anonymous forwarding in blocks/lambda

### DIFF
--- a/lib/prism/translation/parser/compiler.rb
+++ b/lib/prism/translation/parser/compiler.rb
@@ -1187,7 +1187,7 @@ module Prism
                 false
               )
             end,
-            node.body&.accept(copy_compiler(forwarding: implicit_parameters ? [] : find_forwarding(parameters&.parameters))),
+            visit(node.body),
             [node.closing, srange(node.closing_loc)]
           )
         end
@@ -2042,7 +2042,7 @@ module Prism
                   false
                 )
               end,
-              block.body&.accept(copy_compiler(forwarding: implicit_parameters ? [] : find_forwarding(parameters&.parameters))),
+              visit(block.body),
               token(block.closing_loc)
             )
           else

--- a/test/prism/fixtures/lambda.txt
+++ b/test/prism/fixtures/lambda.txt
@@ -10,6 +10,10 @@
 
 -> foo: bar do end
 
+def foo(*, **)
+  ->() { bar(*, **) }
+end
+
 p{|a:
 b|}
 

--- a/test/prism/fixtures/methods.txt
+++ b/test/prism/fixtures/methods.txt
@@ -109,6 +109,8 @@ def foo = 123
 
 def a(*); b(*); end
 
+def a(*, **); b { c(*, **) }; end
+
 def a(...); b(...); end
 
 def a(...); b(1, 2, ...); end

--- a/test/prism/snapshots/lambda.txt
+++ b/test/prism/snapshots/lambda.txt
@@ -1,10 +1,10 @@
-@ ProgramNode (location: (1,0)-(23,2))
+@ ProgramNode (location: (1,0)-(27,2))
 ├── flags: ∅
 ├── locals: []
 └── statements:
-    @ StatementsNode (location: (1,0)-(23,2))
+    @ StatementsNode (location: (1,0)-(27,2))
     ├── flags: ∅
-    └── body: (length: 9)
+    └── body: (length: 10)
         ├── @ LambdaNode (location: (1,0)-(3,4))
         │   ├── flags: newline
         │   ├── locals: [:foo]
@@ -219,41 +219,118 @@
         │   │   ├── opening_loc: ∅
         │   │   └── closing_loc: ∅
         │   └── body: ∅
-        ├── @ CallNode (location: (13,0)-(14,3))
+        ├── @ DefNode (location: (13,0)-(15,3))
+        │   ├── flags: newline
+        │   ├── name: :foo
+        │   ├── name_loc: (13,4)-(13,7) = "foo"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (13,8)-(13,13))
+        │   │   ├── flags: ∅
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest:
+        │   │   │   @ RestParameterNode (location: (13,8)-(13,9))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (13,8)-(13,9) = "*"
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest:
+        │   │   │   @ KeywordRestParameterNode (location: (13,11)-(13,13))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (13,11)-(13,13) = "**"
+        │   │   └── block: ∅
+        │   ├── body:
+        │   │   @ StatementsNode (location: (14,2)-(14,21))
+        │   │   ├── flags: ∅
+        │   │   └── body: (length: 1)
+        │   │       └── @ LambdaNode (location: (14,2)-(14,21))
+        │   │           ├── flags: newline
+        │   │           ├── locals: []
+        │   │           ├── operator_loc: (14,2)-(14,4) = "->"
+        │   │           ├── opening_loc: (14,7)-(14,8) = "{"
+        │   │           ├── closing_loc: (14,20)-(14,21) = "}"
+        │   │           ├── parameters:
+        │   │           │   @ BlockParametersNode (location: (14,4)-(14,6))
+        │   │           │   ├── flags: ∅
+        │   │           │   ├── parameters: ∅
+        │   │           │   ├── locals: (length: 0)
+        │   │           │   ├── opening_loc: (14,4)-(14,5) = "("
+        │   │           │   └── closing_loc: (14,5)-(14,6) = ")"
+        │   │           └── body:
+        │   │               @ StatementsNode (location: (14,9)-(14,19))
+        │   │               ├── flags: ∅
+        │   │               └── body: (length: 1)
+        │   │                   └── @ CallNode (location: (14,9)-(14,19))
+        │   │                       ├── flags: newline, ignore_visibility
+        │   │                       ├── receiver: ∅
+        │   │                       ├── call_operator_loc: ∅
+        │   │                       ├── name: :bar
+        │   │                       ├── message_loc: (14,9)-(14,12) = "bar"
+        │   │                       ├── opening_loc: (14,12)-(14,13) = "("
+        │   │                       ├── arguments:
+        │   │                       │   @ ArgumentsNode (location: (14,13)-(14,18))
+        │   │                       │   ├── flags: contains_keywords, contains_keyword_splat, contains_splat
+        │   │                       │   └── arguments: (length: 2)
+        │   │                       │       ├── @ SplatNode (location: (14,13)-(14,14))
+        │   │                       │       │   ├── flags: ∅
+        │   │                       │       │   ├── operator_loc: (14,13)-(14,14) = "*"
+        │   │                       │       │   └── expression: ∅
+        │   │                       │       └── @ KeywordHashNode (location: (14,16)-(14,18))
+        │   │                       │           ├── flags: ∅
+        │   │                       │           └── elements: (length: 1)
+        │   │                       │               └── @ AssocSplatNode (location: (14,16)-(14,18))
+        │   │                       │                   ├── flags: ∅
+        │   │                       │                   ├── value: ∅
+        │   │                       │                   └── operator_loc: (14,16)-(14,18) = "**"
+        │   │                       ├── closing_loc: (14,18)-(14,19) = ")"
+        │   │                       └── block: ∅
+        │   ├── locals: []
+        │   ├── def_keyword_loc: (13,0)-(13,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (13,7)-(13,8) = "("
+        │   ├── rparen_loc: (13,13)-(13,14) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (15,0)-(15,3) = "end"
+        ├── @ CallNode (location: (17,0)-(18,3))
         │   ├── flags: newline, ignore_visibility
         │   ├── receiver: ∅
         │   ├── call_operator_loc: ∅
         │   ├── name: :p
-        │   ├── message_loc: (13,0)-(13,1) = "p"
+        │   ├── message_loc: (17,0)-(17,1) = "p"
         │   ├── opening_loc: ∅
         │   ├── arguments: ∅
         │   ├── closing_loc: ∅
         │   └── block:
-        │       @ BlockNode (location: (13,1)-(14,3))
+        │       @ BlockNode (location: (17,1)-(18,3))
         │       ├── flags: ∅
         │       ├── locals: [:a]
         │       ├── parameters:
-        │       │   @ BlockParametersNode (location: (13,2)-(14,2))
+        │       │   @ BlockParametersNode (location: (17,2)-(18,2))
         │       │   ├── flags: ∅
         │       │   ├── parameters:
-        │       │   │   @ ParametersNode (location: (13,3)-(14,1))
+        │       │   │   @ ParametersNode (location: (17,3)-(18,1))
         │       │   │   ├── flags: ∅
         │       │   │   ├── requireds: (length: 0)
         │       │   │   ├── optionals: (length: 0)
         │       │   │   ├── rest: ∅
         │       │   │   ├── posts: (length: 0)
         │       │   │   ├── keywords: (length: 1)
-        │       │   │   │   └── @ OptionalKeywordParameterNode (location: (13,3)-(14,1))
+        │       │   │   │   └── @ OptionalKeywordParameterNode (location: (17,3)-(18,1))
         │       │   │   │       ├── flags: ∅
         │       │   │   │       ├── name: :a
-        │       │   │   │       ├── name_loc: (13,3)-(13,5) = "a:"
+        │       │   │   │       ├── name_loc: (17,3)-(17,5) = "a:"
         │       │   │   │       └── value:
-        │       │   │   │           @ CallNode (location: (14,0)-(14,1))
+        │       │   │   │           @ CallNode (location: (18,0)-(18,1))
         │       │   │   │           ├── flags: variable_call, ignore_visibility
         │       │   │   │           ├── receiver: ∅
         │       │   │   │           ├── call_operator_loc: ∅
         │       │   │   │           ├── name: :b
-        │       │   │   │           ├── message_loc: (14,0)-(14,1) = "b"
+        │       │   │   │           ├── message_loc: (18,0)-(18,1) = "b"
         │       │   │   │           ├── opening_loc: ∅
         │       │   │   │           ├── arguments: ∅
         │       │   │   │           ├── closing_loc: ∅
@@ -261,39 +338,39 @@
         │       │   │   ├── keyword_rest: ∅
         │       │   │   └── block: ∅
         │       │   ├── locals: (length: 0)
-        │       │   ├── opening_loc: (13,2)-(13,3) = "|"
-        │       │   └── closing_loc: (14,1)-(14,2) = "|"
+        │       │   ├── opening_loc: (17,2)-(17,3) = "|"
+        │       │   └── closing_loc: (18,1)-(18,2) = "|"
         │       ├── body: ∅
-        │       ├── opening_loc: (13,1)-(13,2) = "{"
-        │       └── closing_loc: (14,2)-(14,3) = "}"
-        ├── @ LambdaNode (location: (16,0)-(17,4))
+        │       ├── opening_loc: (17,1)-(17,2) = "{"
+        │       └── closing_loc: (18,2)-(18,3) = "}"
+        ├── @ LambdaNode (location: (20,0)-(21,4))
         │   ├── flags: newline
         │   ├── locals: [:a]
-        │   ├── operator_loc: (16,0)-(16,2) = "->"
-        │   ├── opening_loc: (17,2)-(17,3) = "{"
-        │   ├── closing_loc: (17,3)-(17,4) = "}"
+        │   ├── operator_loc: (20,0)-(20,2) = "->"
+        │   ├── opening_loc: (21,2)-(21,3) = "{"
+        │   ├── closing_loc: (21,3)-(21,4) = "}"
         │   ├── parameters:
-        │   │   @ BlockParametersNode (location: (16,2)-(17,2))
+        │   │   @ BlockParametersNode (location: (20,2)-(21,2))
         │   │   ├── flags: ∅
         │   │   ├── parameters:
-        │   │   │   @ ParametersNode (location: (16,3)-(17,1))
+        │   │   │   @ ParametersNode (location: (20,3)-(21,1))
         │   │   │   ├── flags: ∅
         │   │   │   ├── requireds: (length: 0)
         │   │   │   ├── optionals: (length: 0)
         │   │   │   ├── rest: ∅
         │   │   │   ├── posts: (length: 0)
         │   │   │   ├── keywords: (length: 1)
-        │   │   │   │   └── @ OptionalKeywordParameterNode (location: (16,3)-(17,1))
+        │   │   │   │   └── @ OptionalKeywordParameterNode (location: (20,3)-(21,1))
         │   │   │   │       ├── flags: ∅
         │   │   │   │       ├── name: :a
-        │   │   │   │       ├── name_loc: (16,3)-(16,5) = "a:"
+        │   │   │   │       ├── name_loc: (20,3)-(20,5) = "a:"
         │   │   │   │       └── value:
-        │   │   │   │           @ CallNode (location: (17,0)-(17,1))
+        │   │   │   │           @ CallNode (location: (21,0)-(21,1))
         │   │   │   │           ├── flags: variable_call, ignore_visibility
         │   │   │   │           ├── receiver: ∅
         │   │   │   │           ├── call_operator_loc: ∅
         │   │   │   │           ├── name: :b
-        │   │   │   │           ├── message_loc: (17,0)-(17,1) = "b"
+        │   │   │   │           ├── message_loc: (21,0)-(21,1) = "b"
         │   │   │   │           ├── opening_loc: ∅
         │   │   │   │           ├── arguments: ∅
         │   │   │   │           ├── closing_loc: ∅
@@ -301,37 +378,37 @@
         │   │   │   ├── keyword_rest: ∅
         │   │   │   └── block: ∅
         │   │   ├── locals: (length: 0)
-        │   │   ├── opening_loc: (16,2)-(16,3) = "("
-        │   │   └── closing_loc: (17,1)-(17,2) = ")"
+        │   │   ├── opening_loc: (20,2)-(20,3) = "("
+        │   │   └── closing_loc: (21,1)-(21,2) = ")"
         │   └── body: ∅
-        ├── @ LambdaNode (location: (19,0)-(20,3))
+        ├── @ LambdaNode (location: (23,0)-(24,3))
         │   ├── flags: newline
         │   ├── locals: [:a]
-        │   ├── operator_loc: (19,0)-(19,2) = "->"
-        │   ├── opening_loc: (20,1)-(20,2) = "{"
-        │   ├── closing_loc: (20,2)-(20,3) = "}"
+        │   ├── operator_loc: (23,0)-(23,2) = "->"
+        │   ├── opening_loc: (24,1)-(24,2) = "{"
+        │   ├── closing_loc: (24,2)-(24,3) = "}"
         │   ├── parameters:
-        │   │   @ BlockParametersNode (location: (19,2)-(20,1))
+        │   │   @ BlockParametersNode (location: (23,2)-(24,1))
         │   │   ├── flags: ∅
         │   │   ├── parameters:
-        │   │   │   @ ParametersNode (location: (19,2)-(20,1))
+        │   │   │   @ ParametersNode (location: (23,2)-(24,1))
         │   │   │   ├── flags: ∅
         │   │   │   ├── requireds: (length: 0)
         │   │   │   ├── optionals: (length: 0)
         │   │   │   ├── rest: ∅
         │   │   │   ├── posts: (length: 0)
         │   │   │   ├── keywords: (length: 1)
-        │   │   │   │   └── @ OptionalKeywordParameterNode (location: (19,2)-(20,1))
+        │   │   │   │   └── @ OptionalKeywordParameterNode (location: (23,2)-(24,1))
         │   │   │   │       ├── flags: ∅
         │   │   │   │       ├── name: :a
-        │   │   │   │       ├── name_loc: (19,2)-(19,4) = "a:"
+        │   │   │   │       ├── name_loc: (23,2)-(23,4) = "a:"
         │   │   │   │       └── value:
-        │   │   │   │           @ CallNode (location: (20,0)-(20,1))
+        │   │   │   │           @ CallNode (location: (24,0)-(24,1))
         │   │   │   │           ├── flags: variable_call, ignore_visibility
         │   │   │   │           ├── receiver: ∅
         │   │   │   │           ├── call_operator_loc: ∅
         │   │   │   │           ├── name: :b
-        │   │   │   │           ├── message_loc: (20,0)-(20,1) = "b"
+        │   │   │   │           ├── message_loc: (24,0)-(24,1) = "b"
         │   │   │   │           ├── opening_loc: ∅
         │   │   │   │           ├── arguments: ∅
         │   │   │   │           ├── closing_loc: ∅
@@ -342,27 +419,27 @@
         │   │   ├── opening_loc: ∅
         │   │   └── closing_loc: ∅
         │   └── body: ∅
-        └── @ LambdaNode (location: (22,0)-(23,2))
+        └── @ LambdaNode (location: (26,0)-(27,2))
             ├── flags: newline
             ├── locals: [:a]
-            ├── operator_loc: (22,0)-(22,2) = "->"
-            ├── opening_loc: (23,0)-(23,1) = "{"
-            ├── closing_loc: (23,1)-(23,2) = "}"
+            ├── operator_loc: (26,0)-(26,2) = "->"
+            ├── opening_loc: (27,0)-(27,1) = "{"
+            ├── closing_loc: (27,1)-(27,2) = "}"
             ├── parameters:
-            │   @ BlockParametersNode (location: (22,2)-(22,4))
+            │   @ BlockParametersNode (location: (26,2)-(26,4))
             │   ├── flags: ∅
             │   ├── parameters:
-            │   │   @ ParametersNode (location: (22,2)-(22,4))
+            │   │   @ ParametersNode (location: (26,2)-(26,4))
             │   │   ├── flags: ∅
             │   │   ├── requireds: (length: 0)
             │   │   ├── optionals: (length: 0)
             │   │   ├── rest: ∅
             │   │   ├── posts: (length: 0)
             │   │   ├── keywords: (length: 1)
-            │   │   │   └── @ RequiredKeywordParameterNode (location: (22,2)-(22,4))
+            │   │   │   └── @ RequiredKeywordParameterNode (location: (26,2)-(26,4))
             │   │   │       ├── flags: ∅
             │   │   │       ├── name: :a
-            │   │   │       └── name_loc: (22,2)-(22,4) = "a:"
+            │   │   │       └── name_loc: (26,2)-(26,4) = "a:"
             │   │   ├── keyword_rest: ∅
             │   │   └── block: ∅
             │   ├── locals: (length: 0)

--- a/test/prism/snapshots/methods.txt
+++ b/test/prism/snapshots/methods.txt
@@ -1,10 +1,10 @@
-@ ProgramNode (location: (1,0)-(188,3))
+@ ProgramNode (location: (1,0)-(190,3))
 ├── flags: ∅
 ├── locals: [:a, :c, :foo]
 └── statements:
-    @ StatementsNode (location: (1,0)-(188,3))
+    @ StatementsNode (location: (1,0)-(190,3))
     ├── flags: ∅
-    └── body: (length: 70)
+    └── body: (length: 71)
         ├── @ DefNode (location: (1,0)-(2,3))
         │   ├── flags: newline
         │   ├── name: :foo
@@ -1056,50 +1056,87 @@
         │   ├── rparen_loc: (110,7)-(110,8) = ")"
         │   ├── equal_loc: ∅
         │   └── end_keyword_loc: (110,16)-(110,19) = "end"
-        ├── @ DefNode (location: (112,0)-(112,23))
+        ├── @ DefNode (location: (112,0)-(112,33))
         │   ├── flags: newline
         │   ├── name: :a
         │   ├── name_loc: (112,4)-(112,5) = "a"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (112,6)-(112,9))
+        │   │   @ ParametersNode (location: (112,6)-(112,11))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 0)
-        │   │   ├── rest: ∅
+        │   │   ├── rest:
+        │   │   │   @ RestParameterNode (location: (112,6)-(112,7))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (112,6)-(112,7) = "*"
         │   │   ├── posts: (length: 0)
         │   │   ├── keywords: (length: 0)
         │   │   ├── keyword_rest:
-        │   │   │   @ ForwardingParameterNode (location: (112,6)-(112,9))
-        │   │   │   └── flags: ∅
+        │   │   │   @ KeywordRestParameterNode (location: (112,9)-(112,11))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (112,9)-(112,11) = "**"
         │   │   └── block: ∅
         │   ├── body:
-        │   │   @ StatementsNode (location: (112,12)-(112,18))
+        │   │   @ StatementsNode (location: (112,14)-(112,28))
         │   │   ├── flags: ∅
         │   │   └── body: (length: 1)
-        │   │       └── @ CallNode (location: (112,12)-(112,18))
+        │   │       └── @ CallNode (location: (112,14)-(112,28))
         │   │           ├── flags: newline, ignore_visibility
         │   │           ├── receiver: ∅
         │   │           ├── call_operator_loc: ∅
         │   │           ├── name: :b
-        │   │           ├── message_loc: (112,12)-(112,13) = "b"
-        │   │           ├── opening_loc: (112,13)-(112,14) = "("
-        │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (112,14)-(112,17))
-        │   │           │   ├── flags: contains_forwarding
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ ForwardingArgumentsNode (location: (112,14)-(112,17))
-        │   │           │           └── flags: ∅
-        │   │           ├── closing_loc: (112,17)-(112,18) = ")"
-        │   │           └── block: ∅
+        │   │           ├── message_loc: (112,14)-(112,15) = "b"
+        │   │           ├── opening_loc: ∅
+        │   │           ├── arguments: ∅
+        │   │           ├── closing_loc: ∅
+        │   │           └── block:
+        │   │               @ BlockNode (location: (112,16)-(112,28))
+        │   │               ├── flags: ∅
+        │   │               ├── locals: []
+        │   │               ├── parameters: ∅
+        │   │               ├── body:
+        │   │               │   @ StatementsNode (location: (112,18)-(112,26))
+        │   │               │   ├── flags: ∅
+        │   │               │   └── body: (length: 1)
+        │   │               │       └── @ CallNode (location: (112,18)-(112,26))
+        │   │               │           ├── flags: newline, ignore_visibility
+        │   │               │           ├── receiver: ∅
+        │   │               │           ├── call_operator_loc: ∅
+        │   │               │           ├── name: :c
+        │   │               │           ├── message_loc: (112,18)-(112,19) = "c"
+        │   │               │           ├── opening_loc: (112,19)-(112,20) = "("
+        │   │               │           ├── arguments:
+        │   │               │           │   @ ArgumentsNode (location: (112,20)-(112,25))
+        │   │               │           │   ├── flags: contains_keywords, contains_keyword_splat, contains_splat
+        │   │               │           │   └── arguments: (length: 2)
+        │   │               │           │       ├── @ SplatNode (location: (112,20)-(112,21))
+        │   │               │           │       │   ├── flags: ∅
+        │   │               │           │       │   ├── operator_loc: (112,20)-(112,21) = "*"
+        │   │               │           │       │   └── expression: ∅
+        │   │               │           │       └── @ KeywordHashNode (location: (112,23)-(112,25))
+        │   │               │           │           ├── flags: ∅
+        │   │               │           │           └── elements: (length: 1)
+        │   │               │           │               └── @ AssocSplatNode (location: (112,23)-(112,25))
+        │   │               │           │                   ├── flags: ∅
+        │   │               │           │                   ├── value: ∅
+        │   │               │           │                   └── operator_loc: (112,23)-(112,25) = "**"
+        │   │               │           ├── closing_loc: (112,25)-(112,26) = ")"
+        │   │               │           └── block: ∅
+        │   │               ├── opening_loc: (112,16)-(112,17) = "{"
+        │   │               └── closing_loc: (112,27)-(112,28) = "}"
         │   ├── locals: []
         │   ├── def_keyword_loc: (112,0)-(112,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: (112,5)-(112,6) = "("
-        │   ├── rparen_loc: (112,9)-(112,10) = ")"
+        │   ├── rparen_loc: (112,11)-(112,12) = ")"
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (112,20)-(112,23) = "end"
-        ├── @ DefNode (location: (114,0)-(114,29))
+        │   └── end_keyword_loc: (112,30)-(112,33) = "end"
+        ├── @ DefNode (location: (114,0)-(114,23))
         │   ├── flags: newline
         │   ├── name: :a
         │   ├── name_loc: (114,4)-(114,5) = "a"
@@ -1117,10 +1154,10 @@
         │   │   │   └── flags: ∅
         │   │   └── block: ∅
         │   ├── body:
-        │   │   @ StatementsNode (location: (114,12)-(114,24))
+        │   │   @ StatementsNode (location: (114,12)-(114,18))
         │   │   ├── flags: ∅
         │   │   └── body: (length: 1)
-        │   │       └── @ CallNode (location: (114,12)-(114,24))
+        │   │       └── @ CallNode (location: (114,12)-(114,18))
         │   │           ├── flags: newline, ignore_visibility
         │   │           ├── receiver: ∅
         │   │           ├── call_operator_loc: ∅
@@ -1128,18 +1165,12 @@
         │   │           ├── message_loc: (114,12)-(114,13) = "b"
         │   │           ├── opening_loc: (114,13)-(114,14) = "("
         │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (114,14)-(114,23))
+        │   │           │   @ ArgumentsNode (location: (114,14)-(114,17))
         │   │           │   ├── flags: contains_forwarding
-        │   │           │   └── arguments: (length: 3)
-        │   │           │       ├── @ IntegerNode (location: (114,14)-(114,15))
-        │   │           │       │   ├── flags: static_literal, decimal
-        │   │           │       │   └── value: 1
-        │   │           │       ├── @ IntegerNode (location: (114,17)-(114,18))
-        │   │           │       │   ├── flags: static_literal, decimal
-        │   │           │       │   └── value: 2
-        │   │           │       └── @ ForwardingArgumentsNode (location: (114,20)-(114,23))
+        │   │           │   └── arguments: (length: 1)
+        │   │           │       └── @ ForwardingArgumentsNode (location: (114,14)-(114,17))
         │   │           │           └── flags: ∅
-        │   │           ├── closing_loc: (114,23)-(114,24) = ")"
+        │   │           ├── closing_loc: (114,17)-(114,18) = ")"
         │   │           └── block: ∅
         │   ├── locals: []
         │   ├── def_keyword_loc: (114,0)-(114,3) = "def"
@@ -1147,201 +1178,14 @@
         │   ├── lparen_loc: (114,5)-(114,6) = "("
         │   ├── rparen_loc: (114,9)-(114,10) = ")"
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (114,26)-(114,29) = "end"
-        ├── @ DefNode (location: (116,0)-(117,3))
+        │   └── end_keyword_loc: (114,20)-(114,23) = "end"
+        ├── @ DefNode (location: (116,0)-(116,29))
         │   ├── flags: newline
         │   ├── name: :a
-        │   ├── name_loc: (116,12)-(116,13) = "a"
-        │   ├── receiver:
-        │   │   @ ParenthesesNode (location: (116,4)-(116,11))
-        │   │   ├── flags: ∅
-        │   │   ├── body:
-        │   │   │   @ LocalVariableWriteNode (location: (116,5)-(116,10))
-        │   │   │   ├── flags: ∅
-        │   │   │   ├── name: :c
-        │   │   │   ├── depth: 0
-        │   │   │   ├── name_loc: (116,5)-(116,6) = "c"
-        │   │   │   ├── value:
-        │   │   │   │   @ CallNode (location: (116,9)-(116,10))
-        │   │   │   │   ├── flags: variable_call, ignore_visibility
-        │   │   │   │   ├── receiver: ∅
-        │   │   │   │   ├── call_operator_loc: ∅
-        │   │   │   │   ├── name: :b
-        │   │   │   │   ├── message_loc: (116,9)-(116,10) = "b"
-        │   │   │   │   ├── opening_loc: ∅
-        │   │   │   │   ├── arguments: ∅
-        │   │   │   │   ├── closing_loc: ∅
-        │   │   │   │   └── block: ∅
-        │   │   │   └── operator_loc: (116,7)-(116,8) = "="
-        │   │   ├── opening_loc: (116,4)-(116,5) = "("
-        │   │   └── closing_loc: (116,10)-(116,11) = ")"
-        │   ├── parameters: ∅
-        │   ├── body: ∅
-        │   ├── locals: []
-        │   ├── def_keyword_loc: (116,0)-(116,3) = "def"
-        │   ├── operator_loc: (116,11)-(116,12) = "."
-        │   ├── lparen_loc: ∅
-        │   ├── rparen_loc: ∅
-        │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (117,0)-(117,3) = "end"
-        ├── @ DefNode (location: (119,0)-(120,3))
-        │   ├── flags: newline
-        │   ├── name: :a
-        │   ├── name_loc: (119,4)-(119,5) = "a"
+        │   ├── name_loc: (116,4)-(116,5) = "a"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (119,6)-(119,8))
-        │   │   ├── flags: ∅
-        │   │   ├── requireds: (length: 0)
-        │   │   ├── optionals: (length: 0)
-        │   │   ├── rest: ∅
-        │   │   ├── posts: (length: 0)
-        │   │   ├── keywords: (length: 0)
-        │   │   ├── keyword_rest: ∅
-        │   │   └── block:
-        │   │       @ BlockParameterNode (location: (119,6)-(119,8))
-        │   │       ├── flags: ∅
-        │   │       ├── name: :b
-        │   │       ├── name_loc: (119,7)-(119,8) = "b"
-        │   │       └── operator_loc: (119,6)-(119,7) = "&"
-        │   ├── body: ∅
-        │   ├── locals: [:b]
-        │   ├── def_keyword_loc: (119,0)-(119,3) = "def"
-        │   ├── operator_loc: ∅
-        │   ├── lparen_loc: ∅
-        │   ├── rparen_loc: ∅
-        │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (120,0)-(120,3) = "end"
-        ├── @ DefNode (location: (122,0)-(123,3))
-        │   ├── flags: newline
-        │   ├── name: :a
-        │   ├── name_loc: (122,4)-(122,5) = "a"
-        │   ├── receiver: ∅
-        │   ├── parameters:
-        │   │   @ ParametersNode (location: (122,6)-(122,7))
-        │   │   ├── flags: ∅
-        │   │   ├── requireds: (length: 0)
-        │   │   ├── optionals: (length: 0)
-        │   │   ├── rest: ∅
-        │   │   ├── posts: (length: 0)
-        │   │   ├── keywords: (length: 0)
-        │   │   ├── keyword_rest: ∅
-        │   │   └── block:
-        │   │       @ BlockParameterNode (location: (122,6)-(122,7))
-        │   │       ├── flags: ∅
-        │   │       ├── name: ∅
-        │   │       ├── name_loc: ∅
-        │   │       └── operator_loc: (122,6)-(122,7) = "&"
-        │   ├── body: ∅
-        │   ├── locals: []
-        │   ├── def_keyword_loc: (122,0)-(122,3) = "def"
-        │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (122,5)-(122,6) = "("
-        │   ├── rparen_loc: (122,7)-(122,8) = ")"
-        │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (123,0)-(123,3) = "end"
-        ├── @ DefNode (location: (125,0)-(126,3))
-        │   ├── flags: newline
-        │   ├── name: :a
-        │   ├── name_loc: (125,10)-(125,11) = "a"
-        │   ├── receiver:
-        │   │   @ ClassVariableReadNode (location: (125,4)-(125,9))
-        │   │   ├── flags: ∅
-        │   │   └── name: :@@var
-        │   ├── parameters: ∅
-        │   ├── body: ∅
-        │   ├── locals: []
-        │   ├── def_keyword_loc: (125,0)-(125,3) = "def"
-        │   ├── operator_loc: (125,9)-(125,10) = "."
-        │   ├── lparen_loc: ∅
-        │   ├── rparen_loc: ∅
-        │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (126,0)-(126,3) = "end"
-        ├── @ DefNode (location: (128,0)-(129,3))
-        │   ├── flags: newline
-        │   ├── name: :C
-        │   ├── name_loc: (128,12)-(128,13) = "C"
-        │   ├── receiver:
-        │   │   @ ParenthesesNode (location: (128,4)-(128,11))
-        │   │   ├── flags: ∅
-        │   │   ├── body:
-        │   │   │   @ LocalVariableWriteNode (location: (128,5)-(128,10))
-        │   │   │   ├── flags: ∅
-        │   │   │   ├── name: :a
-        │   │   │   ├── depth: 0
-        │   │   │   ├── name_loc: (128,5)-(128,6) = "a"
-        │   │   │   ├── value:
-        │   │   │   │   @ CallNode (location: (128,9)-(128,10))
-        │   │   │   │   ├── flags: variable_call, ignore_visibility
-        │   │   │   │   ├── receiver: ∅
-        │   │   │   │   ├── call_operator_loc: ∅
-        │   │   │   │   ├── name: :b
-        │   │   │   │   ├── message_loc: (128,9)-(128,10) = "b"
-        │   │   │   │   ├── opening_loc: ∅
-        │   │   │   │   ├── arguments: ∅
-        │   │   │   │   ├── closing_loc: ∅
-        │   │   │   │   └── block: ∅
-        │   │   │   └── operator_loc: (128,7)-(128,8) = "="
-        │   │   ├── opening_loc: (128,4)-(128,5) = "("
-        │   │   └── closing_loc: (128,10)-(128,11) = ")"
-        │   ├── parameters: ∅
-        │   ├── body: ∅
-        │   ├── locals: []
-        │   ├── def_keyword_loc: (128,0)-(128,3) = "def"
-        │   ├── operator_loc: (128,11)-(128,12) = "."
-        │   ├── lparen_loc: ∅
-        │   ├── rparen_loc: ∅
-        │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (129,0)-(129,3) = "end"
-        ├── @ DefNode (location: (131,0)-(131,28))
-        │   ├── flags: newline
-        │   ├── name: :Array_function
-        │   ├── name_loc: (131,9)-(131,23) = "Array_function"
-        │   ├── receiver:
-        │   │   @ SelfNode (location: (131,4)-(131,8))
-        │   │   └── flags: ∅
-        │   ├── parameters: ∅
-        │   ├── body: ∅
-        │   ├── locals: []
-        │   ├── def_keyword_loc: (131,0)-(131,3) = "def"
-        │   ├── operator_loc: (131,8)-(131,9) = "."
-        │   ├── lparen_loc: ∅
-        │   ├── rparen_loc: ∅
-        │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (131,25)-(131,28) = "end"
-        ├── @ ConstantWriteNode (location: (133,0)-(133,9))
-        │   ├── flags: newline
-        │   ├── name: :Const
-        │   ├── name_loc: (133,0)-(133,5) = "Const"
-        │   ├── value:
-        │   │   @ IntegerNode (location: (133,8)-(133,9))
-        │   │   ├── flags: static_literal, decimal
-        │   │   └── value: 1
-        │   └── operator_loc: (133,6)-(133,7) = "="
-        ├── @ DefNode (location: (133,11)-(134,3))
-        │   ├── flags: newline
-        │   ├── name: :a
-        │   ├── name_loc: (133,21)-(133,22) = "a"
-        │   ├── receiver:
-        │   │   @ ConstantReadNode (location: (133,15)-(133,20))
-        │   │   ├── flags: ∅
-        │   │   └── name: :Const
-        │   ├── parameters: ∅
-        │   ├── body: ∅
-        │   ├── locals: []
-        │   ├── def_keyword_loc: (133,11)-(133,14) = "def"
-        │   ├── operator_loc: (133,20)-(133,21) = "."
-        │   ├── lparen_loc: ∅
-        │   ├── rparen_loc: ∅
-        │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (134,0)-(134,3) = "end"
-        ├── @ DefNode (location: (136,0)-(136,31))
-        │   ├── flags: newline
-        │   ├── name: :a
-        │   ├── name_loc: (136,4)-(136,5) = "a"
-        │   ├── receiver: ∅
-        │   ├── parameters:
-        │   │   @ ParametersNode (location: (136,6)-(136,9))
+        │   │   @ ParametersNode (location: (116,6)-(116,9))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 0)
@@ -1349,304 +1193,540 @@
         │   │   ├── posts: (length: 0)
         │   │   ├── keywords: (length: 0)
         │   │   ├── keyword_rest:
-        │   │   │   @ ForwardingParameterNode (location: (136,6)-(136,9))
+        │   │   │   @ ForwardingParameterNode (location: (116,6)-(116,9))
         │   │   │   └── flags: ∅
         │   │   └── block: ∅
         │   ├── body:
-        │   │   @ StatementsNode (location: (136,12)-(136,26))
+        │   │   @ StatementsNode (location: (116,12)-(116,24))
         │   │   ├── flags: ∅
         │   │   └── body: (length: 1)
-        │   │       └── @ InterpolatedStringNode (location: (136,12)-(136,26))
-        │   │           ├── flags: newline
-        │   │           ├── opening_loc: (136,12)-(136,13) = "\""
-        │   │           ├── parts: (length: 2)
-        │   │           │   ├── @ StringNode (location: (136,13)-(136,16))
-        │   │           │   │   ├── flags: static_literal, frozen
-        │   │           │   │   ├── opening_loc: ∅
-        │   │           │   │   ├── content_loc: (136,13)-(136,16) = "foo"
-        │   │           │   │   ├── closing_loc: ∅
-        │   │           │   │   └── unescaped: "foo"
-        │   │           │   └── @ EmbeddedStatementsNode (location: (136,16)-(136,25))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── opening_loc: (136,16)-(136,18) = "\#{"
-        │   │           │       ├── statements:
-        │   │           │       │   @ StatementsNode (location: (136,18)-(136,24))
-        │   │           │       │   ├── flags: ∅
-        │   │           │       │   └── body: (length: 1)
-        │   │           │       │       └── @ CallNode (location: (136,18)-(136,24))
-        │   │           │       │           ├── flags: ignore_visibility
-        │   │           │       │           ├── receiver: ∅
-        │   │           │       │           ├── call_operator_loc: ∅
-        │   │           │       │           ├── name: :b
-        │   │           │       │           ├── message_loc: (136,18)-(136,19) = "b"
-        │   │           │       │           ├── opening_loc: (136,19)-(136,20) = "("
-        │   │           │       │           ├── arguments:
-        │   │           │       │           │   @ ArgumentsNode (location: (136,20)-(136,23))
-        │   │           │       │           │   ├── flags: contains_forwarding
-        │   │           │       │           │   └── arguments: (length: 1)
-        │   │           │       │           │       └── @ ForwardingArgumentsNode (location: (136,20)-(136,23))
-        │   │           │       │           │           └── flags: ∅
-        │   │           │       │           ├── closing_loc: (136,23)-(136,24) = ")"
-        │   │           │       │           └── block: ∅
-        │   │           │       └── closing_loc: (136,24)-(136,25) = "}"
-        │   │           └── closing_loc: (136,25)-(136,26) = "\""
-        │   ├── locals: []
-        │   ├── def_keyword_loc: (136,0)-(136,3) = "def"
-        │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (136,5)-(136,6) = "("
-        │   ├── rparen_loc: (136,9)-(136,10) = ")"
-        │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (136,28)-(136,31) = "end"
-        ├── @ DefNode (location: (138,0)-(140,3))
-        │   ├── flags: newline
-        │   ├── name: :foo
-        │   ├── name_loc: (138,4)-(138,7) = "foo"
-        │   ├── receiver: ∅
-        │   ├── parameters: ∅
-        │   ├── body:
-        │   │   @ StatementsNode (location: (139,2)-(139,30))
-        │   │   ├── flags: ∅
-        │   │   └── body: (length: 1)
-        │   │       └── @ CallNode (location: (139,2)-(139,30))
-        │   │           ├── flags: newline
-        │   │           ├── receiver:
-        │   │           │   @ HashNode (location: (139,2)-(139,4))
-        │   │           │   ├── flags: static_literal
-        │   │           │   ├── opening_loc: (139,2)-(139,3) = "{"
-        │   │           │   ├── elements: (length: 0)
-        │   │           │   └── closing_loc: (139,3)-(139,4) = "}"
-        │   │           ├── call_operator_loc: (139,4)-(139,5) = "."
-        │   │           ├── name: :merge
-        │   │           ├── message_loc: (139,5)-(139,10) = "merge"
-        │   │           ├── opening_loc: ∅
+        │   │       └── @ CallNode (location: (116,12)-(116,24))
+        │   │           ├── flags: newline, ignore_visibility
+        │   │           ├── receiver: ∅
+        │   │           ├── call_operator_loc: ∅
+        │   │           ├── name: :b
+        │   │           ├── message_loc: (116,12)-(116,13) = "b"
+        │   │           ├── opening_loc: (116,13)-(116,14) = "("
         │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (139,11)-(139,30))
-        │   │           │   ├── flags: contains_keywords, contains_keyword_splat
-        │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ KeywordHashNode (location: (139,11)-(139,30))
-        │   │           │           ├── flags: ∅
-        │   │           │           └── elements: (length: 3)
-        │   │           │               ├── @ AssocSplatNode (location: (139,11)-(139,16))
-        │   │           │               │   ├── flags: ∅
-        │   │           │               │   ├── value:
-        │   │           │               │   │   @ CallNode (location: (139,13)-(139,16))
-        │   │           │               │   │   ├── flags: variable_call, ignore_visibility
-        │   │           │               │   │   ├── receiver: ∅
-        │   │           │               │   │   ├── call_operator_loc: ∅
-        │   │           │               │   │   ├── name: :bar
-        │   │           │               │   │   ├── message_loc: (139,13)-(139,16) = "bar"
-        │   │           │               │   │   ├── opening_loc: ∅
-        │   │           │               │   │   ├── arguments: ∅
-        │   │           │               │   │   ├── closing_loc: ∅
-        │   │           │               │   │   └── block: ∅
-        │   │           │               │   └── operator_loc: (139,11)-(139,13) = "**"
-        │   │           │               ├── @ AssocSplatNode (location: (139,18)-(139,23))
-        │   │           │               │   ├── flags: ∅
-        │   │           │               │   ├── value:
-        │   │           │               │   │   @ CallNode (location: (139,20)-(139,23))
-        │   │           │               │   │   ├── flags: variable_call, ignore_visibility
-        │   │           │               │   │   ├── receiver: ∅
-        │   │           │               │   │   ├── call_operator_loc: ∅
-        │   │           │               │   │   ├── name: :baz
-        │   │           │               │   │   ├── message_loc: (139,20)-(139,23) = "baz"
-        │   │           │               │   │   ├── opening_loc: ∅
-        │   │           │               │   │   ├── arguments: ∅
-        │   │           │               │   │   ├── closing_loc: ∅
-        │   │           │               │   │   └── block: ∅
-        │   │           │               │   └── operator_loc: (139,18)-(139,20) = "**"
-        │   │           │               └── @ AssocSplatNode (location: (139,25)-(139,30))
-        │   │           │                   ├── flags: ∅
-        │   │           │                   ├── value:
-        │   │           │                   │   @ CallNode (location: (139,27)-(139,30))
-        │   │           │                   │   ├── flags: variable_call, ignore_visibility
-        │   │           │                   │   ├── receiver: ∅
-        │   │           │                   │   ├── call_operator_loc: ∅
-        │   │           │                   │   ├── name: :qux
-        │   │           │                   │   ├── message_loc: (139,27)-(139,30) = "qux"
-        │   │           │                   │   ├── opening_loc: ∅
-        │   │           │                   │   ├── arguments: ∅
-        │   │           │                   │   ├── closing_loc: ∅
-        │   │           │                   │   └── block: ∅
-        │   │           │                   └── operator_loc: (139,25)-(139,27) = "**"
-        │   │           ├── closing_loc: ∅
+        │   │           │   @ ArgumentsNode (location: (116,14)-(116,23))
+        │   │           │   ├── flags: contains_forwarding
+        │   │           │   └── arguments: (length: 3)
+        │   │           │       ├── @ IntegerNode (location: (116,14)-(116,15))
+        │   │           │       │   ├── flags: static_literal, decimal
+        │   │           │       │   └── value: 1
+        │   │           │       ├── @ IntegerNode (location: (116,17)-(116,18))
+        │   │           │       │   ├── flags: static_literal, decimal
+        │   │           │       │   └── value: 2
+        │   │           │       └── @ ForwardingArgumentsNode (location: (116,20)-(116,23))
+        │   │           │           └── flags: ∅
+        │   │           ├── closing_loc: (116,23)-(116,24) = ")"
         │   │           └── block: ∅
         │   ├── locals: []
-        │   ├── def_keyword_loc: (138,0)-(138,3) = "def"
+        │   ├── def_keyword_loc: (116,0)-(116,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (116,5)-(116,6) = "("
+        │   ├── rparen_loc: (116,9)-(116,10) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (116,26)-(116,29) = "end"
+        ├── @ DefNode (location: (118,0)-(119,3))
+        │   ├── flags: newline
+        │   ├── name: :a
+        │   ├── name_loc: (118,12)-(118,13) = "a"
+        │   ├── receiver:
+        │   │   @ ParenthesesNode (location: (118,4)-(118,11))
+        │   │   ├── flags: ∅
+        │   │   ├── body:
+        │   │   │   @ LocalVariableWriteNode (location: (118,5)-(118,10))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── name: :c
+        │   │   │   ├── depth: 0
+        │   │   │   ├── name_loc: (118,5)-(118,6) = "c"
+        │   │   │   ├── value:
+        │   │   │   │   @ CallNode (location: (118,9)-(118,10))
+        │   │   │   │   ├── flags: variable_call, ignore_visibility
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── name: :b
+        │   │   │   │   ├── message_loc: (118,9)-(118,10) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── block: ∅
+        │   │   │   └── operator_loc: (118,7)-(118,8) = "="
+        │   │   ├── opening_loc: (118,4)-(118,5) = "("
+        │   │   └── closing_loc: (118,10)-(118,11) = ")"
+        │   ├── parameters: ∅
+        │   ├── body: ∅
+        │   ├── locals: []
+        │   ├── def_keyword_loc: (118,0)-(118,3) = "def"
+        │   ├── operator_loc: (118,11)-(118,12) = "."
+        │   ├── lparen_loc: ∅
+        │   ├── rparen_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (119,0)-(119,3) = "end"
+        ├── @ DefNode (location: (121,0)-(122,3))
+        │   ├── flags: newline
+        │   ├── name: :a
+        │   ├── name_loc: (121,4)-(121,5) = "a"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (121,6)-(121,8))
+        │   │   ├── flags: ∅
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest: ∅
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block:
+        │   │       @ BlockParameterNode (location: (121,6)-(121,8))
+        │   │       ├── flags: ∅
+        │   │       ├── name: :b
+        │   │       ├── name_loc: (121,7)-(121,8) = "b"
+        │   │       └── operator_loc: (121,6)-(121,7) = "&"
+        │   ├── body: ∅
+        │   ├── locals: [:b]
+        │   ├── def_keyword_loc: (121,0)-(121,3) = "def"
         │   ├── operator_loc: ∅
         │   ├── lparen_loc: ∅
         │   ├── rparen_loc: ∅
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (140,0)-(140,3) = "end"
-        ├── @ DefNode (location: (142,0)-(143,3))
+        │   └── end_keyword_loc: (122,0)-(122,3) = "end"
+        ├── @ DefNode (location: (124,0)-(125,3))
         │   ├── flags: newline
-        │   ├── name: :bar
-        │   ├── name_loc: (142,4)-(142,7) = "bar"
+        │   ├── name: :a
+        │   ├── name_loc: (124,4)-(124,5) = "a"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (142,8)-(142,19))
+        │   │   @ ParametersNode (location: (124,6)-(124,7))
+        │   │   ├── flags: ∅
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest: ∅
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block:
+        │   │       @ BlockParameterNode (location: (124,6)-(124,7))
+        │   │       ├── flags: ∅
+        │   │       ├── name: ∅
+        │   │       ├── name_loc: ∅
+        │   │       └── operator_loc: (124,6)-(124,7) = "&"
+        │   ├── body: ∅
+        │   ├── locals: []
+        │   ├── def_keyword_loc: (124,0)-(124,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (124,5)-(124,6) = "("
+        │   ├── rparen_loc: (124,7)-(124,8) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (125,0)-(125,3) = "end"
+        ├── @ DefNode (location: (127,0)-(128,3))
+        │   ├── flags: newline
+        │   ├── name: :a
+        │   ├── name_loc: (127,10)-(127,11) = "a"
+        │   ├── receiver:
+        │   │   @ ClassVariableReadNode (location: (127,4)-(127,9))
+        │   │   ├── flags: ∅
+        │   │   └── name: :@@var
+        │   ├── parameters: ∅
+        │   ├── body: ∅
+        │   ├── locals: []
+        │   ├── def_keyword_loc: (127,0)-(127,3) = "def"
+        │   ├── operator_loc: (127,9)-(127,10) = "."
+        │   ├── lparen_loc: ∅
+        │   ├── rparen_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (128,0)-(128,3) = "end"
+        ├── @ DefNode (location: (130,0)-(131,3))
+        │   ├── flags: newline
+        │   ├── name: :C
+        │   ├── name_loc: (130,12)-(130,13) = "C"
+        │   ├── receiver:
+        │   │   @ ParenthesesNode (location: (130,4)-(130,11))
+        │   │   ├── flags: ∅
+        │   │   ├── body:
+        │   │   │   @ LocalVariableWriteNode (location: (130,5)-(130,10))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── name: :a
+        │   │   │   ├── depth: 0
+        │   │   │   ├── name_loc: (130,5)-(130,6) = "a"
+        │   │   │   ├── value:
+        │   │   │   │   @ CallNode (location: (130,9)-(130,10))
+        │   │   │   │   ├── flags: variable_call, ignore_visibility
+        │   │   │   │   ├── receiver: ∅
+        │   │   │   │   ├── call_operator_loc: ∅
+        │   │   │   │   ├── name: :b
+        │   │   │   │   ├── message_loc: (130,9)-(130,10) = "b"
+        │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   ├── arguments: ∅
+        │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   └── block: ∅
+        │   │   │   └── operator_loc: (130,7)-(130,8) = "="
+        │   │   ├── opening_loc: (130,4)-(130,5) = "("
+        │   │   └── closing_loc: (130,10)-(130,11) = ")"
+        │   ├── parameters: ∅
+        │   ├── body: ∅
+        │   ├── locals: []
+        │   ├── def_keyword_loc: (130,0)-(130,3) = "def"
+        │   ├── operator_loc: (130,11)-(130,12) = "."
+        │   ├── lparen_loc: ∅
+        │   ├── rparen_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (131,0)-(131,3) = "end"
+        ├── @ DefNode (location: (133,0)-(133,28))
+        │   ├── flags: newline
+        │   ├── name: :Array_function
+        │   ├── name_loc: (133,9)-(133,23) = "Array_function"
+        │   ├── receiver:
+        │   │   @ SelfNode (location: (133,4)-(133,8))
+        │   │   └── flags: ∅
+        │   ├── parameters: ∅
+        │   ├── body: ∅
+        │   ├── locals: []
+        │   ├── def_keyword_loc: (133,0)-(133,3) = "def"
+        │   ├── operator_loc: (133,8)-(133,9) = "."
+        │   ├── lparen_loc: ∅
+        │   ├── rparen_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (133,25)-(133,28) = "end"
+        ├── @ ConstantWriteNode (location: (135,0)-(135,9))
+        │   ├── flags: newline
+        │   ├── name: :Const
+        │   ├── name_loc: (135,0)-(135,5) = "Const"
+        │   ├── value:
+        │   │   @ IntegerNode (location: (135,8)-(135,9))
+        │   │   ├── flags: static_literal, decimal
+        │   │   └── value: 1
+        │   └── operator_loc: (135,6)-(135,7) = "="
+        ├── @ DefNode (location: (135,11)-(136,3))
+        │   ├── flags: newline
+        │   ├── name: :a
+        │   ├── name_loc: (135,21)-(135,22) = "a"
+        │   ├── receiver:
+        │   │   @ ConstantReadNode (location: (135,15)-(135,20))
+        │   │   ├── flags: ∅
+        │   │   └── name: :Const
+        │   ├── parameters: ∅
+        │   ├── body: ∅
+        │   ├── locals: []
+        │   ├── def_keyword_loc: (135,11)-(135,14) = "def"
+        │   ├── operator_loc: (135,20)-(135,21) = "."
+        │   ├── lparen_loc: ∅
+        │   ├── rparen_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (136,0)-(136,3) = "end"
+        ├── @ DefNode (location: (138,0)-(138,31))
+        │   ├── flags: newline
+        │   ├── name: :a
+        │   ├── name_loc: (138,4)-(138,5) = "a"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (138,6)-(138,9))
+        │   │   ├── flags: ∅
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest: ∅
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest:
+        │   │   │   @ ForwardingParameterNode (location: (138,6)-(138,9))
+        │   │   │   └── flags: ∅
+        │   │   └── block: ∅
+        │   ├── body:
+        │   │   @ StatementsNode (location: (138,12)-(138,26))
+        │   │   ├── flags: ∅
+        │   │   └── body: (length: 1)
+        │   │       └── @ InterpolatedStringNode (location: (138,12)-(138,26))
+        │   │           ├── flags: newline
+        │   │           ├── opening_loc: (138,12)-(138,13) = "\""
+        │   │           ├── parts: (length: 2)
+        │   │           │   ├── @ StringNode (location: (138,13)-(138,16))
+        │   │           │   │   ├── flags: static_literal, frozen
+        │   │           │   │   ├── opening_loc: ∅
+        │   │           │   │   ├── content_loc: (138,13)-(138,16) = "foo"
+        │   │           │   │   ├── closing_loc: ∅
+        │   │           │   │   └── unescaped: "foo"
+        │   │           │   └── @ EmbeddedStatementsNode (location: (138,16)-(138,25))
+        │   │           │       ├── flags: ∅
+        │   │           │       ├── opening_loc: (138,16)-(138,18) = "\#{"
+        │   │           │       ├── statements:
+        │   │           │       │   @ StatementsNode (location: (138,18)-(138,24))
+        │   │           │       │   ├── flags: ∅
+        │   │           │       │   └── body: (length: 1)
+        │   │           │       │       └── @ CallNode (location: (138,18)-(138,24))
+        │   │           │       │           ├── flags: ignore_visibility
+        │   │           │       │           ├── receiver: ∅
+        │   │           │       │           ├── call_operator_loc: ∅
+        │   │           │       │           ├── name: :b
+        │   │           │       │           ├── message_loc: (138,18)-(138,19) = "b"
+        │   │           │       │           ├── opening_loc: (138,19)-(138,20) = "("
+        │   │           │       │           ├── arguments:
+        │   │           │       │           │   @ ArgumentsNode (location: (138,20)-(138,23))
+        │   │           │       │           │   ├── flags: contains_forwarding
+        │   │           │       │           │   └── arguments: (length: 1)
+        │   │           │       │           │       └── @ ForwardingArgumentsNode (location: (138,20)-(138,23))
+        │   │           │       │           │           └── flags: ∅
+        │   │           │       │           ├── closing_loc: (138,23)-(138,24) = ")"
+        │   │           │       │           └── block: ∅
+        │   │           │       └── closing_loc: (138,24)-(138,25) = "}"
+        │   │           └── closing_loc: (138,25)-(138,26) = "\""
+        │   ├── locals: []
+        │   ├── def_keyword_loc: (138,0)-(138,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (138,5)-(138,6) = "("
+        │   ├── rparen_loc: (138,9)-(138,10) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (138,28)-(138,31) = "end"
+        ├── @ DefNode (location: (140,0)-(142,3))
+        │   ├── flags: newline
+        │   ├── name: :foo
+        │   ├── name_loc: (140,4)-(140,7) = "foo"
+        │   ├── receiver: ∅
+        │   ├── parameters: ∅
+        │   ├── body:
+        │   │   @ StatementsNode (location: (141,2)-(141,30))
+        │   │   ├── flags: ∅
+        │   │   └── body: (length: 1)
+        │   │       └── @ CallNode (location: (141,2)-(141,30))
+        │   │           ├── flags: newline
+        │   │           ├── receiver:
+        │   │           │   @ HashNode (location: (141,2)-(141,4))
+        │   │           │   ├── flags: static_literal
+        │   │           │   ├── opening_loc: (141,2)-(141,3) = "{"
+        │   │           │   ├── elements: (length: 0)
+        │   │           │   └── closing_loc: (141,3)-(141,4) = "}"
+        │   │           ├── call_operator_loc: (141,4)-(141,5) = "."
+        │   │           ├── name: :merge
+        │   │           ├── message_loc: (141,5)-(141,10) = "merge"
+        │   │           ├── opening_loc: ∅
+        │   │           ├── arguments:
+        │   │           │   @ ArgumentsNode (location: (141,11)-(141,30))
+        │   │           │   ├── flags: contains_keywords, contains_keyword_splat
+        │   │           │   └── arguments: (length: 1)
+        │   │           │       └── @ KeywordHashNode (location: (141,11)-(141,30))
+        │   │           │           ├── flags: ∅
+        │   │           │           └── elements: (length: 3)
+        │   │           │               ├── @ AssocSplatNode (location: (141,11)-(141,16))
+        │   │           │               │   ├── flags: ∅
+        │   │           │               │   ├── value:
+        │   │           │               │   │   @ CallNode (location: (141,13)-(141,16))
+        │   │           │               │   │   ├── flags: variable_call, ignore_visibility
+        │   │           │               │   │   ├── receiver: ∅
+        │   │           │               │   │   ├── call_operator_loc: ∅
+        │   │           │               │   │   ├── name: :bar
+        │   │           │               │   │   ├── message_loc: (141,13)-(141,16) = "bar"
+        │   │           │               │   │   ├── opening_loc: ∅
+        │   │           │               │   │   ├── arguments: ∅
+        │   │           │               │   │   ├── closing_loc: ∅
+        │   │           │               │   │   └── block: ∅
+        │   │           │               │   └── operator_loc: (141,11)-(141,13) = "**"
+        │   │           │               ├── @ AssocSplatNode (location: (141,18)-(141,23))
+        │   │           │               │   ├── flags: ∅
+        │   │           │               │   ├── value:
+        │   │           │               │   │   @ CallNode (location: (141,20)-(141,23))
+        │   │           │               │   │   ├── flags: variable_call, ignore_visibility
+        │   │           │               │   │   ├── receiver: ∅
+        │   │           │               │   │   ├── call_operator_loc: ∅
+        │   │           │               │   │   ├── name: :baz
+        │   │           │               │   │   ├── message_loc: (141,20)-(141,23) = "baz"
+        │   │           │               │   │   ├── opening_loc: ∅
+        │   │           │               │   │   ├── arguments: ∅
+        │   │           │               │   │   ├── closing_loc: ∅
+        │   │           │               │   │   └── block: ∅
+        │   │           │               │   └── operator_loc: (141,18)-(141,20) = "**"
+        │   │           │               └── @ AssocSplatNode (location: (141,25)-(141,30))
+        │   │           │                   ├── flags: ∅
+        │   │           │                   ├── value:
+        │   │           │                   │   @ CallNode (location: (141,27)-(141,30))
+        │   │           │                   │   ├── flags: variable_call, ignore_visibility
+        │   │           │                   │   ├── receiver: ∅
+        │   │           │                   │   ├── call_operator_loc: ∅
+        │   │           │                   │   ├── name: :qux
+        │   │           │                   │   ├── message_loc: (141,27)-(141,30) = "qux"
+        │   │           │                   │   ├── opening_loc: ∅
+        │   │           │                   │   ├── arguments: ∅
+        │   │           │                   │   ├── closing_loc: ∅
+        │   │           │                   │   └── block: ∅
+        │   │           │                   └── operator_loc: (141,25)-(141,27) = "**"
+        │   │           ├── closing_loc: ∅
+        │   │           └── block: ∅
+        │   ├── locals: []
+        │   ├── def_keyword_loc: (140,0)-(140,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: ∅
+        │   ├── rparen_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (142,0)-(142,3) = "end"
+        ├── @ DefNode (location: (144,0)-(145,3))
+        │   ├── flags: newline
+        │   ├── name: :bar
+        │   ├── name_loc: (144,4)-(144,7) = "bar"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (144,8)-(144,19))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 0)
         │   │   ├── rest: ∅
         │   │   ├── posts: (length: 0)
         │   │   ├── keywords: (length: 1)
-        │   │   │   └── @ OptionalKeywordParameterNode (location: (142,8)-(142,19))
+        │   │   │   └── @ OptionalKeywordParameterNode (location: (144,8)-(144,19))
         │   │   │       ├── flags: ∅
         │   │   │       ├── name: :a
-        │   │   │       ├── name_loc: (142,8)-(142,10) = "a:"
+        │   │   │       ├── name_loc: (144,8)-(144,10) = "a:"
         │   │   │       └── value:
-        │   │   │           @ ParenthesesNode (location: (142,11)-(142,19))
+        │   │   │           @ ParenthesesNode (location: (144,11)-(144,19))
         │   │   │           ├── flags: ∅
         │   │   │           ├── body:
-        │   │   │           │   @ StatementsNode (location: (142,12)-(142,18))
+        │   │   │           │   @ StatementsNode (location: (144,12)-(144,18))
         │   │   │           │   ├── flags: ∅
         │   │   │           │   └── body: (length: 1)
-        │   │   │           │       └── @ RangeNode (location: (142,12)-(142,18))
+        │   │   │           │       └── @ RangeNode (location: (144,12)-(144,18))
         │   │   │           │           ├── flags: newline, static_literal, exclude_end
         │   │   │           │           ├── left:
-        │   │   │           │           │   @ IntegerNode (location: (142,12)-(142,13))
+        │   │   │           │           │   @ IntegerNode (location: (144,12)-(144,13))
         │   │   │           │           │   ├── flags: static_literal, decimal
         │   │   │           │           │   └── value: 1
         │   │   │           │           ├── right:
-        │   │   │           │           │   @ IntegerNode (location: (142,16)-(142,18))
+        │   │   │           │           │   @ IntegerNode (location: (144,16)-(144,18))
         │   │   │           │           │   ├── flags: static_literal, decimal
         │   │   │           │           │   └── value: 10
-        │   │   │           │           └── operator_loc: (142,13)-(142,16) = "..."
-        │   │   │           ├── opening_loc: (142,11)-(142,12) = "("
-        │   │   │           └── closing_loc: (142,18)-(142,19) = ")"
+        │   │   │           │           └── operator_loc: (144,13)-(144,16) = "..."
+        │   │   │           ├── opening_loc: (144,11)-(144,12) = "("
+        │   │   │           └── closing_loc: (144,18)-(144,19) = ")"
         │   │   ├── keyword_rest: ∅
         │   │   └── block: ∅
         │   ├── body: ∅
         │   ├── locals: [:a]
-        │   ├── def_keyword_loc: (142,0)-(142,3) = "def"
+        │   ├── def_keyword_loc: (144,0)-(144,3) = "def"
         │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (142,7)-(142,8) = "("
-        │   ├── rparen_loc: (142,19)-(142,20) = ")"
+        │   ├── lparen_loc: (144,7)-(144,8) = "("
+        │   ├── rparen_loc: (144,19)-(144,20) = ")"
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (143,0)-(143,3) = "end"
-        ├── @ DefNode (location: (145,0)-(146,3))
+        │   └── end_keyword_loc: (145,0)-(145,3) = "end"
+        ├── @ DefNode (location: (147,0)-(148,3))
         │   ├── flags: newline
         │   ├── name: :bar
-        │   ├── name_loc: (145,4)-(145,7) = "bar"
+        │   ├── name_loc: (147,4)-(147,7) = "bar"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (145,8)-(145,18))
+        │   │   @ ParametersNode (location: (147,8)-(147,18))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 0)
         │   │   ├── rest: ∅
         │   │   ├── posts: (length: 0)
         │   │   ├── keywords: (length: 1)
-        │   │   │   └── @ OptionalKeywordParameterNode (location: (145,8)-(145,18))
+        │   │   │   └── @ OptionalKeywordParameterNode (location: (147,8)-(147,18))
         │   │   │       ├── flags: ∅
         │   │   │       ├── name: :a
-        │   │   │       ├── name_loc: (145,8)-(145,10) = "a:"
+        │   │   │       ├── name_loc: (147,8)-(147,10) = "a:"
         │   │   │       └── value:
-        │   │   │           @ ParenthesesNode (location: (145,11)-(145,18))
+        │   │   │           @ ParenthesesNode (location: (147,11)-(147,18))
         │   │   │           ├── flags: ∅
         │   │   │           ├── body:
-        │   │   │           │   @ StatementsNode (location: (145,12)-(145,17))
+        │   │   │           │   @ StatementsNode (location: (147,12)-(147,17))
         │   │   │           │   ├── flags: ∅
         │   │   │           │   └── body: (length: 1)
-        │   │   │           │       └── @ RangeNode (location: (145,12)-(145,17))
+        │   │   │           │       └── @ RangeNode (location: (147,12)-(147,17))
         │   │   │           │           ├── flags: newline, static_literal, exclude_end
         │   │   │           │           ├── left: ∅
         │   │   │           │           ├── right:
-        │   │   │           │           │   @ IntegerNode (location: (145,15)-(145,17))
+        │   │   │           │           │   @ IntegerNode (location: (147,15)-(147,17))
         │   │   │           │           │   ├── flags: static_literal, decimal
         │   │   │           │           │   └── value: 10
-        │   │   │           │           └── operator_loc: (145,12)-(145,15) = "..."
-        │   │   │           ├── opening_loc: (145,11)-(145,12) = "("
-        │   │   │           └── closing_loc: (145,17)-(145,18) = ")"
+        │   │   │           │           └── operator_loc: (147,12)-(147,15) = "..."
+        │   │   │           ├── opening_loc: (147,11)-(147,12) = "("
+        │   │   │           └── closing_loc: (147,17)-(147,18) = ")"
         │   │   ├── keyword_rest: ∅
         │   │   └── block: ∅
         │   ├── body: ∅
         │   ├── locals: [:a]
-        │   ├── def_keyword_loc: (145,0)-(145,3) = "def"
+        │   ├── def_keyword_loc: (147,0)-(147,3) = "def"
         │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (145,7)-(145,8) = "("
-        │   ├── rparen_loc: (145,18)-(145,19) = ")"
+        │   ├── lparen_loc: (147,7)-(147,8) = "("
+        │   ├── rparen_loc: (147,18)-(147,19) = ")"
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (146,0)-(146,3) = "end"
-        ├── @ DefNode (location: (148,0)-(149,3))
+        │   └── end_keyword_loc: (148,0)-(148,3) = "end"
+        ├── @ DefNode (location: (150,0)-(151,3))
         │   ├── flags: newline
         │   ├── name: :bar
-        │   ├── name_loc: (148,4)-(148,7) = "bar"
+        │   ├── name_loc: (150,4)-(150,7) = "bar"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (148,8)-(148,17))
+        │   │   @ ParametersNode (location: (150,8)-(150,17))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 0)
         │   │   ├── rest: ∅
         │   │   ├── posts: (length: 0)
         │   │   ├── keywords: (length: 1)
-        │   │   │   └── @ OptionalKeywordParameterNode (location: (148,8)-(148,17))
+        │   │   │   └── @ OptionalKeywordParameterNode (location: (150,8)-(150,17))
         │   │   │       ├── flags: ∅
         │   │   │       ├── name: :a
-        │   │   │       ├── name_loc: (148,8)-(148,10) = "a:"
+        │   │   │       ├── name_loc: (150,8)-(150,10) = "a:"
         │   │   │       └── value:
-        │   │   │           @ ParenthesesNode (location: (148,11)-(148,17))
+        │   │   │           @ ParenthesesNode (location: (150,11)-(150,17))
         │   │   │           ├── flags: ∅
         │   │   │           ├── body:
-        │   │   │           │   @ StatementsNode (location: (148,12)-(148,16))
+        │   │   │           │   @ StatementsNode (location: (150,12)-(150,16))
         │   │   │           │   ├── flags: ∅
         │   │   │           │   └── body: (length: 1)
-        │   │   │           │       └── @ RangeNode (location: (148,12)-(148,16))
+        │   │   │           │       └── @ RangeNode (location: (150,12)-(150,16))
         │   │   │           │           ├── flags: newline, static_literal, exclude_end
         │   │   │           │           ├── left:
-        │   │   │           │           │   @ IntegerNode (location: (148,12)-(148,13))
+        │   │   │           │           │   @ IntegerNode (location: (150,12)-(150,13))
         │   │   │           │           │   ├── flags: static_literal, decimal
         │   │   │           │           │   └── value: 1
         │   │   │           │           ├── right: ∅
-        │   │   │           │           └── operator_loc: (148,13)-(148,16) = "..."
-        │   │   │           ├── opening_loc: (148,11)-(148,12) = "("
-        │   │   │           └── closing_loc: (148,16)-(148,17) = ")"
+        │   │   │           │           └── operator_loc: (150,13)-(150,16) = "..."
+        │   │   │           ├── opening_loc: (150,11)-(150,12) = "("
+        │   │   │           └── closing_loc: (150,16)-(150,17) = ")"
         │   │   ├── keyword_rest: ∅
         │   │   └── block: ∅
         │   ├── body: ∅
         │   ├── locals: [:a]
-        │   ├── def_keyword_loc: (148,0)-(148,3) = "def"
+        │   ├── def_keyword_loc: (150,0)-(150,3) = "def"
         │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (148,7)-(148,8) = "("
-        │   ├── rparen_loc: (148,17)-(148,18) = ")"
+        │   ├── lparen_loc: (150,7)-(150,8) = "("
+        │   ├── rparen_loc: (150,17)-(150,18) = ")"
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (149,0)-(149,3) = "end"
-        ├── @ DefNode (location: (151,0)-(152,3))
+        │   └── end_keyword_loc: (151,0)-(151,3) = "end"
+        ├── @ DefNode (location: (153,0)-(154,3))
         │   ├── flags: newline
         │   ├── name: :bar
-        │   ├── name_loc: (151,4)-(151,7) = "bar"
+        │   ├── name_loc: (153,4)-(153,7) = "bar"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (151,8)-(151,20))
+        │   │   @ ParametersNode (location: (153,8)-(153,20))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 1)
-        │   │   │   └── @ OptionalParameterNode (location: (151,8)-(151,20))
+        │   │   │   └── @ OptionalParameterNode (location: (153,8)-(153,20))
         │   │   │       ├── flags: ∅
         │   │   │       ├── name: :a
-        │   │   │       ├── name_loc: (151,8)-(151,9) = "a"
-        │   │   │       ├── operator_loc: (151,10)-(151,11) = "="
+        │   │   │       ├── name_loc: (153,8)-(153,9) = "a"
+        │   │   │       ├── operator_loc: (153,10)-(153,11) = "="
         │   │   │       └── value:
-        │   │   │           @ ParenthesesNode (location: (151,12)-(151,20))
+        │   │   │           @ ParenthesesNode (location: (153,12)-(153,20))
         │   │   │           ├── flags: ∅
         │   │   │           ├── body:
-        │   │   │           │   @ StatementsNode (location: (151,13)-(151,19))
+        │   │   │           │   @ StatementsNode (location: (153,13)-(153,19))
         │   │   │           │   ├── flags: ∅
         │   │   │           │   └── body: (length: 1)
-        │   │   │           │       └── @ RangeNode (location: (151,13)-(151,19))
+        │   │   │           │       └── @ RangeNode (location: (153,13)-(153,19))
         │   │   │           │           ├── flags: newline, static_literal, exclude_end
         │   │   │           │           ├── left:
-        │   │   │           │           │   @ IntegerNode (location: (151,13)-(151,14))
+        │   │   │           │           │   @ IntegerNode (location: (153,13)-(153,14))
         │   │   │           │           │   ├── flags: static_literal, decimal
         │   │   │           │           │   └── value: 1
         │   │   │           │           ├── right:
-        │   │   │           │           │   @ IntegerNode (location: (151,17)-(151,19))
+        │   │   │           │           │   @ IntegerNode (location: (153,17)-(153,19))
         │   │   │           │           │   ├── flags: static_literal, decimal
         │   │   │           │           │   └── value: 10
-        │   │   │           │           └── operator_loc: (151,14)-(151,17) = "..."
-        │   │   │           ├── opening_loc: (151,12)-(151,13) = "("
-        │   │   │           └── closing_loc: (151,19)-(151,20) = ")"
+        │   │   │           │           └── operator_loc: (153,14)-(153,17) = "..."
+        │   │   │           ├── opening_loc: (153,12)-(153,13) = "("
+        │   │   │           └── closing_loc: (153,19)-(153,20) = ")"
         │   │   ├── rest: ∅
         │   │   ├── posts: (length: 0)
         │   │   ├── keywords: (length: 0)
@@ -1654,44 +1734,44 @@
         │   │   └── block: ∅
         │   ├── body: ∅
         │   ├── locals: [:a]
-        │   ├── def_keyword_loc: (151,0)-(151,3) = "def"
+        │   ├── def_keyword_loc: (153,0)-(153,3) = "def"
         │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (151,7)-(151,8) = "("
-        │   ├── rparen_loc: (151,20)-(151,21) = ")"
+        │   ├── lparen_loc: (153,7)-(153,8) = "("
+        │   ├── rparen_loc: (153,20)-(153,21) = ")"
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (152,0)-(152,3) = "end"
-        ├── @ DefNode (location: (154,0)-(155,3))
+        │   └── end_keyword_loc: (154,0)-(154,3) = "end"
+        ├── @ DefNode (location: (156,0)-(157,3))
         │   ├── flags: newline
         │   ├── name: :bar
-        │   ├── name_loc: (154,4)-(154,7) = "bar"
+        │   ├── name_loc: (156,4)-(156,7) = "bar"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (154,8)-(154,19))
+        │   │   @ ParametersNode (location: (156,8)-(156,19))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 1)
-        │   │   │   └── @ OptionalParameterNode (location: (154,8)-(154,19))
+        │   │   │   └── @ OptionalParameterNode (location: (156,8)-(156,19))
         │   │   │       ├── flags: ∅
         │   │   │       ├── name: :a
-        │   │   │       ├── name_loc: (154,8)-(154,9) = "a"
-        │   │   │       ├── operator_loc: (154,10)-(154,11) = "="
+        │   │   │       ├── name_loc: (156,8)-(156,9) = "a"
+        │   │   │       ├── operator_loc: (156,10)-(156,11) = "="
         │   │   │       └── value:
-        │   │   │           @ ParenthesesNode (location: (154,12)-(154,19))
+        │   │   │           @ ParenthesesNode (location: (156,12)-(156,19))
         │   │   │           ├── flags: ∅
         │   │   │           ├── body:
-        │   │   │           │   @ StatementsNode (location: (154,13)-(154,18))
+        │   │   │           │   @ StatementsNode (location: (156,13)-(156,18))
         │   │   │           │   ├── flags: ∅
         │   │   │           │   └── body: (length: 1)
-        │   │   │           │       └── @ RangeNode (location: (154,13)-(154,18))
+        │   │   │           │       └── @ RangeNode (location: (156,13)-(156,18))
         │   │   │           │           ├── flags: newline, static_literal, exclude_end
         │   │   │           │           ├── left: ∅
         │   │   │           │           ├── right:
-        │   │   │           │           │   @ IntegerNode (location: (154,16)-(154,18))
+        │   │   │           │           │   @ IntegerNode (location: (156,16)-(156,18))
         │   │   │           │           │   ├── flags: static_literal, decimal
         │   │   │           │           │   └── value: 10
-        │   │   │           │           └── operator_loc: (154,13)-(154,16) = "..."
-        │   │   │           ├── opening_loc: (154,12)-(154,13) = "("
-        │   │   │           └── closing_loc: (154,18)-(154,19) = ")"
+        │   │   │           │           └── operator_loc: (156,13)-(156,16) = "..."
+        │   │   │           ├── opening_loc: (156,12)-(156,13) = "("
+        │   │   │           └── closing_loc: (156,18)-(156,19) = ")"
         │   │   ├── rest: ∅
         │   │   ├── posts: (length: 0)
         │   │   ├── keywords: (length: 0)
@@ -1699,44 +1779,44 @@
         │   │   └── block: ∅
         │   ├── body: ∅
         │   ├── locals: [:a]
-        │   ├── def_keyword_loc: (154,0)-(154,3) = "def"
+        │   ├── def_keyword_loc: (156,0)-(156,3) = "def"
         │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (154,7)-(154,8) = "("
-        │   ├── rparen_loc: (154,19)-(154,20) = ")"
+        │   ├── lparen_loc: (156,7)-(156,8) = "("
+        │   ├── rparen_loc: (156,19)-(156,20) = ")"
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (155,0)-(155,3) = "end"
-        ├── @ DefNode (location: (157,0)-(158,3))
+        │   └── end_keyword_loc: (157,0)-(157,3) = "end"
+        ├── @ DefNode (location: (159,0)-(160,3))
         │   ├── flags: newline
         │   ├── name: :bar
-        │   ├── name_loc: (157,4)-(157,7) = "bar"
+        │   ├── name_loc: (159,4)-(159,7) = "bar"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (157,8)-(157,18))
+        │   │   @ ParametersNode (location: (159,8)-(159,18))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 1)
-        │   │   │   └── @ OptionalParameterNode (location: (157,8)-(157,18))
+        │   │   │   └── @ OptionalParameterNode (location: (159,8)-(159,18))
         │   │   │       ├── flags: ∅
         │   │   │       ├── name: :a
-        │   │   │       ├── name_loc: (157,8)-(157,9) = "a"
-        │   │   │       ├── operator_loc: (157,10)-(157,11) = "="
+        │   │   │       ├── name_loc: (159,8)-(159,9) = "a"
+        │   │   │       ├── operator_loc: (159,10)-(159,11) = "="
         │   │   │       └── value:
-        │   │   │           @ ParenthesesNode (location: (157,12)-(157,18))
+        │   │   │           @ ParenthesesNode (location: (159,12)-(159,18))
         │   │   │           ├── flags: ∅
         │   │   │           ├── body:
-        │   │   │           │   @ StatementsNode (location: (157,13)-(157,17))
+        │   │   │           │   @ StatementsNode (location: (159,13)-(159,17))
         │   │   │           │   ├── flags: ∅
         │   │   │           │   └── body: (length: 1)
-        │   │   │           │       └── @ RangeNode (location: (157,13)-(157,17))
+        │   │   │           │       └── @ RangeNode (location: (159,13)-(159,17))
         │   │   │           │           ├── flags: newline, static_literal, exclude_end
         │   │   │           │           ├── left:
-        │   │   │           │           │   @ IntegerNode (location: (157,13)-(157,14))
+        │   │   │           │           │   @ IntegerNode (location: (159,13)-(159,14))
         │   │   │           │           │   ├── flags: static_literal, decimal
         │   │   │           │           │   └── value: 1
         │   │   │           │           ├── right: ∅
-        │   │   │           │           └── operator_loc: (157,14)-(157,17) = "..."
-        │   │   │           ├── opening_loc: (157,12)-(157,13) = "("
-        │   │   │           └── closing_loc: (157,17)-(157,18) = ")"
+        │   │   │           │           └── operator_loc: (159,14)-(159,17) = "..."
+        │   │   │           ├── opening_loc: (159,12)-(159,13) = "("
+        │   │   │           └── closing_loc: (159,17)-(159,18) = ")"
         │   │   ├── rest: ∅
         │   │   ├── posts: (length: 0)
         │   │   ├── keywords: (length: 0)
@@ -1744,22 +1824,22 @@
         │   │   └── block: ∅
         │   ├── body: ∅
         │   ├── locals: [:a]
-        │   ├── def_keyword_loc: (157,0)-(157,3) = "def"
+        │   ├── def_keyword_loc: (159,0)-(159,3) = "def"
         │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (157,7)-(157,8) = "("
-        │   ├── rparen_loc: (157,18)-(157,19) = ")"
+        │   ├── lparen_loc: (159,7)-(159,8) = "("
+        │   ├── rparen_loc: (159,18)-(159,19) = ")"
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (158,0)-(158,3) = "end"
-        ├── @ DefNode (location: (160,0)-(162,3))
+        │   └── end_keyword_loc: (160,0)-(160,3) = "end"
+        ├── @ DefNode (location: (162,0)-(164,3))
         │   ├── flags: newline
         │   ├── name: :method
-        │   ├── name_loc: (160,4)-(160,10) = "method"
+        │   ├── name_loc: (162,4)-(162,10) = "method"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (160,11)-(160,12))
+        │   │   @ ParametersNode (location: (162,11)-(162,12))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 1)
-        │   │   │   └── @ RequiredParameterNode (location: (160,11)-(160,12))
+        │   │   │   └── @ RequiredParameterNode (location: (162,11)-(162,12))
         │   │   │       ├── flags: ∅
         │   │   │       └── name: :a
         │   │   ├── optionals: (length: 0)
@@ -1769,172 +1849,124 @@
         │   │   ├── keyword_rest: ∅
         │   │   └── block: ∅
         │   ├── body:
-        │   │   @ StatementsNode (location: (161,2)-(161,14))
+        │   │   @ StatementsNode (location: (163,2)-(163,14))
         │   │   ├── flags: ∅
         │   │   └── body: (length: 1)
-        │   │       └── @ CallNode (location: (161,2)-(161,14))
+        │   │       └── @ CallNode (location: (163,2)-(163,14))
         │   │           ├── flags: newline
         │   │           ├── receiver:
-        │   │           │   @ CallNode (location: (161,2)-(161,6))
+        │   │           │   @ CallNode (location: (163,2)-(163,6))
         │   │           │   ├── flags: variable_call, ignore_visibility
         │   │           │   ├── receiver: ∅
         │   │           │   ├── call_operator_loc: ∅
         │   │           │   ├── name: :item
-        │   │           │   ├── message_loc: (161,2)-(161,6) = "item"
+        │   │           │   ├── message_loc: (163,2)-(163,6) = "item"
         │   │           │   ├── opening_loc: ∅
         │   │           │   ├── arguments: ∅
         │   │           │   ├── closing_loc: ∅
         │   │           │   └── block: ∅
         │   │           ├── call_operator_loc: ∅
         │   │           ├── name: :>>
-        │   │           ├── message_loc: (161,7)-(161,9) = ">>"
+        │   │           ├── message_loc: (163,7)-(163,9) = ">>"
         │   │           ├── opening_loc: ∅
         │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (161,10)-(161,14))
+        │   │           │   @ ArgumentsNode (location: (163,10)-(163,14))
         │   │           │   ├── flags: ∅
         │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ CallNode (location: (161,10)-(161,14))
+        │   │           │       └── @ CallNode (location: (163,10)-(163,14))
         │   │           │           ├── flags: ignore_visibility
         │   │           │           ├── receiver: ∅
         │   │           │           ├── call_operator_loc: ∅
         │   │           │           ├── name: :a
-        │   │           │           ├── message_loc: (161,10)-(161,11) = "a"
+        │   │           │           ├── message_loc: (163,10)-(163,11) = "a"
         │   │           │           ├── opening_loc: ∅
         │   │           │           ├── arguments: ∅
         │   │           │           ├── closing_loc: ∅
         │   │           │           └── block:
-        │   │           │               @ BlockNode (location: (161,12)-(161,14))
+        │   │           │               @ BlockNode (location: (163,12)-(163,14))
         │   │           │               ├── flags: ∅
         │   │           │               ├── locals: []
         │   │           │               ├── parameters: ∅
         │   │           │               ├── body: ∅
-        │   │           │               ├── opening_loc: (161,12)-(161,13) = "{"
-        │   │           │               └── closing_loc: (161,13)-(161,14) = "}"
+        │   │           │               ├── opening_loc: (163,12)-(163,13) = "{"
+        │   │           │               └── closing_loc: (163,13)-(163,14) = "}"
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
         │   ├── locals: [:a]
-        │   ├── def_keyword_loc: (160,0)-(160,3) = "def"
+        │   ├── def_keyword_loc: (162,0)-(162,3) = "def"
         │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (160,10)-(160,11) = "("
-        │   ├── rparen_loc: (160,12)-(160,13) = ")"
+        │   ├── lparen_loc: (162,10)-(162,11) = "("
+        │   ├── rparen_loc: (162,12)-(162,13) = ")"
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (162,0)-(162,3) = "end"
-        ├── @ LocalVariableWriteNode (location: (164,0)-(164,7))
+        │   └── end_keyword_loc: (164,0)-(164,3) = "end"
+        ├── @ LocalVariableWriteNode (location: (166,0)-(166,7))
         │   ├── flags: newline
         │   ├── name: :foo
         │   ├── depth: 0
-        │   ├── name_loc: (164,0)-(164,3) = "foo"
+        │   ├── name_loc: (166,0)-(166,3) = "foo"
         │   ├── value:
-        │   │   @ IntegerNode (location: (164,6)-(164,7))
+        │   │   @ IntegerNode (location: (166,6)-(166,7))
         │   │   ├── flags: static_literal, decimal
         │   │   └── value: 1
-        │   └── operator_loc: (164,4)-(164,5) = "="
-        ├── @ DefNode (location: (165,0)-(165,16))
+        │   └── operator_loc: (166,4)-(166,5) = "="
+        ├── @ DefNode (location: (167,0)-(167,16))
         │   ├── flags: newline
         │   ├── name: :bar
-        │   ├── name_loc: (165,8)-(165,11) = "bar"
+        │   ├── name_loc: (167,8)-(167,11) = "bar"
         │   ├── receiver:
-        │   │   @ LocalVariableReadNode (location: (165,4)-(165,7))
+        │   │   @ LocalVariableReadNode (location: (167,4)-(167,7))
         │   │   ├── flags: ∅
         │   │   ├── name: :foo
         │   │   └── depth: 0
         │   ├── parameters: ∅
         │   ├── body: ∅
         │   ├── locals: []
-        │   ├── def_keyword_loc: (165,0)-(165,3) = "def"
-        │   ├── operator_loc: (165,7)-(165,8) = "."
+        │   ├── def_keyword_loc: (167,0)-(167,3) = "def"
+        │   ├── operator_loc: (167,7)-(167,8) = "."
         │   ├── lparen_loc: ∅
         │   ├── rparen_loc: ∅
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (165,13)-(165,16) = "end"
-        ├── @ DefNode (location: (167,0)-(167,18))
-        │   ├── flags: newline
-        │   ├── name: :f
-        │   ├── name_loc: (167,4)-(167,5) = "f"
-        │   ├── receiver: ∅
-        │   ├── parameters:
-        │   │   @ ParametersNode (location: (167,6)-(167,7))
-        │   │   ├── flags: ∅
-        │   │   ├── requireds: (length: 0)
-        │   │   ├── optionals: (length: 0)
-        │   │   ├── rest:
-        │   │   │   @ RestParameterNode (location: (167,6)-(167,7))
-        │   │   │   ├── flags: ∅
-        │   │   │   ├── name: ∅
-        │   │   │   ├── name_loc: ∅
-        │   │   │   └── operator_loc: (167,6)-(167,7) = "*"
-        │   │   ├── posts: (length: 0)
-        │   │   ├── keywords: (length: 0)
-        │   │   ├── keyword_rest: ∅
-        │   │   └── block: ∅
-        │   ├── body:
-        │   │   @ StatementsNode (location: (167,10)-(167,13))
-        │   │   ├── flags: ∅
-        │   │   └── body: (length: 1)
-        │   │       └── @ ArrayNode (location: (167,10)-(167,13))
-        │   │           ├── flags: newline, contains_splat
-        │   │           ├── elements: (length: 1)
-        │   │           │   └── @ SplatNode (location: (167,11)-(167,12))
-        │   │           │       ├── flags: ∅
-        │   │           │       ├── operator_loc: (167,11)-(167,12) = "*"
-        │   │           │       └── expression: ∅
-        │   │           ├── opening_loc: (167,10)-(167,11) = "["
-        │   │           └── closing_loc: (167,12)-(167,13) = "]"
-        │   ├── locals: []
-        │   ├── def_keyword_loc: (167,0)-(167,3) = "def"
-        │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (167,5)-(167,6) = "("
-        │   ├── rparen_loc: (167,7)-(167,8) = ")"
-        │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (167,15)-(167,18) = "end"
-        ├── @ DefNode (location: (169,0)-(169,15))
+        │   └── end_keyword_loc: (167,13)-(167,16) = "end"
+        ├── @ DefNode (location: (169,0)-(169,18))
         │   ├── flags: newline
         │   ├── name: :f
         │   ├── name_loc: (169,4)-(169,5) = "f"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (169,6)-(169,10))
+        │   │   @ ParametersNode (location: (169,6)-(169,7))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 0)
-        │   │   ├── rest: ∅
+        │   │   ├── rest:
+        │   │   │   @ RestParameterNode (location: (169,6)-(169,7))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── name: ∅
+        │   │   │   ├── name_loc: ∅
+        │   │   │   └── operator_loc: (169,6)-(169,7) = "*"
         │   │   ├── posts: (length: 0)
-        │   │   ├── keywords: (length: 1)
-        │   │   │   └── @ OptionalKeywordParameterNode (location: (169,6)-(169,10))
-        │   │   │       ├── flags: ∅
-        │   │   │       ├── name: :x
-        │   │   │       ├── name_loc: (169,6)-(169,8) = "x:"
-        │   │   │       └── value:
-        │   │   │           @ CallNode (location: (169,8)-(169,10))
-        │   │   │           ├── flags: ∅
-        │   │   │           ├── receiver:
-        │   │   │           │   @ CallNode (location: (169,9)-(169,10))
-        │   │   │           │   ├── flags: variable_call, ignore_visibility
-        │   │   │           │   ├── receiver: ∅
-        │   │   │           │   ├── call_operator_loc: ∅
-        │   │   │           │   ├── name: :a
-        │   │   │           │   ├── message_loc: (169,9)-(169,10) = "a"
-        │   │   │           │   ├── opening_loc: ∅
-        │   │   │           │   ├── arguments: ∅
-        │   │   │           │   ├── closing_loc: ∅
-        │   │   │           │   └── block: ∅
-        │   │   │           ├── call_operator_loc: ∅
-        │   │   │           ├── name: :-@
-        │   │   │           ├── message_loc: (169,8)-(169,9) = "-"
-        │   │   │           ├── opening_loc: ∅
-        │   │   │           ├── arguments: ∅
-        │   │   │           ├── closing_loc: ∅
-        │   │   │           └── block: ∅
+        │   │   ├── keywords: (length: 0)
         │   │   ├── keyword_rest: ∅
         │   │   └── block: ∅
-        │   ├── body: ∅
-        │   ├── locals: [:x]
+        │   ├── body:
+        │   │   @ StatementsNode (location: (169,10)-(169,13))
+        │   │   ├── flags: ∅
+        │   │   └── body: (length: 1)
+        │   │       └── @ ArrayNode (location: (169,10)-(169,13))
+        │   │           ├── flags: newline, contains_splat
+        │   │           ├── elements: (length: 1)
+        │   │           │   └── @ SplatNode (location: (169,11)-(169,12))
+        │   │           │       ├── flags: ∅
+        │   │           │       ├── operator_loc: (169,11)-(169,12) = "*"
+        │   │           │       └── expression: ∅
+        │   │           ├── opening_loc: (169,10)-(169,11) = "["
+        │   │           └── closing_loc: (169,12)-(169,13) = "]"
+        │   ├── locals: []
         │   ├── def_keyword_loc: (169,0)-(169,3) = "def"
         │   ├── operator_loc: ∅
-        │   ├── lparen_loc: ∅
-        │   ├── rparen_loc: ∅
+        │   ├── lparen_loc: (169,5)-(169,6) = "("
+        │   ├── rparen_loc: (169,7)-(169,8) = ")"
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (169,12)-(169,15) = "end"
+        │   └── end_keyword_loc: (169,15)-(169,18) = "end"
         ├── @ DefNode (location: (171,0)-(171,15))
         │   ├── flags: newline
         │   ├── name: :f
@@ -1967,8 +1999,8 @@
         │   │   │           │   ├── closing_loc: ∅
         │   │   │           │   └── block: ∅
         │   │   │           ├── call_operator_loc: ∅
-        │   │   │           ├── name: :+@
-        │   │   │           ├── message_loc: (171,8)-(171,9) = "+"
+        │   │   │           ├── name: :-@
+        │   │   │           ├── message_loc: (171,8)-(171,9) = "-"
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
@@ -2015,8 +2047,8 @@
         │   │   │           │   ├── closing_loc: ∅
         │   │   │           │   └── block: ∅
         │   │   │           ├── call_operator_loc: ∅
-        │   │   │           ├── name: :!
-        │   │   │           ├── message_loc: (173,8)-(173,9) = "!"
+        │   │   │           ├── name: :+@
+        │   │   │           ├── message_loc: (173,8)-(173,9) = "+"
         │   │   │           ├── opening_loc: ∅
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
@@ -2031,30 +2063,44 @@
         │   ├── rparen_loc: ∅
         │   ├── equal_loc: ∅
         │   └── end_keyword_loc: (173,12)-(173,15) = "end"
-        ├── @ DefNode (location: (175,0)-(175,20))
+        ├── @ DefNode (location: (175,0)-(175,15))
         │   ├── flags: newline
-        │   ├── name: :foo
-        │   ├── name_loc: (175,4)-(175,7) = "foo"
+        │   ├── name: :f
+        │   ├── name_loc: (175,4)-(175,5) = "f"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (175,8)-(175,15))
+        │   │   @ ParametersNode (location: (175,6)-(175,10))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 0)
         │   │   ├── rest: ∅
         │   │   ├── posts: (length: 0)
         │   │   ├── keywords: (length: 1)
-        │   │   │   └── @ OptionalKeywordParameterNode (location: (175,8)-(175,15))
+        │   │   │   └── @ OptionalKeywordParameterNode (location: (175,6)-(175,10))
         │   │   │       ├── flags: ∅
         │   │   │       ├── name: :x
-        │   │   │       ├── name_loc: (175,8)-(175,10) = "x:"
+        │   │   │       ├── name_loc: (175,6)-(175,8) = "x:"
         │   │   │       └── value:
-        │   │   │           @ StringNode (location: (175,10)-(175,15))
+        │   │   │           @ CallNode (location: (175,8)-(175,10))
         │   │   │           ├── flags: ∅
-        │   │   │           ├── opening_loc: (175,10)-(175,12) = "%("
-        │   │   │           ├── content_loc: (175,12)-(175,14) = "xx"
-        │   │   │           ├── closing_loc: (175,14)-(175,15) = ")"
-        │   │   │           └── unescaped: "xx"
+        │   │   │           ├── receiver:
+        │   │   │           │   @ CallNode (location: (175,9)-(175,10))
+        │   │   │           │   ├── flags: variable_call, ignore_visibility
+        │   │   │           │   ├── receiver: ∅
+        │   │   │           │   ├── call_operator_loc: ∅
+        │   │   │           │   ├── name: :a
+        │   │   │           │   ├── message_loc: (175,9)-(175,10) = "a"
+        │   │   │           │   ├── opening_loc: ∅
+        │   │   │           │   ├── arguments: ∅
+        │   │   │           │   ├── closing_loc: ∅
+        │   │   │           │   └── block: ∅
+        │   │   │           ├── call_operator_loc: ∅
+        │   │   │           ├── name: :!
+        │   │   │           ├── message_loc: (175,8)-(175,9) = "!"
+        │   │   │           ├── opening_loc: ∅
+        │   │   │           ├── arguments: ∅
+        │   │   │           ├── closing_loc: ∅
+        │   │   │           └── block: ∅
         │   │   ├── keyword_rest: ∅
         │   │   └── block: ∅
         │   ├── body: ∅
@@ -2064,14 +2110,48 @@
         │   ├── lparen_loc: ∅
         │   ├── rparen_loc: ∅
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (175,17)-(175,20) = "end"
-        ├── @ DefNode (location: (177,0)-(179,3))
+        │   └── end_keyword_loc: (175,12)-(175,15) = "end"
+        ├── @ DefNode (location: (177,0)-(177,20))
         │   ├── flags: newline
         │   ├── name: :foo
         │   ├── name_loc: (177,4)-(177,7) = "foo"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (177,8)-(177,11))
+        │   │   @ ParametersNode (location: (177,8)-(177,15))
+        │   │   ├── flags: ∅
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest: ∅
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 1)
+        │   │   │   └── @ OptionalKeywordParameterNode (location: (177,8)-(177,15))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── name: :x
+        │   │   │       ├── name_loc: (177,8)-(177,10) = "x:"
+        │   │   │       └── value:
+        │   │   │           @ StringNode (location: (177,10)-(177,15))
+        │   │   │           ├── flags: ∅
+        │   │   │           ├── opening_loc: (177,10)-(177,12) = "%("
+        │   │   │           ├── content_loc: (177,12)-(177,14) = "xx"
+        │   │   │           ├── closing_loc: (177,14)-(177,15) = ")"
+        │   │   │           └── unescaped: "xx"
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body: ∅
+        │   ├── locals: [:x]
+        │   ├── def_keyword_loc: (177,0)-(177,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: ∅
+        │   ├── rparen_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (177,17)-(177,20) = "end"
+        ├── @ DefNode (location: (179,0)-(181,3))
+        │   ├── flags: newline
+        │   ├── name: :foo
+        │   ├── name_loc: (179,4)-(179,7) = "foo"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (179,8)-(179,11))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 0)
@@ -2079,67 +2159,67 @@
         │   │   ├── posts: (length: 0)
         │   │   ├── keywords: (length: 0)
         │   │   ├── keyword_rest:
-        │   │   │   @ ForwardingParameterNode (location: (177,8)-(177,11))
+        │   │   │   @ ForwardingParameterNode (location: (179,8)-(179,11))
         │   │   │   └── flags: ∅
         │   │   └── block: ∅
         │   ├── body:
-        │   │   @ StatementsNode (location: (178,2)-(178,10))
+        │   │   @ StatementsNode (location: (180,2)-(180,10))
         │   │   ├── flags: ∅
         │   │   └── body: (length: 1)
-        │   │       └── @ CallNode (location: (178,2)-(178,10))
+        │   │       └── @ CallNode (location: (180,2)-(180,10))
         │   │           ├── flags: newline, ignore_visibility
         │   │           ├── receiver: ∅
         │   │           ├── call_operator_loc: ∅
         │   │           ├── name: :bar
-        │   │           ├── message_loc: (178,2)-(178,5) = "bar"
-        │   │           ├── opening_loc: (178,5)-(178,6) = "("
+        │   │           ├── message_loc: (180,2)-(180,5) = "bar"
+        │   │           ├── opening_loc: (180,5)-(180,6) = "("
         │   │           ├── arguments:
-        │   │           │   @ ArgumentsNode (location: (178,6)-(178,9))
+        │   │           │   @ ArgumentsNode (location: (180,6)-(180,9))
         │   │           │   ├── flags: contains_forwarding
         │   │           │   └── arguments: (length: 1)
-        │   │           │       └── @ ForwardingArgumentsNode (location: (178,6)-(178,9))
+        │   │           │       └── @ ForwardingArgumentsNode (location: (180,6)-(180,9))
         │   │           │           └── flags: ∅
-        │   │           ├── closing_loc: (178,9)-(178,10) = ")"
+        │   │           ├── closing_loc: (180,9)-(180,10) = ")"
         │   │           └── block: ∅
         │   ├── locals: []
-        │   ├── def_keyword_loc: (177,0)-(177,3) = "def"
+        │   ├── def_keyword_loc: (179,0)-(179,3) = "def"
         │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (177,7)-(177,8) = "("
-        │   ├── rparen_loc: (177,11)-(177,12) = ")"
+        │   ├── lparen_loc: (179,7)-(179,8) = "("
+        │   ├── rparen_loc: (179,11)-(179,12) = ")"
         │   ├── equal_loc: ∅
-        │   └── end_keyword_loc: (179,0)-(179,3) = "end"
-        ├── @ DefNode (location: (181,0)-(181,42))
+        │   └── end_keyword_loc: (181,0)-(181,3) = "end"
+        ├── @ DefNode (location: (183,0)-(183,42))
         │   ├── flags: newline
         │   ├── name: :foo
-        │   ├── name_loc: (181,4)-(181,7) = "foo"
+        │   ├── name_loc: (183,4)-(183,7) = "foo"
         │   ├── receiver: ∅
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (181,8)-(181,37))
+        │   │   @ ParametersNode (location: (183,8)-(183,37))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 1)
-        │   │   │   └── @ OptionalParameterNode (location: (181,8)-(181,37))
+        │   │   │   └── @ OptionalParameterNode (location: (183,8)-(183,37))
         │   │   │       ├── flags: ∅
         │   │   │       ├── name: :bar
-        │   │   │       ├── name_loc: (181,8)-(181,11) = "bar"
-        │   │   │       ├── operator_loc: (181,12)-(181,13) = "="
+        │   │   │       ├── name_loc: (183,8)-(183,11) = "bar"
+        │   │   │       ├── operator_loc: (183,12)-(183,13) = "="
         │   │   │       └── value:
-        │   │   │           @ ParenthesesNode (location: (181,14)-(181,37))
+        │   │   │           @ ParenthesesNode (location: (183,14)-(183,37))
         │   │   │           ├── flags: ∅
         │   │   │           ├── body:
-        │   │   │           │   @ StatementsNode (location: (181,15)-(181,36))
+        │   │   │           │   @ StatementsNode (location: (183,15)-(183,36))
         │   │   │           │   ├── flags: ∅
         │   │   │           │   └── body: (length: 2)
-        │   │   │           │       ├── @ DefNode (location: (181,15)-(181,33))
+        │   │   │           │       ├── @ DefNode (location: (183,15)-(183,33))
         │   │   │           │       │   ├── flags: newline
         │   │   │           │       │   ├── name: :baz
-        │   │   │           │       │   ├── name_loc: (181,19)-(181,22) = "baz"
+        │   │   │           │       │   ├── name_loc: (183,19)-(183,22) = "baz"
         │   │   │           │       │   ├── receiver: ∅
         │   │   │           │       │   ├── parameters:
-        │   │   │           │       │   │   @ ParametersNode (location: (181,23)-(181,26))
+        │   │   │           │       │   │   @ ParametersNode (location: (183,23)-(183,26))
         │   │   │           │       │   │   ├── flags: ∅
         │   │   │           │       │   │   ├── requireds: (length: 1)
-        │   │   │           │       │   │   │   └── @ RequiredParameterNode (location: (181,23)-(181,26))
+        │   │   │           │       │   │   │   └── @ RequiredParameterNode (location: (183,23)-(183,26))
         │   │   │           │       │   │   │       ├── flags: ∅
         │   │   │           │       │   │   │       └── name: :bar
         │   │   │           │       │   │   ├── optionals: (length: 0)
@@ -2149,79 +2229,79 @@
         │   │   │           │       │   │   ├── keyword_rest: ∅
         │   │   │           │       │   │   └── block: ∅
         │   │   │           │       │   ├── body:
-        │   │   │           │       │   │   @ StatementsNode (location: (181,30)-(181,33))
+        │   │   │           │       │   │   @ StatementsNode (location: (183,30)-(183,33))
         │   │   │           │       │   │   ├── flags: ∅
         │   │   │           │       │   │   └── body: (length: 1)
-        │   │   │           │       │   │       └── @ LocalVariableReadNode (location: (181,30)-(181,33))
+        │   │   │           │       │   │       └── @ LocalVariableReadNode (location: (183,30)-(183,33))
         │   │   │           │       │   │           ├── flags: ∅
         │   │   │           │       │   │           ├── name: :bar
         │   │   │           │       │   │           └── depth: 0
         │   │   │           │       │   ├── locals: [:bar]
-        │   │   │           │       │   ├── def_keyword_loc: (181,15)-(181,18) = "def"
+        │   │   │           │       │   ├── def_keyword_loc: (183,15)-(183,18) = "def"
         │   │   │           │       │   ├── operator_loc: ∅
-        │   │   │           │       │   ├── lparen_loc: (181,22)-(181,23) = "("
-        │   │   │           │       │   ├── rparen_loc: (181,26)-(181,27) = ")"
-        │   │   │           │       │   ├── equal_loc: (181,28)-(181,29) = "="
+        │   │   │           │       │   ├── lparen_loc: (183,22)-(183,23) = "("
+        │   │   │           │       │   ├── rparen_loc: (183,26)-(183,27) = ")"
+        │   │   │           │       │   ├── equal_loc: (183,28)-(183,29) = "="
         │   │   │           │       │   └── end_keyword_loc: ∅
-        │   │   │           │       └── @ IntegerNode (location: (181,35)-(181,36))
+        │   │   │           │       └── @ IntegerNode (location: (183,35)-(183,36))
         │   │   │           │           ├── flags: newline, static_literal, decimal
         │   │   │           │           └── value: 1
-        │   │   │           ├── opening_loc: (181,14)-(181,15) = "("
-        │   │   │           └── closing_loc: (181,36)-(181,37) = ")"
+        │   │   │           ├── opening_loc: (183,14)-(183,15) = "("
+        │   │   │           └── closing_loc: (183,36)-(183,37) = ")"
         │   │   ├── rest: ∅
         │   │   ├── posts: (length: 0)
         │   │   ├── keywords: (length: 0)
         │   │   ├── keyword_rest: ∅
         │   │   └── block: ∅
         │   ├── body:
-        │   │   @ StatementsNode (location: (181,41)-(181,42))
+        │   │   @ StatementsNode (location: (183,41)-(183,42))
         │   │   ├── flags: ∅
         │   │   └── body: (length: 1)
-        │   │       └── @ IntegerNode (location: (181,41)-(181,42))
+        │   │       └── @ IntegerNode (location: (183,41)-(183,42))
         │   │           ├── flags: static_literal, decimal
         │   │           └── value: 2
         │   ├── locals: [:bar]
-        │   ├── def_keyword_loc: (181,0)-(181,3) = "def"
+        │   ├── def_keyword_loc: (183,0)-(183,3) = "def"
         │   ├── operator_loc: ∅
-        │   ├── lparen_loc: (181,7)-(181,8) = "("
-        │   ├── rparen_loc: (181,37)-(181,38) = ")"
-        │   ├── equal_loc: (181,39)-(181,40) = "="
+        │   ├── lparen_loc: (183,7)-(183,8) = "("
+        │   ├── rparen_loc: (183,37)-(183,38) = ")"
+        │   ├── equal_loc: (183,39)-(183,40) = "="
         │   └── end_keyword_loc: ∅
-        ├── @ DefNode (location: (183,0)-(183,37))
+        ├── @ DefNode (location: (185,0)-(185,37))
         │   ├── flags: newline
         │   ├── name: :foo
-        │   ├── name_loc: (183,21)-(183,24) = "foo"
+        │   ├── name_loc: (185,21)-(185,24) = "foo"
         │   ├── receiver:
-        │   │   @ ParenthesesNode (location: (183,4)-(183,20))
+        │   │   @ ParenthesesNode (location: (185,4)-(185,20))
         │   │   ├── flags: ∅
         │   │   ├── body:
-        │   │   │   @ ClassNode (location: (183,5)-(183,19))
+        │   │   │   @ ClassNode (location: (185,5)-(185,19))
         │   │   │   ├── flags: ∅
         │   │   │   ├── locals: []
-        │   │   │   ├── class_keyword_loc: (183,5)-(183,10) = "class"
+        │   │   │   ├── class_keyword_loc: (185,5)-(185,10) = "class"
         │   │   │   ├── constant_path:
-        │   │   │   │   @ ConstantReadNode (location: (183,11)-(183,14))
+        │   │   │   │   @ ConstantReadNode (location: (185,11)-(185,14))
         │   │   │   │   ├── flags: ∅
         │   │   │   │   └── name: :Foo
         │   │   │   ├── inheritance_operator_loc: ∅
         │   │   │   ├── superclass: ∅
         │   │   │   ├── body: ∅
-        │   │   │   ├── end_keyword_loc: (183,16)-(183,19) = "end"
+        │   │   │   ├── end_keyword_loc: (185,16)-(185,19) = "end"
         │   │   │   └── name: :Foo
-        │   │   ├── opening_loc: (183,4)-(183,5) = "("
-        │   │   └── closing_loc: (183,19)-(183,20) = ")"
+        │   │   ├── opening_loc: (185,4)-(185,5) = "("
+        │   │   └── closing_loc: (185,19)-(185,20) = ")"
         │   ├── parameters:
-        │   │   @ ParametersNode (location: (183,25)-(183,32))
+        │   │   @ ParametersNode (location: (185,25)-(185,32))
         │   │   ├── flags: ∅
         │   │   ├── requireds: (length: 0)
         │   │   ├── optionals: (length: 1)
-        │   │   │   └── @ OptionalParameterNode (location: (183,25)-(183,32))
+        │   │   │   └── @ OptionalParameterNode (location: (185,25)-(185,32))
         │   │   │       ├── flags: ∅
         │   │   │       ├── name: :bar
-        │   │   │       ├── name_loc: (183,25)-(183,28) = "bar"
-        │   │   │       ├── operator_loc: (183,29)-(183,30) = "="
+        │   │   │       ├── name_loc: (185,25)-(185,28) = "bar"
+        │   │   │       ├── operator_loc: (185,29)-(185,30) = "="
         │   │   │       └── value:
-        │   │   │           @ IntegerNode (location: (183,31)-(183,32))
+        │   │   │           @ IntegerNode (location: (185,31)-(185,32))
         │   │   │           ├── flags: static_literal, decimal
         │   │   │           └── value: 1
         │   │   ├── rest: ∅
@@ -2230,71 +2310,71 @@
         │   │   ├── keyword_rest: ∅
         │   │   └── block: ∅
         │   ├── body:
-        │   │   @ StatementsNode (location: (183,36)-(183,37))
+        │   │   @ StatementsNode (location: (185,36)-(185,37))
         │   │   ├── flags: ∅
         │   │   └── body: (length: 1)
-        │   │       └── @ IntegerNode (location: (183,36)-(183,37))
+        │   │       └── @ IntegerNode (location: (185,36)-(185,37))
         │   │           ├── flags: static_literal, decimal
         │   │           └── value: 2
         │   ├── locals: [:bar]
-        │   ├── def_keyword_loc: (183,0)-(183,3) = "def"
-        │   ├── operator_loc: (183,20)-(183,21) = "."
-        │   ├── lparen_loc: (183,24)-(183,25) = "("
-        │   ├── rparen_loc: (183,32)-(183,33) = ")"
-        │   ├── equal_loc: (183,34)-(183,35) = "="
+        │   ├── def_keyword_loc: (185,0)-(185,3) = "def"
+        │   ├── operator_loc: (185,20)-(185,21) = "."
+        │   ├── lparen_loc: (185,24)-(185,25) = "("
+        │   ├── rparen_loc: (185,32)-(185,33) = ")"
+        │   ├── equal_loc: (185,34)-(185,35) = "="
         │   └── end_keyword_loc: ∅
-        └── @ ModuleNode (location: (185,0)-(188,3))
+        └── @ ModuleNode (location: (187,0)-(190,3))
             ├── flags: newline
             ├── locals: []
-            ├── module_keyword_loc: (185,0)-(185,6) = "module"
+            ├── module_keyword_loc: (187,0)-(187,6) = "module"
             ├── constant_path:
-            │   @ ConstantReadNode (location: (185,7)-(185,10))
+            │   @ ConstantReadNode (location: (187,7)-(187,10))
             │   ├── flags: ∅
             │   └── name: :Foo
             ├── body:
-            │   @ StatementsNode (location: (186,2)-(187,5))
+            │   @ StatementsNode (location: (188,2)-(189,5))
             │   ├── flags: ∅
             │   └── body: (length: 1)
-            │       └── @ DefNode (location: (186,2)-(187,5))
+            │       └── @ DefNode (location: (188,2)-(189,5))
             │           ├── flags: newline
             │           ├── name: :clone
-            │           ├── name_loc: (186,6)-(186,11) = "clone"
+            │           ├── name_loc: (188,6)-(188,11) = "clone"
             │           ├── receiver: ∅
             │           ├── parameters:
-            │           │   @ ParametersNode (location: (186,12)-(186,39))
+            │           │   @ ParametersNode (location: (188,12)-(188,39))
             │           │   ├── flags: ∅
             │           │   ├── requireds: (length: 0)
             │           │   ├── optionals: (length: 1)
-            │           │   │   └── @ OptionalParameterNode (location: (186,12)-(186,39))
+            │           │   │   └── @ OptionalParameterNode (location: (188,12)-(188,39))
             │           │   │       ├── flags: ∅
             │           │   │       ├── name: :opts
-            │           │   │       ├── name_loc: (186,12)-(186,16) = "opts"
-            │           │   │       ├── operator_loc: (186,17)-(186,18) = "="
+            │           │   │       ├── name_loc: (188,12)-(188,16) = "opts"
+            │           │   │       ├── operator_loc: (188,17)-(188,18) = "="
             │           │   │       └── value:
-            │           │   │           @ OrNode (location: (186,19)-(186,39))
+            │           │   │           @ OrNode (location: (188,19)-(188,39))
             │           │   │           ├── flags: ∅
             │           │   │           ├── left:
-            │           │   │           │   @ NilNode (location: (186,19)-(186,22))
+            │           │   │           │   @ NilNode (location: (188,19)-(188,22))
             │           │   │           │   └── flags: static_literal
             │           │   │           ├── right:
-            │           │   │           │   @ ParenthesesNode (location: (186,26)-(186,39))
+            │           │   │           │   @ ParenthesesNode (location: (188,26)-(188,39))
             │           │   │           │   ├── flags: ∅
             │           │   │           │   ├── body:
-            │           │   │           │   │   @ StatementsNode (location: (186,27)-(186,38))
+            │           │   │           │   │   @ StatementsNode (location: (188,27)-(188,38))
             │           │   │           │   │   ├── flags: ∅
             │           │   │           │   │   └── body: (length: 1)
-            │           │   │           │   │       └── @ ReturnNode (location: (186,27)-(186,38))
+            │           │   │           │   │       └── @ ReturnNode (location: (188,27)-(188,38))
             │           │   │           │   │           ├── flags: newline
-            │           │   │           │   │           ├── keyword_loc: (186,27)-(186,33) = "return"
+            │           │   │           │   │           ├── keyword_loc: (188,27)-(188,33) = "return"
             │           │   │           │   │           └── arguments:
-            │           │   │           │   │               @ ArgumentsNode (location: (186,34)-(186,38))
+            │           │   │           │   │               @ ArgumentsNode (location: (188,34)-(188,38))
             │           │   │           │   │               ├── flags: ∅
             │           │   │           │   │               └── arguments: (length: 1)
-            │           │   │           │   │                   └── @ SelfNode (location: (186,34)-(186,38))
+            │           │   │           │   │                   └── @ SelfNode (location: (188,34)-(188,38))
             │           │   │           │   │                       └── flags: ∅
-            │           │   │           │   ├── opening_loc: (186,26)-(186,27) = "("
-            │           │   │           │   └── closing_loc: (186,38)-(186,39) = ")"
-            │           │   │           └── operator_loc: (186,23)-(186,25) = "||"
+            │           │   │           │   ├── opening_loc: (188,26)-(188,27) = "("
+            │           │   │           │   └── closing_loc: (188,38)-(188,39) = ")"
+            │           │   │           └── operator_loc: (188,23)-(188,25) = "||"
             │           │   ├── rest: ∅
             │           │   ├── posts: (length: 0)
             │           │   ├── keywords: (length: 0)
@@ -2302,11 +2382,11 @@
             │           │   └── block: ∅
             │           ├── body: ∅
             │           ├── locals: [:opts]
-            │           ├── def_keyword_loc: (186,2)-(186,5) = "def"
+            │           ├── def_keyword_loc: (188,2)-(188,5) = "def"
             │           ├── operator_loc: ∅
-            │           ├── lparen_loc: (186,11)-(186,12) = "("
-            │           ├── rparen_loc: (186,39)-(186,40) = ")"
+            │           ├── lparen_loc: (188,11)-(188,12) = "("
+            │           ├── rparen_loc: (188,39)-(188,40) = ")"
             │           ├── equal_loc: ∅
-            │           └── end_keyword_loc: (187,2)-(187,5) = "end"
-            ├── end_keyword_loc: (188,0)-(188,3) = "end"
+            │           └── end_keyword_loc: (189,2)-(189,5) = "end"
+            ├── end_keyword_loc: (190,0)-(190,3) = "end"
             └── name: :Foo


### PR DESCRIPTION
Blocks and lambdas inherit anonymous arguments from the method they are a part of. They themselves don't allow to introduce new anonymous arguments. While you can write this:
```rb
def foo(*)
  bar { |**| }
end
```
referecing the new parameter inside of the block will always be a syntax error.

I actually thought that the code snippet above would be a syntax error but apparently not. It seems a bit inconsistent but whatever :shrug: 