### PR TITLE
Reject `def f a, (b) = 1`

### DIFF
--- a/test/prism/errors/endless_method_command_call_parameters.txt
+++ b/test/prism/errors/endless_method_command_call_parameters.txt
@@ -1,24 +1,27 @@
 def f x: = 1
-      ^~ could not parse the endless method parameters
+         ^ could not parse the endless method parameters
 
 def f ... = 1
-      ^~~ could not parse the endless method parameters
+          ^ could not parse the endless method parameters
 
 def f * = 1
-      ^ could not parse the endless method parameters
-
-def f ** = 1
-      ^~ could not parse the endless method parameters
-
-def f & = 1
-      ^ could not parse the endless method parameters
-
-def f *a = 1
-       ^ could not parse the endless method parameters
-
-def f **a = 1
         ^ could not parse the endless method parameters
 
+def f ** = 1
+         ^ could not parse the endless method parameters
+
+def f & = 1
+        ^ could not parse the endless method parameters
+
+def f *a = 1
+         ^ could not parse the endless method parameters
+
+def f **a = 1
+          ^ could not parse the endless method parameters
+
 def f &a = 1
-       ^ could not parse the endless method parameters
+         ^ could not parse the endless method parameters
+
+def f a, (b) = 1
+             ^ could not parse the endless method parameters
 


### PR DESCRIPTION
Fixes [[#Bug 21660]](https://bugs.ruby-lang.org/issues/21660), followup to https://github.com/ruby/prism/pull/3674