### PR TITLE
Split assertion per expressions

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -6169,7 +6169,10 @@ pm_numbered_reference_read_node_number(pm_parser_t *parser, const pm_token_t *to
     const uint8_t *end = token->end;
 
     ptrdiff_t diff = end - start;
-    assert(diff > 0 && ((unsigned long) diff < SIZE_MAX));
+    assert(diff > 0);
+#if PTRDIFF_MAX > SIZE_MAX
+    assert(diff < (ptrdiff_t) SIZE_MAX);
+#endif
     size_t length = (size_t) diff;
 
     char *digits = xcalloc(length + 1, sizeof(char));


### PR DESCRIPTION
Expressions joined with `&&` are better asserted separately, so that it is clear from the failure message which expression is false.

Also, `unsigned long` may not be enough for `ptrdiff_t`, e.g., Windows.
Saying that `ptrdiff_t` can be larger than `SIZE_MAX` means that `PTRDIFF_MAX` is larger than `SIZE_MAX` and `ptrdiff_t` is sufficient to represent `SIZE_MAX`, otherwise if `PTRDIFF_MAX` is smaller than `SIZE_MAX`, `diff` will always be smaller than `SIZE_MAX` as well.
`diff` could be equal to `SIZE_MAX` only if `PTRDIFF_MAX` is equal to `SIZE_MAX` and these assertions would pass, but I don't think there is any platform where that is the case.