### PR TITLE
Move remaining parser translator ast failures to know failures

### DIFF
--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -80,13 +80,16 @@ module Prism
       "seattlerb/heredoc_with_extra_carriage_returns_windows.txt",
       "seattlerb/heredoc_with_only_carriage_returns_windows.txt",
       "seattlerb/heredoc_with_only_carriage_returns.txt",
+
+      # https://github.com/whitequark/parser/issues/1026
+      # Regex with \c escape
+      "unescaping.txt",
+      "seattlerb/regexp_esc_C_slash.txt",
     ]
 
     # These files are either failing to parse or failing to translate, so we'll
     # skip them for now.
     skip_all = skip_incorrect | [
-      "unescaping.txt",
-      "seattlerb/regexp_esc_C_slash.txt",
     ]
 
     # Not sure why these files are failing on JRuby, but skipping them for now.


### PR DESCRIPTION
These are both affected by the same issue and I would argue that this is a parser bug. Either way, there is really no point to aligning these in my opinion.