### PR TITLE
Only cancel in-progress workflows for pull requests

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,7 +1,7 @@
 name: Build Library Artifacts
 
 concurrency:
-  group: "${{github.workflow}}-${{github.ref}}"
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/cruby-bindings.yml
+++ b/.github/workflows/cruby-bindings.yml
@@ -1,7 +1,7 @@
 name: CRuby bindings
 
 concurrency:
-  group: "${{github.workflow}}-${{github.ref}}"
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,7 +1,7 @@
 name: Documentation
 
 concurrency:
-  group: "${{github.workflow}}-${{github.ref}}"
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Main
 
 concurrency:
-  group: "${{github.workflow}}-${{github.ref}}"
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value

This way, if a bunch of stuff gets merged one after the other, CI on main is not often displayed red.

`build-artifacts.yml` doesn't run on PRs but I don't think it hurt to have this uniform in case it gets copied around