### PR TITLE
Restore a comment for `Prism::Translation::Parser#initialize`

### DIFF
--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -33,6 +33,8 @@ module Prism
 
       Racc_debug_parser = false # :nodoc:
 
+      # The `builder` argument is used to create the parser using our custom builder class by default.
+      #
       # By using the `:parser` keyword argument, you can translate in a way that is compatible with
       # the Parser gem using any parser.
       #


### PR DESCRIPTION
This restores the missing method comments in https://github.com/ruby/prism/pull/3479.