### PR TITLE
Trivial parser translator optimizations

### DIFF
--- a/lib/prism/translation/parser/lexer.rb
+++ b/lib/prism/translation/parser/lexer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "set"
 require "strscan"
 require_relative "../../polyfill/append_as_bytes"
 
@@ -9,16 +10,17 @@ module Prism
       # Accepts a list of prism tokens and converts them into the expected
       # format for the parser gem.
       class Lexer
+        # These tokens are always skipped
+        TYPES_ALWAYS_SKIP = %i[IGNORED_NEWLINE __END__ EOF].to_set
+        private_constant :TYPES_ALWAYS_SKIP
+
         # The direct translating of types between the two lexers.
         TYPES = {
           # These tokens should never appear in the output of the lexer.
-          EOF: nil,
           MISSING: nil,
           NOT_PROVIDED: nil,
-          IGNORED_NEWLINE: nil,
           EMBDOC_END: nil,
           EMBDOC_LINE: nil,
-          __END__: nil,
 
           # These tokens have more or less direct mappings.
           AMPERSAND: :tAMPER2,
@@ -194,18 +196,18 @@ module Prism
         #
         # NOTE: In edge cases like `-> (foo = -> (bar) {}) do end`, please note that `kDO` is still returned
         # instead of `kDO_LAMBDA`, which is expected: https://github.com/ruby/prism/pull/3046
-        LAMBDA_TOKEN_TYPES = [:kDO_LAMBDA, :tLAMBDA, :tLAMBEG]
+        LAMBDA_TOKEN_TYPES = [:kDO_LAMBDA, :tLAMBDA, :tLAMBEG].to_set
 
         # The `PARENTHESIS_LEFT` token in Prism is classified as either `tLPAREN` or `tLPAREN2` in the Parser gem.
         # The following token types are listed as those classified as `tLPAREN`.
         LPAREN_CONVERSION_TOKEN_TYPES = [
           :kBREAK, :kCASE, :tDIVIDE, :kFOR, :kIF, :kNEXT, :kRETURN, :kUNTIL, :kWHILE, :tAMPER, :tANDOP, :tBANG, :tCOMMA, :tDOT2, :tDOT3,
           :tEQL, :tLPAREN, :tLPAREN2, :tLPAREN_ARG, :tLSHFT, :tNL, :tOP_ASGN, :tOROP, :tPIPE, :tSEMI, :tSTRING_DBEG, :tUMINUS, :tUPLUS
-        ]
+        ].to_set
 
         # Types of tokens that are allowed to continue a method call with comments in-between.
         # For these, the parser gem doesn't emit a newline token after the last comment.
-        COMMENT_CONTINUATION_TYPES = [:COMMENT, :AMPERSAND_DOT, :DOT]
+        COMMENT_CONTINUATION_TYPES = [:COMMENT, :AMPERSAND_DOT, :DOT].to_set
         private_constant :COMMENT_CONTINUATION_TYPES
 
         # Heredocs are complex and require us to keep track of a bit of info to refer to later
@@ -252,7 +254,7 @@ module Prism
           while index < length
             token, state = lexed[index]
             index += 1
-            next if %i[IGNORED_NEWLINE __END__ EOF].include?(token.type)
+            next if TYPES_ALWAYS_SKIP.include?(token.type)
 
             type = TYPES.fetch(token.type)
             value = token.value
@@ -344,7 +346,7 @@ module Prism
             when :tSTRING_BEG
               next_token = lexed[index][0]
               next_next_token = lexed[index + 1][0]
-              basic_quotes = ["\"", "'"].include?(value)
+              basic_quotes = value == '"' || value == "'"
 
               if basic_quotes && next_token&.type == :STRING_END
                 next_location = token.location.join(next_token.location)

--- a/lib/prism/translation/parser/lexer.rb
+++ b/lib/prism/translation/parser/lexer.rb
@@ -262,10 +262,11 @@ module Prism
 
             case type
             when :kDO
-              types = tokens.map(&:first)
-              nearest_lambda_token_type = types.reverse.find { |type| LAMBDA_TOKEN_TYPES.include?(type) }
+              nearest_lambda_token = tokens.reverse_each.find do |token|
+                LAMBDA_TOKEN_TYPES.include?(token.first)
+              end
 
-              if nearest_lambda_token_type == :tLAMBDA
+              if nearest_lambda_token&.first == :tLAMBDA
                 type = :kDO_LAMBDA
               end
             when :tCHARACTER


### PR DESCRIPTION
I ran it over the RuboCop codebase. Here are some numbers:

Before:
```
 hyperfine -w 2 -r 10 "bundle exec ruby test.rb"
Benchmark 1: bundle exec ruby test.rb
  Time (mean ± σ):     24.055 s ±  0.410 s    [User: 23.661 s, System: 0.305 s]
  Range (min … max):   23.464 s … 24.610 s    10 runs
```

After:
```
$ hyperfine -w 2 -r 10 "bundle exec ruby test.rb"
Benchmark 1: bundle exec ruby test.rb
  Time (mean ± σ):     21.464 s ±  0.447 s    [User: 21.156 s, System: 0.220 s]
  Range (min … max):   20.888 s … 22.240 s    10 runs
```

So, about 11% faster just with this. The majority of the time is still spent translating, only ~10% is actually spend by prism parsing/lexing it.

Benchmark file:
```rb
require "prism"
require "prism/translation/parser"


Dir.glob("../rubocop/**/*.rb").each do
  buffer = Parser::Source::Buffer.new(it, 1)
  buffer.source = File.read(it)
  Prism::Translation::Parser33.new.tokenize(buffer)
end
```