### PR TITLE
Modify `build-artifacts.yml` to package libprism source instead

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -11,10 +11,7 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -28,12 +25,18 @@ jobs:
     - name: Build library
       run: bundle exec rake compile
 
+    - name: Package libprism source
+      run: |
+        mkdir -p build/libprism-src
+        cp -r src build/libprism-src/src
+        cp -r include build/libprism-src/include
+        cp Makefile build/libprism-src/Makefile
+        tar -czf build/libprism-src.tar.gz -C build libprism-src
+
     - name: Upload to release
       if: github.event_name == 'release'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       uses: softprops/action-gh-release@v2
       with:
-        files: |
-          build/libprism.so
-          build/libprism.dylib
+        files: build/libprism-src.tar.gz


### PR DESCRIPTION
Instead of uploading the built `libprism.so` and `libprism.dylib`, which still requires headers files to be built, Prism can upload the full source, headers, and the Makefile as a tarball that can be used to build `libprism` from source.

The reason default release artifacts are not enough is because some source and header files are generated through Prism's rake tasks.

Example release: https://github.com/Shopify/prism/releases/tag/v1.3.2

Note: This is @paracycle's brilliant idea 🚀 