### PR TITLE
Group dependabot updates in fewer PRs to minimize noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,18 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      single-pr:
+        patterns:
+          - "*"
   - package-ecosystem: 'maven'
     directory: '/java-wasm'
     schedule:
       interval: 'weekly'
+    groups:
+      single-pr:
+        patterns:
+          - "*"
   - package-ecosystem: 'bundler'
     directories:
       - '/gemfiles/2.7'
@@ -22,3 +30,7 @@ updates:
       - '/gemfiles/typecheck'
     schedule:
       interval: 'weekly'
+    groups:
+      single-pr:
+        patterns:
+          - "*"


### PR DESCRIPTION
* See #3449

I followed https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#prioritizing-meaningful-updates and https://slar.se/dependabots-dependency-grouping.html