### PR TITLE
Clear flags on interpolated strings

### DIFF
--- a/snapshots/dos_endings.txt
+++ b/snapshots/dos_endings.txt
@@ -17,7 +17,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (1,5)-(2,12))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: ∅
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (1,5)-(1,9))
@@ -86,7 +86,7 @@
             │   │           ├── flags: ∅
             │   │           ├── receiver:
             │   │           │   @ InterpolatedStringNode (location: (17,8)-(17,14))
-            │   │           │   ├── flags: static_literal
+            │   │           │   ├── flags: ∅
             │   │           │   ├── opening_loc: (17,8)-(17,14) = "<<~EOF"
             │   │           │   ├── parts: (length: 2)
             │   │           │   │   ├── @ StringNode (location: (18,0)-(19,0))

--- a/snapshots/dstring.txt
+++ b/snapshots/dstring.txt
@@ -41,7 +41,7 @@
         │   │       └── closing_loc: (5,7)-(5,8) = "}"
         │   └── closing_loc: (5,8)-(5,9) = "\""
         ├── @ InterpolatedStringNode (location: (7,0)-(9,2))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: ∅
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (7,0)-(8,2))

--- a/snapshots/heredocs_leading_whitespace.txt
+++ b/snapshots/heredocs_leading_whitespace.txt
@@ -30,7 +30,7 @@
         │   ├── closing_loc: (19,0)-(20,0) = "  FOO\n"
         │   └── unescaped: "a\nb\n"
         ├── @ InterpolatedStringNode (location: (21,0)-(21,10))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (21,0)-(21,10) = "<<~'  FOO'"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (22,0)-(23,0))
@@ -47,7 +47,7 @@
         │   │       └── unescaped: "b\n"
         │   └── closing_loc: (24,0)-(25,0) = "     FOO\n"
         └── @ InterpolatedStringNode (location: (26,0)-(26,10))
-            ├── flags: newline, static_literal
+            ├── flags: newline
             ├── opening_loc: (26,0)-(26,10) = "<<~'  FOO'"
             ├── parts: (length: 2)
             │   ├── @ StringNode (location: (27,0)-(28,0))

--- a/snapshots/heredocs_nested.txt
+++ b/snapshots/heredocs_nested.txt
@@ -6,7 +6,7 @@
     ├── flags: ∅
     └── body: (length: 2)
         ├── @ InterpolatedStringNode (location: (1,0)-(1,7))
-        │   ├── flags: newline, static_literal, mutable
+        │   ├── flags: newline
         │   ├── opening_loc: (1,0)-(1,7) = "<<~RUBY"
         │   ├── parts: (length: 4)
         │   │   ├── @ StringNode (location: (2,0)-(3,0))

--- a/snapshots/heredocs_with_fake_newlines.txt
+++ b/snapshots/heredocs_with_fake_newlines.txt
@@ -12,7 +12,7 @@
         │   ├── closing_loc: (13,0)-(14,0) = "RUBY\n"
         │   └── unescaped: "  \n\n  \n\n  exit\n  \\n\n  \n\n\n\n\n  argh\n  \\\n  \\  foo\nbar\n  \f\n  ok\n"
         ├── @ InterpolatedStringNode (location: (15,0)-(15,7))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (15,0)-(15,7) = "<<~RUBY"
         │   ├── parts: (length: 11)
         │   │   ├── @ StringNode (location: (16,0)-(17,0))

--- a/snapshots/heredocs_with_ignored_newlines.txt
+++ b/snapshots/heredocs_with_ignored_newlines.txt
@@ -12,7 +12,7 @@
         │   ├── closing_loc: (2,0)-(3,0) = "HERE\n"
         │   └── unescaped: ""
         └── @ InterpolatedStringNode (location: (4,0)-(4,8))
-            ├── flags: newline, static_literal
+            ├── flags: newline
             ├── opening_loc: (4,0)-(4,8) = "<<~THERE"
             ├── parts: (length: 9)
             │   ├── @ StringNode (location: (5,0)-(6,0))

