### PR TITLE
Speed up snapshots test

### DIFF
--- a/test/prism/snapshots_test.rb
+++ b/test/prism/snapshots_test.rb
@@ -48,7 +48,7 @@ module Prism
       result = Prism.parse(source, filepath: fixture.path, version: version)
       assert result.success?
 
-      printed = PP.pp(result.value, +"", 79)
+      printed = result.value.inspect
       snapshot = fixture.snapshot_path
 
       if File.exist?(snapshot)


### PR DESCRIPTION
Using pp does extra work that doesn't seem to do much of anything. This brings `SnapshotsTest` runtime down to 8 from 10 seconds for me

Creating inspect output still dominates the total runtime