### PR TITLE
Fix merge mishap

### DIFF
--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -31,11 +31,6 @@ module Prism
         end
       end
 
-      # Create the parser with our custom builder class
-      def initialize(builder = Parser::Builder.new)
-        super
-      end
-
       Racc_debug_parser = false # :nodoc:
 
       # By using the `:parser` keyword argument, you can translate in a way that is compatible with
@@ -61,7 +56,7 @@ module Prism
       # In an object passed to the `:parser` keyword argument, the `parse` and `parse_lex` methods
       # should be implemented as needed.
       #
-      def initialize(builder = ::Parser::Builders::Default.new, parser: Prism)
+      def initialize(builder = Prism::Translation::Parser::Builder.new, parser: Prism)
         @parser = parser
 
         super(builder)


### PR DESCRIPTION
Caused by https://github.com/ruby/prism/pull/3478 and https://github.com/ruby/prism/pull/3443

I also made the builder reference more explicit to clearly distinquish between `::Parser` and `Prism::Translation::Parser`