--- a/snapshots/seattlerb/difficult0_.txt
+++ b/snapshots/seattlerb/difficult0_.txt
@@ -37,7 +37,7 @@
             │           │   │   ├── flags: ∅
             │           │   │   └── arguments: (length: 1)
             │           │   │       └── @ InterpolatedStringNode (location: (1,9)-(4,4))
-            │           │   │           ├── flags: static_literal
+            │           │   │           ├── flags: ∅
             │           │   │           ├── opening_loc: (1,9)-(1,10) = "'"
             │           │   │           ├── parts: (length: 2)
             │           │   │           │   ├── @ StringNode (location: (1,10)-(2,0))

--- a/snapshots/seattlerb/dstr_str.txt
+++ b/snapshots/seattlerb/dstr_str.txt
@@ -6,7 +6,7 @@
     ├── flags: ∅
     └── body: (length: 1)
         └── @ InterpolatedStringNode (location: (1,0)-(1,10))
-            ├── flags: newline, static_literal, mutable
+            ├── flags: newline
             ├── opening_loc: (1,0)-(1,1) = "\""
             ├── parts: (length: 2)
             │   ├── @ EmbeddedStatementsNode (location: (1,1)-(1,7))

--- a/snapshots/seattlerb/heredoc_nested.txt
+++ b/snapshots/seattlerb/heredoc_nested.txt
@@ -6,10 +6,10 @@
     ├── flags: ∅
     └── body: (length: 1)
         └── @ ArrayNode (location: (1,0)-(7,2))
-            ├── flags: newline, static_literal
+            ├── flags: newline
             ├── elements: (length: 2)
             │   ├── @ InterpolatedStringNode (location: (1,1)-(1,4))
-            │   │   ├── flags: static_literal, mutable
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: (1,1)-(1,4) = "<<A"
             │   │   ├── parts: (length: 3)
             │   │   │   ├── @ EmbeddedStatementsNode (location: (2,0)-(2,6))

--- a/snapshots/seattlerb/heredoc_squiggly.txt
+++ b/snapshots/seattlerb/heredoc_squiggly.txt
@@ -12,7 +12,7 @@
             ├── name_loc: (1,0)-(1,1) = "a"
             ├── value:
             │   @ InterpolatedStringNode (location: (1,4)-(1,12))
-            │   ├── flags: static_literal
+            │   ├── flags: ∅
             │   ├── opening_loc: (1,4)-(1,12) = "<<~\"EOF\""
             │   ├── parts: (length: 3)
             │   │   ├── @ StringNode (location: (2,0)-(3,0))

--- a/snapshots/seattlerb/heredoc_squiggly_blank_lines.txt
+++ b/snapshots/seattlerb/heredoc_squiggly_blank_lines.txt
@@ -12,7 +12,7 @@
             ├── name_loc: (1,0)-(1,1) = "a"
             ├── value:
             │   @ InterpolatedStringNode (location: (1,4)-(1,10))
-            │   ├── flags: static_literal
+            │   ├── flags: ∅
             │   ├── opening_loc: (1,4)-(1,10) = "<<~EOF"
             │   ├── parts: (length: 3)
             │   │   ├── @ StringNode (location: (2,0)-(3,0))

--- a/snapshots/seattlerb/heredoc_squiggly_tabs.txt
+++ b/snapshots/seattlerb/heredoc_squiggly_tabs.txt
@@ -12,7 +12,7 @@
             ├── name_loc: (1,0)-(1,1) = "a"
             ├── value:
             │   @ InterpolatedStringNode (location: (1,4)-(1,12))
-            │   ├── flags: static_literal
+            │   ├── flags: ∅
             │   ├── opening_loc: (1,4)-(1,12) = "<<~\"EOF\""
             │   ├── parts: (length: 2)
             │   │   ├── @ StringNode (location: (2,0)-(3,0))

