### PR TITLE
Bump deprecated Ubuntu runners

### DIFF
--- a/.github/workflows/cruby-bindings.yml
+++ b/.github/workflows/cruby-bindings.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set up latest ruby head
         uses: ruby/setup-ruby@v1
@@ -37,6 +37,7 @@ jobs:
         working-directory: ruby/ruby
       - name: Build Ruby
         run: |
+          ruby tool/downloader.rb -d tool -e gnu config.guess config.sub
           autoconf
           ./configure -C --disable-install-doc
           make -j2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
We experienced failures due to the GH brownout, this should be the fix. ( cc. @enebo )