### PR TITLE
fix(rust): ub on empty slices

### DIFF
--- a/rust/ruby-prism/build.rs
+++ b/rust/ruby-prism/build.rs
@@ -334,6 +334,9 @@ fn write_node(file: &mut File, flags: &[Flags], node: &Node) -> Result<(), Box<d
                 writeln!(file, "    pub fn {}(&self) -> &[u8] {{", field.name)?;
                 writeln!(file, "        unsafe {{")?;
                 writeln!(file, "            let source = (*self.pointer).{}.source;", field.name)?;
+                writeln!(file, "            if source.is_null() {{")?;
+                writeln!(file, "                return &[];")?;
+                writeln!(file, "            }}")?;
                 writeln!(file, "            let length = (*self.pointer).{}.length;", field.name)?;
                 writeln!(file, "            std::slice::from_raw_parts(source, length)")?;
                 writeln!(file, "        }}")?;

--- a/rust/ruby-prism/src/lib.rs
+++ b/rust/ruby-prism/src/lib.rs
@@ -1158,6 +1158,13 @@ end
     }
 
     #[test]
+    fn regex_value_test() {
+        let result = parse(b"//");
+        let node = result.node().as_program_node().unwrap().statements().body().iter().next().unwrap().as_regular_expression_node().unwrap();
+        assert_eq!(node.unescaped(), b"");
+    }
+
+    #[test]
     fn node_field_lifetime_test() {
         // The code below wouldn't typecheck prior to https://github.com/ruby/prism/pull/2519,
         // but we need to stop clippy from complaining about it.


### PR DESCRIPTION
Hi!

This PR fixes undefined behavior caused by passing a NULL pointer to `std::slice::from_raw_parts` which manifests in the following test:

```rust
#[test]
fn regex_value_test() {
    let result = parse(b"//");
    let node = result.node().as_program_node().unwrap().statements().body().iter().next().unwrap().as_regular_expression_node().unwrap();
    assert_eq!(node.unescaped(), b"");
}
```

with the following error:

```
running 1 test
thread 'tests::regex_value_test' panicked at core/src/panicking.rs:223:5:
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread caused non-unwinding panic. aborting.
error: test failed, to rerun pass `--lib`

Caused by:
  process didn't exit successfully: `/tmp/prism/rust/target/aarch64-apple-darwin/debug/deps/ruby_prism-3a39e9d2b3dfec9b regex_value_test` (signal: 6, SIGABRT: process abort signal)
```

The fix itself is a check for NULL before constructing a slice.