--- a/snapshots/seattlerb/heredoc_squiggly_tabs_extra.txt
+++ b/snapshots/seattlerb/heredoc_squiggly_tabs_extra.txt
@@ -12,7 +12,7 @@
             ├── name_loc: (1,0)-(1,1) = "a"
             ├── value:
             │   @ InterpolatedStringNode (location: (1,4)-(1,12))
-            │   ├── flags: static_literal
+            │   ├── flags: ∅
             │   ├── opening_loc: (1,4)-(1,12) = "<<~\"EOF\""
             │   ├── parts: (length: 2)
             │   │   ├── @ StringNode (location: (2,0)-(3,0))

--- a/snapshots/seattlerb/heredoc_squiggly_visually_blank_lines.txt
+++ b/snapshots/seattlerb/heredoc_squiggly_visually_blank_lines.txt
@@ -12,7 +12,7 @@
             ├── name_loc: (1,0)-(1,1) = "a"
             ├── value:
             │   @ InterpolatedStringNode (location: (1,4)-(1,10))
-            │   ├── flags: static_literal
+            │   ├── flags: ∅
             │   ├── opening_loc: (1,4)-(1,10) = "<<~EOF"
             │   ├── parts: (length: 3)
             │   │   ├── @ StringNode (location: (2,0)-(3,0))

--- a/snapshots/seattlerb/str_lit_concat_bad_encodings.txt
+++ b/snapshots/seattlerb/str_lit_concat_bad_encodings.txt
@@ -6,7 +6,7 @@
     ├── flags: ∅
     └── body: (length: 1)
         └── @ InterpolatedStringNode (location: (1,0)-(2,66))
-            ├── flags: newline, static_literal
+            ├── flags: newline
             ├── opening_loc: ∅
             ├── parts: (length: 2)
             │   ├── @ StringNode (location: (1,0)-(1,62))

--- a/snapshots/seattlerb/str_str.txt
+++ b/snapshots/seattlerb/str_str.txt
@@ -6,7 +6,7 @@
     ├── flags: ∅
     └── body: (length: 1)
         └── @ InterpolatedStringNode (location: (1,0)-(1,10))
-            ├── flags: newline, static_literal, mutable
+            ├── flags: newline
             ├── opening_loc: (1,0)-(1,1) = "\""
             ├── parts: (length: 2)
             │   ├── @ StringNode (location: (1,1)-(1,3))

--- a/snapshots/seattlerb/str_str_str.txt
+++ b/snapshots/seattlerb/str_str_str.txt
@@ -6,7 +6,7 @@
     ├── flags: ∅
     └── body: (length: 1)
         └── @ InterpolatedStringNode (location: (1,0)-(1,12))
-            ├── flags: newline, static_literal, mutable
+            ├── flags: newline
             ├── opening_loc: (1,0)-(1,1) = "\""
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (1,1)-(1,3))

--- a/snapshots/spanning_heredoc.txt
+++ b/snapshots/spanning_heredoc.txt
@@ -78,7 +78,7 @@
         │   │       │   ├── closing_loc: (12,0)-(13,0) = "A\n"
         │   │       │   └── unescaped: "c\n"
         │   │       └── @ InterpolatedStringNode (location: (10,9)-(13,2))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (10,9)-(10,10) = "\""
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (10,10)-(10,12))
@@ -114,7 +114,7 @@
         │   │       │   ├── closing_loc: (18,0)-(19,0) = "A\n"
         │   │       │   └── unescaped: "e\n"
         │   │       └── @ InterpolatedStringNode (location: (16,9)-(19,2))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (16,9)-(16,12) = "%q["
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (16,12)-(16,14))
@@ -150,7 +150,7 @@
         │   │       │   ├── closing_loc: (24,0)-(25,0) = "A\n"
         │   │       │   └── unescaped: "g\n"
         │   │       └── @ InterpolatedStringNode (location: (22,9)-(25,2))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (22,9)-(22,12) = "%Q["
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (22,12)-(22,14))
@@ -222,10 +222,10 @@
         │   │       │   ├── closing_loc: (37,0)-(38,0) = "A\n"
         │   │       │   └── unescaped: "k\n"
         │   │       └── @ ArrayNode (location: (35,9)-(38,2))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── elements: (length: 1)
         │   │           │   └── @ InterpolatedStringNode (location: (35,12)-(38,1))
