### PR TITLE
Bump dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,24 +9,26 @@ GEM
     ast (2.4.3)
     benchmark-ips (2.14.0)
     date (3.4.1)
-    ffi (1.17.1)
+    erb (5.0.2)
+    ffi (1.17.2)
     mini_portile2 (2.8.9)
     nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     onigmo (0.1.0)
-    parser (3.3.7.4)
+    parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)
-    psych (5.2.3)
+    psych (5.2.6)
       date
       stringio
     racc (1.8.1)
-    rake (13.2.1)
-    rake-compiler (1.2.9)
+    rake (13.3.0)
+    rake-compiler (1.3.0)
       rake
-    rdoc (6.12.0)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     ruby_memcheck (3.0.1)
       nokogiri
@@ -34,8 +36,8 @@ GEM
       racc (~> 1.5)
       sexp_processor (~> 4.16)
     sexp_processor (4.17.3)
-    stringio (3.1.5)
-    test-unit (3.6.7)
+    stringio (3.1.7)
+    test-unit (3.7.0)
       power_assert
 
 PLATFORMS


### PR DESCRIPTION
ruby-3.5-dev requires stringio 3.1.7 to compile. See https://github.com/ruby/stringio/pull/129

Not sure how CI does it, but this makes bundle install possible locally with ruby-dev