### PR TITLE
Better handle multiline interpolated strings in the parser translator

### DIFF
--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -71,7 +71,6 @@ module Prism
       "seattlerb/pctW_lineno.txt",
       "seattlerb/regexp_esc_C_slash.txt",
       "unparser/corpus/literal/literal.txt",
-      "unparser/corpus/semantic/dstr.txt",
       "whitequark/parser_slash_slash_n_escaping_in_literals.txt",
     ]
 


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/12870

For example:

```rb
"a
#{}
c
"
```

The parser gem produces
```rb
s(:dstr,
  s(:str, "a\n"),
  s(:begin),
  s(:str, "\n"),
  s(:str, "c\n"))
```

While the translator wraps the last two string nodes in a dstr. There was already logic that kinda was supposed to handle this but it was too specific, applying only when the interpolation contains a single string node.

Much of this logic should be shared between interpolated symbols and regexps. It's also incorrect when the node contains a literal `\\n` (same as for plain string nodes at the moment).

After https://github.com/ruby/prism/pull/3373 is merged, the added method for creating string nodes can be used to make it more correct in all of these cases.