### PR TITLE
Fix example marker for case statement predicate

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1800,7 +1800,7 @@ nodes:
           Represents the predicate of the case statement. This can be either `nil` or any [non-void expressions](https://github.com/ruby/prism/blob/main/docs/parsing_rules.md#non-void-expression).
 
               case true; when false; end
-              ^^^^
+                   ^^^^
       - name: conditions
         type: node[]
         kind: WhenNode


### PR DESCRIPTION
I was looking for what to call the thing based to the case keyword.
Is this change correct?
The `case` keyword gets marked below under `case_keyword_loc`.