### PR TITLE
RubyParser translation for stabby lambdas with `it`

### DIFF
--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -1151,7 +1151,7 @@ module Prism
         def visit_lambda_node(node)
           parameters =
             case node.parameters
-            when nil, NumberedParametersNode
+            when nil, ItParametersNode, NumberedParametersNode
               s(node, :args)
             else
               visit(node.parameters)

--- a/snapshots/it.txt
+++ b/snapshots/it.txt
@@ -1,31 +1,46 @@
-@ ProgramNode (location: (1,0)-(3,3))
+@ ProgramNode (location: (1,0)-(5,9))
 ├── flags: ∅
 ├── locals: []
 └── statements:
-    @ StatementsNode (location: (1,0)-(3,3))
+    @ StatementsNode (location: (1,0)-(5,9))
     ├── flags: ∅
-    └── body: (length: 1)
-        └── @ CallNode (location: (1,0)-(3,3))
-            ├── flags: newline, ignore_visibility
-            ├── receiver: ∅
-            ├── call_operator_loc: ∅
-            ├── name: :x
-            ├── message_loc: (1,0)-(1,1) = "x"
-            ├── opening_loc: ∅
-            ├── arguments: ∅
-            ├── closing_loc: ∅
-            └── block:
-                @ BlockNode (location: (1,2)-(3,3))
+    └── body: (length: 2)
+        ├── @ CallNode (location: (1,0)-(3,3))
+        │   ├── flags: newline, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :x
+        │   ├── message_loc: (1,0)-(1,1) = "x"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   └── block:
+        │       @ BlockNode (location: (1,2)-(3,3))
+        │       ├── flags: ∅
+        │       ├── locals: []
+        │       ├── parameters:
+        │       │   @ ItParametersNode (location: (1,2)-(3,3))
+        │       │   └── flags: ∅
+        │       ├── body:
+        │       │   @ StatementsNode (location: (2,2)-(2,4))
+        │       │   ├── flags: ∅
+        │       │   └── body: (length: 1)
+        │       │       └── @ ItLocalVariableReadNode (location: (2,2)-(2,4))
+        │       │           └── flags: newline
+        │       ├── opening_loc: (1,2)-(1,4) = "do"
+        │       └── closing_loc: (3,0)-(3,3) = "end"
+        └── @ LambdaNode (location: (5,0)-(5,9))
+            ├── flags: newline
+            ├── locals: []
+            ├── operator_loc: (5,0)-(5,2) = "->"
+            ├── opening_loc: (5,3)-(5,4) = "{"
+            ├── closing_loc: (5,8)-(5,9) = "}"
+            ├── parameters:
+            │   @ ItParametersNode (location: (5,0)-(5,9))
+            │   └── flags: ∅
+            └── body:
+                @ StatementsNode (location: (5,5)-(5,7))
                 ├── flags: ∅
-                ├── locals: []
-                ├── parameters:
-                │   @ ItParametersNode (location: (1,2)-(3,3))
-                │   └── flags: ∅
-                ├── body:
-                │   @ StatementsNode (location: (2,2)-(2,4))
-                │   ├── flags: ∅
-                │   └── body: (length: 1)
-                │       └── @ ItLocalVariableReadNode (location: (2,2)-(2,4))
-                │           └── flags: newline
-                ├── opening_loc: (1,2)-(1,4) = "do"
-                └── closing_loc: (3,0)-(3,3) = "end"
+                └── body: (length: 1)
+                    └── @ ItLocalVariableReadNode (location: (5,5)-(5,7))
+                        └── flags: newline

--- a/test/prism/fixtures/it.txt
+++ b/test/prism/fixtures/it.txt
@@ -1,3 +1,5 @@
 x do
   it
 end
+
+-> { it }

--- a/test/prism/ruby/parser_test.rb
+++ b/test/prism/ruby/parser_test.rb
@@ -171,9 +171,13 @@ module Prism
       actual_ast = Prism::Translation::Parser34.new.tokenize(buffer)[0]
 
       it_block_parameter_sexp = parse_sexp {
+        s(:begin,
         s(:itblock,
           s(:send, nil, :x), :it,
-          s(:lvar, :it))
+          s(:lvar, :it)),
+        s(:itblock,
+          s(:lambda), :it,
+          s(:lvar, :it)))
       }
 
       assert_equal(it_block_parameter_sexp, actual_ast.to_sexp)


### PR DESCRIPTION
Similar to #3409

However, I'm a little confused and I may be missing something.

The tests pass (as you can see) and the expected output in Prism's test is:
```ruby
s(:iter, s(:lambda), s(:args), (:call, nil, :it))
```

However, when I run RubyParser myself, I get

```ruby
3.4.2 :002 > RubyParser.new.parse('-> { it }')
 => s(:iter, s(:lambda), 0, s(:call, nil, :it)) 
```

I honestly can't explain the discrepancy. :confused: 