### PR TITLE
Fix parser translator heredoc dedention with leading interpolation

### DIFF
--- a/lib/prism/translation/parser/lexer.rb
+++ b/lib/prism/translation/parser/lexer.rb
@@ -569,6 +569,11 @@ module Prism
 
             # String content inside nested heredocs and interpolation is ignored
             if next_token.type == :HEREDOC_START || next_token.type == :EMBEXPR_BEGIN
+              # When interpolation is the first token of a line there is no string
+              # content to check against. There will be no common whitespace.
+              if nesting_level == 0 && next_token.location.start_column == 0
+                result = 0
+              end
               nesting_level += 1
             elsif next_token.type == :HEREDOC_END || next_token.type == :EMBEXPR_END
               nesting_level -= 1

--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -98,7 +98,6 @@ module Prism
       "heredocs_with_ignored_newlines.txt",
       "methods.txt",
       "strings.txt",
-      "tilde_heredocs.txt",
       "seattlerb/backticks_interpolation_line.txt",
       "seattlerb/bug169.txt",
       "seattlerb/case_in.txt",


### PR DESCRIPTION
```rb
<<~F
  foo
#{}
  bar
F
```

has zero common whitespace.