### PR TITLE
Fix jruby CI

### DIFF
--- a/gemfiles/jruby/Gemfile
+++ b/gemfiles/jruby/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-ruby "~> 3.4.2", engine: "jruby", engine_version: "~> 10.0.0.0"
+ruby "~> 3.4.2", engine: "jruby", engine_version: "~> 10.0.0"
 
 gemspec path: "../.."
 


### PR DESCRIPTION
The current version constraint is too specific and doesn't allow 10.0.1.0 which was recently released