### PR TITLE
Add rbs signature for `Prism::Comment#slice`

### DIFF
--- a/sig/prism/parse_result.rbs
+++ b/sig/prism/parse_result.rbs
@@ -84,6 +84,7 @@ module Prism
 
     def initialize: (Location location) -> void
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
+    def slice: () -> String
   end
 
   interface _Comment


### PR DESCRIPTION
`Prism::Comment` has an instance method `#slice`.

https://github.com/ruby/prism/blob/7262d09d220966c6902e8b8514909b08bb5f8c0c/lib/prism/parse_result.rb#L522-L524