### PR TITLE
 Dynamically register events to dispatch

### DIFF
--- a/sig/prism/dispatcher.rbs
+++ b/sig/prism/dispatcher.rbs
@@ -4,8 +4,11 @@ module Prism
 
     def initialize: () -> void
     def register: (untyped, *Symbol) -> void
+    def register_public_methods: (untyped) -> void
     def dispatch: (Prism::node) -> void
     def dispatch_once: (Prism::node) -> void
+
+    private def register_events: (untyped, Array[Symbol]) -> void
 
     class DispatchOnce < Visitor
       attr_reader listeners: Hash[Symbol, Array[untyped]]

--- a/templates/lib/prism/dispatcher.rb.erb
+++ b/templates/lib/prism/dispatcher.rb.erb
@@ -44,6 +44,19 @@ module Prism
     #
     # def register: (Listener, *Symbol) -> void
     def register(listener, *events)
+      register_events(listener, events)
+    end
+
+    # Register all public methods of a listener that match the pattern
+    # `on_<node_name>_(enter|leave)`.
+    #
+    # def register_public_methods: (Listener) -> void
+    def register_public_methods(listener)
+      register_events(listener, listener.public_methods(false).grep(/\Aon_.+_(?:enter|leave)\z/))
+    end
+
+    # Register a listener for the given events.
+    private def register_events(listener, events)
       events.each { |event| (listeners[event] ||= []) << listener }
     end
 


### PR DESCRIPTION
> [!NOTE]
> This draft PR is a companion to https://github.com/Shopify/ruby-lsp/pull/3291, which proposes this approach. Tests and other things have been omitted for now in the interest of getting feedback on the approach first, and will be added if we decide to move forward.

Instead of requiring the consumer to provide a list of all events which they wish to handle, we can give them to option of dynamically detecting them, by scanning the listener's public methods.

This approach is similar to that used by Minitest (scanning for `test_` methods) and Rails generators (running all public methods in the order they are defined).

While this is slower than specifying a hard coded list, the penalty is only during registration. There is no change the the behaviour of dispatching the events. It is also a non-breaking change, so consumers can continue specifying each event if desired.