### PR TITLE
[rust] add an API for accessing magic comments

### DIFF
--- a/rust/ruby-prism-sys/build/main.rs
+++ b/rust/ruby-prism-sys/build/main.rs
@@ -117,6 +117,7 @@ fn generate_bindings(ruby_include_path: &Path) -> bindgen::Bindings {
         .allowlist_type("pm_comment_t")
         .allowlist_type("pm_diagnostic_t")
         .allowlist_type("pm_list_t")
+        .allowlist_type("pm_magic_comment_t")
         .allowlist_type("pm_node_t")
         .allowlist_type("pm_node_type")
         .allowlist_type("pm_pack_size")


### PR DESCRIPTION
This is useful, and easier than scanning through the entire comments list.