### PR TITLE
fix: SIGSEGV on malformed shebang

### DIFF
--- a/rust/ruby-prism/src/lib.rs
+++ b/rust/ruby-prism/src/lib.rs
@@ -1238,4 +1238,12 @@ end
         extractor.push_scope(node.as_program_node().unwrap().statements().body().iter().next().unwrap());
         assert_eq!(3, extractor.scopes.len());
     }
+
+    #[test]
+    fn malformed_shebang() {
+        let source = "#!\x00";
+        let result = parse(source.as_ref());
+        assert!(result.errors().next().is_none());
+        assert!(result.warnings().next().is_none());
+    }
 }

--- a/src/prism.c
+++ b/src/prism.c
@@ -22663,7 +22663,7 @@ pm_parser_init(pm_parser_t *parser, const uint8_t *source, size_t size, const pm
             }
 
             search_shebang = false;
-        } else if (options->main_script && !parser->parsing_eval) {
+        } else if (options != NULL && options->main_script && !parser->parsing_eval) {
             search_shebang = true;
         }
     }


### PR DESCRIPTION
Without the fix, the new test gives the following on `cargo test`:

```
test tests::call_flags_test ... ok
error: test failed, to rerun pass `-p ruby-prism --lib`

Caused by:
  process didn't exit successfully: `/tmp/prism/rust/target/debug/deps/ruby_prism-65349bb1fc339892` (signal: 11, SIGSEGV: invalid memory reference)
```