### PR TITLE
Reenable 3.4 windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,8 +267,8 @@ jobs:
           - { ruby: "3.1", os: "windows-latest", gemfile: "3.1" }
           - { ruby: "3.2", os: "windows-latest", gemfile: "3.2" }
           - { ruby: "3.3", os: "windows-latest", gemfile: "3.3" }
-          # - { ruby: "3.4", os: "windows-latest", gemfile: "3.4" }
-          # - { ruby: "head", os: "windows-latest", gemfile: "3.5" }
+          - { ruby: "3.4", os: "windows-latest", gemfile: "3.4" }
+          - { ruby: "head", os: "windows-latest", gemfile: "3.5" }
           - { ruby: "jruby", os: "windows-latest", gemfile: "jruby" }
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.target.gemfile }}/Gemfile


### PR DESCRIPTION
It was omitted from https://github.com/ruby/prism/pull/3348 because it was not available yet at that time