### PR TITLE
Use `method_defined?` instead of `instance_methods.include?`

### DIFF
--- a/lib/prism/polyfill/scan_byte.rb
+++ b/lib/prism/polyfill/scan_byte.rb
@@ -3,7 +3,7 @@
 require "strscan"
 
 # Polyfill for StringScanner#scan_byte, which didn't exist until Ruby 3.4.
-if !(StringScanner.instance_methods.include?(:scan_byte))
+if !(StringScanner.method_defined?(:scan_byte))
   StringScanner.include(
     Module.new {
       def scan_byte # :nodoc:


### PR DESCRIPTION
While the latter creates an intermediate array of all method names including all ancestors, the former just traverse the inheritance chain and can stop if found once.