### PR TITLE
Fix fuzzing builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,12 @@ build/fuzz.%: $(SOURCES) fuzz/%.c fuzz/fuzz.c
 	$(ECHO) "building $* fuzzer"
 	$(Q) $(MAKEDIRS) $(@D)
 	$(ECHO) "building main fuzz binary"
-	$(Q) AFL_HARDEN=1 afl-clang-lto $(DEBUG_FLAGS) $(CPPFLAGS) $(CFLAGS) $(FUZZ_FLAGS) -O0 -fsanitize-ignorelist=fuzz/asan.ignore -fsanitize=fuzzer,address -ggdb3 -std=c99 -Iinclude -o $@ $^
+	$(Q) afl-clang-lto $(DEBUG_FLAGS) $(CPPFLAGS) $(CFLAGS) $(FUZZ_FLAGS) -O0 -fsanitize-ignorelist=fuzz/asan.ignore -fsanitize=fuzzer,address -ggdb3 -std=c99 -Iinclude -o $@ $^
 	$(ECHO) "building cmplog binary"
-	$(Q) AFL_HARDEN=1 AFL_LLVM_CMPLOG=1 afl-clang-lto $(DEBUG_FLAGS) $(CPPFLAGS) $(CFLAGS) $(FUZZ_FLAGS) -O0 -fsanitize-ignorelist=fuzz/asan.ignore -fsanitize=fuzzer,address -ggdb3 -std=c99 -Iinclude -o $@.cmplog $^
+	$(Q) AFL_LLVM_CMPLOG=1 afl-clang-lto $(DEBUG_FLAGS) $(CPPFLAGS) $(CFLAGS) $(FUZZ_FLAGS) -O0 -fsanitize-ignorelist=fuzz/asan.ignore -fsanitize=fuzzer,address -ggdb3 -std=c99 -Iinclude -o $@.cmplog $^
 
 build/fuzz.heisenbug.%: $(SOURCES) fuzz/%.c fuzz/heisenbug.c
-	$(Q) AFL_HARDEN=1 afl-clang-lto $(DEBUG_FLAGS) $(CPPFLAGS) $(CFLAGS) $(FUZZ_FLAGS) -O0 -fsanitize-ignorelist=fuzz/asan.ignore -fsanitize=fuzzer,address -ggdb3 -std=c99 -Iinclude -o $@ $^
+	$(Q) afl-clang-lto $(DEBUG_FLAGS) $(CPPFLAGS) $(CFLAGS) $(FUZZ_FLAGS) -O0 -fsanitize-ignorelist=fuzz/asan.ignore -fsanitize=fuzzer,address -ggdb3 -std=c99 -Iinclude -o $@ $^
 
 fuzz-debug:
 	$(ECHO) "entering debug shell"

--- a/fuzz/docker/Dockerfile
+++ b/fuzz/docker/Dockerfile
@@ -1,8 +1,9 @@
-FROM aflplusplus/aflplusplus
+FROM aflplusplus/aflplusplus:v4.32c
 
 ARG USERNAME=prism
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
+ARG RUBY_VERSION=3.3.10
 ENV MAKEFLAGS=-j8
 
 RUN groupadd --gid $USER_GID $USERNAME \
@@ -12,10 +13,10 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
 
-RUN wget https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz
-RUN tar -xvf ruby-3.2.2.tar.gz
+RUN wget https://cache.ruby-lang.org/pub/ruby/3.3/ruby-${RUBY_VERSION}.tar.gz -O ruby.tar.gz
+RUN mkdir ruby-source && tar -xvf ruby.tar.gz -C ruby-source --strip-components=1
 RUN apt update && apt -y install libyaml-dev libz-dev libssl-dev
-RUN cd ruby-3.2.2 && ./configure --disable-install-doc && make && make install
+RUN cd ruby-source && ./configure --disable-install-doc && make && make install
 RUN gem install rake-compiler ruby_memcheck
 RUN git clone https://github.com/pwndbg/pwndbg && cd pwndbg && ./setup.sh
 ENV LC_CTYPE=C.UTF-8


### PR DESCRIPTION
* pin to a specific version of AFL++ container image
* update Ruby version
* remove AFL_HARDEN

Fixes #3730.