### PR TITLE
Enforce a minimum `parser` version for the parser translator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.0)
+    parser (3.3.7.2)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/2.7/Gemfile.lock
+++ b/gemfiles/2.7/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   specs:
     ast (2.4.2)
     onigmo (0.1.0)
-    parser (3.3.7.1)
+    parser (3.3.7.2)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/3.0/Gemfile.lock
+++ b/gemfiles/3.0/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.1)
+    parser (3.3.7.2)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.4)

--- a/gemfiles/3.1/Gemfile.lock
+++ b/gemfiles/3.1/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.1)
+    parser (3.3.7.2)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/3.2/Gemfile.lock
+++ b/gemfiles/3.2/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.1)
+    parser (3.3.7.2)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/3.3/Gemfile.lock
+++ b/gemfiles/3.3/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.1)
+    parser (3.3.7.2)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/3.4/Gemfile.lock
+++ b/gemfiles/3.4/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.1)
+    parser (3.3.7.2)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/3.5/Gemfile.lock
+++ b/gemfiles/3.5/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.1)
+    parser (3.3.7.2)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/jruby/Gemfile.lock
+++ b/gemfiles/jruby/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    parser (3.3.7.1)
+    parser (3.3.7.2)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/truffleruby/Gemfile.lock
+++ b/gemfiles/truffleruby/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    parser (3.3.7.1)
+    parser (3.3.7.2)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/typecheck/Gemfile.lock
+++ b/gemfiles/typecheck/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
     minitest (5.25.4)
     netrc (0.11.0)
     parallel (1.26.3)
-    parser (3.3.7.1)
+    parser (3.3.7.2)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/lib/prism/translation/parser.rb
+++ b/lib/prism/translation/parser.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 begin
+  required_version = ">= 3.3.7.2"
+  gem "parser", required_version
   require "parser"
 rescue LoadError
-  warn(%q{Error: Unable to load parser. Add `gem "parser"` to your Gemfile.})
+  warn(<<~MSG)
+    Error: Unable to load parser #{required_version}. \
+    Add `gem "parser"` to your Gemfile or run `bundle update parser`.
+  MSG
   exit(1)
 end
 


### PR DESCRIPTION
There hasn't been much that would actually affect parsers usage of it. But, when adding new node types, these usually appear in the `Parser::Meta::NODE_TYPES`.

`itblock` was added, gets emitted by prism, and then `rubocop-ast` blindly delegates to `on_itblock`. These methods are dynamically created through `NODE_TYPES`, which means that it will error if it doesn't contain `itblock`. Ref https://github.com/rubocop/rubocop-ast/issues/366

This is unfortunate because in `rubocop-ast` these methods are eagerly defined but the prism translator is lazily loaded on demand.
The simplest solution is to add them on the `parser` side (even if they are not emitted directly), and require that a version that contains those be used.

In summary when adding a new node type:
* Add it to `Parser::Meta::PRISM_TRANSLATION_PARSER_NODE_TYPES` (gets included in `NODE_TYPES`), see https://github.com/whitequark/parser/pull/1071
* Bump the minimum `parser` version used by `prism` to a version that contains the above change
* Actually emit that node type in `prism`