### PR TITLE
Change `bin/prism lex`, add `bin/prism lex_compat`

### DIFF
--- a/bin/prism
+++ b/bin/prism
@@ -15,6 +15,7 @@ module Prism
       when "encoding"   then encoding(argv)
       when "error"      then error(argv)
       when "lex"        then lex(argv)
+      when "lex_compat" then lex_compat(argv)
       when "locals"     then locals(argv)
       when "parse"      then parse(argv)
       when "parser"     then parser(argv)
@@ -31,6 +32,7 @@ module Prism
             bin/prism encoding [encoding]
             bin/prism error [name] [source]
             bin/prism lex [source]
+            bin/prism lex_compat [source]
             bin/prism locals [source]
             bin/prism parse [source]
             bin/prism parser [source]
@@ -194,6 +196,21 @@ module Prism
 
     # bin/prism lex [source]
     def lex(argv)
+      source, filepath = read_source(argv)
+      prism = Prism.lex(source, filepath: filepath)
+      max_token_type_length = prism.value.max_by { |token,| token.type.length }[0].type.length
+
+      prism.value.each do |token,|
+        loc = token.location
+        puts(format(
+          "%-#{max_token_type_length + 1}s(%s,%s)-(%s,%s) %s",
+          token.type, loc.start_line, loc.start_column, loc.end_line, loc.end_column, token.value.inspect
+        ))
+      end
+    end
+
+    # bin/prism lex_compat [source]
+    def lex_compat(argv)
       source, filepath = read_source(argv)
 
       ripper_value =


### PR DESCRIPTION
* Current `bin/prism lex` becomes `bin/prism lex_compat`
* Change `bin/prism lex` to only output prism tokens

I sometimes find myself wanting to look at tokens but on the cli it only compares against other sources. Then I check the code and see that that `VERBOSE=1` does something but the output isn't very readable and doesn't fit on my terminal screen.

The new output looks like this:
```
$ bin/prism lex -e "foo(1, BAR, baz, 'bat')"
IDENTIFIER        (1,0)-(1,3) "foo"
PARENTHESIS_LEFT  (1,3)-(1,4) "("
INTEGER           (1,4)-(1,5) "1"
COMMA             (1,5)-(1,6) ","
CONSTANT          (1,7)-(1,10) "BAR"
COMMA             (1,10)-(1,11) ","
IDENTIFIER        (1,12)-(1,15) "baz"
COMMA             (1,15)-(1,16) ","
STRING_BEGIN      (1,17)-(1,18) "'"
STRING_CONTENT    (1,18)-(1,21) "bat"
STRING_END        (1,21)-(1,22) "'"
PARENTHESIS_RIGHT (1,22)-(1,23) ")"
EOF               (1,23)-(1,23) ""
```