### PR TITLE
Fix block paremeters and `it` for RubyParser

### DIFF
--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -1559,7 +1559,7 @@ module Prism
           else
             parameters =
               case block.parameters
-              when nil, NumberedParametersNode
+              when nil, ItParametersNode, NumberedParametersNode
                 0
               else
                 visit(block.parameters)

--- a/test/prism/fixtures/it.txt
+++ b/test/prism/fixtures/it.txt
@@ -1,0 +1,3 @@
+x do
+  it
+end

--- a/test/prism/snapshots/it.txt
+++ b/test/prism/snapshots/it.txt
@@ -1,0 +1,31 @@
+@ ProgramNode (location: (1,0)-(3,3))
+├── flags: ∅
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (1,0)-(3,3))
+    ├── flags: ∅
+    └── body: (length: 1)
+        └── @ CallNode (location: (1,0)-(3,3))
+            ├── flags: newline, ignore_visibility
+            ├── receiver: ∅
+            ├── call_operator_loc: ∅
+            ├── name: :x
+            ├── message_loc: (1,0)-(1,1) = "x"
+            ├── opening_loc: ∅
+            ├── arguments: ∅
+            ├── closing_loc: ∅
+            └── block:
+                @ BlockNode (location: (1,2)-(3,3))
+                ├── flags: ∅
+                ├── locals: []
+                ├── parameters:
+                │   @ ItParametersNode (location: (1,2)-(3,3))
+                │   └── flags: ∅
+                ├── body:
+                │   @ StatementsNode (location: (2,2)-(2,4))
+                │   ├── flags: ∅
+                │   └── body: (length: 1)
+                │       └── @ ItLocalVariableReadNode (location: (2,2)-(2,4))
+                │           └── flags: newline
+                ├── opening_loc: (1,2)-(1,4) = "do"
+                └── closing_loc: (3,0)-(3,3) = "end"


### PR DESCRIPTION
Testing with `x { it } `:

**Before:**

RubyParser:
```ruby
s(:iter, s(:call, nil, :x), 0, s(:call, nil, :it))
```

Prism:
```ruby
s(:iter, s(:call, nil, :x), [], s(:call, nil, :it))
```

**After:**

RubyParser:
```ruby
s(:iter, s(:call, nil, :x), 0, s(:call, nil, :it))
```
Prism:
```ruby
s(:iter, s(:call, nil, :x), 0, s(:call, nil, :it))
```