### PR TITLE
Increase value of PRISM_DEPTH_MAXIMUM to 10000

### DIFF
--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -34,7 +34,7 @@
  * specifying a maximum depth to which we are allowed to recurse.
  */
 #ifndef PRISM_DEPTH_MAXIMUM
-    #define PRISM_DEPTH_MAXIMUM 1000
+    #define PRISM_DEPTH_MAXIMUM 10000
 #endif
 
 /**


### PR DESCRIPTION
The previous value of 1_000 was added with [a reference to the Bison parser](https://www.gnu.org/software/bison/manual/html_node/Memory-Management.html), but the value of YYMAXDEPTH in the Bison docs is 10_000, not 1_000.

See https://github.com/ruby/prism/issues/1774#issuecomment-2593716858 cc @kddnewton 