-        │   │           │       ├── flags: static_literal
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── parts: (length: 2)
         │   │           │       │   ├── @ StringNode (location: (35,12)-(35,14))

--- a/snapshots/strings.txt
+++ b/snapshots/strings.txt
@@ -875,7 +875,7 @@
         │   ├── closing_loc: ∅
         │   └── unescaped: "a"
         ├── @ InterpolatedStringNode (location: (173,0)-(173,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: ∅
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (173,0)-(173,2))

--- a/snapshots/tilde_heredocs.txt
+++ b/snapshots/tilde_heredocs.txt
@@ -46,7 +46,7 @@
         │   ├── closing_loc: (9,0)-(10,0) = "EOF\n"
         │   └── unescaped: "a\n"
         ├── @ InterpolatedStringNode (location: (11,0)-(11,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (11,0)-(11,6) = "<<~EOF"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (12,0)-(13,0))
@@ -175,7 +175,7 @@
         │   │       └── unescaped: "\n"
         │   └── closing_loc: (33,0)-(34,0) = "EOF\n"
         ├── @ InterpolatedStringNode (location: (35,0)-(35,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (35,0)-(35,6) = "<<~EOF"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (36,0)-(37,0))
@@ -192,7 +192,7 @@
         │   │       └── unescaped: "b\n"
         │   └── closing_loc: (38,0)-(39,0) = "EOF\n"
         ├── @ InterpolatedStringNode (location: (40,0)-(40,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (40,0)-(40,6) = "<<~EOF"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (41,0)-(42,0))
@@ -209,7 +209,7 @@
         │   │       └── unescaped: " b\n"
         │   └── closing_loc: (43,0)-(44,0) = "EOF\n"
         ├── @ InterpolatedStringNode (location: (45,0)-(45,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (45,0)-(45,6) = "<<~EOF"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (46,0)-(47,0))
@@ -232,7 +232,7 @@
         │   ├── closing_loc: (52,0)-(53,0) = "EOF\n"
         │   └── unescaped: "a \#{1}\n"
         ├── @ InterpolatedStringNode (location: (54,0)-(54,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (54,0)-(54,6) = "<<~EOF"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (55,0)-(56,0))
@@ -249,7 +249,7 @@
         │   │       └── unescaped: " b\n"
         │   └── closing_loc: (57,0)-(58,0) = "EOF\n"
         ├── @ InterpolatedStringNode (location: (59,0)-(59,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (59,0)-(59,6) = "<<~EOF"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (60,0)-(61,0))
@@ -266,7 +266,7 @@
         │   │       └── unescaped: "b\n"
         │   └── closing_loc: (62,0)-(63,0) = "EOF\n"
         ├── @ InterpolatedStringNode (location: (64,0)-(64,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (64,0)-(64,6) = "<<~EOF"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (65,0)-(66,0))
@@ -283,7 +283,7 @@
         │   │       └── unescaped: "b\n"
         │   └── closing_loc: (67,0)-(68,0) = "EOF\n"
         ├── @ InterpolatedStringNode (location: (69,0)-(69,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (69,0)-(69,6) = "<<~EOF"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (70,0)-(71,0))
@@ -306,7 +306,7 @@
         │   │       └── unescaped: "b\n"
         │   └── closing_loc: (73,0)-(74,0) = "EOF\n"
         ├── @ InterpolatedStringNode (location: (75,0)-(75,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (75,0)-(75,6) = "<<~EOF"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (76,0)-(77,0))
@@ -329,7 +329,7 @@
         │   │       └── unescaped: "b\n"
         │   └── closing_loc: (79,0)-(80,0) = "EOF\n"
         ├── @ InterpolatedStringNode (location: (81,0)-(81,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (81,0)-(81,6) = "<<~EOF"
         │   ├── parts: (length: 5)
         │   │   ├── @ StringNode (location: (82,0)-(83,0))

--- a/snapshots/unparser/corpus/literal/literal.txt
+++ b/snapshots/unparser/corpus/literal/literal.txt
@@ -388,7 +388,7 @@
         │       ├── numerator: 1
         │       └── denominator: 1
         ├── @ InterpolatedStringNode (location: (28,0)-(28,11))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: ∅
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (28,0)-(28,5))

--- a/snapshots/unparser/corpus/semantic/dstr.txt
+++ b/snapshots/unparser/corpus/semantic/dstr.txt
@@ -114,7 +114,7 @@
         │   │       └── unescaped: "b\n"
         │   └── closing_loc: (35,0)-(36,0) = "DOC\n"
         ├── @ InterpolatedStringNode (location: (37,0)-(37,6))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: (37,0)-(37,6) = "<<~DOC"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (38,0)-(39,0))
@@ -495,7 +495,7 @@
         │   │       └── closing_loc: (120,4)-(120,5) = "\""
         │   └── closing_loc: ∅
         ├── @ InterpolatedStringNode (location: (122,0)-(122,8))
-        │   ├── flags: newline, static_literal
+        │   ├── flags: newline
         │   ├── opening_loc: ∅
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (122,0)-(122,2))

--- a/snapshots/whitequark/dedenting_heredoc.txt
+++ b/snapshots/whitequark/dedenting_heredoc.txt
@@ -17,7 +17,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (1,2)-(1,8))
-        │   │           ├── flags: static_literal, mutable
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (1,2)-(1,8) = "<<~\"E\""
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (2,0)-(3,0))
@@ -109,7 +109,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (11,2)-(11,6))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (11,2)-(11,6) = "<<~E"
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (12,0)-(13,0))
@@ -139,7 +139,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (16,2)-(16,6))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (16,2)-(16,6) = "<<~E"
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (17,0)-(18,0))
@@ -169,7 +169,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (21,2)-(21,6))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (21,2)-(21,6) = "<<~E"
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (22,0)-(23,0))
@@ -199,7 +199,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (26,2)-(26,6))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (26,2)-(26,6) = "<<~E"
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (27,0)-(28,0))
@@ -229,7 +229,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (31,2)-(31,6))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (31,2)-(31,6) = "<<~E"
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (32,0)-(33,0))
@@ -259,7 +259,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (36,2)-(36,6))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (36,2)-(36,6) = "<<~E"
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (37,0)-(38,0))
@@ -308,7 +308,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (44,2)-(44,6))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (44,2)-(44,6) = "<<~E"
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (45,0)-(46,0))
@@ -344,7 +344,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (50,2)-(50,6))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (50,2)-(50,6) = "<<~E"
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (51,0)-(52,0))
@@ -380,7 +380,7 @@
         │   │   ├── flags: ∅
         │   │   └── arguments: (length: 1)
         │   │       └── @ InterpolatedStringNode (location: (56,2)-(56,6))
