### PR TITLE
[Bug #21010] Reject endless method definition of `[]=`

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -1740,7 +1740,8 @@ char_is_global_name_punctuation(const uint8_t b) {
 static inline bool
 token_is_setter_name(pm_token_t *token) {
     return (
-        (token->type == PM_TOKEN_IDENTIFIER) &&
+        ((token->type == PM_TOKEN_IDENTIFIER) ||
+         (token->type == PM_TOKEN_BRACKET_LEFT_RIGHT_EQUAL)) &&
         (token->end - token->start >= 2) &&
         (token->end[-1] == '=')
     );

--- a/test/prism/errors/defs_endless_method.txt
+++ b/test/prism/errors/defs_endless_method.txt
@@ -1,0 +1,12 @@
+def f=(k,v)=1
+    ^~ invalid method name; a setter method cannot be defined in an endless method definition
+
+def obj.f=(k,v)=1
+        ^~ invalid method name; a setter method cannot be defined in an endless method definition
+
+def []=(k,v)=1
+    ^~~ invalid method name; a setter method cannot be defined in an endless method definition
+
+def obj.[]=(k,v)=1
+        ^~~ invalid method name; a setter method cannot be defined in an endless method definition
+


### PR DESCRIPTION
Fixes: https://bugs.ruby-lang.org/issues/20785