### PR TITLE
Add `repl` sub-command

### DIFF
--- a/bin/prism
+++ b/bin/prism
@@ -20,6 +20,7 @@ module Prism
       when "parser"     then parser(argv)
       when "ripper"     then ripper(argv)
       when "rubyparser" then rubyparser(argv)
+      when "repl"       then repl
       else
         puts <<~TXT
           Usage:
@@ -35,6 +36,7 @@ module Prism
             bin/prism parser [source]
             bin/prism ripper [source]
             bin/prism rubyparser [source]
+            bin/prism repl
         TXT
       end
     end
@@ -322,6 +324,25 @@ module Prism
 
       puts "Prism:"
       pp prism
+    end
+
+    # bin/prism repl
+    def repl
+      loop do
+        print "Prism> "
+
+        input = gets
+        break if input.nil?
+
+        result = Prism.parse(input.chomp)
+
+        statements_node = result.value.statements
+        statements = statements_node.body
+
+        result.errors.each { |e| p(e) }
+
+        p(statements.one? ? statements.first : statements)
+      end
     end
 
     ############################################################################


### PR DESCRIPTION
I built this for myself, and found it really useful for faster debugging.

Example usage:

```
$ bin/prism repl
Prism> 1
@ IntegerNode (location: (1,0)-(1,1))
├── flags: newline, static_literal, decimal
└── value: 1

Prism> 1 +
#<Prism::ParseError @type=:expect_expression_after_operator @message="unexpected end-of-input; expected an expression after the operator" @location=#<Prism::Location @start_offset=3 @length=0 start_line=1> @level=:syntax>
#<Prism::ParseError @type=:unexpected_token_close_context @message="unexpected end-of-input, assuming it is closing the parent top level context" @location=#<Prism::Location @start_offset=3 @length=0 start_line=1> @level=:syntax>
@ CallNode (location: (1,0)-(1,3))
├── flags: newline
├── receiver:
│   @ IntegerNode (location: (1,0)-(1,1))
│   ├── flags: static_literal, decimal
│   └── value: 1
├── call_operator_loc: ∅
├── name: :+
├── message_loc: (1,2)-(1,3) = "+"
├── opening_loc: ∅
├── arguments:
│   @ ArgumentsNode (location: (1,2)-(1,3))
│   ├── flags: ∅
│   └── arguments: (length: 1)
│       └── @ MissingNode (location: (1,2)-(1,3))
│           └── flags: ∅
├── closing_loc: ∅
└── block: ∅
```

(Well really, it's more a read-parse-print-loop, "RPPL", not "REPL" 😛)