### PR TITLE
Use pm_arguments_end for function call

### DIFF
--- a/snapshots/method_calls.txt
+++ b/snapshots/method_calls.txt
@@ -278,7 +278,7 @@
         │   ├── arguments: ∅
         │   ├── closing_loc: ∅
         │   └── block: ∅
-        ├── @ CallNode (location: (25,0)-(25,8))
+        ├── @ CallNode (location: (25,0)-(25,9))
         │   ├── flags: newline, ignore_visibility
         │   ├── receiver: ∅
         │   ├── call_operator_loc: ∅
@@ -781,7 +781,7 @@
         │   │               └── block: ∅
         │   ├── closing_loc: (58,9)-(58,10) = ")"
         │   └── block: ∅
-        ├── @ CallNode (location: (60,0)-(60,39))
+        ├── @ CallNode (location: (60,0)-(60,40))
         │   ├── flags: newline, ignore_visibility
         │   ├── receiver: ∅
         │   ├── call_operator_loc: ∅
@@ -1156,7 +1156,7 @@
         │   │                   └── operator_loc: ∅
         │   ├── closing_loc: (70,40)-(70,41) = ")"
         │   └── block: ∅
-        ├── @ CallNode (location: (72,0)-(72,35))
+        ├── @ CallNode (location: (72,0)-(72,36))
         │   ├── flags: newline, ignore_visibility
         │   ├── receiver: ∅
         │   ├── call_operator_loc: ∅

--- a/snapshots/seattlerb/call_block_arg_named.txt
+++ b/snapshots/seattlerb/call_block_arg_named.txt
@@ -1,11 +1,11 @@
-@ ProgramNode (location: (1,0)-(1,6))
+@ ProgramNode (location: (1,0)-(1,7))
 ├── flags: ∅
 ├── locals: []
 └── statements:
-    @ StatementsNode (location: (1,0)-(1,6))
+    @ StatementsNode (location: (1,0)-(1,7))
     ├── flags: ∅
     └── body: (length: 1)
-        └── @ CallNode (location: (1,0)-(1,6))
+        └── @ CallNode (location: (1,0)-(1,7))
             ├── flags: newline, ignore_visibility
             ├── receiver: ∅
             ├── call_operator_loc: ∅

--- a/snapshots/unparser/corpus/literal/send.txt
+++ b/snapshots/unparser/corpus/literal/send.txt
@@ -813,7 +813,7 @@
         │   │           └── unescaped: "bar"
         │   ├── closing_loc: ∅
         │   └── block: ∅
-        ├── @ CallNode (location: (50,0)-(50,17))
+        ├── @ CallNode (location: (50,0)-(50,18))
         │   ├── flags: newline, ignore_visibility
         │   ├── receiver: ∅
         │   ├── call_operator_loc: ∅
@@ -860,7 +860,7 @@
         │       │   ├── opening_loc: (50,5)-(50,6) = "("
         │       │   └── closing_loc: (50,16)-(50,17) = ")"
         │       └── operator_loc: (50,4)-(50,5) = "&"
-        ├── @ CallNode (location: (51,0)-(51,10))
+        ├── @ CallNode (location: (51,0)-(51,11))
         │   ├── flags: newline, ignore_visibility
         │   ├── receiver: ∅
         │   ├── call_operator_loc: ∅
@@ -884,7 +884,7 @@
         │       │   ├── closing_loc: ∅
         │       │   └── block: ∅
         │       └── operator_loc: (51,4)-(51,5) = "&"
-        ├── @ CallNode (location: (52,0)-(52,17))
+        ├── @ CallNode (location: (52,0)-(52,18))
         │   ├── flags: newline, ignore_visibility
         │   ├── receiver: ∅
         │   ├── call_operator_loc: ∅

--- a/snapshots/unparser/corpus/literal/since/31.txt
+++ b/snapshots/unparser/corpus/literal/since/31.txt
@@ -26,10 +26,10 @@
         │   │       ├── name_loc: ∅
         │   │       └── operator_loc: (1,8)-(1,9) = "&"
         │   ├── body:
-        │   │   @ StatementsNode (location: (2,2)-(2,7))
+        │   │   @ StatementsNode (location: (2,2)-(2,8))
         │   │   ├── flags: ∅
         │   │   └── body: (length: 1)
-        │   │       └── @ CallNode (location: (2,2)-(2,7))
+        │   │       └── @ CallNode (location: (2,2)-(2,8))
         │   │           ├── flags: newline, ignore_visibility
         │   │           ├── receiver: ∅
         │   │           ├── call_operator_loc: ∅
@@ -74,10 +74,10 @@
             │       ├── name_loc: ∅
             │       └── operator_loc: (5,11)-(5,12) = "&"
             ├── body:
-            │   @ StatementsNode (location: (6,2)-(6,7))
+            │   @ StatementsNode (location: (6,2)-(6,8))
             │   ├── flags: ∅
             │   └── body: (length: 1)
-            │       └── @ CallNode (location: (6,2)-(6,7))
+            │       └── @ CallNode (location: (6,2)-(6,8))
             │           ├── flags: newline, ignore_visibility
             │           ├── receiver: ∅
             │           ├── call_operator_loc: ∅

--- a/snapshots/whitequark/anonymous_blockarg.txt
+++ b/snapshots/whitequark/anonymous_blockarg.txt
@@ -26,10 +26,10 @@
             │       ├── name_loc: ∅
             │       └── operator_loc: (1,8)-(1,9) = "&"
             ├── body:
-            │   @ StatementsNode (location: (1,12)-(1,17))
+            │   @ StatementsNode (location: (1,12)-(1,18))
             │   ├── flags: ∅
             │   └── body: (length: 1)
