### PR TITLE
WIP: Improve the `build-artifacts` GitHub action

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -28,12 +28,17 @@ jobs:
     - name: Build library
       run: bundle exec rake compile
 
+    - name: Package files
+      run: |
+        mkdir dist
+        cp -r include dist/
+        cp build/libprism.a dist/
+        tar -czf prism-${{ matrix.os }}.tar.gz -C dist .
+
     - name: Upload to release
       if: github.event_name == 'release'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       uses: softprops/action-gh-release@v2
       with:
-        files: |
-          build/libprism.so
-          build/libprism.dylib
+        files: prism-${{ matrix.os }}.tar.gz


### PR DESCRIPTION
Ignore this for now -- working on the best approach!

Follow up to #3272

After doing some testing on the Sorbet project, we realized that we want to package pre-built headers along with a binary (because some of the headers are only generated during the compilation process), and also that Bazel works a lot better with static libraries, hence uploading `libprism.a` rather than the `dylib` or `so` file. 

I tested this job on the [Shopify fork](https://github.com/Shopify/prism/actions/runs/12712675711) to make sure it still works.