### PR TITLE
Add a multiple statements flag to parentheses

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -719,6 +719,11 @@ flags:
       - name: REPEATED_PARAMETER
         comment: "a parameter name that has been repeated in the method signature"
     comment: Flags for parameter nodes.
+  - name: ParenthesesNodeFlags
+    values:
+      - name: MULTIPLE_STATEMENTS
+        comment: "parentheses that contain multiple potentially void statements"
+    comment: Flags for parentheses nodes.
   - name: RangeFlags
     values:
       - name: EXCLUDE_END
@@ -3851,6 +3856,7 @@ nodes:
                 ^^^^^^^
           end
   - name: ParenthesesNode
+    flags: ParenthesesNodeFlags
     fields:
       - name: body
         type: node?

--- a/src/prism.c
+++ b/src/prism.c
@@ -6406,12 +6406,13 @@ pm_program_node_create(pm_parser_t *parser, pm_constant_id_list_t *locals, pm_st
  * Allocate and initialize new ParenthesesNode node.
  */
 static pm_parentheses_node_t *
-pm_parentheses_node_create(pm_parser_t *parser, const pm_token_t *opening, pm_node_t *body, const pm_token_t *closing) {
+pm_parentheses_node_create(pm_parser_t *parser, const pm_token_t *opening, pm_node_t *body, const pm_token_t *closing, pm_node_flags_t flags) {
     pm_parentheses_node_t *node = PM_NODE_ALLOC(parser, pm_parentheses_node_t);
 
     *node = (pm_parentheses_node_t) {
         {
             .type = PM_PARENTHESES_NODE,
+            .flags = flags,
             .node_id = PM_NODE_IDENTIFY(parser),
             .location = {
                 .start = opening->start,
@@ -17551,7 +17552,7 @@ parse_pattern_primitives(pm_parser_t *parser, pm_constant_id_list_t *captures, p
                 pm_node_t *body = parse_pattern(parser, captures, PM_PARSE_PATTERN_SINGLE, PM_ERR_PATTERN_EXPRESSION_AFTER_PAREN, (uint16_t) (depth + 1));
                 accept1(parser, PM_TOKEN_NEWLINE);
                 expect1(parser, PM_TOKEN_PARENTHESIS_RIGHT, PM_ERR_PATTERN_TERM_PAREN);
-                pm_node_t *right = (pm_node_t *) pm_parentheses_node_create(parser, &opening, body, &parser->previous);
+                pm_node_t *right = (pm_node_t *) pm_parentheses_node_create(parser, &opening, body, &parser->previous, 0);
 
                 if (node == NULL) {
                     node = right;
@@ -18174,12 +18175,19 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
         case PM_TOKEN_PARENTHESIS_LEFT:
         case PM_TOKEN_PARENTHESIS_LEFT_PARENTHESES: {
             pm_token_t opening = parser->current;
+            pm_node_flags_t flags = 0;
 
             pm_node_list_t current_block_exits = { 0 };
             pm_node_list_t *previous_block_exits = push_block_exits(parser, &current_block_exits);
 
             parser_lex(parser);
-            while (accept2(parser, PM_TOKEN_SEMICOLON, PM_TOKEN_NEWLINE));
+            while (true) {
+                if (accept1(parser, PM_TOKEN_SEMICOLON)) {
+                    flags |= PM_PARENTHESES_NODE_FLAGS_MULTIPLE_STATEMENTS;
+                } else if (!accept1(parser, PM_TOKEN_NEWLINE)) {
+                    break;
+                }
+            }
 
             // If this is the end of the file or we match a right parenthesis, then
             // we have an empty parentheses node, and we can immediately return.
@@ -18189,7 +18197,7 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
                 pop_block_exits(parser, previous_block_exits);
                 pm_node_list_free(&current_block_exits);
 
-                return (pm_node_t *) pm_parentheses_node_create(parser, &opening, NULL, &parser->previous);
+                return (pm_node_t *) pm_parentheses_node_create(parser, &opening, NULL, &parser->previous, flags);
             }
 
             // Otherwise, we're going to parse the first statement in the list
@@ -18202,9 +18210,23 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
             // Determine if this statement is followed by a terminator. In the
             // case of a single statement, this is fine. But in the case of
             // multiple statements it's required.
-            bool terminator_found = accept2(parser, PM_TOKEN_NEWLINE, PM_TOKEN_SEMICOLON);
+            bool terminator_found = false;
+
+            if (accept1(parser, PM_TOKEN_SEMICOLON)) {
+                terminator_found = true;
+                flags |= PM_PARENTHESES_NODE_FLAGS_MULTIPLE_STATEMENTS;
+            } else if (accept1(parser, PM_TOKEN_NEWLINE)) {
+                terminator_found = true;
+            }
+
             if (terminator_found) {
-                while (accept2(parser, PM_TOKEN_NEWLINE, PM_TOKEN_SEMICOLON));
+                while (true) {
+                    if (accept1(parser, PM_TOKEN_SEMICOLON)) {
+                        flags |= PM_PARENTHESES_NODE_FLAGS_MULTIPLE_STATEMENTS;
+                    } else if (!accept1(parser, PM_TOKEN_NEWLINE)) {
+                        break;
+                    }
+                }
             }
 
             // If we hit a right parenthesis, then we're done parsing the
@@ -18276,13 +18298,15 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
                 pm_statements_node_t *statements = pm_statements_node_create(parser);
                 pm_statements_node_body_append(parser, statements, statement, true);
 
-                return (pm_node_t *) pm_parentheses_node_create(parser, &opening, (pm_node_t *) statements, &parser->previous);
+                return (pm_node_t *) pm_parentheses_node_create(parser, &opening, (pm_node_t *) statements, &parser->previous, flags);
             }
 
             // If we have more than one statement in the set of parentheses,
             // then we are going to parse all of them as a list of statements.
             // We'll do that here.
             context_push(parser, PM_CONTEXT_PARENS);
+            flags |= PM_PARENTHESES_NODE_FLAGS_MULTIPLE_STATEMENTS;
+
             pm_statements_node_t *statements = pm_statements_node_create(parser);
             pm_statements_node_body_append(parser, statements, statement, true);
 
@@ -18359,7 +18383,7 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
             pm_node_list_free(&current_block_exits);
 
             pm_void_statements_check(parser, statements, true);
-            return (pm_node_t *) pm_parentheses_node_create(parser, &opening, (pm_node_t *) statements, &parser->previous);
+            return (pm_node_t *) pm_parentheses_node_create(parser, &opening, (pm_node_t *) statements, &parser->previous, flags);
         }
         case PM_TOKEN_BRACE_LEFT: {
             // If we were passed a current_hash_keys via the parser, then that
@@ -19405,7 +19429,7 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
                     expect2(parser, PM_TOKEN_DOT, PM_TOKEN_COLON_COLON, PM_ERR_DEF_RECEIVER_TERM);
 
                     operator = parser->previous;
-                    receiver = (pm_node_t *) pm_parentheses_node_create(parser, &lparen, expression, &rparen);
+                    receiver = (pm_node_t *) pm_parentheses_node_create(parser, &lparen, expression, &rparen, 0);
 
                     // To push `PM_CONTEXT_DEF_PARAMS` again is for the same
                     // reason as described the above.
@@ -19738,7 +19762,7 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
                 pm_token_t lparen = parser->previous;
 
                 if (accept1(parser, PM_TOKEN_PARENTHESIS_RIGHT)) {
-                    receiver = (pm_node_t *) pm_parentheses_node_create(parser, &lparen, NULL, &parser->previous);
+                    receiver = (pm_node_t *) pm_parentheses_node_create(parser, &lparen, NULL, &parser->previous, 0);
                 } else {
                     arguments.opening_loc = PM_LOCATION_TOKEN_VALUE(&lparen);
                     receiver = parse_expression(parser, PM_BINDING_POWER_COMPOSITION, true, false, PM_ERR_NOT_EXPRESSION, (uint16_t) (depth + 1));

--- a/test/prism/snapshots/break.txt
+++ b/test/prism/snapshots/break.txt
@@ -257,7 +257,7 @@
         │       │           │   ├── flags: ∅
         │       │           │   └── arguments: (length: 1)
         │       │           │       └── @ ParenthesesNode (location: (14,11)-(17,1))
-        │       │           │           ├── flags: ∅
+        │       │           │           ├── flags: multiple_statements
         │       │           │           ├── body:
         │       │           │           │   @ StatementsNode (location: (15,2)-(16,3))
         │       │           │           │   ├── flags: ∅

--- a/test/prism/snapshots/methods.txt
+++ b/test/prism/snapshots/methods.txt
@@ -2206,7 +2206,7 @@
         │   │   │       ├── operator_loc: (183,12)-(183,13) = "="
         │   │   │       └── value:
         │   │   │           @ ParenthesesNode (location: (183,14)-(183,37))
-        │   │   │           ├── flags: ∅
+        │   │   │           ├── flags: multiple_statements
         │   │   │           ├── body:
         │   │   │           │   @ StatementsNode (location: (183,15)-(183,36))
         │   │   │           │   ├── flags: ∅

--- a/test/prism/snapshots/next.txt
+++ b/test/prism/snapshots/next.txt
@@ -257,7 +257,7 @@
         │       │           │   ├── flags: ∅
         │       │           │   └── arguments: (length: 1)
         │       │           │       └── @ ParenthesesNode (location: (14,10)-(17,1))
-        │       │           │           ├── flags: ∅
+        │       │           │           ├── flags: multiple_statements
         │       │           │           ├── body:
         │       │           │           │   @ StatementsNode (location: (15,2)-(16,3))
         │       │           │           │   ├── flags: ∅

--- a/test/prism/snapshots/nils.txt
+++ b/test/prism/snapshots/nils.txt
@@ -13,7 +13,7 @@
         │   ├── opening_loc: (3,0)-(3,1) = "("
         │   └── closing_loc: (3,1)-(3,2) = ")"
         ├── @ ParenthesesNode (location: (5,0)-(8,1))
-        │   ├── flags: newline
+        │   ├── flags: newline, multiple_statements
         │   ├── body: ∅
         │   ├── opening_loc: (5,0)-(5,1) = "("
         │   └── closing_loc: (8,0)-(8,1) = ")"

--- a/test/prism/snapshots/return.txt
+++ b/test/prism/snapshots/return.txt
@@ -134,7 +134,7 @@
         │       ├── flags: ∅
         │       └── arguments: (length: 1)
         │           └── @ ParenthesesNode (location: (16,6)-(19,1))
-        │               ├── flags: ∅
+        │               ├── flags: multiple_statements
         │               ├── body:
         │               │   @ StatementsNode (location: (17,2)-(18,3))
         │               │   ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/def.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/def.txt
@@ -590,7 +590,7 @@
         │   │   │       ├── operator_loc: (63,12)-(63,13) = "="
         │   │   │       └── value:
         │   │   │           @ ParenthesesNode (location: (63,14)-(63,24))
-        │   │   │           ├── flags: ∅
+        │   │   │           ├── flags: multiple_statements
         │   │   │           ├── body:
         │   │   │           │   @ StatementsNode (location: (63,15)-(63,23))
         │   │   │           │   ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/send.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/send.txt
@@ -177,7 +177,7 @@
         │   │   ├── flags: ∅
         │   │   ├── predicate:
         │   │   │   @ ParenthesesNode (location: (16,5)-(17,10))
-        │   │   │   ├── flags: ∅
+        │   │   │   ├── flags: multiple_statements
         │   │   │   ├── body:
         │   │   │   │   @ StatementsNode (location: (16,6)-(17,9))
         │   │   │   │   ├── flags: ∅

--- a/test/prism/snapshots/variables.txt
+++ b/test/prism/snapshots/variables.txt
@@ -383,7 +383,7 @@
         │   │   └── closing_loc: ∅
         │   └── operator_loc: (43,4)-(43,5) = "="
         ├── @ ParenthesesNode (location: (45,0)-(45,9))
-        │   ├── flags: newline
+        │   ├── flags: newline, multiple_statements
         │   ├── body:
         │   │   @ StatementsNode (location: (45,1)-(45,8))
         │   │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/cond_begin_masgn.txt
+++ b/test/prism/snapshots/whitequark/cond_begin_masgn.txt
@@ -10,7 +10,7 @@
             ├── if_keyword_loc: (1,0)-(1,2) = "if"
             ├── predicate:
             │   @ ParenthesesNode (location: (1,3)-(1,20))
-            │   ├── flags: ∅
+            │   ├── flags: multiple_statements
             │   ├── body:
             │   │   @ StatementsNode (location: (1,4)-(1,19))
             │   │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/ruby_bug_19281.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_19281.txt
@@ -27,7 +27,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 3)
         │   │       ├── @ ParenthesesNode (location: (1,4)-(1,9))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: multiple_statements
         │   │       │   ├── body:
         │   │       │   │   @ StatementsNode (location: (1,5)-(1,8))
         │   │       │   │   ├── flags: ∅
@@ -86,7 +86,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 3)
         │   │       ├── @ ParenthesesNode (location: (3,4)-(3,7))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: multiple_statements
         │   │       │   ├── body: ∅
         │   │       │   ├── opening_loc: (3,4)-(3,5) = "("
         │   │       │   └── closing_loc: (3,6)-(3,7) = ")"
@@ -114,7 +114,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 3)
         │   │       ├── @ ParenthesesNode (location: (5,2)-(5,7))
-        │   │       │   ├── flags: ∅
+        │   │       │   ├── flags: multiple_statements
         │   │       │   ├── body:
         │   │       │   │   @ StatementsNode (location: (5,3)-(5,6))
         │   │       │   │   ├── flags: ∅
@@ -163,7 +163,7 @@
             │   ├── flags: ∅
             │   └── arguments: (length: 3)
             │       ├── @ ParenthesesNode (location: (7,2)-(7,5))
-            │       │   ├── flags: ∅
+            │       │   ├── flags: multiple_statements
             │       │   ├── body: ∅
             │       │   ├── opening_loc: (7,2)-(7,3) = "("
             │       │   └── closing_loc: (7,4)-(7,5) = ")"


### PR DESCRIPTION
This can get triggered even if the list of statements only contains a single statement. This is necessary to properly support compiling

```ruby
defined? (;a)
defined? (a;)
```

as "expression". Previously these were parsed as statements lists with single statements in them.