### PR TITLE
Reenable windows CI that were disabled because of fiddle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
           - macos-latest
-          # - windows-latest <-- failing with fiddle error, temporarily disabled
+          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5
@@ -145,7 +145,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
           - macos-latest
-          # - windows-latest <-- failing with fiddle error, temporarily disabled
+          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
Followup to https://github.com/ruby/prism/commit/cd91afe4fe424a3e423992c3e77558121c669b60
Hopefully those are resolved as well.