### PR TITLE
Migrate Linux arm64 case from Travis CI to GitHub Actions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: jammy
 
 matrix:
   include:
-    - arch: arm64
     - arch: ppc64le
     - arch: s390x
   fast_finish: true


### PR DESCRIPTION
This PR fixes #3420. There are 2 commits in this PR.

The 1st commit is to add ubuntu-24.04-arm (arm64) cases in GitHub Actions. I added ubuntu-24.04-arm (arm64) cases to the build and build-debug jobs. Note that there is no runner name running the latest Ubuntu OS Arm64 version such as `ubuntu-latest-arm`.[1]

The 2nd commit is to drop the Linux arm64 case in Travis CI.

[1] https://github.com/orgs/community/discussions/148648#discussioncomment-11858287
