### PR TITLE
CI: build-ibm: Use nproc instead of hard-coded number 2.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install ruby-full bundler libyaml-dev
     - name: Install dependencies
-      run: sudo bundle install --jobs 2
+      run: sudo bundle install --jobs $(nproc)
     - name: Run Ruby tests
       run: bundle exec rake
       shell: bash


### PR DESCRIPTION
This PR is just a small refactoring in the CI's build-ibm job to use the `$(nproc)` instead of hard-coded number `2`. I noticed this was better, and applied it on ruby/openssl repository. So, I want to apply the change to this ruby/prism repository.

https://github.com/ruby/openssl/pull/946/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R44
