### PR TITLE
Bump `bin/prism bundle` to Ruby 4.0

### DIFF
--- a/bin/prism
+++ b/bin/prism
@@ -99,7 +99,7 @@ module Prism
         ["3.2", ["3.2"]],
         ["3.3", ["3.3"]],
         ["3.4", ["3.4", "typecheck"]],
-        ["3.5", ["3.5"]],
+        ["4.0", ["4.0"]],
         ["jruby", ["jruby"]],
         ["truffleruby", ["truffleruby"]]
       ].each do |ruby_version, gemfiles|


### PR DESCRIPTION
`gemfiles/3.5/Gemfile` has been updated to `gemfiles/4.0/Gemfile` by #3715.