### PR TITLE
Test against parse.y

### DIFF
--- a/.github/workflows/cruby-bindings.yml
+++ b/.github/workflows/cruby-bindings.yml
@@ -12,6 +12,14 @@ on:
 
 jobs:
   test-all:
+    strategy:
+      matrix:
+        # Some tests in this repository are only run against parse.y
+        # We test them here in order to not fail ruby/ruby CI.
+        parser:
+          - prism
+          - parse.y
+
     runs-on: ubuntu-24.04
     steps:
       - name: Set up latest ruby head
@@ -39,9 +47,11 @@ jobs:
         run: |
           ruby tool/downloader.rb -d tool -e gnu config.guess config.sub
           autoconf
-          ./configure -C --disable-install-doc
+          ./configure -C --disable-install-doc --with-parser=${{ matrix.parser }}
           make -j$(nproc)
         working-directory: ruby/ruby
       - name: make test-all
+        env:
+          RUN_OPTS: --parser=${{ matrix.parser }}
         run: make -j$(nproc) -s test-all
         working-directory: ruby/ruby

--- a/test/prism/fixtures_test.rb
+++ b/test/prism/fixtures_test.rb
@@ -28,6 +28,12 @@ module Prism
       except << "3.4/circular_parameters.txt"
     end
 
+    # Valid only on Ruby 3.3
+    except << "3.3-3.3/block_args_in_array_assignment.txt"
+    except << "3.3-3.3/it_with_ordinary_parameter.txt"
+    except << "3.3-3.3/keyword_args_in_array_assignment.txt"
+    except << "3.3-3.3/return_in_sclass.txt"
+
     # Leaving these out until they are supported by parse.y.
     except << "3.5/leading_logical.txt"
     except << "3.5/endless_methods_command_call.txt"

--- a/test/prism/locals_test.rb
+++ b/test/prism/locals_test.rb
@@ -31,6 +31,12 @@ module Prism
       # CRuby is eliminating dead code.
       "whitequark/ruby_bug_10653.txt",
 
+      # Valid only on Ruby 3.3
+      "3.3-3.3/block_args_in_array_assignment.txt",
+      "3.3-3.3/it_with_ordinary_parameter.txt",
+      "3.3-3.3/keyword_args_in_array_assignment.txt",
+      "3.3-3.3/return_in_sclass.txt",
+
       # Leaving these out until they are supported by parse.y.
       "3.5/leading_logical.txt",
       "3.5/endless_methods_command_call.txt",


### PR DESCRIPTION
https://github.com/ruby/prism/commit/17a6a19bbae5c8b438a94816ed67c3852547d859 broke ruby/ruby CI because some tests are only run against parse.y
This should help catch stuff like that