### PR TITLE
Fix typo in visitor example code

### DIFF
--- a/templates/lib/prism/visitor.rb.erb
+++ b/templates/lib/prism/visitor.rb.erb
@@ -34,7 +34,7 @@ module Prism
   #
   #     class FooCalls < Prism::Visitor
   #       def visit_call_node(node)
-  #         if node.name == "foo"
+  #         if node.name == :foo
   #           # Do something with the node
   #         end
   #


### PR DESCRIPTION
Node names are symbols so `node.name == "foo"` would never be true.