### PR TITLE
Add tests to `regexp_encoding_option_mismatch`

### DIFF
--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -64,6 +64,24 @@ module Prism
       assert_equal :"", Prism.parse_statement("+.@foo,+=foo").write_name
     end
 
+    def test_regexp_encoding_option_mismatch_error
+      # UTF-8 char with ASCII-8BIT modifier
+      result = Prism.parse('/Ȃ/n')
+      assert_includes result.errors.map(&:type), :regexp_encoding_option_mismatch
+
+      # UTF-8 char with EUC-JP modifier
+      result = Prism.parse('/Ȃ/e')
+      assert_includes result.errors.map(&:type), :regexp_encoding_option_mismatch
+
+      # UTF-8 char with Windows-31J modifier
+      result = Prism.parse('/Ȃ/s')
+      assert_includes result.errors.map(&:type), :regexp_encoding_option_mismatch
+
+      # UTF-8 char with UTF-8 modifier
+      result = Prism.parse('/Ȃ/u')
+      assert_empty result.errors
+    end
+
     private
 
     def assert_errors(filepath, version)


### PR DESCRIPTION
(related to #2667)

The error can be seen in CRuby with `parse.y` enabled:
```bash
ruby --parser=parse.y -e "p /Ȃ/e.encoding"

#=> -e:1: regexp encoding option 'e' differs from source encoding 'UTF-8'
ruby: compile error (SyntaxError)
```

It could also be seen on Ruby 3.4.7 with Prism enabled:
```bash
ruby -e "p /Ȃ/e.encoding"
-e: -e:1: syntax error found (SyntaxError)
#=> > 1 | p /Ȃ/e.encoding
        |       ^ regexp encoding option 'e' differs from source encoding 'UTF-8'
```

And by parsing directly, you get the error too:
```
bin/parse -e "p /Ȃ/e.encoding"

Errors:
[#<Prism::ParseError @type=:regexp_encoding_option_mismatch @message="regexp encoding option 'e' differs from source encoding 'UTF-8'" @location=#<Prism::Location @start_offset=7 @length=1 start_line=1> @level=:syntax>]
```

Looking at the [CRuby](https://github.com/ruby/ruby/blob/4c7525082c353bfa717cb17f9ae75d940cb69d20/parse.y#L15305-L15337) and [Prism](https://github.com/ruby/prism/blob/f2426824aafaac59cafa0342e1e232d63384afd1/src/prism.c#L7255-L7256) implementations, both are doing the same checks.

But the CRuby code is only enabled for Ripper (with the `#ifndef RIPPER`).

So maybe the problem is that Ruby + Prism  is raising the Syntax error, but it should only be raised when using Ripper, and not during normal execution? But that would contradict the original issue description, which expects the syntax error to be raised.

I might be missing some context here about what the right behaviour should be, but I went ahead and added some tests to make sure the current behavior is the expected one. Hope this makes sense! 

Thanks!