### PR TITLE
Allow compiling from source on windows:

### DIFF
--- a/ext/prism/extconf.rb
+++ b/ext/prism/extconf.rb
@@ -37,7 +37,7 @@ end
 def generate_templates
   Dir.chdir(File.expand_path("../..", __dir__)) do
     if !File.exist?("include/prism/ast.h") && Dir.exist?(".git")
-      system("templates/template.rb", exception: true)
+      system(RbConfig.ruby, "templates/template.rb", exception: true)
     end
   end
 end


### PR DESCRIPTION
👋 

I'm trying to compile Prism from source on a Windows machine but it unforutnately fails when trying to render the template due to the shebang that doesn't exist on Windows 
https://github.com/ruby/prism/blob/2e577c0e95345fa3866dcb626138dcc77635791f/templates/template.rb#L1

I modified the `system` call to call ruby with its full path directly instead.