### PR TITLE
Throw syntax error for endless method with `[]=`

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -1740,9 +1740,10 @@ char_is_global_name_punctuation(const uint8_t b) {
 static inline bool
 token_is_setter_name(pm_token_t *token) {
     return (
-        (token->type == PM_TOKEN_IDENTIFIER) &&
+        (token->type == PM_TOKEN_BRACKET_LEFT_RIGHT_EQUAL) ||
+        ((token->type == PM_TOKEN_IDENTIFIER) &&
         (token->end - token->start >= 2) &&
-        (token->end[-1] == '=')
+        (token->end[-1] == '='))
     );
 }
 

--- a/test/prism/errors/setter_method_cannot_be_defined_in_an_endless_method_definition.txt
+++ b/test/prism/errors/setter_method_cannot_be_defined_in_an_endless_method_definition.txt
@@ -1,3 +1,6 @@
 def a=() = 42
     ^~ invalid method name; a setter method cannot be defined in an endless method definition
 
+def []=() = 42
+    ^~~ invalid method name; a setter method cannot be defined in an endless method definition
+


### PR DESCRIPTION
Prism shoudld throw a syntax error for endless methods when the method name uses brackets. Previously it would not. This matches the behavior of parse.y.

Fixes https://bugs.ruby-lang.org/issues/21010