### PR TITLE
Fully destroy call operator write arguments

### DIFF
--- a/test/prism/errors/destroy_call_operator_write_arguments.txt
+++ b/test/prism/errors/destroy_call_operator_write_arguments.txt
@@ -1,0 +1,11 @@
+t next&&do end&=
+        ^~ unexpected 'do'; expected an expression after the operator
+  ^~~~ unexpected void value expression
+  ^~~~ unexpected void value expression
+^~~~~~~~~~~~~~ unexpected write target
+              ^~ unexpected operator after a call with arguments
+              ^~ unexpected operator after a call with a block
+''while=
+  ^~~~~ expected a predicate expression for the `while` statement
+       ^ unexpected '='; target cannot be written
+


### PR DESCRIPTION
If we are about to delete a call operator write argument, it needs to be removed from the list of block exits as well.

Fixes #3754