### PR TITLE
Fix truffleruby CI

### DIFF
--- a/gemfiles/truffleruby/Gemfile
+++ b/gemfiles/truffleruby/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-ruby "~> 3.3.5", engine: "truffleruby", engine_version: "~> 24.2.0"
+ruby "~> 3.3.7", engine: "truffleruby", engine_version: "~> 25.0.0"
 
 gemspec path: "../.."
 

--- a/gemfiles/truffleruby/Gemfile.lock
+++ b/gemfiles/truffleruby/Gemfile.lock
@@ -34,7 +34,7 @@ DEPENDENCIES
   test-unit
 
 RUBY VERSION
-   ruby 3.3.5p0 (truffleruby 24.2.0)
+   ruby 3.3.7p0 (truffleruby 25.0.0)
 
 BUNDLED WITH
    2.4.19


### PR DESCRIPTION
Truffleruby 25 got released yesterday.

https://github.com/oracle/truffleruby/releases/tag/graal-25.0.0