### PR TITLE
Fix unintended change

### DIFF
--- a/snapshots/seattlerb/dstr_evstr.txt
+++ b/snapshots/seattlerb/dstr_evstr.txt
@@ -6,7 +6,7 @@
     ├── flags: ∅
     └── body: (length: 1)
         └── @ InterpolatedStringNode (location: (1,0)-(1,12))
-            ├── flags: newline, mutable
+            ├── flags: newline
             ├── opening_loc: (1,0)-(1,1) = "\""
             ├── parts: (length: 2)
             │   ├── @ EmbeddedStatementsNode (location: (1,1)-(1,7))

--- a/snapshots/string_concatination_frozen_false.txt
+++ b/snapshots/string_concatination_frozen_false.txt
@@ -39,7 +39,7 @@
             │   │   ├── closing_loc: (5,10)-(5,11) = "'"
             │   │   └── unescaped: "bar"
             │   └── @ InterpolatedStringNode (location: (5,12)-(5,23))
-            │       ├── flags: mutable
+            │       ├── flags: ∅
             │       ├── opening_loc: (5,12)-(5,13) = "\""
             │       ├── parts: (length: 2)
             │       │   ├── @ StringNode (location: (5,13)-(5,16))

--- a/snapshots/string_concatination_frozen_true.txt
+++ b/snapshots/string_concatination_frozen_true.txt
@@ -39,7 +39,7 @@
             │   │   ├── closing_loc: (5,10)-(5,11) = "'"
             │   │   └── unescaped: "bar"
             │   └── @ InterpolatedStringNode (location: (5,12)-(5,23))
-            │       ├── flags: frozen
+            │       ├── flags: ∅
             │       ├── opening_loc: (5,12)-(5,13) = "\""
             │       ├── parts: (length: 2)
             │       │   ├── @ StringNode (location: (5,13)-(5,16))

--- a/src/prism.c
+++ b/src/prism.c
@@ -5281,7 +5281,8 @@ pm_interpolated_string_node_append(pm_interpolated_string_node_t *node, pm_node_
     switch (PM_NODE_TYPE(part)) {
         case PM_STRING_NODE:
             // If inner string is not frozen, it stops being a static literal. We should *not* clear other flags,
-            // because concatenating two frozen strings (`'foo' 'bar'`) is still frozen.
+            // because concatenating two frozen strings (`'foo' 'bar'`) is still frozen. This holds true for
+            // as long as this interpolation only consists of other string literals.
             if (!PM_NODE_FLAG_P(part, PM_STRING_FLAGS_FROZEN)) {
                 pm_node_flag_unset((pm_node_t *) node, PM_NODE_FLAG_STATIC_LITERAL);
             }
@@ -5324,7 +5325,7 @@ pm_interpolated_string_node_append(pm_interpolated_string_node_t *node, pm_node_
             } else {
                 // In all other cases, we lose the static literal flag here and
                 // become mutable.
-                pm_node_flag_unset((pm_node_t *) node, PM_NODE_FLAG_STATIC_LITERAL);
+                CLEAR_FLAGS(node);
             }
 
             break;


### PR DESCRIPTION
This is not needed for https://bugs.ruby-lang.org/issues/21187

It does not seem to change generated instructions either way but I think this is more correct.