### PR TITLE
Free current_block_exits for the program

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -22524,8 +22524,9 @@ parse_program(pm_parser_t *parser) {
         statements = wrap_statements(parser, statements);
     } else {
         flush_block_exits(parser, previous_block_exits);
-        pm_node_list_free(&current_block_exits);
     }
+
+    pm_node_list_free(&current_block_exits);
 
     // If this is an empty file, then we're still going to parse all of the
     // statements in order to gather up all of the comments and such. Here we'll


### PR DESCRIPTION
We need to free the current_block_exits in parse_program when we're done with it to prevent memory leaks. This fixes the following memory leak detected when running Ruby using `RUBY_FREE_AT_EXIT=1 ruby -nc -e "break"`:

    Direct leak of 32 byte(s) in 1 object(s) allocated from:
        #0 0x5bd3c5bc66c8 in realloc (miniruby+0x616c8) (BuildId: ba6a96e5a060aec6fd9f05ed7e95d9627e1dbd74)
        #1 0x5bd3c5f91fd9 in pm_node_list_grow prism/templates/src/node.c.erb:35:40
        #2 0x5bd3c5f91e9d in pm_node_list_append prism/templates/src/node.c.erb:48:9
        #3 0x5bd3c6001fa0 in parse_block_exit prism/prism.c:15788:17
        #4 0x5bd3c5fee155 in parse_expression_prefix prism/prism.c:19221:50
        #5 0x5bd3c5fe9970 in parse_expression prism/prism.c:22235:23
        #6 0x5bd3c5fe0586 in parse_statements prism/prism.c:13976:27
        #7 0x5bd3c5fd6792 in parse_program prism/prism.c:22508:40