### PR TITLE
Further refine string handling in the parser translator

### DIFF
--- a/lib/prism/translation/parser/compiler.rb
+++ b/lib/prism/translation/parser/compiler.rb
@@ -74,7 +74,29 @@ module Prism
         # []
         # ^^
         def visit_array_node(node)
-          builder.array(token(node.opening_loc), visit_all(node.elements), token(node.closing_loc))
+          if node.opening&.start_with?("%w", "%W", "%i", "%I")
+            elements = node.elements.flat_map do |element|
+              if element.is_a?(StringNode)
+                if element.content.include?("\n")
+                  string_nodes_from_line_continuations(element.unescaped, element.content, element.content_loc.start_offset, node.opening)
+                else
+                  [builder.string_internal([element.unescaped, srange(element.content_loc)])]
+                end
+              elsif element.is_a?(InterpolatedStringNode)
+                builder.string_compose(
+                  token(element.opening_loc),
+                  string_nodes_from_interpolation(element, node.opening),
+                  token(element.closing_loc)
+                )
+              else
+                [visit(element)]
+              end
+            end
+          else
+            elements = visit_all(node.elements)
+          end
+
+          builder.array(token(node.opening_loc), elements, token(node.closing_loc))
         end
 
         # foo => [bar]
@@ -1085,19 +1107,9 @@ module Prism
             return visit_heredoc(node) { |children, closing| builder.string_compose(token(node.opening_loc), children, closing) }
           end
 
-          parts = node.parts.flat_map do |part|
-            # When the content of a string node is split across multiple lines, the
-            # parser gem creates individual string nodes for each line the content is part of.
-            if part.type == :string_node && part.content.include?("\n") && part.opening_loc.nil?
-              string_nodes_from_line_continuations(part.unescaped, part.content, part.content_loc.start_offset, node.opening)
-            else
-              visit(part)
-            end
-          end
-
           builder.string_compose(
             token(node.opening_loc),
-            parts,
+            string_nodes_from_interpolation(node, node.opening),
             token(node.closing_loc)
           )
         end
@@ -1116,14 +1128,14 @@ module Prism
         # ^^^^^^^^^^^^
         def visit_interpolated_x_string_node(node)
           if node.heredoc?
-            visit_heredoc(node) { |children, closing| builder.xstring_compose(token(node.opening_loc), children, closing) }
-          else
-            builder.xstring_compose(
-              token(node.opening_loc),
-              visit_all(node.parts),
-              token(node.closing_loc)
-            )
+            return visit_heredoc(node) { |children, closing| builder.xstring_compose(token(node.opening_loc), children, closing) }
           end
+
+          builder.xstring_compose(
+            token(node.opening_loc),
+            string_nodes_from_interpolation(node, node.opening),
+            token(node.closing_loc)
+          )
         end
 
         # -> { it }
@@ -2011,13 +2023,6 @@ module Prism
           end
         end
 
-        # The parser gem automatically converts \r\n to \n, meaning our offsets
-        # need to be adjusted to always subtract 1 from the length.
-        def chomped_bytesize(line)
-          chomped = line.chomp
-          chomped.bytesize + (chomped == line ? 0 : 1)
-        end
-
         # Visit a heredoc that can be either a string or an xstring.
         def visit_heredoc(node)
           children = Array.new
@@ -2086,55 +2091,88 @@ module Prism
           end
         end
 
+        # When the content of a string node is split across multiple lines, the
+        # parser gem creates individual string nodes for each line the content is part of.
+        def string_nodes_from_interpolation(node, opening)
+          node.parts.flat_map do |part|
+            if part.type == :string_node && part.content.include?("\n") && part.opening_loc.nil?
+              string_nodes_from_line_continuations(part.unescaped, part.content, part.content_loc.start_offset, opening)
+            else
+              visit(part)
+            end
+          end
+        end
+
         # Create parser string nodes from a single prism node. The parser gem
         # "glues" strings together when a line continuation is encountered.
         def string_nodes_from_line_continuations(unescaped, escaped, start_offset, opening)
           unescaped = unescaped.lines
           escaped = escaped.lines
+          percent_array = opening&.start_with?("%w", "%W", "%i", "%I")
 
-          escaped_lengths = []
-          normalized_lengths = []
-          # Keeps track of where an unescaped line should start a new token. An unescaped
-          # \n would otherwise be indistinguishable from the actual newline at the end of
-          # of the line. The parser gem only emits a new string node at "real" newlines,
-          # line continuations don't start a new node as well.
-          do_next_tokens = []
+          # Non-interpolating strings
+          if opening&.end_with?("'") || opening&.start_with?("%q", "%s", "%w", "%i")
+            current_length = 0
+            current_line = +""
 
-          if opening&.end_with?("'")
-            escaped.each do |line|
-              escaped_lengths << line.bytesize
-              normalized_lengths << chomped_bytesize(line)
-              do_next_tokens << true
+            escaped.filter_map.with_index do |escaped_line, index|
+              unescaped_line = unescaped.fetch(index, "")
+              current_length += escaped_line.bytesize
+              current_line << unescaped_line
+
+              # Glue line continuations together. Only %w and %i arrays can contain these.
+              if percent_array && escaped_line[/(\\)*\n$/, 1]&.length&.odd?
+                next unless index == escaped.count - 1
+              end
+              s = builder.string_internal([current_line, srange_offsets(start_offset, start_offset + current_length)])
+              start_offset += escaped_line.bytesize
+              current_line = +""
+              current_length = 0
+              s
             end
           else
+            escaped_lengths = []
+            normalized_lengths = []
+            # Keeps track of where an unescaped line should start a new token. An unescaped
+            # \n would otherwise be indistinguishable from the actual newline at the end of
+            # of the line. The parser gem only emits a new string node at "real" newlines,
+            # line continuations don't start a new node as well.
+            do_next_tokens = []
+
             escaped
               .chunk_while { |before, after| before[/(\\*)\r?\n$/, 1]&.length&.odd? || false }
               .each do |lines|
                 escaped_lengths << lines.sum(&:bytesize)
-                normalized_lengths << lines.sum { |line| chomped_bytesize(line) }
                 unescaped_lines_count = lines.sum do |line|
                   line.scan(/(\\*)n/).count { |(backslashes)| backslashes&.length&.odd? || false }
                 end
-                do_next_tokens.concat(Array.new(unescaped_lines_count + 1, false))
+                extra = 1
+                extra = lines.count if percent_array # Account for line continuations in percent arrays
+
+                normalized_lengths.concat(Array.new(unescaped_lines_count + extra, 0))
+                normalized_lengths[-1] = lines.sum { |line| line.bytesize }
+                do_next_tokens.concat(Array.new(unescaped_lines_count + extra, false))
                 do_next_tokens[-1] = true
               end
-          end
 
-          current_line = +""
-          current_normalized_length = 0
+            current_line = +""
+            current_normalized_length = 0
 
-          unescaped.filter_map.with_index do |unescaped_line, index|
-            current_line << unescaped_line
-            current_normalized_length += normalized_lengths.fetch(index, 0)
+            emitted_count = 0
+            unescaped.filter_map.with_index do |unescaped_line, index|
+              current_line << unescaped_line
+              current_normalized_length += normalized_lengths.fetch(index, 0)
 
-            if do_next_tokens[index]
-              inner_part = builder.string_internal([current_line, srange_offsets(start_offset, start_offset + current_normalized_length)])
-              start_offset += escaped_lengths.fetch(index, 0)
-              current_line = +""
-              current_normalized_length = 0
-              inner_part
-            else
-              nil
+              if do_next_tokens[index]
+                inner_part = builder.string_internal([current_line, srange_offsets(start_offset, start_offset + current_normalized_length)])
+                start_offset += escaped_lengths.fetch(emitted_count, 0)
+                current_line = +""
+                current_normalized_length = 0
+                emitted_count += 1
+                inner_part
+              else
+                nil
+              end
             end
           end
         end

--- a/lib/prism/translation/parser/lexer.rb
+++ b/lib/prism/translation/parser/lexer.rb
@@ -353,11 +353,15 @@ module Prism
                 location = range(next_location.start_offset, next_location.end_offset)
                 index += 1
               elsif value.start_with?("'", '"', "%")
