### PR TITLE
Skip `power_assert` 3.0 on Ruby < 3.1`

### DIFF
--- a/gemfiles/2.7/Gemfile
+++ b/gemfiles/2.7/Gemfile
@@ -8,6 +8,7 @@ gemspec path: "../.."
 
 gem "onigmo", platforms: :ruby
 gem "parser"
+gem "power_assert", "~> 2.0" # https://github.com/test-unit/test-unit/pull/329
 gem "rake-compiler"
 gem "rake"
 gem "rbs"

--- a/gemfiles/2.7/Gemfile.lock
+++ b/gemfiles/2.7/Gemfile.lock
@@ -30,6 +30,7 @@ PLATFORMS
 DEPENDENCIES
   onigmo
   parser
+  power_assert (~> 2.0)
   prism!
   rake
   rake-compiler

--- a/gemfiles/3.0/Gemfile
+++ b/gemfiles/3.0/Gemfile
@@ -8,6 +8,7 @@ gemspec path: "../.."
 
 gem "onigmo", platforms: :ruby
 gem "parser"
+gem "power_assert", "~> 2.0" # https://github.com/test-unit/test-unit/pull/329
 gem "rake-compiler"
 gem "rake"
 gem "rbs"

--- a/gemfiles/3.0/Gemfile.lock
+++ b/gemfiles/3.0/Gemfile.lock
@@ -38,6 +38,7 @@ PLATFORMS
 DEPENDENCIES
   onigmo
   parser
+  power_assert (~> 2.0)
   prism!
   rake
   rake-compiler


### PR DESCRIPTION
It requires Ruby 3.1 but declares no `required_ruby_version`. Ref: https://github.com/test-unit/test-unit/pull/329#issuecomment-3484622030

https://github.com/ruby/prism/pull/3704
https://github.com/ruby/prism/actions/runs/19042061678/job/54381447946
> /Users/runner/hostedtoolcache/Ruby/2.7.8/arm64/lib/ruby/gems/2.7.0/gems/onigmo-0.1.0/lib/onigmo/node.rb:27:in `private_class_method': undefined method `new' for class `#<Class:Onigmo::Node>' (NameError)
Did you mean?  next

https://github.com/ruby/power_assert/releases/tag/v3.0.0
> Drop support for ruby < 3.1