### PR TITLE
Fix parser translator tokens for `%x(#{})`

### DIFF
--- a/lib/prism/translation/parser/lexer.rb
+++ b/lib/prism/translation/parser/lexer.rb
@@ -483,7 +483,8 @@ module Prism
                 type = :tIDENTIFIER
               end
             when :tXSTRING_BEG
-              if (next_token = lexed[index][0]) && next_token.type != :STRING_CONTENT && next_token.type != :STRING_END
+              if (next_token = lexed[index][0]) && !%i[STRING_CONTENT STRING_END EMBEXPR_BEGIN].include?(next_token.type)
+                # self.`()
                 type = :tBACK_REF2
               end
               quote_stack.push(value)

--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -98,7 +98,6 @@ module Prism
       "heredocs_with_ignored_newlines.txt",
       "methods.txt",
       "strings.txt",
-      "seattlerb/backticks_interpolation_line.txt",
       "seattlerb/bug169.txt",
       "seattlerb/case_in.txt",
       "seattlerb/difficult4__leading_dots2.txt",


### PR DESCRIPTION
It falsely considered it to be a single backtick command