### PR TITLE
Support forwarding flags on scopes

### DIFF
--- a/include/prism/options.h
+++ b/include/prism/options.h
@@ -39,7 +39,25 @@ typedef struct pm_options_scope {
 
     /** The names of the locals in the scope. */
     pm_string_t *locals;
+
+    /** Flags for the set of forwarding parameters in this scope. */
+    uint8_t forwarding;
 } pm_options_scope_t;
+
+/** The default value for parameters. */
+static const uint8_t PM_OPTIONS_SCOPE_FORWARDING_NONE = 0x0;
+
+/** When the scope is fowarding with the * parameter. */
+static const uint8_t PM_OPTIONS_SCOPE_FORWARDING_POSITIONALS = 0x1;
+
+/** When the scope is fowarding with the ** parameter. */
+static const uint8_t PM_OPTIONS_SCOPE_FORWARDING_KEYWORDS = 0x2;
+
+/** When the scope is fowarding with the & parameter. */
+static const uint8_t PM_OPTIONS_SCOPE_FORWARDING_BLOCK = 0x4;
+
+/** When the scope is fowarding with the ... parameter. */
+static const uint8_t PM_OPTIONS_SCOPE_FORWARDING_ALL = 0x8;
 
 // Forward declaration needed by the callback typedef.
 struct pm_options;
