### PR TITLE
Allow xcalloc() to return NULL when size is 0 for portability

### DIFF
--- a/src/util/pm_constant_pool.c
+++ b/src/util/pm_constant_pool.c
@@ -15,8 +15,12 @@ pm_constant_id_list_init(pm_constant_id_list_t *list) {
  */
 void
 pm_constant_id_list_init_capacity(pm_constant_id_list_t *list, size_t capacity) {
-    list->ids = xcalloc(capacity, sizeof(pm_constant_id_t));
-    if (list->ids == NULL) abort();
+    if (capacity) {
+        list->ids = xcalloc(capacity, sizeof(pm_constant_id_t));
+        if (list->ids == NULL) abort();
+    } else {
+        list->ids = NULL;
+    }
 
     list->size = 0;
     list->capacity = capacity;


### PR DESCRIPTION
According to the calloc(3) man page, when nmemb or size is 0, `calloc()` can either return NULL or a unique pointer that can be passed to free(): https://manpages.org/calloc/3

While gcc (13.3.0) and clang (15.0.7), in my environment, return *a unique pointer* in this case, mruby's `mrb_calloc` returns *NULL*.
See https://github.com/mruby/mruby/blob/3.3.0/src/gc.c#L253

Since `pm_constant_pool_init()` is commonly called with capacity=0 during normal operation of Prism, `xcalloc()` needs to handle NULL returns to integrate with mruby.

Per free()'s and realloc()'s specifications, passing a NULL pointer is a valid operation, so this change should be safe.