### PR TITLE
Replace `serde_yaml` with `serde_json`

### DIFF
--- a/rakelib/cargo.rake
+++ b/rakelib/cargo.rake
@@ -3,6 +3,9 @@ namespace :cargo do
 
   desc "Build and test the Rust packages"
   task build: [:templates] do
+    require "json"
+    require "yaml"
+
     gemspec = Gem::Specification.load("prism.gemspec")
 
     prism_sys_dir = Pathname(File.expand_path(File.join(__dir__, "../rust", "ruby-prism-sys")))
@@ -18,7 +21,11 @@ namespace :cargo do
 
     rm_rf(prism_dir.join("vendor"))
     mkdir_p(prism_vendor_dir)
-    cp(File.expand_path("../config.yml", __dir__), prism_vendor_dir.join("config.yml"))
+
+    # This used `serde_yaml` previously, which is now deprecated. Convert it to json
+    # so that `serde_json` can be used instead, keeping it strongly typed.
+    config_yaml = YAML.load_file(File.expand_path("../config.yml", __dir__))
+    File.write(prism_vendor_dir.join("config.json"), JSON.dump(config_yaml))
 
     # Align the Cargo.toml version with the gemspec version
     CRATES.each do |crate|

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -79,32 +79,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-
-[[package]]
-name = "indexmap"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
 
 [[package]]
 name = "itertools"
@@ -228,7 +206,7 @@ version = "1.6.0"
 dependencies = [
  "ruby-prism-sys",
  "serde",
- "serde_yaml",
+ "serde_json",
 ]
 
 [[package]]
@@ -272,16 +250,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.27"
+name = "serde_json"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
 dependencies = [
- "indexmap",
  "itoa",
  "ryu",
  "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -306,12 +282,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "winapi"

--- a/rust/ruby-prism/Cargo.toml
+++ b/rust/ruby-prism/Cargo.toml
@@ -23,7 +23,7 @@ include = ["src/", "build.rs", "Cargo.toml", "Cargo.lock", "vendor"]
 
 [build-dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
+serde_json = "1.0"
 
 [dependencies]
 ruby-prism-sys = { version = "1.6.0", path = "../ruby-prism-sys" }

--- a/rust/ruby-prism/build.rs
+++ b/rust/ruby-prism/build.rs
@@ -117,12 +117,12 @@ struct Config {
 ///
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let prism_dir = format!("prism-{}", env!("CARGO_PKG_VERSION"));
-    let config_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("vendor").join(prism_dir).join("config.yml");
+    let config_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("vendor").join(prism_dir).join("config.json");
 
     let config_file = std::fs::File::open(&config_path)?;
     println!("cargo:rerun-if-changed={}", config_path.to_str().unwrap());
 
-    let config: Config = serde_yaml::from_reader(config_file)?;
+    let config: Config = serde_json::from_reader(config_file)?;
     write_bindings(&config)?;
 
     Ok(())


### PR DESCRIPTION
`serde_yaml` was deprecated more than a year ago. See https://github.com/dtolnay/serde-yaml

Didn't find a nice replacement that is also typed. So why not just convert it to json?