### PR TITLE
Mark some parser translator tests as being known failures

### DIFF
--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -72,15 +72,20 @@ module Prism
 
       # Contains an escaped multibyte character. This is supposed to drop to backslash
       "seattlerb/regexp_escape_extended.txt",
+
+      # https://github.com/whitequark/parser/issues/1020
+      # These contain consecutive \r characters, followed by \n. Prism only receives
+      # the already modified source buffer which dropped one \r but must know the
+      # original code to parse it correctly.
+      "seattlerb/heredoc_with_extra_carriage_returns_windows.txt",
+      "seattlerb/heredoc_with_only_carriage_returns_windows.txt",
+      "seattlerb/heredoc_with_only_carriage_returns.txt",
     ]
 
     # These files are either failing to parse or failing to translate, so we'll
     # skip them for now.
     skip_all = skip_incorrect | [
       "unescaping.txt",
-      "seattlerb/heredoc_with_extra_carriage_returns_windows.txt",
-      "seattlerb/heredoc_with_only_carriage_returns_windows.txt",
-      "seattlerb/heredoc_with_only_carriage_returns.txt",
       "seattlerb/pctW_lineno.txt",
       "seattlerb/regexp_esc_C_slash.txt",
       "unparser/corpus/literal/literal.txt",


### PR DESCRIPTION
Without a change from `parser`, this is impossible to correctly handle.

I played around with the following:

```diff
diff --git a/lib/prism/translation/parser.rb b/lib/prism/translation/parser.rb
index 6b417be4..92525bd4 100644
--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -76,9 +76,9 @@ module Prism
 
       # Parses a source buffer and returns the AST, the source code comments,
       # and the tokens emitted by the lexer.
-      def tokenize(source_buffer, recover = false)
+      def tokenize(source_buffer, recover = false, raw_source: source_buffer.source)
         @source_buffer = source_buffer
-        source = source_buffer.source
+        source = raw_source
 
         offset_cache = build_offset_cache(source)
         result =
diff --git a/test/prism/ruby/parser_test.rb b/test/prism/ruby/parser_test.rb
index 0a2ca196..9df3c48e 100644
--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -145,7 +145,8 @@ module Prism
 
     def assert_equal_parses(fixture, compare_asts: true, compare_tokens: true, compare_comments: true)
       buffer = Parser::Source::Buffer.new(fixture.path, 1)
-      buffer.source = fixture.read
+      raw_source = fixture.read
+      buffer.source = raw_source
 
       parser = Parser::Ruby33.new
       parser.diagnostics.consumer = ->(*) {}
@@ -159,7 +160,7 @@ module Prism
         end
 
       actual_ast, actual_comments, actual_tokens =
-        ignore_warnings { Prism::Translation::Parser33.new.tokenize(buffer) }
+        ignore_warnings { Prism::Translation::Parser33.new.tokenize(buffer, raw_source: raw_source) }
 
       if expected_ast == actual_ast
         if !compare_asts
```

But I think that would mean to keep track of every encountered \r\n and keep some global offset to make everything correct. That seems like quite the hassle for barely any gain.