### PR TITLE
Fix character literal forced encoding

### DIFF
--- a/snapshots/character_literal.txt
+++ b/snapshots/character_literal.txt
@@ -1,0 +1,37 @@
+@ ProgramNode (location: (2,0)-(2,11))
+├── flags: ∅
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (2,0)-(2,11))
+    ├── flags: ∅
+    └── body: (length: 1)
+        └── @ CallNode (location: (2,0)-(2,11))
+            ├── flags: newline, ignore_visibility
+            ├── receiver: ∅
+            ├── call_operator_loc: ∅
+            ├── name: :p
+            ├── message_loc: (2,0)-(2,1) = "p"
+            ├── opening_loc: ∅
+            ├── arguments:
+            │   @ ArgumentsNode (location: (2,2)-(2,11))
+            │   ├── flags: ∅
+            │   └── arguments: (length: 1)
+            │       └── @ InterpolatedStringNode (location: (2,2)-(2,11))
+            │           ├── flags: static_literal
+            │           ├── opening_loc: ∅
+            │           ├── parts: (length: 2)
+            │           │   ├── @ StringNode (location: (2,2)-(2,9))
+            │           │   │   ├── flags: static_literal, forced_utf8_encoding, frozen
+            │           │   │   ├── opening_loc: (2,2)-(2,3) = "?"
+            │           │   │   ├── content_loc: (2,3)-(2,9) = "\\u3042"
+            │           │   │   ├── closing_loc: ∅
+            │           │   │   └── unescaped: "\x{E381}\x82"
+            │           │   └── @ StringNode (location: (2,9)-(2,11))
+            │           │       ├── flags: static_literal, frozen
+            │           │       ├── opening_loc: (2,9)-(2,10) = "\""
+            │           │       ├── content_loc: (2,10)-(2,10) = ""
+            │           │       ├── closing_loc: (2,10)-(2,11) = "\""
+            │           │       └── unescaped: ""
+            │           └── closing_loc: ∅
+            ├── closing_loc: ∅
+            └── block: ∅

--- a/test/prism/fixtures/character_literal.txt
+++ b/test/prism/fixtures/character_literal.txt
@@ -1,0 +1,2 @@
+# encoding: Windows-31J
+p ?\u3042""

--- a/test/prism/ruby/ruby_parser_test.rb
+++ b/test/prism/ruby/ruby_parser_test.rb
@@ -16,6 +16,7 @@ end
 module Prism
   class RubyParserTest < TestCase
     todos = [
+      "character_literal.txt",
       "encoding_euc_jp.txt",
       "regex_char_width.txt",
       "seattlerb/masgn_colon3.txt",


### PR DESCRIPTION
If a character literal was followed by a string concatenation, then the forced encoding of the string concatenation could accidentally overwrite the explicit encoding of the character literal. We now handle this properly.

Fixes https://github.com/ruby/prism/issues/3512