-            │       └── @ CallNode (location: (1,12)-(1,17))
+            │       └── @ CallNode (location: (1,12)-(1,18))
             │           ├── flags: newline, ignore_visibility
             │           ├── receiver: ∅
             │           ├── call_operator_loc: ∅

--- a/snapshots/whitequark/args_args_assocs.txt
+++ b/snapshots/whitequark/args_args_assocs.txt
@@ -1,8 +1,8 @@
-@ ProgramNode (location: (1,0)-(3,24))
+@ ProgramNode (location: (1,0)-(3,25))
 ├── flags: ∅
 ├── locals: []
 └── statements:
-    @ StatementsNode (location: (1,0)-(3,24))
+    @ StatementsNode (location: (1,0)-(3,25))
     ├── flags: ∅
     └── body: (length: 2)
         ├── @ CallNode (location: (1,0)-(1,19))
@@ -45,7 +45,7 @@
         │   │                   └── operator_loc: (1,14)-(1,16) = "=>"
         │   ├── closing_loc: (1,18)-(1,19) = ")"
         │   └── block: ∅
-        └── @ CallNode (location: (3,0)-(3,24))
+        └── @ CallNode (location: (3,0)-(3,25))
             ├── flags: newline, ignore_visibility
             ├── receiver: ∅
             ├── call_operator_loc: ∅

--- a/snapshots/whitequark/args_args_star.txt
+++ b/snapshots/whitequark/args_args_star.txt
@@ -1,8 +1,8 @@
-@ ProgramNode (location: (1,0)-(3,19))
+@ ProgramNode (location: (1,0)-(3,20))
 ├── flags: ∅
 ├── locals: []
 └── statements:
-    @ StatementsNode (location: (1,0)-(3,19))
+    @ StatementsNode (location: (1,0)-(3,20))
     ├── flags: ∅
     └── body: (length: 2)
         ├── @ CallNode (location: (1,0)-(1,14))
@@ -42,7 +42,7 @@
         │   │               └── block: ∅
         │   ├── closing_loc: (1,13)-(1,14) = ")"
         │   └── block: ∅
-        └── @ CallNode (location: (3,0)-(3,19))
+        └── @ CallNode (location: (3,0)-(3,20))
             ├── flags: newline, ignore_visibility
             ├── receiver: ∅
             ├── call_operator_loc: ∅

--- a/snapshots/whitequark/args_block_pass.txt
+++ b/snapshots/whitequark/args_block_pass.txt
@@ -1,11 +1,11 @@
-@ ProgramNode (location: (1,0)-(1,8))
+@ ProgramNode (location: (1,0)-(1,9))
 ├── flags: ∅
 ├── locals: []
 └── statements:
-    @ StatementsNode (location: (1,0)-(1,8))
+    @ StatementsNode (location: (1,0)-(1,9))
     ├── flags: ∅
     └── body: (length: 1)
-        └── @ CallNode (location: (1,0)-(1,8))
+        └── @ CallNode (location: (1,0)-(1,9))
             ├── flags: newline, ignore_visibility
             ├── receiver: ∅
             ├── call_operator_loc: ∅

--- a/snapshots/whitequark/args_star.txt
+++ b/snapshots/whitequark/args_star.txt
@@ -1,8 +1,8 @@
-@ ProgramNode (location: (1,0)-(3,14))
+@ ProgramNode (location: (1,0)-(3,15))
 ├── flags: ∅
 ├── locals: []
 └── statements:
-    @ StatementsNode (location: (1,0)-(3,14))
+    @ StatementsNode (location: (1,0)-(3,15))
     ├── flags: ∅
     └── body: (length: 2)
         ├── @ CallNode (location: (1,0)-(1,9))
@@ -32,7 +32,7 @@
         │   │               └── block: ∅
         │   ├── closing_loc: (1,8)-(1,9) = ")"
         │   └── block: ∅
-        └── @ CallNode (location: (3,0)-(3,14))
+        └── @ CallNode (location: (3,0)-(3,15))
             ├── flags: newline, ignore_visibility
             ├── receiver: ∅
             ├── call_operator_loc: ∅

--- a/src/prism.c
+++ b/src/prism.c
@@ -18570,17 +18570,11 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
                     call->closing_loc = arguments.closing_loc;
                     call->block = arguments.block;
 
-                    if (arguments.block != NULL) {
-                        call->base.location.end = arguments.block->location.end;
-                    } else if (arguments.closing_loc.start == NULL) {
-                        if (arguments.arguments != NULL) {
-                            call->base.location.end = arguments.arguments->base.location.end;
-                        } else {
-                            call->base.location.end = call->message_loc.end;
-                        }
-                    } else {
-                        call->base.location.end = arguments.closing_loc.end;
+                    const uint8_t *end = pm_arguments_end(&arguments);
+                    if (!end) {
+                        end = call->message_loc.end;
                     }
+                    call->base.location.end = end;
                 }
             } else {
                 // Otherwise, we know the identifier is in the local table. This


### PR DESCRIPTION
Previously, the location of CallNode was incorrect when it accepts a block parameter:

```
ruby -rprism -e 'pp Prism.parse("foo(&blk)").value.statements.body[0]']
@ CallNode (location: (1,0)-(1,8))  # <=== It should be (1,0)-(1,9)
├── flags: ∅
├── receiver: ∅
├── call_operator_loc: ∅
├── name: :foo
├── message_loc: (1,0)-(1,3) = "foo"
├── opening_loc: (1,3)-(1,4) = "("
├── arguments: ∅
├── closing_loc: (1,8)-(1,9) = ")"
*snip*

$ ruby -rprism -e 'pp Prism.parse("foo(&blk)").value.statements.body[0].slice'
"foo(&blk"
```

Note that the slice lacks the closing parenthesis.