### PR TITLE
[rust] add `len` function for `NodeList`

### DIFF
--- a/rust/ruby-prism/src/lib.rs
+++ b/rust/ruby-prism/src/lib.rs
@@ -155,6 +155,12 @@ impl<'pr> NodeList<'pr> {
     pub const fn len(&self) -> usize {
         unsafe { self.pointer.as_ref().size }
     }
+
+    /// Returns whether the list is empty.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl<'pr> IntoIterator for &NodeList<'pr> {
@@ -802,6 +808,7 @@ mod tests {
 
         let node = result.node();
         assert_eq!(node.as_program_node().unwrap().statements().body().len(), 1);
+        assert!(!node.as_program_node().unwrap().statements().body().is_empty());
         let module = node.as_program_node().unwrap().statements().body().iter().next().unwrap();
         let module = module.as_module_node().unwrap();
         let locals = module.locals().iter().collect::<Vec<_>>();


### PR DESCRIPTION
Getting the length of a `NodeList` currently requires using `count()`:

https://github.com/fables-tales/rubyfmt/blob/ab02a7888892bbc34d05a70e304d95806f8a83f4/librubyfmt/src/format_prism.rs#L659-L660

I _think_ the compiler might be smart enough to unroll the loop and collapse down the iterations to compute the actual size in constant time, but why create work for the compiler if you don't have to?