### PR TITLE
Trusted publishing workflows

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -19,10 +19,8 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
-
-      - name: Install dependencies
-        run: bundle install --jobs 4 --retry 3
+          ruby-version: "3.4"
+          bundler-cache: true
 
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -33,9 +33,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"
-
-      - name: Install dependencies
-        run: bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Publish to RubyGems
         uses: rubygems/release-gem@v1

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,16 +19,14 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: "3.4"
+          bundler-cache: true
 
       - name: Set up node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        run: bundle install --jobs 4 --retry 3
 
       - name: rake templates
         run: bundle exec rake templates


### PR DESCRIPTION
I'm working on adding trusted publishing workflows so we can automate gem / crate / npm package releases.  Once we get this working correctly, we can simply push a tag to GitHub, and all of the packages will be released automatically.

The plan is to add one workflow per publisher.

- [x] RubyGems workflow
- [x] crates.io workflow
- [x] npmjs workflow

I set up the RubyGems workflow based on [other gems that we publish](https://github.com/ruby/psych/blob/master/.github/workflows/push_gem.yml).

I'm less confident about the other workflows, but I used [this documentation for crates.io](https://crates.io/docs/trusted-publishing) as well as [this documentation for npm](https://docs.npmjs.com/trusted-publishers).

I based the crates workflow and the npm workflow off of their respective CI workflows, but I'd really appreciate reviews from other folks.  Once we have something to release, we can test these workflows. 😄 