### PR TITLE
Be explicit in tests which files `parser` can't parse

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/2.7/Gemfile.lock
+++ b/gemfiles/2.7/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   specs:
     ast (2.4.2)
     onigmo (0.1.0)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/3.0/Gemfile.lock
+++ b/gemfiles/3.0/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.4)

--- a/gemfiles/3.1/Gemfile.lock
+++ b/gemfiles/3.1/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/3.2/Gemfile.lock
+++ b/gemfiles/3.2/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/3.3/Gemfile.lock
+++ b/gemfiles/3.3/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/3.4/Gemfile.lock
+++ b/gemfiles/3.4/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/3.5/Gemfile.lock
+++ b/gemfiles/3.5/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/jruby/Gemfile.lock
+++ b/gemfiles/jruby/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/truffleruby/Gemfile.lock
+++ b/gemfiles/truffleruby/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/gemfiles/typecheck/Gemfile.lock
+++ b/gemfiles/typecheck/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
     mutex_m (0.3.0)
     netrc (0.11.0)
     parallel (1.26.3)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)

--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -56,6 +56,16 @@ Parser::AST::Node.prepend(
 
 module Prism
   class ParserTest < TestCase
+    # These files contain code with valid syntax that can't be parsed.
+    skip_syntax_error = [
+      # alias/undef with %s(abc) symbol literal
+      "alias.txt",
+      "seattlerb/bug_215.txt",
+
+      # 1.. && 2
+      "ranges.txt",
+    ]
+
     # These files contain code that is being parsed incorrectly by the parser
     # gem, and therefore we don't want to compare against our translation.
     skip_incorrect = [
@@ -133,7 +143,7 @@ module Prism
       "whitequark/space_args_block.txt"
     ]
 
-    Fixture.each do |fixture|
+    Fixture.each(except: skip_syntax_error) do |fixture|
       define_method(fixture.test_name) do
         assert_equal_parses(
           fixture,
@@ -190,11 +200,7 @@ module Prism
       parser.diagnostics.all_errors_are_fatal = true
 
       expected_ast, expected_comments, expected_tokens =
-        begin
-          ignore_warnings { parser.tokenize(buffer) }
-        rescue ArgumentError, Parser::SyntaxError
-          return
-        end
+        ignore_warnings { parser.tokenize(buffer) }
 
       actual_ast, actual_comments, actual_tokens =
         ignore_warnings { Prism::Translation::Parser33.new.tokenize(buffer) }


### PR DESCRIPTION
It also updates to latest `parser`, which allows numbered parameters in pattern matching pin, passing `patterns.txt` and `case.txt`.

This threw me off in my last two PRs because the tests seemed to just pass. Turns out, it just wasn't doing anything.