### PR TITLE
Fix parser translator ranges for mulltiline strings with multiline bytes

### DIFF
--- a/lib/prism/translation/parser/lexer.rb
+++ b/lib/prism/translation/parser/lexer.rb
@@ -409,7 +409,7 @@ module Prism
                 # it emits a single string node. The backslash (and remaining newline) is removed.
                 current_line = +""
                 adjustment = 0
-                start_offset = offset_cache[token.location.start_offset]
+                start_offset = token.location.start_offset
                 emit = false
 
                 lines.each.with_index do |line, index|


### PR DESCRIPTION
A rather silly issue with a rather simple fix.
The ranges already use the offset cache, this effectivly double-encoded them.

Properly fixes https://github.com/rubocop/rubocop/issues/12982
Fixes https://github.com/rubocop/rubocop/issues/13204

I didn't at tests since it seems highly specific but I can add one if you prefer.