-        │   │           ├── flags: static_literal
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (56,2)-(56,6) = "<<~E"
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (57,0)-(58,0))

--- a/snapshots/whitequark/dedenting_interpolating_heredoc_fake_line_continuation.txt
+++ b/snapshots/whitequark/dedenting_interpolating_heredoc_fake_line_continuation.txt
@@ -6,7 +6,7 @@
     ├── flags: ∅
     └── body: (length: 1)
         └── @ InterpolatedStringNode (location: (1,0)-(1,8))
-            ├── flags: newline, static_literal
+            ├── flags: newline
             ├── opening_loc: (1,0)-(1,8) = "<<~'FOO'"
             ├── parts: (length: 2)
             │   ├── @ StringNode (location: (2,0)-(3,0))

--- a/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.txt
+++ b/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.txt
@@ -6,7 +6,7 @@
     ├── flags: ∅
     └── body: (length: 1)
         └── @ InterpolatedStringNode (location: (1,0)-(1,8))
-            ├── flags: newline, static_literal
+            ├── flags: newline
             ├── opening_loc: (1,0)-(1,8) = "<<~'FOO'"
             ├── parts: (length: 2)
             │   ├── @ StringNode (location: (2,0)-(3,0))

--- a/snapshots/whitequark/parser_bug_640.txt
+++ b/snapshots/whitequark/parser_bug_640.txt
@@ -6,7 +6,7 @@
     ├── flags: ∅
     └── body: (length: 1)
         └── @ InterpolatedStringNode (location: (1,0)-(1,6))