-                if next_token&.type == :STRING_CONTENT && next_token.value.lines.count <= 1 && next_next_token&.type == :STRING_END
-                  # the parser gem doesn't simplify strings when its value ends in a newline
-                  if !(string_value = next_token.value).end_with?("\n") && basic_quotes
+                if next_token&.type == :STRING_CONTENT && next_next_token&.type == :STRING_END
+                  string_value = next_token.value
+                  if simplify_string?(string_value, value)
                     next_location = token.location.join(next_next_token.location)
-                    value = unescape_string(string_value, value)
+                    if percent_array?(value)
+                      value = percent_array_unescape(string_value)
+                    else
+                      value = unescape_string(string_value, value)
+                    end
                     type = :tSTRING
                     location = range(next_location.start_offset, next_location.end_offset)
                     index += 2
@@ -399,17 +403,31 @@ module Prism
               is_percent_array = percent_array?(quote_stack.last)
 
               if (lines = token.value.lines).one?
-                # Heredoc interpolation can have multiple STRING_CONTENT nodes on the same line.
-                is_first_token_on_line = lexed[index - 1] && token.location.start_line != lexed[index - 2][0].location&.start_line
-                # The parser gem only removes indentation when the heredoc is not nested
-                not_nested = heredoc_stack.size == 1
-                if is_percent_array
-                  value = percent_array_unescape(value)
-                elsif is_first_token_on_line && not_nested && (current_heredoc = heredoc_stack.last).common_whitespace > 0
-                  value = trim_heredoc_whitespace(value, current_heredoc)
-                end
+                # Prism usually emits a single token for strings with line continuations.
+                # For squiggly heredocs they are not joined so we do that manually here.
+                current_string = +""
+                current_length = 0
+                start_offset = token.location.start_offset
+                while token.type == :STRING_CONTENT
+                  current_length += token.value.bytesize
+                  # Heredoc interpolation can have multiple STRING_CONTENT nodes on the same line.
+                  is_first_token_on_line = lexed[index - 1] && token.location.start_line != lexed[index - 2][0].location&.start_line
+                  # The parser gem only removes indentation when the heredoc is not nested
+                  not_nested = heredoc_stack.size == 1
+                  if is_percent_array
+                    value = percent_array_unescape(token.value)
+                  elsif is_first_token_on_line && not_nested && (current_heredoc = heredoc_stack.last).common_whitespace > 0
+                    value = trim_heredoc_whitespace(token.value, current_heredoc)
+                  end
 
-                value = unescape_string(value, quote_stack.last)
+                  current_string << unescape_string(value, quote_stack.last)
+                  if (backslash_count = token.value[/(\\{1,})\n/, 1]&.length).nil? || backslash_count.even? || !interpolation?(quote_stack.last)
+                    tokens << [:tSTRING_CONTENT, [current_string, range(start_offset, start_offset + current_length)]]
+                    break
+                  end
+                  token = lexed[index][0]
+                  index += 1
+                end
               else
                 # When the parser gem encounters a line continuation inside of a multiline string,
                 # it emits a single string node. The backslash (and remaining newline) is removed.
@@ -447,8 +465,8 @@ module Prism
                     adjustment = 0
                   end
                 end
-                next
               end
+              next
             when :tSTRING_DVAR
               value = nil
             when :tSTRING_END
@@ -571,12 +589,13 @@ module Prism
           while (lexed[next_token_index] && next_token = lexed[next_token_index][0])
             next_token_index += 1
             next_next_token = lexed[next_token_index] && lexed[next_token_index][0]
+            first_token_on_line = next_token.location.start_column == 0
 
             # String content inside nested heredocs and interpolation is ignored
             if next_token.type == :HEREDOC_START || next_token.type == :EMBEXPR_BEGIN
               # When interpolation is the first token of a line there is no string
               # content to check against. There will be no common whitespace.
-              if nesting_level == 0 && next_token.location.start_column == 0
+              if nesting_level == 0 && first_token_on_line
                 result = 0
               end
               nesting_level += 1
@@ -584,7 +603,7 @@ module Prism
               nesting_level -= 1
               # When we encountered the matching heredoc end, we can exit
               break if nesting_level == -1
-            elsif next_token.type == :STRING_CONTENT && nesting_level == 0
+            elsif next_token.type == :STRING_CONTENT && nesting_level == 0 && first_token_on_line
               common_whitespace = 0
               next_token.value[/^\s*/].each_char do |char|
                 if char == "\t"
@@ -674,8 +693,11 @@ module Prism
               # Append what was just skipped over, excluding the found backslash.
               result.append_as_bytes(string.byteslice(scanner.pos - skipped, skipped - 1))
 
-              # Simple single-character escape sequences like \n
-              if (replacement = ESCAPES[scanner.peek(1)])
+              if scanner.peek(1) == "\n"
+                # Line continuation
+                scanner.pos += 1
+              elsif (replacement = ESCAPES[scanner.peek(1)])
+                # Simple single-character escape sequences like \n
                 result.append_as_bytes(replacement)
                 scanner.pos += 1
               elsif (octal = scanner.check(/[0-7]{1,3}/))
@@ -714,6 +736,23 @@ module Prism
           end
         end
 
+        # Certain strings are merged into a single string token.
+        def simplify_string?(value, quote)
+          case quote
+          when "'"
+            # Only simplify 'foo'
+            !value.include?("\n")
+          when '"'
+            # Simplify when every line ends with a line continuation, or it is the last line
+            value.lines.all? do |line|
+              !line.end_with?("\n") || line[/(\\*)$/, 1]&.length&.odd?
+            end
+          else
+            # %q and similar are never simplified
+            false
+          end
+        end
+
         # In a percent array, certain whitespace can be preceeded with a backslash,
         # causing the following characters to be part of the previous element.
         def percent_array_unescape(string)
@@ -737,7 +776,7 @@ module Prism
 
         # Determine if characters preceeded by a backslash should be escaped or not
         def interpolation?(quote)
-          quote != "'" && !quote.start_with?("%q", "%w", "%i")
+          !quote.end_with?("'") && !quote.start_with?("%q", "%w", "%i", "%s")
         end
 
         # Regexp allow interpolation but are handled differently during unescaping

--- a/test/prism/fixtures/heredocs_with_fake_newlines.txt
+++ b/test/prism/fixtures/heredocs_with_fake_newlines.txt
@@ -1,0 +1,55 @@
+<<-RUBY
+  \n
+  \n
+  exit
+  \\n
+  \n\n\n\n
+  argh
+  \\
+  \\\
+  foo\nbar
+  \f
+  ok
+RUBY
+
+<<~RUBY
+  \n
+  \n
+  exit
+  \\n
+  \n\n\n\n
+  argh
+  \\
+  \\\
+  foo\nbar
+  \f
+  ok
+RUBY
+
+<<~RUBY
+  #{123}\n
+  \n
+  exit
+  \\#{123}n
+  \n#{123}\n\n\n
+  argh
+  \\#{123}baz
+  \\\
+  foo\nbar
+  \f
+  ok
+RUBY
+
+<<'RUBY'
+  \n
+  \n
+  exit
+  \n
+  \n\n\n\n
+  argh
+  \
+  \
+  foo\nbar
+  \f
+  ok
+RUBY

--- a/test/prism/fixtures/strings.txt
+++ b/test/prism/fixtures/strings.txt
@@ -72,6 +72,21 @@ b\nar
 %w[foo\ bar\\ baz\\\
  bat]
 
+%W[#{foo}\
+bar
+baz #{bat}
+]
+
+%w(foo\n)
+
+%w(foo\
+)
+
+%w(foo \n)
+
+%W(foo\
+bar)
+
 %w[foo     bar]
 
 %w[

--- a/test/prism/lex_test.rb
+++ b/test/prism/lex_test.rb
@@ -15,7 +15,11 @@ module Prism
       # the heredoc are combined into a single token. See
       # https://bugs.ruby-lang.org/issues/19838.
       "spanning_heredoc.txt",
-      "spanning_heredoc_newlines.txt"
+      "spanning_heredoc_newlines.txt",
+      # Prism emits a single :on_tstring_content in <<- style heredocs when there
+      # is a line continuation preceeded by escaped backslashes. It should emit two, same
+      # as if the backslashes are not present.
+      "heredocs_with_fake_newlines.txt",
     ]
 
     if RUBY_VERSION < "3.3.0"

--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -86,10 +86,7 @@ module Prism
     # skip them for now.
     skip_all = skip_incorrect | [
       "unescaping.txt",
-      "seattlerb/pctW_lineno.txt",
       "seattlerb/regexp_esc_C_slash.txt",
-      "unparser/corpus/literal/literal.txt",
-      "whitequark/parser_slash_slash_n_escaping_in_literals.txt",
     ]
 
     # Not sure why these files are failing on JRuby, but skipping them for now.
