### PR TITLE
Follow fix for method call with `in` bug

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -22304,14 +22304,23 @@ parse_expression(pm_parser_t *parser, pm_binding_power_t binding_power, bool acc
                     return node;
                 }
                 break;
-            case PM_CALL_NODE:
+            case PM_CALL_NODE: {
                 // These expressions are also statements, by virtue of the
                 // right-hand side of the expression (i.e., the last argument to
                 // the call node) being an implicit array.
                 if (PM_NODE_FLAG_P(node, PM_CALL_NODE_FLAGS_IMPLICIT_ARRAY) && pm_binding_powers[parser->current.type].left > PM_BINDING_POWER_MODIFIER) {
                     return node;
                 }
+
+                // Method calls with arguments (without parentheses)
+                // cannot be followed by the `in` operator.
+                pm_call_node_t *cast = (pm_call_node_t *) node;
+                if (cast->arguments != NULL && cast->opening_loc.start == NULL && parser->current.type == PM_TOKEN_KEYWORD_IN) {
+                    return node;
+                }
+
                 break;
+            }
             default:
                 break;
         }

--- a/test/prism/errors/command_call_in.txt
+++ b/test/prism/errors/command_call_in.txt
@@ -2,4 +2,17 @@ foo 1 in a
       ^~ unexpected 'in', expecting end-of-input
       ^~ unexpected 'in', ignoring it
 a = foo 2 in b
+A.print foo in 'BAR'
+            ^~ unexpected 'in', expecting end-of-input
+            ^~ unexpected 'in', ignoring it
+A.print foo: bar in 'BAR'
+                 ^~ unexpected 'in', expecting end-of-input
+                 ^~ unexpected 'in', ignoring it
+A.print message: in 'BAR'
+                 ^~ unexpected 'in', expecting end-of-input
+                 ^~ unexpected 'in', ignoring it
+A.print message:
+in 'BAR'
+^~ unexpected 'in', expecting end-of-input
+^~ unexpected 'in', ignoring it
 


### PR DESCRIPTION
This PR is a followup to #3558 and fixes the following cases, which should throw a syntax error but were not:

```ruby
A.print message: in 'BAR'

A.print message:
in 'BAR'
```

To fix this we check for methods calls with arguments and no parens that then call `in`.

Note I had claude write this because I wasn't sure where the problem was but then edited it to remove extra unnecessary code the robot wrote.

cc/ @tenderlove 