### PR TITLE
Properly ignore sorbet for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,5 @@ updates:
       ruby-deps:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "sorbet"


### PR DESCRIPTION
Followup to https://github.com/ruby/prism/commit/878cd2916ed2a43d1733f1ba42cf40076a3a19e3

Should be able to fix this once rbs 4.0.0 is released

Newer `spoom` (through newer `tapioca`) depends on rbs 4.0.0.dev and other dependencies only allow rbs < 4.0.0. So resolving is very awkward right now.