@@ -102,7 +99,6 @@ module Prism
     skip_tokens = [
       "dash_heredocs.txt",
       "embdoc_no_newline_at_end.txt",
-      "heredocs_with_ignored_newlines.txt",
       "methods.txt",
       "seattlerb/bug169.txt",
       "seattlerb/case_in.txt",
@@ -113,9 +109,9 @@ module Prism
       "seattlerb/parse_line_heredoc.txt",
       "seattlerb/pct_w_heredoc_interp_nested.txt",
       "seattlerb/required_kwarg_no_value.txt",
-      "seattlerb/slashy_newlines_within_string.txt",
       "seattlerb/TestRubyParserShared.txt",
       "unparser/corpus/literal/assignment.txt",
+      "unparser/corpus/literal/literal.txt",
       "whitequark/args.txt",
       "whitequark/beginless_erange_after_newline.txt",
       "whitequark/beginless_irange_after_newline.txt",
@@ -124,13 +120,11 @@ module Prism
       "whitequark/lbrace_arg_after_command_args.txt",
       "whitequark/multiple_pattern_matches.txt",
       "whitequark/newline_in_hash_argument.txt",
-      "whitequark/parser_bug_640.txt",
       "whitequark/pattern_matching_expr_in_paren.txt",
       "whitequark/pattern_matching_hash.txt",
       "whitequark/pin_expr.txt",
       "whitequark/ruby_bug_14690.txt",
       "whitequark/ruby_bug_9669.txt",
-      "whitequark/slash_newline_in_heredocs.txt",
       "whitequark/space_args_arg_block.txt",
       "whitequark/space_args_block.txt"
     ]

