### PR TITLE
Reject `1 if foo = bar baz`

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -20909,7 +20909,7 @@ parse_assignment_values(pm_parser_t *parser, pm_binding_power_t previous_binding
     bool permitted = true;
     if (previous_binding_power != PM_BINDING_POWER_STATEMENT && match1(parser, PM_TOKEN_USTAR)) permitted = false;
 
-    pm_node_t *value = parse_starred_expression(parser, binding_power, previous_binding_power == PM_BINDING_POWER_ASSIGNMENT ? accepts_command_call : previous_binding_power < PM_BINDING_POWER_MATCH, diag_id, (uint16_t) (depth + 1));
+    pm_node_t *value = parse_starred_expression(parser, binding_power, previous_binding_power == PM_BINDING_POWER_ASSIGNMENT ? accepts_command_call : previous_binding_power < PM_BINDING_POWER_MODIFIER, diag_id, (uint16_t) (depth + 1));
     if (!permitted) pm_parser_err_node(parser, value, PM_ERR_UNEXPECTED_MULTI_WRITE);
 
     parse_assignment_value_local(parser, value);

--- a/test/prism/errors/command_calls_33.txt
+++ b/test/prism/errors/command_calls_33.txt
@@ -1,0 +1,6 @@
+1 if foo = bar baz
+               ^~~ unexpected local variable or method, expecting end-of-input
+
+1 and foo = bar baz
+                ^~~ unexpected local variable or method, expecting end-of-input
+


### PR DESCRIPTION
and also `1 and foo = bar baz`

This is a partial fix for https://github.com/ruby/prism/issues/3106. It still accepts `a = b c and 1`