### PR TITLE
Add `Prism::Translation::ParserCurrent`

### DIFF
--- a/docs/parser_translation.md
+++ b/docs/parser_translation.md
@@ -6,17 +6,23 @@ Prism ships with the ability to translate its syntax tree into the syntax tree u
 
 The `parser` gem provides multiple parsers to support different versions of the Ruby grammar. This includes all of the Ruby versions going back to 1.8, as well as third-party parsers like MacRuby and RubyMotion. The `prism` gem provides another parser that uses the `prism` parser to build the syntax tree.
 
-You can use the `prism` parser like you would any other. After requiring the parser, you should be able to call any of the regular `Parser::Base` APIs that you would normally use.
+You can use the `prism` parser like you would any other. After requiring `prism`, you should be able to call any of the regular `Parser::Base` APIs that you would normally use.
 
 ```ruby
 require "prism"
 
-Prism::Translation::Parser.parse_file("path/to/file.rb")
+# Same as `Parser::Ruby34`
+Prism::Translation::Parser34.parse_file("path/to/file.rb")
+
+# Same as `Parser::CurrentRuby`
+Prism::Translation::ParserCurrent.parse("puts 'Hello World!'")
 ```
+
+All the parsers are autoloaded, so you don't have to worry about requiring them yourself.
 
 ### RuboCop
 
-Prism as a parser engine is directly supported since RuboCop 1.62. The class used for parsing is `Prism::Translation::Parser`.
+Prism as a parser engine is directly supported since RuboCop 1.62.
 
 First, specify `prism` in your Gemfile:
 

--- a/lib/prism/translation.rb
+++ b/lib/prism/translation.rb
@@ -5,6 +5,7 @@ module Prism
   # syntax trees.
   module Translation # steep:ignore
     autoload :Parser, "prism/translation/parser"
+    autoload :ParserCurrent, "prism/translation/parser_current"
     autoload :Parser33, "prism/translation/parser33"
     autoload :Parser34, "prism/translation/parser34"
     autoload :Parser35, "prism/translation/parser35"

--- a/lib/prism/translation/parser_current.rb
+++ b/lib/prism/translation/parser_current.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# typed: ignore
+
+module Prism
+  module Translation
+    case RUBY_VERSION
+    when /^3\.3\./
+      ParserCurrent = Parser33
+    when /^3\.4\./
+      ParserCurrent = Parser34
+    when /^3\.5\./
+      ParserCurrent = Parser35
+    else
+      # Keep this in sync with released Ruby.
+      parser = Parser34
+      warn "warning: `Prism::Translation::Current` is loading #{parser.name}, " \
+           "but you are running #{RUBY_VERSION.to_f}."
+      ParserCurrent = parser
+    end
+  end
+end

--- a/prism.gemspec
+++ b/prism.gemspec
@@ -96,6 +96,7 @@ Gem::Specification.new do |spec|
     "lib/prism/string_query.rb",
     "lib/prism/translation.rb",
     "lib/prism/translation/parser.rb",
+    "lib/prism/translation/parser_current.rb",
     "lib/prism/translation/parser33.rb",
     "lib/prism/translation/parser34.rb",
     "lib/prism/translation/parser35.rb",

--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -155,6 +155,15 @@ module Prism
       assert_empty(warnings)
     end
 
+    if RUBY_VERSION >= "3.3"
+      def test_current_parser_for_current_ruby
+        major, minor, _patch = Gem::Version.new(RUBY_VERSION).segments
+        # Let's just hope there never is a Ruby 3.10 or similar
+        expected = major * 10 + minor
+        assert_equal(expected, Translation::ParserCurrent.new.version)
+      end
+    end
+
     def test_it_block_parameter_syntax
       it_fixture_path = Pathname(__dir__).join("../../../test/prism/fixtures/it.txt")
 


### PR DESCRIPTION
It's not my favorite api but for users that currently use the same thing from `parser`, moving over is more difficult
than it needs to be.

If you plan to support both old and new ruby versions, you definitly need to branch somewhere on the ruby version
to either choose prism or parser.
But with prism you then need to enumerate all the versions again and choose the correct one.

Also, don't recommend to use `Prism::Translation::Parser` in docs. It's version-less but actually always just uses Ruby 3.4 which is probably not what the user intended.

Note: parser also warns when the patch version doesn't match what it expects. But I don't think prism has such a concept, and anyways it would require releases anytime ruby releases, which I don't think is very desirable.

I wrote something on how to migrate to parser/prism in https://github.com/whitequark/parser/pull/1072 and it contains the following snippet:

```rb
code_version = RUBY_VERSION.to_f

if code_version <= 3.3
  require 'parser/current'
  parser = Parser::CurrentRuby
else
  require 'prism'
  case code_version
  when 3.3
    Prism::Translation::Parser33
  when 3.4
    Prism::Translation::Parser34
  else
    warn "Unknown Ruby version #{code_version}, using 3.4 as a fallback"
    Prism::Translation::Parser34
  end
end
```

With this change, it can be written like this (and doesn't require changes from the programmer when new rubies get released)
```rb
code_version = RUBY_VERSION.to_f


if code_version <= 3.3
  require 'parser/current'
  parser = Parser::CurrentRuby
else
  require 'prism'
  parser = Prism::Translation::ParserCurrent
end
```