--- a/test/prism/ruby/ripper_test.rb
+++ b/test/prism/ruby/ripper_test.rb
@@ -32,6 +32,7 @@ module Prism
     # Skip these tests that we haven't implemented yet.
     omitted = [
       "dos_endings.txt",
+      "heredocs_with_fake_newlines.txt",
       "heredocs_with_ignored_newlines.txt",
       "seattlerb/block_call_dot_op2_brace_block.txt",
       "seattlerb/block_command_operation_colon.txt",

--- a/test/prism/ruby/ruby_parser_test.rb
+++ b/test/prism/ruby/ruby_parser_test.rb
@@ -53,6 +53,7 @@ module Prism
       "alias.txt",
       "dsym_str.txt",
       "dos_endings.txt",
+      "heredocs_with_fake_newlines.txt",
       "heredocs_with_ignored_newlines.txt",
       "method_calls.txt",
       "methods.txt",

--- a/test/prism/snapshots/heredocs_with_fake_newlines.txt
+++ b/test/prism/snapshots/heredocs_with_fake_newlines.txt
@@ -1,0 +1,223 @@
+@ ProgramNode (location: (1,0)-(43,8))
+├── flags: ∅
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (1,0)-(43,8))
+    ├── flags: ∅
+    └── body: (length: 4)
+        ├── @ StringNode (location: (1,0)-(1,7))
+        │   ├── flags: newline
+        │   ├── opening_loc: (1,0)-(1,7) = "<<-RUBY"
+        │   ├── content_loc: (2,0)-(13,0) = "  \\n\n  \\n\n  exit\n  \\\\n\n  \\n\\n\\n\\n\n  argh\n  \\\\\n  \\\\\\\n  foo\\nbar\n  \\f\n  ok\n"
+        │   ├── closing_loc: (13,0)-(14,0) = "RUBY\n"
+        │   └── unescaped: "  \n\n  \n\n  exit\n  \\n\n  \n\n\n\n\n  argh\n  \\\n  \\  foo\nbar\n  \f\n  ok\n"
+        ├── @ InterpolatedStringNode (location: (15,0)-(15,7))
+        │   ├── flags: newline, static_literal
+        │   ├── opening_loc: (15,0)-(15,7) = "<<~RUBY"
+        │   ├── parts: (length: 11)
+        │   │   ├── @ StringNode (location: (16,0)-(17,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (16,0)-(17,0) = "  \\n\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\n\n"
+        │   │   ├── @ StringNode (location: (17,0)-(18,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (17,0)-(18,0) = "  \\n\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\n\n"
+        │   │   ├── @ StringNode (location: (18,0)-(19,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (18,0)-(19,0) = "  exit\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "exit\n"
+        │   │   ├── @ StringNode (location: (19,0)-(20,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (19,0)-(20,0) = "  \\\\n\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\\n\n"
+        │   │   ├── @ StringNode (location: (20,0)-(21,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (20,0)-(21,0) = "  \\n\\n\\n\\n\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\n\n\n\n\n"
+        │   │   ├── @ StringNode (location: (21,0)-(22,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (21,0)-(22,0) = "  argh\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "argh\n"
+        │   │   ├── @ StringNode (location: (22,0)-(23,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (22,0)-(23,0) = "  \\\\\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\\\n"
+        │   │   ├── @ StringNode (location: (23,0)-(24,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (23,0)-(24,0) = "  \\\\\\\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\\"
+        │   │   ├── @ StringNode (location: (24,0)-(25,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (24,0)-(25,0) = "  foo\\nbar\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "foo\nbar\n"
+        │   │   ├── @ StringNode (location: (25,0)-(26,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (25,0)-(26,0) = "  \\f\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\f\n"
+        │   │   └── @ StringNode (location: (26,0)-(27,0))
+        │   │       ├── flags: static_literal, frozen
+        │   │       ├── opening_loc: ∅
+        │   │       ├── content_loc: (26,0)-(27,0) = "  ok\n"
+        │   │       ├── closing_loc: ∅
+        │   │       └── unescaped: "ok\n"
+        │   └── closing_loc: (27,0)-(28,0) = "RUBY\n"
+        ├── @ InterpolatedStringNode (location: (29,0)-(29,7))
+        │   ├── flags: newline
+        │   ├── opening_loc: (29,0)-(29,7) = "<<~RUBY"
+        │   ├── parts: (length: 18)
+        │   │   ├── @ EmbeddedStatementsNode (location: (30,2)-(30,8))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: (30,2)-(30,4) = "\#{"
+        │   │   │   ├── statements:
+        │   │   │   │   @ StatementsNode (location: (30,4)-(30,7))
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── body: (length: 1)
+        │   │   │   │       └── @ IntegerNode (location: (30,4)-(30,7))
+        │   │   │   │           ├── flags: static_literal, decimal
+        │   │   │   │           └── value: 123
+        │   │   │   └── closing_loc: (30,7)-(30,8) = "}"
+        │   │   ├── @ StringNode (location: (30,8)-(31,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (30,8)-(31,0) = "\\n\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\n\n"
+        │   │   ├── @ StringNode (location: (31,0)-(32,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (31,0)-(32,0) = "  \\n\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\n\n"
+        │   │   ├── @ StringNode (location: (32,0)-(33,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (32,0)-(33,0) = "  exit\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "exit\n"
+        │   │   ├── @ StringNode (location: (33,0)-(33,4))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (33,0)-(33,4) = "  \\\\"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\\"
+        │   │   ├── @ EmbeddedStatementsNode (location: (33,4)-(33,10))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: (33,4)-(33,6) = "\#{"
+        │   │   │   ├── statements:
+        │   │   │   │   @ StatementsNode (location: (33,6)-(33,9))
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── body: (length: 1)
+        │   │   │   │       └── @ IntegerNode (location: (33,6)-(33,9))
+        │   │   │   │           ├── flags: static_literal, decimal
+        │   │   │   │           └── value: 123
+        │   │   │   └── closing_loc: (33,9)-(33,10) = "}"
+        │   │   ├── @ StringNode (location: (33,10)-(34,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (33,10)-(34,0) = "n\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "n\n"
+        │   │   ├── @ StringNode (location: (34,0)-(34,4))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (34,0)-(34,4) = "  \\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\n"
+        │   │   ├── @ EmbeddedStatementsNode (location: (34,4)-(34,10))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: (34,4)-(34,6) = "\#{"
+        │   │   │   ├── statements:
+        │   │   │   │   @ StatementsNode (location: (34,6)-(34,9))
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── body: (length: 1)
+        │   │   │   │       └── @ IntegerNode (location: (34,6)-(34,9))
+        │   │   │   │           ├── flags: static_literal, decimal
+        │   │   │   │           └── value: 123
+        │   │   │   └── closing_loc: (34,9)-(34,10) = "}"
+        │   │   ├── @ StringNode (location: (34,10)-(35,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (34,10)-(35,0) = "\\n\\n\\n\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\n\n\n\n"
+        │   │   ├── @ StringNode (location: (35,0)-(36,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (35,0)-(36,0) = "  argh\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "argh\n"
+        │   │   ├── @ StringNode (location: (36,0)-(36,4))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (36,0)-(36,4) = "  \\\\"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\\"
+        │   │   ├── @ EmbeddedStatementsNode (location: (36,4)-(36,10))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: (36,4)-(36,6) = "\#{"
+        │   │   │   ├── statements:
+        │   │   │   │   @ StatementsNode (location: (36,6)-(36,9))
+        │   │   │   │   ├── flags: ∅
+        │   │   │   │   └── body: (length: 1)
+        │   │   │   │       └── @ IntegerNode (location: (36,6)-(36,9))
+        │   │   │   │           ├── flags: static_literal, decimal
+        │   │   │   │           └── value: 123
+        │   │   │   └── closing_loc: (36,9)-(36,10) = "}"
+        │   │   ├── @ StringNode (location: (36,10)-(37,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (36,10)-(37,0) = "baz\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "baz\n"
+        │   │   ├── @ StringNode (location: (37,0)-(38,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (37,0)-(38,0) = "  \\\\\\\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\\"
+        │   │   ├── @ StringNode (location: (38,0)-(39,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (38,0)-(39,0) = "  foo\\nbar\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "foo\nbar\n"
+        │   │   ├── @ StringNode (location: (39,0)-(40,0))
+        │   │   │   ├── flags: static_literal, frozen
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (39,0)-(40,0) = "  \\f\n"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "\f\n"
+        │   │   └── @ StringNode (location: (40,0)-(41,0))
+        │   │       ├── flags: static_literal, frozen
+        │   │       ├── opening_loc: ∅
+        │   │       ├── content_loc: (40,0)-(41,0) = "  ok\n"
+        │   │       ├── closing_loc: ∅
+        │   │       └── unescaped: "ok\n"
+        │   └── closing_loc: (41,0)-(42,0) = "RUBY\n"
+        └── @ StringNode (location: (43,0)-(43,8))
+            ├── flags: newline
+            ├── opening_loc: (43,0)-(43,8) = "<<'RUBY'"
+            ├── content_loc: (44,0)-(55,0) = "  \\n\n  \\n\n  exit\n  \\n\n  \\n\\n\\n\\n\n  argh\n  \\\n  \\\n  foo\\nbar\n  \\f\n  ok\n"
+            ├── closing_loc: (55,0)-(56,0) = "RUBY\n"
+            └── unescaped: "  \\n\n  \\n\n  exit\n  \\n\n  \\n\\n\\n\\n\n  argh\n  \\\n  \\\n  foo\\nbar\n  \\f\n  ok\n"

--- a/test/prism/snapshots/strings.txt
+++ b/test/prism/snapshots/strings.txt
@@ -1,10 +1,10 @@
-@ ProgramNode (location: (1,0)-(132,15))
+@ ProgramNode (location: (1,0)-(147,15))
 ├── flags: ∅
 ├── locals: []
 └── statements:
-    @ StatementsNode (location: (1,0)-(132,15))
+    @ StatementsNode (location: (1,0)-(147,15))
     ├── flags: ∅
-    └── body: (length: 58)
+    └── body: (length: 63)
         ├── @ StringNode (location: (1,0)-(1,6))
         │   ├── flags: newline
         │   ├── opening_loc: (1,0)-(1,2) = "%%"
@@ -364,324 +364,437 @@
         │   │       └── unescaped: "bat"
         │   ├── opening_loc: (72,0)-(72,3) = "%w["
         │   └── closing_loc: (73,4)-(73,5) = "]"
-        ├── @ ArrayNode (location: (75,0)-(75,15))
-        │   ├── flags: newline
-        │   ├── elements: (length: 2)
-        │   │   ├── @ StringNode (location: (75,3)-(75,6))
-        │   │   │   ├── flags: ∅
-        │   │   │   ├── opening_loc: ∅
-        │   │   │   ├── content_loc: (75,3)-(75,6) = "foo"
-        │   │   │   ├── closing_loc: ∅
-        │   │   │   └── unescaped: "foo"
-        │   │   └── @ StringNode (location: (75,11)-(75,14))
-        │   │       ├── flags: ∅
-        │   │       ├── opening_loc: ∅
-        │   │       ├── content_loc: (75,11)-(75,14) = "bar"
-        │   │       ├── closing_loc: ∅
-        │   │       └── unescaped: "bar"
-        │   ├── opening_loc: (75,0)-(75,3) = "%w["
-        │   └── closing_loc: (75,14)-(75,15) = "]"
-        ├── @ ArrayNode (location: (77,0)-(81,1))
-        │   ├── flags: newline
-        │   ├── elements: (length: 4)
-        │   │   ├── @ StringNode (location: (78,2)-(78,3))
-        │   │   │   ├── flags: ∅
-        │   │   │   ├── opening_loc: ∅
-        │   │   │   ├── content_loc: (78,2)-(78,3) = "a"
-        │   │   │   ├── closing_loc: ∅
-        │   │   │   └── unescaped: "a"
-        │   │   ├── @ StringNode (location: (79,2)-(79,3))
-        │   │   │   ├── flags: ∅
-        │   │   │   ├── opening_loc: ∅
-        │   │   │   ├── content_loc: (79,2)-(79,3) = "b"
-        │   │   │   ├── closing_loc: ∅
-        │   │   │   └── unescaped: "b"
-        │   │   ├── @ StringNode (location: (79,6)-(79,7))
-        │   │   │   ├── flags: ∅
-        │   │   │   ├── opening_loc: ∅
-        │   │   │   ├── content_loc: (79,6)-(79,7) = "c"
-        │   │   │   ├── closing_loc: ∅
-        │   │   │   └── unescaped: "c"
-        │   │   └── @ StringNode (location: (80,1)-(80,2))
-        │   │       ├── flags: ∅
-        │   │       ├── opening_loc: ∅
-        │   │       ├── content_loc: (80,1)-(80,2) = "d"
-        │   │       ├── closing_loc: ∅
-        │   │       └── unescaped: "d"
-        │   ├── opening_loc: (77,0)-(77,3) = "%w["
-        │   └── closing_loc: (81,0)-(81,1) = "]"
-        ├── @ ArrayNode (location: (83,0)-(83,18))
-        │   ├── flags: newline
-        │   ├── elements: (length: 1)
-        │   │   └── @ StringNode (location: (83,3)-(83,17))
-        │   │       ├── flags: ∅
-        │   │       ├── opening_loc: ∅
-        │   │       ├── content_loc: (83,3)-(83,17) = "f\\u{006f 006f}"
-        │   │       ├── closing_loc: ∅
-        │   │       └── unescaped: "foo"
-        │   ├── opening_loc: (83,0)-(83,3) = "%W["
-        │   └── closing_loc: (83,17)-(83,18) = "]"
-        ├── @ ArrayNode (location: (85,0)-(85,14))
+        ├── @ ArrayNode (location: (75,0)-(78,1))
         │   ├── flags: newline
         │   ├── elements: (length: 3)
-        │   │   ├── @ StringNode (location: (85,3)-(85,4))
+        │   │   ├── @ InterpolatedStringNode (location: (75,3)-(76,3))
         │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
-        │   │   │   ├── content_loc: (85,3)-(85,4) = "a"
-        │   │   │   ├── closing_loc: ∅
-        │   │   │   └── unescaped: "a"
-        │   │   ├── @ InterpolatedStringNode (location: (85,5)-(85,11))
-        │   │   │   ├── flags: ∅
-        │   │   │   ├── opening_loc: ∅
-        │   │   │   ├── parts: (length: 3)
-        │   │   │   │   ├── @ StringNode (location: (85,5)-(85,6))
-        │   │   │   │   │   ├── flags: static_literal, frozen
-        │   │   │   │   │   ├── opening_loc: ∅
-        │   │   │   │   │   ├── content_loc: (85,5)-(85,6) = "b"
-        │   │   │   │   │   ├── closing_loc: ∅
-        │   │   │   │   │   └── unescaped: "b"
-        │   │   │   │   ├── @ EmbeddedStatementsNode (location: (85,6)-(85,10))
+        │   │   │   ├── parts: (length: 2)
+        │   │   │   │   ├── @ EmbeddedStatementsNode (location: (75,3)-(75,9))
         │   │   │   │   │   ├── flags: ∅
-        │   │   │   │   │   ├── opening_loc: (85,6)-(85,8) = "\#{"
+        │   │   │   │   │   ├── opening_loc: (75,3)-(75,5) = "\#{"
         │   │   │   │   │   ├── statements:
-        │   │   │   │   │   │   @ StatementsNode (location: (85,8)-(85,9))
+        │   │   │   │   │   │   @ StatementsNode (location: (75,5)-(75,8))
         │   │   │   │   │   │   ├── flags: ∅
         │   │   │   │   │   │   └── body: (length: 1)
-        │   │   │   │   │   │       └── @ CallNode (location: (85,8)-(85,9))
+        │   │   │   │   │   │       └── @ CallNode (location: (75,5)-(75,8))
         │   │   │   │   │   │           ├── flags: variable_call, ignore_visibility
         │   │   │   │   │   │           ├── receiver: ∅
         │   │   │   │   │   │           ├── call_operator_loc: ∅
-        │   │   │   │   │   │           ├── name: :c
-        │   │   │   │   │   │           ├── message_loc: (85,8)-(85,9) = "c"
+        │   │   │   │   │   │           ├── name: :foo
+        │   │   │   │   │   │           ├── message_loc: (75,5)-(75,8) = "foo"
         │   │   │   │   │   │           ├── opening_loc: ∅
         │   │   │   │   │   │           ├── arguments: ∅
         │   │   │   │   │   │           ├── closing_loc: ∅
         │   │   │   │   │   │           └── block: ∅
-        │   │   │   │   │   └── closing_loc: (85,9)-(85,10) = "}"
-        │   │   │   │   └── @ StringNode (location: (85,10)-(85,11))
+        │   │   │   │   │   └── closing_loc: (75,8)-(75,9) = "}"
+        │   │   │   │   └── @ StringNode (location: (75,9)-(76,3))
         │   │   │   │       ├── flags: static_literal, frozen
         │   │   │   │       ├── opening_loc: ∅
-        │   │   │   │       ├── content_loc: (85,10)-(85,11) = "d"
+        │   │   │   │       ├── content_loc: (75,9)-(76,3) = "\\\nbar"
+        │   │   │   │       ├── closing_loc: ∅
+        │   │   │   │       └── unescaped: "\nbar"
+        │   │   │   └── closing_loc: ∅
+        │   │   ├── @ StringNode (location: (77,0)-(77,3))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (77,0)-(77,3) = "baz"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "baz"
+        │   │   └── @ InterpolatedStringNode (location: (77,4)-(77,10))
+        │   │       ├── flags: ∅
+        │   │       ├── opening_loc: ∅
+        │   │       ├── parts: (length: 1)
+        │   │       │   └── @ EmbeddedStatementsNode (location: (77,4)-(77,10))
+        │   │       │       ├── flags: ∅
+        │   │       │       ├── opening_loc: (77,4)-(77,6) = "\#{"
+        │   │       │       ├── statements:
+        │   │       │       │   @ StatementsNode (location: (77,6)-(77,9))
+        │   │       │       │   ├── flags: ∅
+        │   │       │       │   └── body: (length: 1)
+        │   │       │       │       └── @ CallNode (location: (77,6)-(77,9))
+        │   │       │       │           ├── flags: variable_call, ignore_visibility
+        │   │       │       │           ├── receiver: ∅
+        │   │       │       │           ├── call_operator_loc: ∅
+        │   │       │       │           ├── name: :bat
+        │   │       │       │           ├── message_loc: (77,6)-(77,9) = "bat"
+        │   │       │       │           ├── opening_loc: ∅
+        │   │       │       │           ├── arguments: ∅
+        │   │       │       │           ├── closing_loc: ∅
+        │   │       │       │           └── block: ∅
+        │   │       │       └── closing_loc: (77,9)-(77,10) = "}"
+        │   │       └── closing_loc: ∅
+        │   ├── opening_loc: (75,0)-(75,3) = "%W["
+        │   └── closing_loc: (78,0)-(78,1) = "]"
+        ├── @ ArrayNode (location: (80,0)-(80,9))
+        │   ├── flags: newline
+        │   ├── elements: (length: 1)
+        │   │   └── @ StringNode (location: (80,3)-(80,8))
+        │   │       ├── flags: ∅
+        │   │       ├── opening_loc: ∅
+        │   │       ├── content_loc: (80,3)-(80,8) = "foo\\n"
+        │   │       ├── closing_loc: ∅
+        │   │       └── unescaped: "foo\\n"
+        │   ├── opening_loc: (80,0)-(80,3) = "%w("
+        │   └── closing_loc: (80,8)-(80,9) = ")"
+        ├── @ ArrayNode (location: (82,0)-(83,1))
+        │   ├── flags: newline
+        │   ├── elements: (length: 1)
+        │   │   └── @ StringNode (location: (82,3)-(83,0))
+        │   │       ├── flags: ∅
+        │   │       ├── opening_loc: ∅
+        │   │       ├── content_loc: (82,3)-(83,0) = "foo\\\n"
+        │   │       ├── closing_loc: ∅
+        │   │       └── unescaped: "foo\n"
+        │   ├── opening_loc: (82,0)-(82,3) = "%w("
+        │   └── closing_loc: (83,0)-(83,1) = ")"
+        ├── @ ArrayNode (location: (85,0)-(85,10))
+        │   ├── flags: newline
+        │   ├── elements: (length: 2)
+        │   │   ├── @ StringNode (location: (85,3)-(85,6))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (85,3)-(85,6) = "foo"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "foo"
+        │   │   └── @ StringNode (location: (85,7)-(85,9))
+        │   │       ├── flags: ∅
+        │   │       ├── opening_loc: ∅
+        │   │       ├── content_loc: (85,7)-(85,9) = "\\n"
+        │   │       ├── closing_loc: ∅
+        │   │       └── unescaped: "\\n"
+        │   ├── opening_loc: (85,0)-(85,3) = "%w("
+        │   └── closing_loc: (85,9)-(85,10) = ")"
+        ├── @ ArrayNode (location: (87,0)-(88,4))
+        │   ├── flags: newline
+        │   ├── elements: (length: 1)
+        │   │   └── @ StringNode (location: (87,3)-(88,3))
+        │   │       ├── flags: ∅
+        │   │       ├── opening_loc: ∅
+        │   │       ├── content_loc: (87,3)-(88,3) = "foo\\\nbar"
+        │   │       ├── closing_loc: ∅
+        │   │       └── unescaped: "foo\nbar"
+        │   ├── opening_loc: (87,0)-(87,3) = "%W("
+        │   └── closing_loc: (88,3)-(88,4) = ")"
+        ├── @ ArrayNode (location: (90,0)-(90,15))
+        │   ├── flags: newline
+        │   ├── elements: (length: 2)
+        │   │   ├── @ StringNode (location: (90,3)-(90,6))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (90,3)-(90,6) = "foo"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "foo"
+        │   │   └── @ StringNode (location: (90,11)-(90,14))
+        │   │       ├── flags: ∅
+        │   │       ├── opening_loc: ∅
+        │   │       ├── content_loc: (90,11)-(90,14) = "bar"
+        │   │       ├── closing_loc: ∅
+        │   │       └── unescaped: "bar"
+        │   ├── opening_loc: (90,0)-(90,3) = "%w["
+        │   └── closing_loc: (90,14)-(90,15) = "]"
+        ├── @ ArrayNode (location: (92,0)-(96,1))
+        │   ├── flags: newline
+        │   ├── elements: (length: 4)
+        │   │   ├── @ StringNode (location: (93,2)-(93,3))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (93,2)-(93,3) = "a"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "a"
+        │   │   ├── @ StringNode (location: (94,2)-(94,3))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (94,2)-(94,3) = "b"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "b"
+        │   │   ├── @ StringNode (location: (94,6)-(94,7))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (94,6)-(94,7) = "c"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "c"
+        │   │   └── @ StringNode (location: (95,1)-(95,2))
+        │   │       ├── flags: ∅
+        │   │       ├── opening_loc: ∅
+        │   │       ├── content_loc: (95,1)-(95,2) = "d"
+        │   │       ├── closing_loc: ∅
+        │   │       └── unescaped: "d"
+        │   ├── opening_loc: (92,0)-(92,3) = "%w["
+        │   └── closing_loc: (96,0)-(96,1) = "]"
+        ├── @ ArrayNode (location: (98,0)-(98,18))
+        │   ├── flags: newline
+        │   ├── elements: (length: 1)
+        │   │   └── @ StringNode (location: (98,3)-(98,17))
+        │   │       ├── flags: ∅
+        │   │       ├── opening_loc: ∅
+        │   │       ├── content_loc: (98,3)-(98,17) = "f\\u{006f 006f}"
+        │   │       ├── closing_loc: ∅
+        │   │       └── unescaped: "foo"
+        │   ├── opening_loc: (98,0)-(98,3) = "%W["
+        │   └── closing_loc: (98,17)-(98,18) = "]"
+        ├── @ ArrayNode (location: (100,0)-(100,14))
+        │   ├── flags: newline
+        │   ├── elements: (length: 3)
+        │   │   ├── @ StringNode (location: (100,3)-(100,4))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── content_loc: (100,3)-(100,4) = "a"
+        │   │   │   ├── closing_loc: ∅
+        │   │   │   └── unescaped: "a"
+        │   │   ├── @ InterpolatedStringNode (location: (100,5)-(100,11))
+        │   │   │   ├── flags: ∅
+        │   │   │   ├── opening_loc: ∅
+        │   │   │   ├── parts: (length: 3)
+        │   │   │   │   ├── @ StringNode (location: (100,5)-(100,6))
+        │   │   │   │   │   ├── flags: static_literal, frozen
+        │   │   │   │   │   ├── opening_loc: ∅
+        │   │   │   │   │   ├── content_loc: (100,5)-(100,6) = "b"
+        │   │   │   │   │   ├── closing_loc: ∅
+        │   │   │   │   │   └── unescaped: "b"
+        │   │   │   │   ├── @ EmbeddedStatementsNode (location: (100,6)-(100,10))
+        │   │   │   │   │   ├── flags: ∅
+        │   │   │   │   │   ├── opening_loc: (100,6)-(100,8) = "\#{"
+        │   │   │   │   │   ├── statements:
+        │   │   │   │   │   │   @ StatementsNode (location: (100,8)-(100,9))
+        │   │   │   │   │   │   ├── flags: ∅
+        │   │   │   │   │   │   └── body: (length: 1)
+        │   │   │   │   │   │       └── @ CallNode (location: (100,8)-(100,9))
+        │   │   │   │   │   │           ├── flags: variable_call, ignore_visibility
+        │   │   │   │   │   │           ├── receiver: ∅
+        │   │   │   │   │   │           ├── call_operator_loc: ∅
+        │   │   │   │   │   │           ├── name: :c
+        │   │   │   │   │   │           ├── message_loc: (100,8)-(100,9) = "c"
+        │   │   │   │   │   │           ├── opening_loc: ∅
+        │   │   │   │   │   │           ├── arguments: ∅
+        │   │   │   │   │   │           ├── closing_loc: ∅
+        │   │   │   │   │   │           └── block: ∅
+        │   │   │   │   │   └── closing_loc: (100,9)-(100,10) = "}"
+        │   │   │   │   └── @ StringNode (location: (100,10)-(100,11))
+        │   │   │   │       ├── flags: static_literal, frozen
+        │   │   │   │       ├── opening_loc: ∅
+        │   │   │   │       ├── content_loc: (100,10)-(100,11) = "d"
         │   │   │   │       ├── closing_loc: ∅
         │   │   │   │       └── unescaped: "d"
         │   │   │   └── closing_loc: ∅
-        │   │   └── @ StringNode (location: (85,12)-(85,13))
+        │   │   └── @ StringNode (location: (100,12)-(100,13))
         │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
-        │   │       ├── content_loc: (85,12)-(85,13) = "e"
+        │   │       ├── content_loc: (100,12)-(100,13) = "e"
         │   │       ├── closing_loc: ∅
         │   │       └── unescaped: "e"
-        │   ├── opening_loc: (85,0)-(85,3) = "%W["
-        │   └── closing_loc: (85,13)-(85,14) = "]"
-        ├── @ ArrayNode (location: (87,0)-(87,9))
+        │   ├── opening_loc: (100,0)-(100,3) = "%W["
+        │   └── closing_loc: (100,13)-(100,14) = "]"
+        ├── @ ArrayNode (location: (102,0)-(102,9))
         │   ├── flags: newline
         │   ├── elements: (length: 3)
-        │   │   ├── @ StringNode (location: (87,3)-(87,4))
+        │   │   ├── @ StringNode (location: (102,3)-(102,4))
         │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
-        │   │   │   ├── content_loc: (87,3)-(87,4) = "a"
+        │   │   │   ├── content_loc: (102,3)-(102,4) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
-        │   │   ├── @ StringNode (location: (87,5)-(87,6))
+        │   │   ├── @ StringNode (location: (102,5)-(102,6))
         │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
-        │   │   │   ├── content_loc: (87,5)-(87,6) = "b"
+        │   │   │   ├── content_loc: (102,5)-(102,6) = "b"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "b"
-        │   │   └── @ StringNode (location: (87,7)-(87,8))
+        │   │   └── @ StringNode (location: (102,7)-(102,8))
         │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
-        │   │       ├── content_loc: (87,7)-(87,8) = "c"
+        │   │       ├── content_loc: (102,7)-(102,8) = "c"
         │   │       ├── closing_loc: ∅
         │   │       └── unescaped: "c"
-        │   ├── opening_loc: (87,0)-(87,3) = "%W["
-        │   └── closing_loc: (87,8)-(87,9) = "]"
-        ├── @ ArrayNode (location: (89,0)-(93,1))
+        │   ├── opening_loc: (102,0)-(102,3) = "%W["
+        │   └── closing_loc: (102,8)-(102,9) = "]"
+        ├── @ ArrayNode (location: (104,0)-(108,1))
         │   ├── flags: newline
         │   ├── elements: (length: 3)
-        │   │   ├── @ StringNode (location: (90,2)-(90,3))
+        │   │   ├── @ StringNode (location: (105,2)-(105,3))
         │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
-        │   │   │   ├── content_loc: (90,2)-(90,3) = "a"
+        │   │   │   ├── content_loc: (105,2)-(105,3) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
-        │   │   ├── @ StringNode (location: (91,2)-(91,3))
+        │   │   ├── @ StringNode (location: (106,2)-(106,3))
         │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
-        │   │   │   ├── content_loc: (91,2)-(91,3) = "b"
+        │   │   │   ├── content_loc: (106,2)-(106,3) = "b"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "b"
-        │   │   └── @ StringNode (location: (92,2)-(92,3))
+        │   │   └── @ StringNode (location: (107,2)-(107,3))
         │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
-        │   │       ├── content_loc: (92,2)-(92,3) = "c"
+        │   │       ├── content_loc: (107,2)-(107,3) = "c"
         │   │       ├── closing_loc: ∅
         │   │       └── unescaped: "c"
-        │   ├── opening_loc: (89,0)-(89,3) = "%w["
-        │   └── closing_loc: (93,0)-(93,1) = "]"
-        ├── @ StringNode (location: (95,0)-(95,15))
+        │   ├── opening_loc: (104,0)-(104,3) = "%w["
+        │   └── closing_loc: (108,0)-(108,1) = "]"
+        ├── @ StringNode (location: (110,0)-(110,15))
         │   ├── flags: newline
-        │   ├── opening_loc: (95,0)-(95,1) = "'"
-        │   ├── content_loc: (95,1)-(95,14) = "\\' foo \\' bar"
-        │   ├── closing_loc: (95,14)-(95,15) = "'"
+        │   ├── opening_loc: (110,0)-(110,1) = "'"
+        │   ├── content_loc: (110,1)-(110,14) = "\\' foo \\' bar"
+        │   ├── closing_loc: (110,14)-(110,15) = "'"
         │   └── unescaped: "' foo ' bar"
-        ├── @ StringNode (location: (97,0)-(97,15))
+        ├── @ StringNode (location: (112,0)-(112,15))
         │   ├── flags: newline
-        │   ├── opening_loc: (97,0)-(97,1) = "'"
-        │   ├── content_loc: (97,1)-(97,14) = "\\\\ foo \\\\ bar"
-        │   ├── closing_loc: (97,14)-(97,15) = "'"
+        │   ├── opening_loc: (112,0)-(112,1) = "'"
+        │   ├── content_loc: (112,1)-(112,14) = "\\\\ foo \\\\ bar"
+        │   ├── closing_loc: (112,14)-(112,15) = "'"
         │   └── unescaped: "\\ foo \\ bar"
-        ├── @ StringNode (location: (99,0)-(102,1))
+        ├── @ StringNode (location: (114,0)-(117,1))
         │   ├── flags: newline
-        │   ├── opening_loc: (99,0)-(99,1) = "'"
-        │   ├── content_loc: (99,1)-(102,0) = "foo\\\nbar\\\\\nbaz\n"
-        │   ├── closing_loc: (102,0)-(102,1) = "'"
+        │   ├── opening_loc: (114,0)-(114,1) = "'"
+        │   ├── content_loc: (114,1)-(117,0) = "foo\\\nbar\\\\\nbaz\n"
+        │   ├── closing_loc: (117,0)-(117,1) = "'"
         │   └── unescaped: "foo\\\nbar\\\nbaz\n"
-        ├── @ InterpolatedStringNode (location: (104,0)-(104,7))
+        ├── @ InterpolatedStringNode (location: (119,0)-(119,7))
         │   ├── flags: newline
-        │   ├── opening_loc: (104,0)-(104,1) = "\""
+        │   ├── opening_loc: (119,0)-(119,1) = "\""
         │   ├── parts: (length: 1)
-        │   │   └── @ EmbeddedVariableNode (location: (104,1)-(104,6))
+        │   │   └── @ EmbeddedVariableNode (location: (119,1)-(119,6))
         │   │       ├── flags: ∅
-        │   │       ├── operator_loc: (104,1)-(104,2) = "#"
+        │   │       ├── operator_loc: (119,1)-(119,2) = "#"
         │   │       └── variable:
-        │   │           @ GlobalVariableReadNode (location: (104,2)-(104,6))
+        │   │           @ GlobalVariableReadNode (location: (119,2)-(119,6))
         │   │           ├── flags: ∅
         │   │           └── name: :$foo
-        │   └── closing_loc: (104,6)-(104,7) = "\""
-        ├── @ InterpolatedStringNode (location: (106,0)-(106,7))
+        │   └── closing_loc: (119,6)-(119,7) = "\""
+        ├── @ InterpolatedStringNode (location: (121,0)-(121,7))
         │   ├── flags: newline
-        │   ├── opening_loc: (106,0)-(106,1) = "\""
+        │   ├── opening_loc: (121,0)-(121,1) = "\""
         │   ├── parts: (length: 1)
-        │   │   └── @ EmbeddedVariableNode (location: (106,1)-(106,6))
+        │   │   └── @ EmbeddedVariableNode (location: (121,1)-(121,6))
         │   │       ├── flags: ∅
-        │   │       ├── operator_loc: (106,1)-(106,2) = "#"
+        │   │       ├── operator_loc: (121,1)-(121,2) = "#"
         │   │       └── variable:
-        │   │           @ InstanceVariableReadNode (location: (106,2)-(106,6))
+        │   │           @ InstanceVariableReadNode (location: (121,2)-(121,6))
         │   │           ├── flags: ∅
         │   │           └── name: :@foo
-        │   └── closing_loc: (106,6)-(106,7) = "\""
-        ├── @ StringNode (location: (108,0)-(108,15))
+        │   └── closing_loc: (121,6)-(121,7) = "\""
+        ├── @ StringNode (location: (123,0)-(123,15))
         │   ├── flags: newline
-        │   ├── opening_loc: (108,0)-(108,1) = "\""
-        │   ├── content_loc: (108,1)-(108,14) = "\\x7 \\x23 \\x61"
-        │   ├── closing_loc: (108,14)-(108,15) = "\""
+        │   ├── opening_loc: (123,0)-(123,1) = "\""
+        │   ├── content_loc: (123,1)-(123,14) = "\\x7 \\x23 \\x61"
+        │   ├── closing_loc: (123,14)-(123,15) = "\""
         │   └── unescaped: "\a # a"
-        ├── @ StringNode (location: (110,0)-(110,13))
+        ├── @ StringNode (location: (125,0)-(125,13))
         │   ├── flags: newline
-        │   ├── opening_loc: (110,0)-(110,1) = "\""
-        │   ├── content_loc: (110,1)-(110,12) = "\\7 \\43 \\141"
-        │   ├── closing_loc: (110,12)-(110,13) = "\""
+        │   ├── opening_loc: (125,0)-(125,1) = "\""
+        │   ├── content_loc: (125,1)-(125,12) = "\\7 \\43 \\141"
+        │   ├── closing_loc: (125,12)-(125,13) = "\""
         │   └── unescaped: "\a # a"
-        ├── @ StringNode (location: (112,0)-(112,17))
+        ├── @ StringNode (location: (127,0)-(127,17))
         │   ├── flags: newline, forced_utf8_encoding
-        │   ├── opening_loc: (112,0)-(112,1) = "\""
-        │   ├── content_loc: (112,1)-(112,16) = "ち\\xE3\\x81\\xFF"
-        │   ├── closing_loc: (112,16)-(112,17) = "\""
+        │   ├── opening_loc: (127,0)-(127,1) = "\""
+        │   ├── content_loc: (127,1)-(127,16) = "ち\\xE3\\x81\\xFF"
+        │   ├── closing_loc: (127,16)-(127,17) = "\""
         │   └── unescaped: "ち\xE3\x81\xFF"
-        ├── @ StringNode (location: (114,0)-(114,6))
+        ├── @ StringNode (location: (129,0)-(129,6))
         │   ├── flags: newline
-        │   ├── opening_loc: (114,0)-(114,2) = "%["
-        │   ├── content_loc: (114,2)-(114,5) = "abc"
-        │   ├── closing_loc: (114,5)-(114,6) = "]"
+        │   ├── opening_loc: (129,0)-(129,2) = "%["
+        │   ├── content_loc: (129,2)-(129,5) = "abc"
+        │   ├── closing_loc: (129,5)-(129,6) = "]"
         │   └── unescaped: "abc"
-        ├── @ StringNode (location: (116,0)-(116,6))
+        ├── @ StringNode (location: (131,0)-(131,6))
         │   ├── flags: newline
-        │   ├── opening_loc: (116,0)-(116,2) = "%("
-        │   ├── content_loc: (116,2)-(116,5) = "abc"
-        │   ├── closing_loc: (116,5)-(116,6) = ")"
+        │   ├── opening_loc: (131,0)-(131,2) = "%("
+        │   ├── content_loc: (131,2)-(131,5) = "abc"
+        │   ├── closing_loc: (131,5)-(131,6) = ")"
         │   └── unescaped: "abc"
-        ├── @ StringNode (location: (118,0)-(118,6))
+        ├── @ StringNode (location: (133,0)-(133,6))
         │   ├── flags: newline
-        │   ├── opening_loc: (118,0)-(118,2) = "%@"
-        │   ├── content_loc: (118,2)-(118,5) = "abc"
-        │   ├── closing_loc: (118,5)-(118,6) = "@"
+        │   ├── opening_loc: (133,0)-(133,2) = "%@"
+        │   ├── content_loc: (133,2)-(133,5) = "abc"
+        │   ├── closing_loc: (133,5)-(133,6) = "@"
         │   └── unescaped: "abc"
-        ├── @ StringNode (location: (120,0)-(120,6))
+        ├── @ StringNode (location: (135,0)-(135,6))
         │   ├── flags: newline
-        │   ├── opening_loc: (120,0)-(120,2) = "%$"
-        │   ├── content_loc: (120,2)-(120,5) = "abc"
-        │   ├── closing_loc: (120,5)-(120,6) = "$"
+        │   ├── opening_loc: (135,0)-(135,2) = "%$"
+        │   ├── content_loc: (135,2)-(135,5) = "abc"
+        │   ├── closing_loc: (135,5)-(135,6) = "$"
         │   └── unescaped: "abc"
-        ├── @ StringNode (location: (122,0)-(122,2))
+        ├── @ StringNode (location: (137,0)-(137,2))
         │   ├── flags: newline
-        │   ├── opening_loc: (122,0)-(122,1) = "?"
-        │   ├── content_loc: (122,1)-(122,2) = "a"
+        │   ├── opening_loc: (137,0)-(137,1) = "?"
+        │   ├── content_loc: (137,1)-(137,2) = "a"
         │   ├── closing_loc: ∅
         │   └── unescaped: "a"
-        ├── @ InterpolatedStringNode (location: (124,0)-(124,6))
+        ├── @ InterpolatedStringNode (location: (139,0)-(139,6))
         │   ├── flags: newline, static_literal
         │   ├── opening_loc: ∅
         │   ├── parts: (length: 2)
-        │   │   ├── @ StringNode (location: (124,0)-(124,2))
+        │   │   ├── @ StringNode (location: (139,0)-(139,2))
         │   │   │   ├── flags: static_literal, frozen
-        │   │   │   ├── opening_loc: (124,0)-(124,1) = "?"
-        │   │   │   ├── content_loc: (124,1)-(124,2) = "a"
+        │   │   │   ├── opening_loc: (139,0)-(139,1) = "?"
+        │   │   │   ├── content_loc: (139,1)-(139,2) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
-        │   │   └── @ StringNode (location: (124,3)-(124,6))
+        │   │   └── @ StringNode (location: (139,3)-(139,6))
         │   │       ├── flags: static_literal, frozen
-        │   │       ├── opening_loc: (124,3)-(124,4) = "\""
-        │   │       ├── content_loc: (124,4)-(124,5) = "a"
-        │   │       ├── closing_loc: (124,5)-(124,6) = "\""
+        │   │       ├── opening_loc: (139,3)-(139,4) = "\""
+        │   │       ├── content_loc: (139,4)-(139,5) = "a"
+        │   │       ├── closing_loc: (139,5)-(139,6) = "\""
         │   │       └── unescaped: "a"
         │   └── closing_loc: ∅
-        ├── @ StringNode (location: (126,0)-(126,7))
+        ├── @ StringNode (location: (141,0)-(141,7))
         │   ├── flags: newline
-        │   ├── opening_loc: (126,0)-(126,3) = "%Q{"
-        │   ├── content_loc: (126,3)-(126,6) = "abc"
-        │   ├── closing_loc: (126,6)-(126,7) = "}"
+        │   ├── opening_loc: (141,0)-(141,3) = "%Q{"
+        │   ├── content_loc: (141,3)-(141,6) = "abc"
+        │   ├── closing_loc: (141,6)-(141,7) = "}"
         │   └── unescaped: "abc"
-        ├── @ StringNode (location: (128,0)-(128,5))
+        ├── @ StringNode (location: (143,0)-(143,5))
         │   ├── flags: newline
-        │   ├── opening_loc: (128,0)-(128,2) = "%^"
-        │   ├── content_loc: (128,2)-(128,4) = "\#$"
-        │   ├── closing_loc: (128,4)-(128,5) = "^"
+        │   ├── opening_loc: (143,0)-(143,2) = "%^"
+        │   ├── content_loc: (143,2)-(143,4) = "\#$"
+        │   ├── closing_loc: (143,4)-(143,5) = "^"
         │   └── unescaped: "\#$"
-        ├── @ StringNode (location: (130,0)-(130,4))
+        ├── @ StringNode (location: (145,0)-(145,4))
         │   ├── flags: newline
-        │   ├── opening_loc: (130,0)-(130,2) = "%@"
-        │   ├── content_loc: (130,2)-(130,3) = "#"
-        │   ├── closing_loc: (130,3)-(130,4) = "@"
+        │   ├── opening_loc: (145,0)-(145,2) = "%@"
+        │   ├── content_loc: (145,2)-(145,3) = "#"
+        │   ├── closing_loc: (145,3)-(145,4) = "@"
         │   └── unescaped: "#"
-        └── @ InterpolatedStringNode (location: (132,0)-(132,15))
+        └── @ InterpolatedStringNode (location: (147,0)-(147,15))
             ├── flags: newline
-            ├── opening_loc: (132,0)-(132,1) = "\""
+            ├── opening_loc: (147,0)-(147,1) = "\""
             ├── parts: (length: 2)
-            │   ├── @ EmbeddedStatementsNode (location: (132,1)-(132,12))
+            │   ├── @ EmbeddedStatementsNode (location: (147,1)-(147,12))
             │   │   ├── flags: ∅
-            │   │   ├── opening_loc: (132,1)-(132,3) = "\#{"
+            │   │   ├── opening_loc: (147,1)-(147,3) = "\#{"
             │   │   ├── statements:
-            │   │   │   @ StatementsNode (location: (132,3)-(132,11))
+            │   │   │   @ StatementsNode (location: (147,3)-(147,11))
             │   │   │   ├── flags: ∅
             │   │   │   └── body: (length: 1)
-            │   │   │       └── @ InterpolatedStringNode (location: (132,3)-(132,11))
+            │   │   │       └── @ InterpolatedStringNode (location: (147,3)-(147,11))
             │   │   │           ├── flags: ∅
-            │   │   │           ├── opening_loc: (132,3)-(132,4) = "\""
+            │   │   │           ├── opening_loc: (147,3)-(147,4) = "\""
             │   │   │           ├── parts: (length: 2)
-            │   │   │           │   ├── @ EmbeddedStatementsNode (location: (132,4)-(132,8))
+            │   │   │           │   ├── @ EmbeddedStatementsNode (location: (147,4)-(147,8))
             │   │   │           │   │   ├── flags: ∅
-            │   │   │           │   │   ├── opening_loc: (132,4)-(132,6) = "\#{"
+            │   │   │           │   │   ├── opening_loc: (147,4)-(147,6) = "\#{"
             │   │   │           │   │   ├── statements:
-            │   │   │           │   │   │   @ StatementsNode (location: (132,6)-(132,7))
+            │   │   │           │   │   │   @ StatementsNode (location: (147,6)-(147,7))
             │   │   │           │   │   │   ├── flags: ∅
             │   │   │           │   │   │   └── body: (length: 1)
-            │   │   │           │   │   │       └── @ ConstantReadNode (location: (132,6)-(132,7))
+            │   │   │           │   │   │       └── @ ConstantReadNode (location: (147,6)-(147,7))
             │   │   │           │   │   │           ├── flags: ∅
             │   │   │           │   │   │           └── name: :B
-            │   │   │           │   │   └── closing_loc: (132,7)-(132,8) = "}"
-            │   │   │           │   └── @ StringNode (location: (132,8)-(132,10))
+            │   │   │           │   │   └── closing_loc: (147,7)-(147,8) = "}"
+            │   │   │           │   └── @ StringNode (location: (147,8)-(147,10))
             │   │   │           │       ├── flags: static_literal, frozen
             │   │   │           │       ├── opening_loc: ∅
-            │   │   │           │       ├── content_loc: (132,8)-(132,10) = " C"
+            │   │   │           │       ├── content_loc: (147,8)-(147,10) = " C"
             │   │   │           │       ├── closing_loc: ∅
             │   │   │           │       └── unescaped: " C"
-            │   │   │           └── closing_loc: (132,10)-(132,11) = "\""
-            │   │   └── closing_loc: (132,11)-(132,12) = "}"
-            │   └── @ StringNode (location: (132,12)-(132,14))
+            │   │   │           └── closing_loc: (147,10)-(147,11) = "\""
+            │   │   └── closing_loc: (147,11)-(147,12) = "}"
+            │   └── @ StringNode (location: (147,12)-(147,14))
             │       ├── flags: static_literal, frozen
             │       ├── opening_loc: ∅
-            │       ├── content_loc: (132,12)-(132,14) = " D"
+            │       ├── content_loc: (147,12)-(147,14) = " D"
             │       ├── closing_loc: ∅
             │       └── unescaped: " D"
-            └── closing_loc: (132,14)-(132,15) = "\""
+            └── closing_loc: (147,14)-(147,15) = "\""


### PR DESCRIPTION
Mostly around newlines and line continuation.
* percent arrays need special backslash handling in the ast
* Fix offset issue for heredocs with many line continuations (used wrong variable as index access)
* More refined rules on when to simplify string tokens
* Handle line continuations in squiggly heredocs
* Correctly dedent squiggly heredocs with interpolation
* Consider `':foo:` and `%s[foo]` to not be interpolation

Appologies for the amount of stuff

I sincerely hope this is the last of it for string handling. I'm not particularly proud of how this code evolved over the last PRs. It seems to handle a large chunk correctly and there are now an appropriate amount of tests so I might come back and try to clean it up a bit in the future.

https://github.com/ruby/prism/issues/2539 can now be closed. All reported problems are now resolved, with this PR removing the last wrong offense from RuboCop for `ruby-spec`.