### PR TITLE
Ensure backwards compatibility with the custom parser builder

### DIFF
--- a/lib/prism/translation/parser/compiler.rb
+++ b/lib/prism/translation/parser/compiler.rb
@@ -1157,7 +1157,17 @@ module Prism
         # -> { it }
         # ^^^^^^^^^
         def visit_it_parameters_node(node)
-          builder.itarg
+          # FIXME: The builder _should_ always be a subclass of the prism builder.
+          # Currently RuboCop passes in its own builder that always inherits from the
+          # parser builder (which is lacking the `itarg` method). Once rubocop-ast
+          # opts in to use the custom prism builder a warning can be emitted when
+          # it is not the expected class, and eventually raise.
+          # https://github.com/rubocop/rubocop-ast/pull/354
+          if builder.is_a?(Translation::Parser::Builder)
+            builder.itarg
+          else
+            builder.args(nil, [], nil, false)
+          end
         end
 
         # foo(bar: baz)


### PR DESCRIPTION
Temoprary backwards-compat code so that current users don't break. I noticed this by accident while doing some testing

Eventually the `Translation::Parser` initializer should asser that the correct class is passed in. I would start with a warning after https://github.com/rubocop/rubocop-ast/pull/354 is merged and released.

cc @koic 