### PR TITLE
Add a custom builder class for the parser translator

### DIFF
--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -31,6 +31,11 @@ module Prism
         end
       end
 
+      # Create the parser with our custom builder class
+      def initialize(builder = Parser::Builder.new)
+        super
+      end
+
       Racc_debug_parser = false # :nodoc:
 
       def version # :nodoc:
@@ -313,6 +318,7 @@ module Prism
         end
       end
 
+      require_relative "parser/builder"
       require_relative "parser/compiler"
       require_relative "parser/lexer"
 

--- a/lib/prism/translation/parser/builder.rb
+++ b/lib/prism/translation/parser/builder.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Prism
+  module Translation
+    class Parser
+      # A builder that knows how to convert more modern Ruby syntax
+      # into whitequark/parser gem's syntax tree.
+      class Builder < ::Parser::Builders::Default
+
+      end
+    end
+  end
+end

--- a/prism.gemspec
+++ b/prism.gemspec
@@ -98,6 +98,7 @@ Gem::Specification.new do |spec|
     "lib/prism/translation/parser33.rb",
     "lib/prism/translation/parser34.rb",
     "lib/prism/translation/parser35.rb",
+    "lib/prism/translation/parser/builder.rb",
     "lib/prism/translation/parser/compiler.rb",
     "lib/prism/translation/parser/lexer.rb",
     "lib/prism/translation/ripper.rb",

--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -16,6 +16,7 @@ end
 
 # First, opt in to every AST feature.
 Parser::Builders::Default.modernize
+Prism::Translation::Parser::Builder.modernize
 
 # The parser gem rejects some strings that would most likely lead to errors
 # in consumers due to encoding problems. RuboCop however monkey-patches this


### PR DESCRIPTION
I want to be able to add new node types to the parser translator, for example `itblock`. The bulk of the work is already done by prism itself. In the `parser` builder, this would be a 5-line change at most but we don't control that here.

Instead, we can add our own builder and either overwrite the few methods we need, or just inline the complete builder. I'm not sure yet which would be better.

`rubocop-ast` uses its own custom builder for `parser`. For this to correctly work with RuboCop, it must explicitly choose to extend the prism builder and use it, same as it currently chooses to use a different parser when prism is used: https://github.com/rubocop/rubocop-ast/blob/02b8d0faeeebc3ba6b5284c9e66569bbae836941/lib/rubocop/ast/processed_source.rb#L330

I'd like to enforce that the builder for prism extends its custom one since it will lead to some pretty weird issues when it uses the one from `parser` otherwise. But first, I'd like to change `rubocop-ast` to make use of this.

------------

It does mean that further node changes when they happen will be decided by prism, and not `parser`. I also have no good idea yet how it would be tested since currently it only checks against a single ruby version. But these are things to think about after. I think this would definitely be the first step.

@koic, please let me know what you think about this PR and what I've written above.