### PR TITLE
Fix infinite loop in error recovery

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -13949,6 +13949,15 @@ parse_statements(pm_parser_t *parser, pm_context_t context, uint16_t depth) {
         if (PM_NODE_TYPE_P(node, PM_MISSING_NODE)) {
             parser_lex(parser);
 
+            // If we are at the end of the file, then we need to stop parsing
+            // the statements entirely at this point. Mark the parser as
+            // recovering, as we know that EOF closes the top-level context, and
+            // then break out of the loop.
+            if (match1(parser, PM_TOKEN_EOF)) {
+                parser->recovering = true;
+                break;
+            }
+
             while (accept2(parser, PM_TOKEN_NEWLINE, PM_TOKEN_SEMICOLON));
             if (context_terminator(context, &parser->current)) break;
         } else if (!accept2(parser, PM_TOKEN_NEWLINE, PM_TOKEN_EOF)) {

--- a/test/prism/errors/block_beginning_with_brace_and_ending_with_end.txt
+++ b/test/prism/errors/block_beginning_with_brace_and_ending_with_end.txt
@@ -1,6 +1,5 @@
 x.each { x end
            ^~~ unexpected 'end', expecting end-of-input
            ^~~ unexpected 'end', ignoring it
-              ^ unexpected end-of-input, assuming it is closing the parent top level context
               ^ expected a block beginning with `{` to end with `}`
 


### PR DESCRIPTION
When recovering from a depth error that occurs at the end of the file, we need to break out of parsing statements.

Fixes [Bug #21114]