-            ├── flags: newline, static_literal
+            ├── flags: newline
             ├── opening_loc: (1,0)-(1,6) = "<<~FOO"
             ├── parts: (length: 2)
             │   ├── @ StringNode (location: (2,0)-(3,0))

--- a/snapshots/whitequark/ruby_bug_11990.txt
+++ b/snapshots/whitequark/ruby_bug_11990.txt
@@ -17,7 +17,7 @@
             │   ├── flags: ∅
             │   └── arguments: (length: 1)
             │       └── @ InterpolatedStringNode (location: (1,2)-(1,12))
-            │           ├── flags: static_literal
+            │           ├── flags: ∅
             │           ├── opening_loc: ∅
             │           ├── parts: (length: 2)
             │           │   ├── @ StringNode (location: (1,2)-(1,6))

--- a/snapshots/whitequark/slash_newline_in_heredocs.txt
+++ b/snapshots/whitequark/slash_newline_in_heredocs.txt
@@ -12,7 +12,7 @@
         │   ├── closing_loc: (5,0)-(6,0) = "E\n"
         │   └── unescaped: "    1     2\n    3\n"
         └── @ InterpolatedStringNode (location: (8,0)-(8,4))
-            ├── flags: newline, static_literal
+            ├── flags: newline
             ├── opening_loc: (8,0)-(8,4) = "<<~E"
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (9,0)-(10,0))

--- a/src/prism.c
+++ b/src/prism.c
@@ -5279,6 +5279,10 @@ pm_interpolated_string_node_append(pm_interpolated_string_node_t *node, pm_node_
 
     switch (PM_NODE_TYPE(part)) {
         case PM_STRING_NODE:
+            // If inner string is not frozen, clear flags for this string
+            if (!PM_NODE_FLAG_P(part, PM_STRING_FLAGS_FROZEN)) {
+                CLEAR_FLAGS(node);
+            }
             part->flags = (pm_node_flags_t) ((part->flags | PM_NODE_FLAG_STATIC_LITERAL | PM_STRING_FLAGS_FROZEN) & ~PM_STRING_FLAGS_MUTABLE);
             break;
         case PM_INTERPOLATED_STRING_NODE:

--- a/test/prism/result/static_literals_test.rb
+++ b/test/prism/result/static_literals_test.rb
@@ -4,6 +4,11 @@ require_relative "../test_helper"
 
 module Prism
   class StaticLiteralsTest < TestCase
+    def test_concatenanted_string_literal_is_not_static
+      node = Prism.parse_statement("'a' 'b'")
+      refute_predicate node, :static_literal?
+    end
+
     def test_static_literals
       assert_warning("1")
       assert_warning("0xA", "10", "10")


### PR DESCRIPTION
When inner strings aren't frozen, we need to clear the flags on interpolated string nodes so that we don't emit wrong instructions.

The compiler is currently incorrectly emitting frozen strings because the parser is erroneously declaring interpolated strings as "frozen". We need to fix this behavior in the parser so we can fix the compiler in CRuby.  This patch is a partial fix for [this bug](https://bugs.ruby-lang.org/issues/21187)