### PR TITLE
Monomorphise visitor methods

### DIFF
--- a/templates/lib/prism/compiler.rb.erb
+++ b/templates/lib/prism/compiler.rb.erb
@@ -35,7 +35,9 @@ module Prism
     <%- nodes.each_with_index do |node, index| -%>
 <%= "\n" if index != 0 -%>
     # Compile a <%= node.name %> node
-    alias visit_<%= node.human %> visit_child_nodes
+    def visit_<%= node.human %>(node)
+      node.compact_child_nodes.map { |node| node.accept(self) }
+    end
     <%- end -%>
   end
 end

--- a/templates/lib/prism/visitor.rb.erb
+++ b/templates/lib/prism/visitor.rb.erb
@@ -47,7 +47,9 @@ module Prism
     <%- nodes.each_with_index do |node, index| -%>
 <%= "\n" if index != 0 -%>
     # Visit a <%= node.name %> node
-    alias visit_<%= node.human %> visit_child_nodes
+    def visit_<%= node.human %>(node)
+      node.compact_child_nodes.each { |node| node.accept(self) }
+    end
     <%- end -%>
   end
 end


### PR DESCRIPTION
The current implementation of the visitor pattern in Prism uses a single method (`visit_child_nodes`) to handle all node types. This can lead to performance issues since the `node` argument will end up being polymorphic, and will prevent effective use of inline caches, which in CRuby are monomorphic.

This commit generates an inlined version of the previous code for each node type, thus making the calls inside visitor methods monomorphic. This should improve performance, especially in cases where the visitor is called frequently.

Thanks to @tenderlove for finding that this was slower than it needed to be.

Benchmark results:
```
❯ ruby bench.rb
ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +PRISM [arm64-darwin20]
Warming up --------------------------------------
             vanilla     1.000 i/100ms
              inline     1.000 i/100ms
Calculating -------------------------------------
             vanilla      0.840 (± 0.0%) i/s     (1.19 s/i) -      5.000 in   5.957006s
              inline      0.951 (± 0.0%) i/s     (1.05 s/i) -      5.000 in   5.256137s

Comparison:
              inline:        1.0 i/s
             vanilla:        0.8 i/s - 1.13x  slower
```

<details>
<summary>Benchmark code</summary>

```ruby
require "benchmark/ips"
require "prism"

class InlinedVisitor < Prism::Visitor
  eval Prism::Visitor
    .instance_methods(false)
    .map { |method| "def #{method}(node); node.compact_child_nodes.each { |node| node.accept(self) }; end" }
    .join("\n")
end

class VanillaVisitor < Prism::Visitor
end

ast = Prism.parse(<<~RUBY).value
  class Foo
    def bar
      baz&.to_s { |foo|  42 }
    end

    def baz
      3 + 4
    end

    def qux
      5 + 6
    end

    def quux
      7 + 8
    end

    def corge
      9 + 10
    end

    def grault
      11 + 12
    end

    def garply
      13 + 14
    end

    def waldo
      15 + 16
    end

    def fred
      17 + 18
    end

    def plugh
      19 + 20
    end

    def xyzzy
      21 + 22
    end

    def thud
      23 + 24
    end

    def foo_bar_baz_qux_quux_corge_grault_garply_waldo_fred_plugh_xyzzy_thud; end
  end
RUBY

vanilla_visitor = VanillaVisitor.new
inlined_visitor = InlinedVisitor.new

Benchmark.ips do |b|
  b.report("vanilla") do
    10_000.times do
    vanilla_visitor.visit(ast)
    vanilla_visitor.visit(ast)
    vanilla_visitor.visit(ast)
    vanilla_visitor.visit(ast)
    vanilla_visitor.visit(ast)
    vanilla_visitor.visit(ast)
    vanilla_visitor.visit(ast)
    vanilla_visitor.visit(ast)
    vanilla_visitor.visit(ast)
    vanilla_visitor.visit(ast)
    end
  end

  b.report("inline") do
    10_000.times do
    inlined_visitor.visit(ast)
    inlined_visitor.visit(ast)
    inlined_visitor.visit(ast)
    inlined_visitor.visit(ast)
    inlined_visitor.visit(ast)
    inlined_visitor.visit(ast)
    inlined_visitor.visit(ast)
    inlined_visitor.visit(ast)
    inlined_visitor.visit(ast)
    inlined_visitor.visit(ast)
    end
  end

  b.compare!
end
```
</details>
