### PR TITLE
Handle invalid string pattern key

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -17336,7 +17336,11 @@ parse_pattern_hash(pm_parser_t *parser, pm_constant_id_list_t *captures, pm_node
             pm_node_t *value = NULL;
 
             if (match7(parser, PM_TOKEN_COMMA, PM_TOKEN_KEYWORD_THEN, PM_TOKEN_BRACE_RIGHT, PM_TOKEN_BRACKET_RIGHT, PM_TOKEN_PARENTHESIS_RIGHT, PM_TOKEN_NEWLINE, PM_TOKEN_SEMICOLON)) {
-                value = parse_pattern_hash_implicit_value(parser, captures, (pm_symbol_node_t *) key);
+                if (PM_NODE_TYPE_P(key, PM_SYMBOL_NODE)) {
+                    value = parse_pattern_hash_implicit_value(parser, captures, (pm_symbol_node_t *) key);
+                } else {
+                    value = (pm_node_t *) pm_missing_node_create(parser, key->location.end, key->location.end);
+                }
             } else {
                 value = parse_pattern(parser, captures, PM_PARSE_PATTERN_SINGLE, PM_ERR_PATTERN_EXPRESSION_AFTER_KEY, (uint16_t) (depth + 1));
             }

--- a/test/prism/errors/pattern_string_key.txt
+++ b/test/prism/errors/pattern_string_key.txt
@@ -1,0 +1,8 @@
+case:a
+in b:"","#{}"
+        ^~~~~ expected a label after the `,` in the hash pattern
+             ^ expected a pattern expression after the key
+             ^ expected a delimiter after the patterns of an `in` clause
+             ^ unexpected end-of-input, assuming it is closing the parent top level context
+             ^ expected an `end` to close the `case` statement
+


### PR DESCRIPTION
When a pattern match is using a string as a hash pattern key and is using it incorrectly, we were previously assuming it was a symbol. In the case of an error, that's not the case. So we need to add a missing node in this case.

Fixes #3749