### PR TITLE
Warn when the parser translator receives an incompatible builder class

### DIFF
--- a/lib/prism.rb
+++ b/lib/prism.rb
@@ -68,6 +68,7 @@ module Prism
 end
 
 require_relative "prism/polyfill/byteindex"
+require_relative "prism/polyfill/warn"
 require_relative "prism/node"
 require_relative "prism/node_ext"
 require_relative "prism/parse_result"

--- a/lib/prism/node_ext.rb
+++ b/lib/prism/node_ext.rb
@@ -9,7 +9,7 @@ module Prism
       location = location[0].label if location
       suggest = replacements.map { |replacement| "#{self.class}##{replacement}" }
 
-      warn(<<~MSG, category: :deprecated)
+      warn(<<~MSG)
         [deprecation]: #{self.class}##{location} is deprecated and will be \
         removed in the next major version. Use #{suggest.join("/")} instead.
         #{(caller(1, 3) || []).join("\n")}

--- a/lib/prism/node_ext.rb
+++ b/lib/prism/node_ext.rb
@@ -9,7 +9,7 @@ module Prism
       location = location[0].label if location
       suggest = replacements.map { |replacement| "#{self.class}##{replacement}" }
 
-      warn(<<~MSG)
+      warn(<<~MSG, uplevel: 1, category: :deprecated)
         [deprecation]: #{self.class}##{location} is deprecated and will be \
         removed in the next major version. Use #{suggest.join("/")} instead.
         #{(caller(1, 3) || []).join("\n")}

--- a/lib/prism/polyfill/warn.rb
+++ b/lib/prism/polyfill/warn.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Polyfill for Kernel#warn with the category parameter. Not all Ruby engines
+# have Method#parameters implemented, so we check the arity instead if
+# necessary.
+if (method = Kernel.instance_method(:warn)).respond_to?(:parameters) ? method.parameters.none? { |_, name| name == :category } : (method.arity == -1)
+  Kernel.prepend(
+    Module.new {
+      def warn(*msgs, uplevel: nil, category: nil) # :nodoc:
+        uplevel =
+          case uplevel
+          when nil
+            1
+          when Integer
+            uplevel + 1
+          else
+            uplevel.to_int + 1
+          end
+
+        super(*msgs, uplevel: uplevel)
+      end
+    }
+  )
+
+  Object.prepend(
+    Module.new {
+      def warn(*msgs, uplevel: nil, category: nil) # :nodoc:
+        uplevel =
+          case uplevel
+          when nil
+            1
+          when Integer
+            uplevel + 1
+          else
+            uplevel.to_int + 1
+          end
+
+        super(*msgs, uplevel: uplevel)
+      end
+    }
+  )
+end

--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -60,7 +60,7 @@ module Prism
       #
       def initialize(builder = Prism::Translation::Parser::Builder.new, parser: Prism)
         if !builder.is_a?(Prism::Translation::Parser::Builder)
-          warn(<<~MSG, uplevel: 1)
+          warn(<<~MSG, uplevel: 1, category: :deprecated)
             [deprecation]: The builder passed to `Prism::Translation::Parser.new` is not a \
             `Prism::Translation::Parser::Builder` subclass. This will raise in the next major version.
           MSG

--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -59,6 +59,12 @@ module Prism
       # should be implemented as needed.
       #
       def initialize(builder = Prism::Translation::Parser::Builder.new, parser: Prism)
+        if !builder.is_a?(Prism::Translation::Parser::Builder)
+          warn(<<~MSG, uplevel: 1)
+            [deprecation]: The builder passed to `Prism::Translation::Parser.new` is not a \
+            `Prism::Translation::Parser::Builder` subclass. This will raise in the next major version.
+          MSG
+        end
         @parser = parser
 
         super(builder)

--- a/prism.gemspec
+++ b/prism.gemspec
@@ -89,6 +89,7 @@ Gem::Specification.new do |spec|
     "lib/prism/polyfill/append_as_bytes.rb",
     "lib/prism/polyfill/byteindex.rb",
     "lib/prism/polyfill/unpack1.rb",
+    "lib/prism/polyfill/warn.rb",
     "lib/prism/reflection.rb",
     "lib/prism/relocation.rb",
     "lib/prism/serialize.rb",

--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -145,6 +145,16 @@ module Prism
       end
     end
 
+    def test_non_prism_builder_class_deprecated
+      warnings = capture_warnings { Prism::Translation::Parser33.new(Parser::Builders::Default.new) }
+
+      assert_include(warnings, "#{__FILE__}:#{__LINE__ - 2}")
+      assert_include(warnings, "is not a `Prism::Translation::Parser::Builder` subclass")
+
+      warnings = capture_warnings { Prism::Translation::Parser33.new }
+      assert_empty(warnings)
+    end
+
     def test_it_block_parameter_syntax
       it_fixture_path = Pathname(__dir__).join("../../../test/prism/fixtures/it.txt")
 

--- a/test/prism/test_helper.rb
+++ b/test/prism/test_helper.rb
@@ -314,15 +314,16 @@ module Prism
       end
     end
 
-    def ignore_warnings
-      previous = $VERBOSE
-      $VERBOSE = nil
+    def capture_warnings
+      $stderr = StringIO.new
+      yield
+      $stderr.string
+    ensure
+      $stderr = STDERR
+    end
 
-      begin
-        yield
-      ensure
-        $VERBOSE = previous
-      end
+    def ignore_warnings
+      capture_warnings { return yield }
     end
   end
 end


### PR DESCRIPTION
In https://github.com/ruby/prism/pull/3494 I added a bit of code so that using the new builder doesn't break stuff. This code can be dropped when it is enforced that builder is _always_ the correct subclass (and makes future issues like that unlikely).