### PR TITLE
Reject pattern match with unexpected double splat inside array

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -20520,12 +20520,13 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
             return (pm_node_t *) node;
         }
         case PM_TOKEN_UMINUS_NUM: {
+            pm_token_t prev = parser->previous;
             parser_lex(parser);
 
             pm_token_t operator = parser->previous;
             pm_node_t *node = parse_expression(parser, pm_binding_powers[parser->previous.type].right, false, false, PM_ERR_UNARY_RECEIVER, (uint16_t) (depth + 1));
 
-            if (accept1(parser, PM_TOKEN_STAR_STAR)) {
+            if ((prev.type != PM_TOKEN_BRACKET_LEFT_ARRAY) && (accept1(parser, PM_TOKEN_STAR_STAR))) {
                 pm_token_t exponent_operator = parser->previous;
                 pm_node_t *exponent = parse_expression(parser, pm_binding_powers[exponent_operator.type].right, false, false, PM_ERR_EXPECT_ARGUMENT, (uint16_t) (depth + 1));
                 node = (pm_node_t *) pm_call_node_binary_create(parser, node, &exponent_operator, exponent, 0);

--- a/test/prism/errors/pattern_match_with_unexpected_splat_inside_arraytxt
+++ b/test/prism/errors/pattern_match_with_unexpected_splat_inside_arraytxt
@@ -1,0 +1,14 @@
+a => [-2*b]
+        ^ expected a `]` to close the pattern expression
+        ^ unexpected '*', expecting end-of-input
+        ^ unexpected '*', ignoring it
+          ^ unexpected ']', expecting end-of-input
+          ^ unexpected ']', ignoring it
+
+a => [-2**b]
+        ^ expected a `]` to close the pattern expression
+        ^~ unexpected '**', expecting end-of-input
+        ^~ unexpected '**', ignoring it
+           ^ unexpected ']', expecting end-of-input
+           ^ unexpected ']', ignoring it
+


### PR DESCRIPTION
`a => [-2**b]` should be SyntaxError

Fixes: https://github.com/ruby/prism/issues/3381