### PR TITLE
Fix clippy lint on rust 1.91

### DIFF
--- a/rust/ruby-prism/build.rs
+++ b/rust/ruby-prism/build.rs
@@ -142,10 +142,10 @@ fn struct_name(name: &str) -> String {
     result
 }
 
-fn kind_to_type(kind: &String) -> String {
-    match kind.as_str() {
+fn kind_to_type(kind: &str) -> String {
+    match kind {
         "non-void expression" | "pattern expression" | "Node" => String::new(),
-        _ => kind.to_string(),
+        _ => kind.to_owned(),
     }
 }
 


### PR DESCRIPTION
```
Compiling ruby-prism v1.6.0 (/home/runner/work/prism/prism/rust/ruby-prism)
error: implicitly cloning a `String` by calling `to_string` on its dereferenced type
   --> ruby-prism/build.rs:148:14
    |
148 |         _ => kind.to_string(),
    |              ^^^^^^^^^^^^^^^^ help: consider using: `kind.clone()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#implicit_clone
    = note: `-D clippy::implicit-clone` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::implicit_clone)]`
```