@@ -338,6 +356,14 @@ PRISM_EXPORTED_FUNCTION bool pm_options_scope_init(pm_options_scope_t *scope, si
 PRISM_EXPORTED_FUNCTION const pm_string_t * pm_options_scope_local_get(const pm_options_scope_t *scope, size_t index);
 
 /**
+ * Set the forwarding option on the given scope struct.
+ *
+ * @param scope The scope struct to set the forwarding on.
+ * @param forwarding The forwarding value to set.
+ */
+PRISM_EXPORTED_FUNCTION void pm_options_scope_forwarding_set(pm_options_scope_t *scope, uint8_t forwarding);
+
+/**
  * Free the internal memory associated with the options.
  *
  * @param options The options struct whose internal memory should be freed.
@@ -386,6 +412,7 @@ PRISM_EXPORTED_FUNCTION void pm_options_free(pm_options_t *options);
  * | # bytes | field                      |
  * | ------- | -------------------------- |
  * | `4`     | the number of locals       |
+ * | `1`     | the forwarding flags       |
  * | ...     | the locals                 |
  *
  * Each local is laid out as follows:

--- a/java/org/prism/ParsingOptions.java
+++ b/java/org/prism/ParsingOptions.java
@@ -36,6 +36,69 @@ public abstract class ParsingOptions {
     public enum CommandLine { A, E, L, N, P, X };
 
     /**
+     * The forwarding options for a given scope in the parser.
+     */
+    public enum Forwarding {
+        NONE(0),
+        POSITIONAL(1),
+        KEYWORD(2),
+        BLOCK(4),
+        ALL(8);
+
+        private final int value;
+
+        Forwarding(int value) {
+            this.value = value;
+        }
+
+        public byte getValue() {
+            return (byte) value;
+        }
+    };
+
+    /**
+     * Represents a scope in the parser.
+     */
+    public static class Scope {
+        private byte[][] locals;
+        private Forwarding[] forwarding;
+
+        Scope(byte[][] locals) {
+            this(locals, new Forwarding[0]);
+        }
+
+        Scope(Forwarding[] forwarding) {
+            this(new byte[0][], forwarding);
+        }
+
+        Scope(byte[][] locals, Forwarding[] forwarding) {
+            this.locals = locals;
+            this.forwarding = forwarding;
+        }
+
+        public byte[][] getLocals() {
+            return locals;
+        }
+
+        public int getForwarding() {
+            int value = 0;
+            for (Forwarding f : forwarding) {
+                value |= f.getValue();
+            }
+            return value;
+        }
+    }
+
+    public static byte[] serialize(byte[] filepath, int line, byte[] encoding, boolean frozenStringLiteral, EnumSet<CommandLine> commandLine, SyntaxVersion version, boolean encodingLocked, boolean mainScript, boolean partialScript, byte[][][] scopes) {
+        Scope[] normalizedScopes = new Scope[scopes.length];
+        for (int i = 0; i < scopes.length; i++) {
+            normalizedScopes[i] = new Scope(scopes[i]);
+        }
+
+        return serialize(filepath, line, encoding, frozenStringLiteral, commandLine, version, encodingLocked, mainScript, partialScript, normalizedScopes);
+    }
+
+    /**
      * Serialize parsing options into byte array.
      *
      * @param filepath the name of the file that is currently being parsed
@@ -50,7 +113,7 @@ public abstract class ParsingOptions {
      * @param scopes scopes surrounding the code that is being parsed with local variable names defined in every scope
      *            ordered from the outermost scope to the innermost one
      */
-    public static byte[] serialize(byte[] filepath, int line, byte[] encoding, boolean frozenStringLiteral, EnumSet<CommandLine> commandLine, SyntaxVersion version, boolean encodingLocked, boolean mainScript, boolean partialScript, byte[][][] scopes) {
+    public static byte[] serialize(byte[] filepath, int line, byte[] encoding, boolean frozenStringLiteral, EnumSet<CommandLine> commandLine, SyntaxVersion version, boolean encodingLocked, boolean mainScript, boolean partialScript, Scope[] scopes) {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
 
         // filepath
@@ -91,12 +154,17 @@ public abstract class ParsingOptions {
         write(output, serializeInt(scopes.length));
 
         // local variables in each scope
-        for (byte[][] scope : scopes) {
+        for (Scope scope : scopes) {
+            byte[][] locals = scope.getLocals();
+
             // number of locals
-            write(output, serializeInt(scope.length));
+            write(output, serializeInt(locals.length));
+
+            // forwarding flags
+            output.write(scope.getForwarding());
 
             // locals
-            for (byte[] local : scope) {
+            for (byte[] local : locals) {
                 write(output, serializeInt(local.length));
                 write(output, local);
             }

--- a/javascript/src/index.js
+++ b/javascript/src/index.js
@@ -11,7 +11,9 @@ export * from "./nodes.js";
 /**
  * Load the prism wasm module and return a parse function.
  *
- * @returns {Promise<(source: string) => ParseResult>}
+ * @typedef {import("./parsePrism.js").Options} Options
+ *
+ * @returns {Promise<(source: string, options?: Options) => ParseResult>}
  */
 export async function loadPrism() {
   const wasm = await WebAssembly.compile(await readFile(fileURLToPath(new URL("prism.wasm", import.meta.url))));
@@ -20,7 +22,7 @@ export async function loadPrism() {
   const instance = await WebAssembly.instantiate(wasm, wasi.getImportObject());
   wasi.initialize(instance);
 
-  return function (source) {
-    return parsePrism(instance.exports, source);
+  return function (source, options = {}) {
+    return parsePrism(instance.exports, source, options);
   }
 }

--- a/javascript/test.js
+++ b/javascript/test.js
@@ -5,6 +5,10 @@ import * as nodes from "./src/nodes.js";
 
 const parse = await loadPrism();
 
+function statement(result) {
+  return result.value.statements.body[0];
+}
+
 test("node", () => {
   const result = parse("foo");
   assert(result.value instanceof nodes.ProgramNode);
@@ -12,12 +16,12 @@ test("node", () => {
 
 test("node? present", () => {
   const result = parse("foo.bar");
-  assert(result.value.statements.body[0].receiver instanceof nodes.CallNode);
+  assert(statement(result).receiver instanceof nodes.CallNode);
 });
 
 test("node? absent", () => {
   const result = parse("foo");
-  assert(result.value.statements.body[0].receiver === null);
+  assert(statement(result).receiver === null);
 });
 
 test("node[]", () => {
@@ -27,7 +31,7 @@ test("node[]", () => {
 
 test("string", () => {
   const result = parse('"foo"');
-  const node = result.value.statements.body[0];
+  const node = statement(result);
 
   assert(!node.isForcedUtf8Encoding())
   assert(!node.isForcedBinaryEncoding())
@@ -39,7 +43,7 @@ test("string", () => {
 
 test("forced utf-8 string using \\u syntax", () => {
   const result = parse('# encoding: utf-8\n"\\u{9E7F}"');
-  const node = result.value.statements.body[0];
+  const node = statement(result);
   const str = node.unescaped;
 
   assert(node.isForcedUtf8Encoding());
@@ -52,7 +56,7 @@ test("forced utf-8 string using \\u syntax", () => {
 
 test("forced utf-8 string with invalid byte sequence", () => {
   const result = parse('# encoding: utf-8\n"\\xFF\\xFF\\xFF"');
-  const node = result.value.statements.body[0];
+  const node = statement(result);
   const str = node.unescaped;
 
   assert(node.isForcedUtf8Encoding());
@@ -68,7 +72,7 @@ test("ascii string with embedded utf-8 character", () => {
   // # encoding: ascii\n"é¹¿"'
   const ascii_str = new Buffer.from([35, 32, 101, 110, 99, 111, 100, 105, 110, 103, 58, 32, 97, 115, 99, 105, 105, 10, 34, 233, 185, 191, 34]);
   const result = parse(ascii_str);
-  const node = result.value.statements.body[0];
+  const node = statement(result);
   const str = node.unescaped;
 
   assert(!node.isForcedUtf8Encoding());
@@ -81,7 +85,7 @@ test("ascii string with embedded utf-8 character", () => {
 
 test("forced binary string", () => {
   const result = parse('# encoding: ascii\n"\\xFF\\xFF\\xFF"');
-  const node = result.value.statements.body[0];
+  const node = statement(result);
   const str = node.unescaped;
 
   assert(!node.isForcedUtf8Encoding());
@@ -96,7 +100,7 @@ test("forced binary string with Unicode character", () => {
   // # encoding: us-ascii\n"\\xFFé¹¿\\xFF"
   const ascii_str = Buffer.from([35, 32, 101, 110, 99, 111, 100, 105, 110, 103, 58, 32, 97, 115, 99, 105, 105, 10, 34, 92, 120, 70, 70, 233, 185, 191, 92, 120, 70, 70, 34]);
   const result = parse(ascii_str);
-  const node = result.value.statements.body[0];
+  const node = statement(result);
   const str = node.unescaped;
 
   assert(!node.isForcedUtf8Encoding());
@@ -114,12 +118,12 @@ test("constant", () => {
 
 test("constant? present", () => {
   const result = parse("def foo(*bar); end");
-  assert(result.value.statements.body[0].parameters.rest.name === "bar");
+  assert(statement(result).parameters.rest.name === "bar");
 });
 
 test("constant? absent", () => {
   const result = parse("def foo(*); end");
-  assert(result.value.statements.body[0].parameters.rest.name === null);
+  assert(statement(result).parameters.rest.name === null);
 });
 
 test("constant[]", async() => {
@@ -134,27 +138,27 @@ test("location", () => {
 
 test("location? present", () => {
   const result = parse("def foo = bar");
-  assert(result.value.statements.body[0].equalLoc !== null);
+  assert(statement(result).equalLoc !== null);
 });
 
 test("location? absent", () => {
   const result = parse("def foo; bar; end");
-  assert(result.value.statements.body[0].equalLoc === null);
+  assert(statement(result).equalLoc === null);
 });
 
 test("uint8", () => {
   const result = parse("-> { _3 }");
-  assert(result.value.statements.body[0].parameters.maximum === 3);
+  assert(statement(result).parameters.maximum === 3);
 });
 
 test("uint32", () => {
   const result = parse("foo = 1");
-  assert(result.value.statements.body[0].depth === 0);
+  assert(statement(result).depth === 0);
 });
 
 test("flags", () => {
   const result = parse("/foo/mi");
-  const regexp = result.value.statements.body[0];
+  const regexp = statement(result);
 
   assert(regexp.isIgnoreCase());
   assert(regexp.isMultiLine());
@@ -163,25 +167,44 @@ test("flags", () => {
 
 test("integer (decimal)", () => {
   const result = parse("10");
-  assert(result.value.statements.body[0].value == 10);
+  assert(statement(result).value === 10);
 });
 
 test("integer (hex)", () => {
   const result = parse("0xA");
-  assert(result.value.statements.body[0].value == 10);
+  assert(statement(result).value === 10);
 });
 
 test("integer (2 nodes)", () => {
   const result = parse("4294967296");
-  assert(result.value.statements.body[0].value == 4294967296n);
+  assert(statement(result).value === 4294967296n);
 });
 
 test("integer (3 nodes)", () => {
   const result = parse("18446744073709552000");
-  assert(result.value.statements.body[0].value == 18446744073709552000n);
+  assert(statement(result).value === 18446744073709552000n);
 });
 
 test("double", () => {
   const result = parse("1.0");
-  assert(result.value.statements.body[0].value == 1.0);
+  assert(statement(result).value === 1.0);
+});
+
+test("scopes", () => {
+  let result;
+
+  result = parse("foo");
+  assert(statement(result) instanceof nodes.CallNode);
+
+  result = parse("foo", { scopes: [["foo"]] });
+  assert(statement(result) instanceof nodes.LocalVariableReadNode);
+
+  result = parse("foo", { scopes: [{ locals: ["foo"] }] });
+  assert(statement(result) instanceof nodes.LocalVariableReadNode);
+
+  result = parse("foo(*)");
+  assert(result.errors.length > 0);
+
+  result = parse("foo(*)", { scopes: [{ forwarding: ["*"] }] });
+  assert(result.errors.length === 0);
 });

--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -879,4 +879,32 @@ module Prism
       freeze
     end
   end
+
+  # This object is passed to the various Prism.* methods that accept the
+  # `scopes` option as an element of the list. It defines both the local
+  # variables visible at that scope as well as the forwarding parameters
+  # available at that scope.
+  class Scope
+    # The list of local variables that are defined in this scope. This should be
+    # defined as an array of symbols.
+    attr_reader :locals
+
+    # The list of local variables that are forwarded to the next scope. This
+    # should by defined as an array of symbols containing the specific values of
+    # :*, :**, :&, or :"...".
+    attr_reader :forwarding
+
+    # Create a new scope object with the given locals and forwarding.
+    def initialize(locals, forwarding)
+      @locals = locals
+      @forwarding = forwarding
+    end
+  end
+
+  # Create a new scope with the given locals and forwarding options that is
+  # suitable for passing into one of the Prism.* methods that accepts the
+  # `scopes` option.
+  def self.scope(locals: [], forwarding: [])
+    Scope.new(locals, forwarding)
+  end
 end

--- a/rbi/prism.rbi
+++ b/rbi/prism.rbi
@@ -60,4 +60,7 @@ module Prism
 
   sig { params(filepath: String, command_line: T.nilable(String), encoding: T.nilable(T.any(FalseClass, Encoding)), freeze: T.nilable(T::Boolean), frozen_string_literal: T.nilable(T::Boolean), line: T.nilable(Integer), main_script: T.nilable(T::Boolean), partial_script: T.nilable(T::Boolean), scopes: T.nilable(T::Array[T::Array[Symbol]]), version: T.nilable(String)).returns(T::Boolean) }
   def self.parse_file_failure?(filepath, command_line: nil, encoding: nil, freeze: nil, frozen_string_literal: nil, line: nil, main_script: nil, partial_script: nil, scopes: nil, version: nil); end
+
+  sig { params(locals: T::Array[Symbol], forwarding: T::Array[Symbol]).returns(Prism::Scope) }
+  def self.scope(locals: [], forwarding: []); end
 end

--- a/rbi/prism/parse_result.rbi
+++ b/rbi/prism/parse_result.rbi
@@ -391,3 +391,14 @@ class Prism::Token
   sig { params(other: T.untyped).returns(T::Boolean) }
   def ==(other); end
 end
+
+class Prism::Scope
+  sig { returns(T::Array[Symbol]) }
+  def locals; end
+
+  sig { returns(T::Array[Symbol]) }
+  def forwarding; end
+
+  sig { params(locals: T::Array[Symbol], forwarding: T::Array[Symbol]).void }
+  def initialize(locals, forwarding); end
+end

--- a/sig/prism/parse_result.rbs
+++ b/sig/prism/parse_result.rbs
@@ -182,4 +182,11 @@ module Prism
     def pretty_print: (untyped q) -> untyped
     def ==: (untyped other) -> bool
   end
+
+  class Scope
+    attr_reader locals: Array[Symbol]
+    attr_reader forwarding: Array[Symbol]
+
+    def initialize: (Array[Symbol] locals, Array[Symbol] forwarding) -> void
+  end
 end

--- a/src/options.c
+++ b/src/options.c
@@ -181,6 +181,7 @@ PRISM_EXPORTED_FUNCTION bool
 pm_options_scope_init(pm_options_scope_t *scope, size_t locals_count) {
     scope->locals_count = locals_count;
     scope->locals = xcalloc(locals_count, sizeof(pm_string_t));
+    scope->forwarding = PM_OPTIONS_SCOPE_FORWARDING_NONE;
     return scope->locals != NULL;
 }
 
@@ -190,6 +191,14 @@ pm_options_scope_init(pm_options_scope_t *scope, size_t locals_count) {
 PRISM_EXPORTED_FUNCTION const pm_string_t *
 pm_options_scope_local_get(const pm_options_scope_t *scope, size_t index) {
     return &scope->locals[index];
+}
+
+/**
+ * Set the forwarding option on the given scope struct.
+ */
+PRISM_EXPORTED_FUNCTION void
+pm_options_scope_forwarding_set(pm_options_scope_t *scope, uint8_t forwarding) {
+    scope->forwarding = forwarding;
 }
 
 /**
@@ -299,6 +308,9 @@ pm_options_read(pm_options_t *options, const char *data) {
                 pm_options_free(options);
                 return;
             }
+
+            uint8_t forwarding = (uint8_t) *data++;
+            pm_options_scope_forwarding_set(&options->scopes[scope_index], forwarding);
 
             for (size_t local_index = 0; local_index < locals_count; local_index++) {
                 uint32_t local_length = pm_options_read_u32(data);

--- a/src/prism.c
+++ b/src/prism.c
@@ -22492,7 +22492,7 @@ pm_parser_init(pm_parser_t *parser, const uint8_t *source, size_t size, const pm
 
             // Scopes given from the outside are not allowed to have numbered
             // parameters.
-            parser->current_scope->parameters |= PM_SCOPE_PARAMETERS_IMPLICIT_DISALLOWED;
+            parser->current_scope->parameters = ((pm_scope_parameters_t) scope->forwarding) | PM_SCOPE_PARAMETERS_IMPLICIT_DISALLOWED;
 
             for (size_t local_index = 0; local_index < scope->locals_count; local_index++) {
                 const pm_string_t *local = pm_options_scope_local_get(scope, local_index);

--- a/templates/sig/prism.rbs.erb
+++ b/templates/sig/prism.rbs.erb
@@ -84,4 +84,6 @@ module Prism
     ?scopes: Array[Array[Symbol]],
     ?verbose: bool
   ) -> ParseResult
+
+  def self.scope: (?locals: Array[Symbol], ?forwarding: Array[Symbol]) -> Scope
 end

--- a/test/prism/api/parse_test.rb
+++ b/test/prism/api/parse_test.rb
@@ -140,6 +140,24 @@ module Prism
       end
     end
 
+    def test_scopes
+      assert_kind_of Prism::CallNode, Prism.parse_statement("foo")
+      assert_kind_of Prism::LocalVariableReadNode, Prism.parse_statement("foo", scopes: [[:foo]])
+      assert_kind_of Prism::LocalVariableReadNode, Prism.parse_statement("foo", scopes: [Prism.scope(locals: [:foo])])
+
+      assert Prism.parse_failure?("foo(*)")
+      assert Prism.parse_success?("foo(*)", scopes: [Prism.scope(forwarding: [:*])])
+
+      assert Prism.parse_failure?("foo(**)")
+      assert Prism.parse_success?("foo(**)", scopes: [Prism.scope(forwarding: [:**])])
+
+      assert Prism.parse_failure?("foo(&)")
+      assert Prism.parse_success?("foo(&)", scopes: [Prism.scope(forwarding: [:&])])
+
+      assert Prism.parse_failure?("foo(...)")
+      assert Prism.parse_success?("foo(...)", scopes: [Prism.scope(forwarding: [:"..."])])
+    end
+
     private
 
     def find_source_file_node(program)


### PR DESCRIPTION
When parent scopes around an eval are forwarding parameters (like *, **, &, or ...) we need to know that information when we are in the parser. As such, we need to support passing that information into the scopes option. In order to do this, unfortunately we need a bunch of changes.

The scopes option was previously an array of array of strings. These corresponded to the names of the locals in the parent scopes. We still support this, but now additionally support passing in a Prism::Scope instance at each index in the array. This Prism::Scope class holds both the names of the locals as well as an array of forwarding parameter names (symbols corresponding to the forwarding parameters). There is convenience function on the Prism module that creates a Prism::Scope object using Prism.scope.

In JavaScript, we now additionally support an object much the same as the Ruby side. In Java, we now have a ParsingOptions.Scope class that holds that information. In the dump APIs, these objects in all 3 languages will add an additional byte for the forwarding flags in the middle of the scopes serialization.

All of this is in service of properly parsing the following code:

```ruby
def foo(*) = eval("bar(*)")
```