### PR TITLE
Simplify build-artifacts GitHub workflow

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -23,7 +23,7 @@ jobs:
         bundler-cache: true
 
     - name: Build library
-      run: bundle exec rake compile
+      run: bundle exec rake templates
 
     - name: Package libprism source
       run: |


### PR DESCRIPTION
Run `bundle exec rake templates` instead of `bundle exec rake compile` because the only generated code needed for release are the headers.