### PR TITLE
Allow command calls in endless method bodies within assignments

### DIFF
--- a/snapshots/endless_methods.txt
+++ b/snapshots/endless_methods.txt
@@ -1,10 +1,10 @@
-@ ProgramNode (location: (1,0)-(5,22))
+@ ProgramNode (location: (1,0)-(7,15))
 ├── flags: ∅
-├── locals: []
+├── locals: [:x]
 └── statements:
-    @ StatementsNode (location: (1,0)-(5,22))
+    @ StatementsNode (location: (1,0)-(7,15))
     ├── flags: ∅
-    └── body: (length: 3)
+    └── body: (length: 4)
         ├── @ DefNode (location: (1,0)-(1,11))
         │   ├── flags: newline
         │   ├── name: :foo
@@ -61,55 +61,95 @@
         │   ├── rparen_loc: ∅
         │   ├── equal_loc: (3,8)-(3,9) = "="
         │   └── end_keyword_loc: ∅
-        └── @ DefNode (location: (5,0)-(5,22))
+        ├── @ DefNode (location: (5,0)-(5,22))
+        │   ├── flags: newline
+        │   ├── name: :method
+        │   ├── name_loc: (5,4)-(5,10) = "method"
+        │   ├── receiver: ∅
+        │   ├── parameters: ∅
+        │   ├── body:
+        │   │   @ StatementsNode (location: (5,13)-(5,22))
+        │   │   ├── flags: ∅
+        │   │   └── body: (length: 1)
+        │   │       └── @ CallNode (location: (5,13)-(5,22))
+        │   │           ├── flags: ∅
+        │   │           ├── receiver:
+        │   │           │   @ CallNode (location: (5,13)-(5,18))
+        │   │           │   ├── flags: ∅
+        │   │           │   ├── receiver:
+        │   │           │   │   @ IntegerNode (location: (5,13)-(5,14))
+        │   │           │   │   ├── flags: static_literal, decimal
+        │   │           │   │   └── value: 1
+        │   │           │   ├── call_operator_loc: ∅
+        │   │           │   ├── name: :+
+        │   │           │   ├── message_loc: (5,15)-(5,16) = "+"
+        │   │           │   ├── opening_loc: ∅
+        │   │           │   ├── arguments:
+        │   │           │   │   @ ArgumentsNode (location: (5,17)-(5,18))
+        │   │           │   │   ├── flags: ∅
+        │   │           │   │   └── arguments: (length: 1)
+        │   │           │   │       └── @ IntegerNode (location: (5,17)-(5,18))
+        │   │           │   │           ├── flags: static_literal, decimal
+        │   │           │   │           └── value: 2
+        │   │           │   ├── closing_loc: ∅
+        │   │           │   └── block: ∅
+        │   │           ├── call_operator_loc: ∅
+        │   │           ├── name: :+
+        │   │           ├── message_loc: (5,19)-(5,20) = "+"
+        │   │           ├── opening_loc: ∅
+        │   │           ├── arguments:
+        │   │           │   @ ArgumentsNode (location: (5,21)-(5,22))
+        │   │           │   ├── flags: ∅
+        │   │           │   └── arguments: (length: 1)
+        │   │           │       └── @ IntegerNode (location: (5,21)-(5,22))
+        │   │           │           ├── flags: static_literal, decimal
+        │   │           │           └── value: 3
+        │   │           ├── closing_loc: ∅
+        │   │           └── block: ∅
+        │   ├── locals: []
+        │   ├── def_keyword_loc: (5,0)-(5,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: ∅
+        │   ├── rparen_loc: ∅
+        │   ├── equal_loc: (5,11)-(5,12) = "="
+        │   └── end_keyword_loc: ∅
+        └── @ LocalVariableWriteNode (location: (7,0)-(7,15))
             ├── flags: newline
-            ├── name: :method
-            ├── name_loc: (5,4)-(5,10) = "method"
-            ├── receiver: ∅
-            ├── parameters: ∅
-            ├── body:
-            │   @ StatementsNode (location: (5,13)-(5,22))
+            ├── name: :x
+            ├── depth: 0
+            ├── name_loc: (7,0)-(7,1) = "x"
+            ├── value:
+            │   @ DefNode (location: (7,4)-(7,15))
             │   ├── flags: ∅
-            │   └── body: (length: 1)
-            │       └── @ CallNode (location: (5,13)-(5,22))
-            │           ├── flags: ∅
-            │           ├── receiver:
-            │           │   @ CallNode (location: (5,13)-(5,18))
-            │           │   ├── flags: ∅
-            │           │   ├── receiver:
-            │           │   │   @ IntegerNode (location: (5,13)-(5,14))
-            │           │   │   ├── flags: static_literal, decimal
-            │           │   │   └── value: 1
-            │           │   ├── call_operator_loc: ∅
-            │           │   ├── name: :+
-            │           │   ├── message_loc: (5,15)-(5,16) = "+"
-            │           │   ├── opening_loc: ∅
-            │           │   ├── arguments:
-            │           │   │   @ ArgumentsNode (location: (5,17)-(5,18))
-            │           │   │   ├── flags: ∅
-            │           │   │   └── arguments: (length: 1)
-            │           │   │       └── @ IntegerNode (location: (5,17)-(5,18))
-            │           │   │           ├── flags: static_literal, decimal
-            │           │   │           └── value: 2
-            │           │   ├── closing_loc: ∅
-            │           │   └── block: ∅
-            │           ├── call_operator_loc: ∅
-            │           ├── name: :+
-            │           ├── message_loc: (5,19)-(5,20) = "+"
-            │           ├── opening_loc: ∅
-            │           ├── arguments:
-            │           │   @ ArgumentsNode (location: (5,21)-(5,22))
-            │           │   ├── flags: ∅
-            │           │   └── arguments: (length: 1)
-            │           │       └── @ IntegerNode (location: (5,21)-(5,22))
-            │           │           ├── flags: static_literal, decimal
-            │           │           └── value: 3
-            │           ├── closing_loc: ∅
-            │           └── block: ∅
-            ├── locals: []
-            ├── def_keyword_loc: (5,0)-(5,3) = "def"
-            ├── operator_loc: ∅
-            ├── lparen_loc: ∅
-            ├── rparen_loc: ∅
-            ├── equal_loc: (5,11)-(5,12) = "="
-            └── end_keyword_loc: ∅
+            │   ├── name: :f
+            │   ├── name_loc: (7,8)-(7,9) = "f"
+            │   ├── receiver: ∅
+            │   ├── parameters: ∅
+            │   ├── body:
+            │   │   @ StatementsNode (location: (7,12)-(7,15))
+            │   │   ├── flags: ∅
+            │   │   └── body: (length: 1)
+            │   │       └── @ CallNode (location: (7,12)-(7,15))
+            │   │           ├── flags: ignore_visibility
+            │   │           ├── receiver: ∅
+            │   │           ├── call_operator_loc: ∅
+            │   │           ├── name: :p
+            │   │           ├── message_loc: (7,12)-(7,13) = "p"
+            │   │           ├── opening_loc: ∅
+            │   │           ├── arguments:
+            │   │           │   @ ArgumentsNode (location: (7,14)-(7,15))
+            │   │           │   ├── flags: ∅
+            │   │           │   └── arguments: (length: 1)
+            │   │           │       └── @ IntegerNode (location: (7,14)-(7,15))
+            │   │           │           ├── flags: static_literal, decimal
+            │   │           │           └── value: 1
+            │   │           ├── closing_loc: ∅
+            │   │           └── block: ∅
+            │   ├── locals: []
+            │   ├── def_keyword_loc: (7,4)-(7,7) = "def"
+            │   ├── operator_loc: ∅
+            │   ├── lparen_loc: ∅
+            │   ├── rparen_loc: ∅
+            │   ├── equal_loc: (7,10)-(7,11) = "="
+            │   └── end_keyword_loc: ∅
+            └── operator_loc: (7,2)-(7,3) = "="

--- a/src/prism.c
+++ b/src/prism.c
@@ -19505,7 +19505,15 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
                 pm_do_loop_stack_push(parser, false);
                 statements = (pm_node_t *) pm_statements_node_create(parser);
 
-                pm_node_t *statement = parse_expression(parser, PM_BINDING_POWER_DEFINED + 1, binding_power < PM_BINDING_POWER_COMPOSITION, false, PM_ERR_DEF_ENDLESS, (uint16_t) (depth + 1));
+                // In endless method bodies, we need to handle command calls carefully.
+                // We want to allow command calls in assignment context but maintain
+                // the same binding power to avoid changing how operators are parsed.
+                // Note that we're intentionally NOT allowing code like `private def foo = puts "Hello"`
+                // because the original parser, parse.y, can't handle it and we want to maintain the same behavior
+                bool allow_command_call = (binding_power == PM_BINDING_POWER_ASSIGNMENT) ||
+                                         (binding_power < PM_BINDING_POWER_COMPOSITION);
+
+                pm_node_t *statement = parse_expression(parser, PM_BINDING_POWER_DEFINED + 1, allow_command_call, false, PM_ERR_DEF_ENDLESS, (uint16_t) (depth + 1));
 
                 if (accept1(parser, PM_TOKEN_KEYWORD_RESCUE_MODIFIER)) {
                     context_push(parser, PM_CONTEXT_RESCUE_MODIFIER);

--- a/test/prism/errors/private_endless_method.txt
+++ b/test/prism/errors/private_endless_method.txt
@@ -1,0 +1,3 @@
+private def foo = puts "Hello"
+                       ^ unexpected string literal, expecting end-of-input
+

--- a/test/prism/fixtures/endless_methods.txt
+++ b/test/prism/fixtures/endless_methods.txt
@@ -3,3 +3,5 @@ def foo = 1
 def bar = A ""
 
 def method = 1 + 2 + 3
+
+x = def f = p 1


### PR DESCRIPTION
(This is another attempt to solve https://github.com/ruby/prism/issues/3473 as #3598 caused `ruby/ruby` tests to fail and got reverted)

Previously, endless method definitions in assignment contexts like `x = def f = p 1` would fail to parse because command calls (method calls without parentheses) were only accepted when the surrounding binding power was less than `PM_BINDING_POWER_COMPOSITION`.

This fix specifically checks for assignment context and allows command calls in those cases while maintaining the existing behavior for other contexts. This ensures that:

- `x = def f = p 1` parses correctly (previously failed)
- `private def f = puts "Hello"` still produces the expected error