### PR TITLE
`-Wsign-conversion`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ FUZZ_OUTPUT_DIR = $(CURDIR)/fuzz/output
 SOEXT ?= $(shell ruby -e 'puts RbConfig::CONFIG["SOEXT"]')
 
 CPPFLAGS := -Iinclude $(CPPFLAGS)
-CFLAGS := -g -O2 -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion -Wno-missing-braces -fPIC -fvisibility=hidden -Wimplicit-fallthrough $(CFLAGS)
-JAVA_WASM_CFLAGS := -g -Oz -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion -Wno-missing-braces -fPIC -fvisibility=hidden -Wimplicit-fallthrough $(JAVA_WASM_CFLAGS)
+CFLAGS := -g -O2 -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion -Wno-missing-braces -fPIC -fvisibility=hidden -Wimplicit-fallthrough -Wsign-conversion $(CFLAGS)
+JAVA_WASM_CFLAGS := -g -Oz -std=c99 -Wall -Werror -Wextra -Wpedantic -Wundef -Wconversion -Wno-missing-braces -fPIC -fvisibility=hidden -Wimplicit-fallthrough -Wsign-conversion $(JAVA_WASM_CFLAGS)
 CC ?= cc
 AR ?= ar
 ARFLAGS ?= -r$(V0:1=v)


### PR DESCRIPTION
selenium-webdriver pinned prism to 1.4.0 because of the following warning (which their compiler treats as an error):

```
src/prism.c: In function ‘context_terminator’:
src/prism.c:8651:62: error: conversion to ‘unsigned int’ from ‘int’ may change
the sign of the result [-Werror=sign-conversion]
8651 |     return token->type < 32 && (context_terminators[context] & (1 <<
token->type));
```

I have seen this warning myself during building, but now I can't reproduce anymore. Perhaps CI will tell me more.