### PR TITLE
Default `MAKEFLAGS` to `-j`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,10 @@ desc "Generate all ERB template based files"
 task templates: Prism::Template::TEMPLATES
 
 make = RUBY_PLATFORM.match?(/openbsd|freebsd/) ? "gmake" : "make"
-task(make: :templates) { sh(make) }
+task(make: :templates) {
+  ENV["MAKEFLAGS"] ||= "-j"
+  sh(make)
+}
 task(make_no_debug: :templates) { sh("#{make} all-no-debug") }
 task(make_minimal: :templates) { sh("#{make} minimal") }
 


### PR DESCRIPTION
This tells `make` to run in parallel by default.  If I do

```
$ rake clobber; time rake compile
```

On the main branch it's like this:

```
________________________________________________________
Executed in    9.71 secs    fish           external
   usr time    8.41 secs  128.00 micros    8.41 secs
   sys time    1.16 secs  530.00 micros    1.16 secs
```

On this branch it's like this:

```
________________________________________________________
Executed in    3.89 secs    fish           external
   usr time   11.49 secs  127.00 micros   11.49 secs
   sys time    2.00 secs  553.00 micros    2.00 secs
```

So this buys me about 6 seconds on my machine