### PR TITLE
Reject endless method as a block parameter default

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -280,6 +280,7 @@ errors:
   - UNEXPECTED_INDEX_KEYWORDS
   - UNEXPECTED_LABEL
   - UNEXPECTED_MULTI_WRITE
+  - UNEXPECTED_PARAMETER_DEFAULT_VALUE
   - UNEXPECTED_RANGE_OPERATOR
   - UNEXPECTED_SAFE_NAVIGATION
   - UNEXPECTED_TOKEN_CLOSE_CONTEXT
@@ -356,6 +357,8 @@ tokens:
     comment: "a newline character outside of other tokens"
   - name: PARENTHESIS_RIGHT
     comment: ")"
+  - name: PIPE
+    comment: "|"
   - name: SEMICOLON
     comment: ";"
   # Tokens from here on are not used for lookup, and can be in any order.
@@ -589,8 +592,6 @@ tokens:
     comment: "%I"
   - name: PERCENT_UPPER_W
     comment: "%W"
-  - name: PIPE
-    comment: "|"
   - name: PIPE_EQUAL
     comment: "|="
   - name: PIPE_PIPE

--- a/include/prism/parser.h
+++ b/include/prism/parser.h
@@ -299,6 +299,9 @@ typedef enum {
     /** a rescue else statement within a do..end block */
     PM_CONTEXT_BLOCK_ELSE,
 
+    /** expressions in block parameters `foo do |...| end ` */
+    PM_CONTEXT_BLOCK_PARAMETERS,
+
     /** a rescue statement within a do..end block */
     PM_CONTEXT_BLOCK_RESCUE,
 

--- a/snapshots/endless_method_as_default_arg.txt
+++ b/snapshots/endless_method_as_default_arg.txt
@@ -1,0 +1,323 @@
+@ ProgramNode (location: (1,0)-(11,20))
+├── flags: ∅
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (1,0)-(11,20))
+    ├── flags: ∅
+    └── body: (length: 6)
+        ├── @ DefNode (location: (1,0)-(1,27))
+        │   ├── flags: newline
+        │   ├── name: :foo
+        │   ├── name_loc: (1,4)-(1,7) = "foo"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (1,8)-(1,21))
+        │   │   ├── flags: ∅
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 1)
+        │   │   │   └── @ OptionalParameterNode (location: (1,8)-(1,21))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── name: :a
+        │   │   │       ├── name_loc: (1,8)-(1,9) = "a"
+        │   │   │       ├── operator_loc: (1,10)-(1,11) = "="
+        │   │   │       └── value:
+        │   │   │           @ DefNode (location: (1,12)-(1,21))
+        │   │   │           ├── flags: ∅
+        │   │   │           ├── name: :f
+        │   │   │           ├── name_loc: (1,16)-(1,17) = "f"
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── parameters: ∅
+        │   │   │           ├── body:
+        │   │   │           │   @ StatementsNode (location: (1,20)-(1,21))
+        │   │   │           │   ├── flags: ∅
+        │   │   │           │   └── body: (length: 1)
+        │   │   │           │       └── @ IntegerNode (location: (1,20)-(1,21))
+        │   │   │           │           ├── flags: static_literal, decimal
+        │   │   │           │           └── value: 1
+        │   │   │           ├── locals: []
+        │   │   │           ├── def_keyword_loc: (1,12)-(1,15) = "def"
+        │   │   │           ├── operator_loc: ∅
+        │   │   │           ├── lparen_loc: ∅
+        │   │   │           ├── rparen_loc: ∅
+        │   │   │           ├── equal_loc: (1,18)-(1,19) = "="
+        │   │   │           └── end_keyword_loc: ∅
+        │   │   ├── rest: ∅
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body: ∅
+        │   ├── locals: [:a]
+        │   ├── def_keyword_loc: (1,0)-(1,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (1,7)-(1,8) = "("
+        │   ├── rparen_loc: (1,21)-(1,22) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (1,24)-(1,27) = "end"
+        ├── @ DefNode (location: (3,0)-(3,30))
+        │   ├── flags: newline
+        │   ├── name: :foo
+        │   ├── name_loc: (3,4)-(3,7) = "foo"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (3,8)-(3,24))
+        │   │   ├── flags: ∅
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 1)
+        │   │   │   └── @ OptionalParameterNode (location: (3,8)-(3,21))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── name: :a
+        │   │   │       ├── name_loc: (3,8)-(3,9) = "a"
+        │   │   │       ├── operator_loc: (3,10)-(3,11) = "="
+        │   │   │       └── value:
+        │   │   │           @ DefNode (location: (3,12)-(3,21))
+        │   │   │           ├── flags: ∅
+        │   │   │           ├── name: :f
+        │   │   │           ├── name_loc: (3,16)-(3,17) = "f"
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── parameters: ∅
+        │   │   │           ├── body:
+        │   │   │           │   @ StatementsNode (location: (3,20)-(3,21))
+        │   │   │           │   ├── flags: ∅
+        │   │   │           │   └── body: (length: 1)
+        │   │   │           │       └── @ IntegerNode (location: (3,20)-(3,21))
+        │   │   │           │           ├── flags: static_literal, decimal
+        │   │   │           │           └── value: 1
+        │   │   │           ├── locals: []
+        │   │   │           ├── def_keyword_loc: (3,12)-(3,15) = "def"
+        │   │   │           ├── operator_loc: ∅
+        │   │   │           ├── lparen_loc: ∅
+        │   │   │           ├── rparen_loc: ∅
+        │   │   │           ├── equal_loc: (3,18)-(3,19) = "="
+        │   │   │           └── end_keyword_loc: ∅
+        │   │   ├── rest: ∅
+        │   │   ├── posts: (length: 1)
+        │   │   │   └── @ RequiredParameterNode (location: (3,23)-(3,24))
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :b
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body: ∅
+        │   ├── locals: [:a, :b]
+        │   ├── def_keyword_loc: (3,0)-(3,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (3,7)-(3,8) = "("
+        │   ├── rparen_loc: (3,24)-(3,25) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (3,27)-(3,30) = "end"
+        ├── @ DefNode (location: (5,0)-(5,30))
+        │   ├── flags: newline
+        │   ├── name: :foo
+        │   ├── name_loc: (5,4)-(5,7) = "foo"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (5,8)-(5,24))
+        │   │   ├── flags: ∅
+        │   │   ├── requireds: (length: 1)
+        │   │   │   └── @ RequiredParameterNode (location: (5,8)-(5,9))
+        │   │   │       ├── flags: ∅
+        │   │   │       └── name: :b
+        │   │   ├── optionals: (length: 1)
+        │   │   │   └── @ OptionalParameterNode (location: (5,11)-(5,24))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── name: :a
+        │   │   │       ├── name_loc: (5,11)-(5,12) = "a"
+        │   │   │       ├── operator_loc: (5,13)-(5,14) = "="
+        │   │   │       └── value:
+        │   │   │           @ DefNode (location: (5,15)-(5,24))
+        │   │   │           ├── flags: ∅
+        │   │   │           ├── name: :f
+        │   │   │           ├── name_loc: (5,19)-(5,20) = "f"
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── parameters: ∅
+        │   │   │           ├── body:
+        │   │   │           │   @ StatementsNode (location: (5,23)-(5,24))
+        │   │   │           │   ├── flags: ∅
+        │   │   │           │   └── body: (length: 1)
+        │   │   │           │       └── @ IntegerNode (location: (5,23)-(5,24))
+        │   │   │           │           ├── flags: static_literal, decimal
+        │   │   │           │           └── value: 1
+        │   │   │           ├── locals: []
+        │   │   │           ├── def_keyword_loc: (5,15)-(5,18) = "def"
+        │   │   │           ├── operator_loc: ∅
+        │   │   │           ├── lparen_loc: ∅
+        │   │   │           ├── rparen_loc: ∅
+        │   │   │           ├── equal_loc: (5,21)-(5,22) = "="
+        │   │   │           └── end_keyword_loc: ∅
+        │   │   ├── rest: ∅
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body: ∅
+        │   ├── locals: [:b, :a]
+        │   ├── def_keyword_loc: (5,0)-(5,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (5,7)-(5,8) = "("
+        │   ├── rparen_loc: (5,24)-(5,25) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (5,27)-(5,30) = "end"
+        ├── @ DefNode (location: (7,0)-(7,26))
+        │   ├── flags: newline
+        │   ├── name: :foo
+        │   ├── name_loc: (7,4)-(7,7) = "foo"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (7,8)-(7,20))
+        │   │   ├── flags: ∅
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 0)
+        │   │   ├── rest: ∅
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 1)
+        │   │   │   └── @ OptionalKeywordParameterNode (location: (7,8)-(7,20))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── name: :a
+        │   │   │       ├── name_loc: (7,8)-(7,10) = "a:"
+        │   │   │       └── value:
+        │   │   │           @ DefNode (location: (7,11)-(7,20))
+        │   │   │           ├── flags: ∅
+        │   │   │           ├── name: :f
+        │   │   │           ├── name_loc: (7,15)-(7,16) = "f"
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── parameters: ∅
+        │   │   │           ├── body:
+        │   │   │           │   @ StatementsNode (location: (7,19)-(7,20))
+        │   │   │           │   ├── flags: ∅
+        │   │   │           │   └── body: (length: 1)
+        │   │   │           │       └── @ IntegerNode (location: (7,19)-(7,20))
+        │   │   │           │           ├── flags: static_literal, decimal
+        │   │   │           │           └── value: 1
+        │   │   │           ├── locals: []
+        │   │   │           ├── def_keyword_loc: (7,11)-(7,14) = "def"
+        │   │   │           ├── operator_loc: ∅
+        │   │   │           ├── lparen_loc: ∅
+        │   │   │           ├── rparen_loc: ∅
+        │   │   │           ├── equal_loc: (7,17)-(7,18) = "="
+        │   │   │           └── end_keyword_loc: ∅
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body: ∅
+        │   ├── locals: [:a]
+        │   ├── def_keyword_loc: (7,0)-(7,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (7,7)-(7,8) = "("
+        │   ├── rparen_loc: (7,20)-(7,21) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (7,23)-(7,26) = "end"
+        ├── @ DefNode (location: (9,0)-(9,29))
+        │   ├── flags: newline
+        │   ├── name: :foo
+        │   ├── name_loc: (9,4)-(9,7) = "foo"
+        │   ├── receiver: ∅
+        │   ├── parameters:
+        │   │   @ ParametersNode (location: (9,8)-(9,23))
+        │   │   ├── flags: ∅
+        │   │   ├── requireds: (length: 0)
+        │   │   ├── optionals: (length: 1)
+        │   │   │   └── @ OptionalParameterNode (location: (9,8)-(9,23))
+        │   │   │       ├── flags: ∅
+        │   │   │       ├── name: :a
+        │   │   │       ├── name_loc: (9,8)-(9,9) = "a"
+        │   │   │       ├── operator_loc: (9,10)-(9,11) = "="
+        │   │   │       └── value:
+        │   │   │           @ DefNode (location: (9,12)-(9,23))
+        │   │   │           ├── flags: ∅
+        │   │   │           ├── name: :f
+        │   │   │           ├── name_loc: (9,16)-(9,17) = "f"
+        │   │   │           ├── receiver: ∅
+        │   │   │           ├── parameters: ∅
+        │   │   │           ├── body:
+        │   │   │           │   @ StatementsNode (location: (9,20)-(9,23))
+        │   │   │           │   ├── flags: ∅
+        │   │   │           │   └── body: (length: 1)
+        │   │   │           │       └── @ CallNode (location: (9,20)-(9,23))
+        │   │   │           │           ├── flags: ∅
+        │   │   │           │           ├── receiver:
+        │   │   │           │           │   @ IntegerNode (location: (9,20)-(9,21))
+        │   │   │           │           │   ├── flags: static_literal, decimal
+        │   │   │           │           │   └── value: 1
+        │   │   │           │           ├── call_operator_loc: ∅
+        │   │   │           │           ├── name: :+
+        │   │   │           │           ├── message_loc: (9,21)-(9,22) = "+"
+        │   │   │           │           ├── opening_loc: ∅
+        │   │   │           │           ├── arguments:
+        │   │   │           │           │   @ ArgumentsNode (location: (9,22)-(9,23))
+        │   │   │           │           │   ├── flags: ∅
+        │   │   │           │           │   └── arguments: (length: 1)
+        │   │   │           │           │       └── @ IntegerNode (location: (9,22)-(9,23))
+        │   │   │           │           │           ├── flags: static_literal, decimal
+        │   │   │           │           │           └── value: 2
+        │   │   │           │           ├── closing_loc: ∅
+        │   │   │           │           ├── equal_loc: ∅
+        │   │   │           │           └── block: ∅
+        │   │   │           ├── locals: []
+        │   │   │           ├── def_keyword_loc: (9,12)-(9,15) = "def"
+        │   │   │           ├── operator_loc: ∅
+        │   │   │           ├── lparen_loc: ∅
+        │   │   │           ├── rparen_loc: ∅
+        │   │   │           ├── equal_loc: (9,18)-(9,19) = "="
+        │   │   │           └── end_keyword_loc: ∅
+        │   │   ├── rest: ∅
+        │   │   ├── posts: (length: 0)
+        │   │   ├── keywords: (length: 0)
+        │   │   ├── keyword_rest: ∅
+        │   │   └── block: ∅
+        │   ├── body: ∅
+        │   ├── locals: [:a]
+        │   ├── def_keyword_loc: (9,0)-(9,3) = "def"
+        │   ├── operator_loc: ∅
+        │   ├── lparen_loc: (9,7)-(9,8) = "("
+        │   ├── rparen_loc: (9,23)-(9,24) = ")"
+        │   ├── equal_loc: ∅
+        │   └── end_keyword_loc: (9,26)-(9,29) = "end"
+        └── @ LambdaNode (location: (11,0)-(11,20))
+            ├── flags: newline
+            ├── locals: [:a]
+            ├── operator_loc: (11,0)-(11,2) = "->"
+            ├── opening_loc: (11,18)-(11,19) = "{"
+            ├── closing_loc: (11,19)-(11,20) = "}"
+            ├── parameters:
+            │   @ BlockParametersNode (location: (11,2)-(11,17))
+            │   ├── flags: ∅
+            │   ├── parameters:
+            │   │   @ ParametersNode (location: (11,3)-(11,16))
+            │   │   ├── flags: ∅
+            │   │   ├── requireds: (length: 0)
+            │   │   ├── optionals: (length: 1)
+            │   │   │   └── @ OptionalParameterNode (location: (11,3)-(11,16))
+            │   │   │       ├── flags: ∅
+            │   │   │       ├── name: :a
+            │   │   │       ├── name_loc: (11,3)-(11,4) = "a"
+            │   │   │       ├── operator_loc: (11,5)-(11,6) = "="
+            │   │   │       └── value:
+            │   │   │           @ DefNode (location: (11,7)-(11,16))
+            │   │   │           ├── flags: ∅
+            │   │   │           ├── name: :f
+            │   │   │           ├── name_loc: (11,11)-(11,12) = "f"
+            │   │   │           ├── receiver: ∅
+            │   │   │           ├── parameters: ∅
+            │   │   │           ├── body:
+            │   │   │           │   @ StatementsNode (location: (11,15)-(11,16))
+            │   │   │           │   ├── flags: ∅
+            │   │   │           │   └── body: (length: 1)
+            │   │   │           │       └── @ IntegerNode (location: (11,15)-(11,16))
+            │   │   │           │           ├── flags: static_literal, decimal
+            │   │   │           │           └── value: 1
+            │   │   │           ├── locals: []
+            │   │   │           ├── def_keyword_loc: (11,7)-(11,10) = "def"
+            │   │   │           ├── operator_loc: ∅
+            │   │   │           ├── lparen_loc: ∅
+            │   │   │           ├── rparen_loc: ∅
+            │   │   │           ├── equal_loc: (11,13)-(11,14) = "="
+            │   │   │           └── end_keyword_loc: ∅
+            │   │   ├── rest: ∅
+            │   │   ├── posts: (length: 0)
+            │   │   ├── keywords: (length: 0)
+            │   │   ├── keyword_rest: ∅
+            │   │   └── block: ∅
+            │   ├── locals: (length: 0)
+            │   ├── opening_loc: (11,2)-(11,3) = "("
+            │   └── closing_loc: (11,16)-(11,17) = ")"
+            └── body: ∅

--- a/src/prism.c
+++ b/src/prism.c
@@ -8606,6 +8606,7 @@ static const uint32_t context_terminators[] = {
     [PM_CONTEXT_BLOCK_KEYWORDS] = (1U << PM_TOKEN_KEYWORD_END) | (1U << PM_TOKEN_KEYWORD_RESCUE) | (1U << PM_TOKEN_KEYWORD_ENSURE),
     [PM_CONTEXT_BLOCK_ENSURE] = (1U << PM_TOKEN_KEYWORD_END),
     [PM_CONTEXT_BLOCK_ELSE] = (1U << PM_TOKEN_KEYWORD_ENSURE) | (1U << PM_TOKEN_KEYWORD_END),
+    [PM_CONTEXT_BLOCK_PARAMETERS] = (1U << PM_TOKEN_PIPE),
     [PM_CONTEXT_BLOCK_RESCUE] = (1U << PM_TOKEN_KEYWORD_ENSURE) | (1U << PM_TOKEN_KEYWORD_RESCUE) | (1U << PM_TOKEN_KEYWORD_ELSE) | (1U << PM_TOKEN_KEYWORD_END),
     [PM_CONTEXT_CASE_WHEN] = (1U << PM_TOKEN_KEYWORD_WHEN) | (1U << PM_TOKEN_KEYWORD_END) | (1U << PM_TOKEN_KEYWORD_ELSE),
     [PM_CONTEXT_CASE_IN] = (1U << PM_TOKEN_KEYWORD_IN) | (1U << PM_TOKEN_KEYWORD_END) | (1U << PM_TOKEN_KEYWORD_ELSE),
@@ -8756,6 +8757,7 @@ context_human(pm_context_t context) {
         case PM_CONTEXT_BEGIN: return "begin statement";
         case PM_CONTEXT_BLOCK_BRACES: return "'{'..'}' block";
         case PM_CONTEXT_BLOCK_KEYWORDS: return "'do'..'end' block";
+        case PM_CONTEXT_BLOCK_PARAMETERS: return "'|'..'|' block parameter";
         case PM_CONTEXT_CASE_WHEN: return "'when' clause";
         case PM_CONTEXT_CASE_IN: return "'in' clause";
         case PM_CONTEXT_CLASS: return "class definition";
@@ -15357,6 +15359,9 @@ parse_block_parameters(
 ) {
     pm_parameters_node_t *parameters = NULL;
     if (!match1(parser, PM_TOKEN_SEMICOLON)) {
+        if (!is_lambda_literal) {
+            context_push(parser, PM_CONTEXT_BLOCK_PARAMETERS);
+        }
         parameters = parse_parameters(
             parser,
             is_lambda_literal ? PM_BINDING_POWER_DEFINED : PM_BINDING_POWER_INDEX,
@@ -15367,6 +15372,9 @@ parse_block_parameters(
             true,
             (uint16_t) (depth + 1)
         );
+        if (!is_lambda_literal) {
+            context_pop(parser);
+        }
     }
 
     pm_block_parameters_node_t *block_parameters = pm_block_parameters_node_create(parser, parameters, opening);
@@ -15722,6 +15730,7 @@ parse_return(pm_parser_t *parser, pm_node_t *node) {
             case PM_CONTEXT_BLOCK_ENSURE:
             case PM_CONTEXT_BLOCK_KEYWORDS:
             case PM_CONTEXT_BLOCK_RESCUE:
+            case PM_CONTEXT_BLOCK_PARAMETERS:
             case PM_CONTEXT_DEF_ELSE:
             case PM_CONTEXT_DEF_ENSURE:
             case PM_CONTEXT_DEF_PARAMS:
@@ -15758,6 +15767,7 @@ parse_block_exit(pm_parser_t *parser, pm_node_t *node) {
             case PM_CONTEXT_BLOCK_KEYWORDS:
             case PM_CONTEXT_BLOCK_ELSE:
             case PM_CONTEXT_BLOCK_ENSURE:
+            case PM_CONTEXT_BLOCK_PARAMETERS:
             case PM_CONTEXT_BLOCK_RESCUE:
             case PM_CONTEXT_DEFINED:
             case PM_CONTEXT_FOR:
@@ -17975,6 +17985,7 @@ parse_retry(pm_parser_t *parser, const pm_node_t *node) {
             case PM_CONTEXT_BEGIN:
             case PM_CONTEXT_BLOCK_BRACES:
             case PM_CONTEXT_BLOCK_KEYWORDS:
+            case PM_CONTEXT_BLOCK_PARAMETERS:
             case PM_CONTEXT_CASE_IN:
             case PM_CONTEXT_CASE_WHEN:
             case PM_CONTEXT_DEFAULT_PARAMS:
@@ -18055,6 +18066,7 @@ parse_yield(pm_parser_t *parser, const pm_node_t *node) {
             case PM_CONTEXT_BLOCK_KEYWORDS:
             case PM_CONTEXT_BLOCK_ELSE:
             case PM_CONTEXT_BLOCK_ENSURE:
+            case PM_CONTEXT_BLOCK_PARAMETERS:
             case PM_CONTEXT_BLOCK_RESCUE:
             case PM_CONTEXT_CASE_IN:
             case PM_CONTEXT_CASE_WHEN:
@@ -19617,6 +19629,12 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, b
                 }
                 if (!accept_endless_def) {
                     pm_parser_err_previous(parser, PM_ERR_DEF_ENDLESS_PARAMETERS);
+                }
+                if (
+                    parser->current_context->context == PM_CONTEXT_DEFAULT_PARAMS &&
+                    parser->current_context->prev->context == PM_CONTEXT_BLOCK_PARAMETERS
+                ) {
+                    PM_PARSER_ERR_FORMAT(parser, def_keyword.start, parser->previous.end, PM_ERR_UNEXPECTED_PARAMETER_DEFAULT_VALUE, "endless method definition");
                 }
                 equal = parser->previous;
 

--- a/templates/src/diagnostic.c.erb
+++ b/templates/src/diagnostic.c.erb
@@ -361,6 +361,7 @@ static const pm_diagnostic_data_t diagnostic_messages[PM_DIAGNOSTIC_ID_MAX] = {
     [PM_ERR_UNEXPECTED_INDEX_KEYWORDS]          = { "unexpected keyword arg given in index assignment; keywords are not allowed in index assignment expressions", PM_ERROR_LEVEL_SYNTAX },
     [PM_ERR_UNEXPECTED_LABEL]                   = { "unexpected label", PM_ERROR_LEVEL_SYNTAX },
     [PM_ERR_UNEXPECTED_MULTI_WRITE]             = { "unexpected multiple assignment; multiple assignment is not allowed in this context", PM_ERROR_LEVEL_SYNTAX },
+    [PM_ERR_UNEXPECTED_PARAMETER_DEFAULT_VALUE] = { "unexpected %s; expected a default value for a parameter", PM_ERROR_LEVEL_SYNTAX },
     [PM_ERR_UNEXPECTED_RANGE_OPERATOR]          = { "unexpected range operator; .. and ... are non-associative and cannot be chained", PM_ERROR_LEVEL_SYNTAX },
     [PM_ERR_UNEXPECTED_SAFE_NAVIGATION]         = { "&. inside multiple assignment destination", PM_ERROR_LEVEL_SYNTAX },
     [PM_ERR_UNEXPECTED_TOKEN_CLOSE_CONTEXT]     = { "unexpected %s, assuming it is closing the parent %s", PM_ERROR_LEVEL_SYNTAX },

--- a/test/prism/errors/block_args_with_endless_def.txt
+++ b/test/prism/errors/block_args_with_endless_def.txt
@@ -1,0 +1,5 @@
+p do |a = def f = 1; b| end
+          ^~~~~~~ unexpected endless method definition; expected a default value for a parameter
+p do |a = def f = 1| 2; b|c end
+          ^~~~~~~ unexpected endless method definition; expected a default value for a parameter
+

--- a/test/prism/fixtures/endless_method_as_default_arg.txt
+++ b/test/prism/fixtures/endless_method_as_default_arg.txt
@@ -1,0 +1,11 @@
+def foo(a = def f = 1); end
+
+def foo(a = def f = 1, b); end
+
+def foo(b, a = def f = 1); end
+
+def foo(a: def f = 1); end
+
+def foo(a = def f = 1+2); end
+
+->(a = def f = 1) {}


### PR DESCRIPTION
Fixes [[Bug #21661]](https://bugs.ruby-lang.org/issues/21661)

It's not particularly nice to me to now have 3 bool parameters for expressions. But I guess this follows https://github.com/ruby/prism/commit/b624e09cc68401646e697c1db37c1a8c2d920181