### PR TITLE
Add support for `Prism.parse(foo, version: "current")`

### DIFF
--- a/lib/prism.rb
+++ b/lib/prism.rb
@@ -37,6 +37,27 @@ module Prism
   private_constant :LexCompat
   private_constant :LexRipper
 
+  # Raised when requested to parse as the currently running Ruby version but Prism has no support for it.
+  class CurrentVersionError < ArgumentError
+    # Initialize a new exception for the given ruby version string.
+    def initialize(version)
+      message = +"invalid version: Requested to parse as `version: 'current'`; "
+      gem_version =
+        begin
+          Gem::Version.new(version)
+        rescue ArgumentError
+        end
+
+      if gem_version && gem_version < Gem::Version.new("3.3.0")
+        message << " #{version} is below the minimum supported syntax."
+      else
+        message << " #{version} is unknown. Please update the `prism` gem."
+      end
+
+      super(message)
+    end
+  end
+
   # :call-seq:
   #   Prism::lex_compat(source, **options) -> LexCompat::Result
   #

--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -423,7 +423,9 @@ module Prism
 
     # Return the value that should be dumped for the version option.
     def dump_options_version(version)
-      case version
+      current = version == "current"
+
+      case current ? RUBY_VERSION : version
       when nil, "latest"
         0 # Handled in pm_parser_init
       when /\A3\.3(\.\d+)?\z/
@@ -433,7 +435,11 @@ module Prism
       when /\A3\.5(\.\d+)?\z/
         3
       else
-        raise ArgumentError, "invalid version: #{version}"
+        if current
+          raise CurrentVersionError, RUBY_VERSION
+        else
+          raise ArgumentError, "invalid version: #{version}"
+        end
       end
     end
 

--- a/templates/sig/prism.rbs.erb
+++ b/templates/sig/prism.rbs.erb
@@ -2,6 +2,10 @@ module Prism
   BACKEND: :CEXT | :FFI
   VERSION: String
 
+  class CurrentVersionError < ArgumentError
+    def initialize: (String version) -> void
+  end
+
   # Methods taking a Ruby source code string:
   <%-
     {


### PR DESCRIPTION
The docs currently say to use `Prism.parse(foo, version: RUBY_VERSION)` for this. By specifying "current" instead, we can have prism raise a more specifc error. It doesn't add much code so I think being more explicit is worth it. It's similar to `Prism::Translation::ParserCurrent` but instead of warning it raises.

For a smooth experience, it requires a prism release right around when a new ruby version is released. But that is also already true for using `RUBY_VERSION`.

Note: Does not use `ruby_version` from `ruby/version.h` because writing a test for that is not really possible. I instead pull it from `RUBY_VERSION` constant at runtime so it can be stubbed.

Ref https://bugs.ruby-lang.org/issues/21618