### PR TITLE
Introduce using slices instead of locations

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -653,10 +653,6 @@ tokens:
     comment: "a separator between words in a list"
   - name: __END__
     comment: "marker for the point in the file at which the parser should stop"
-  - name: MISSING
-    comment: "a token that was expected but not found"
-  - name: NOT_PROVIDED
-    comment: "a token that was not present but it is okay"
 flags:
   - name: ArgumentsNodeFlags
     values:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ The available values for `type` are:
 * `constant` - A field that is an integer that represents an index in the constant pool. This is a `pm_constant_id_t` in C.
 * `constant[]` - A field that is an array of constants. This is a `pm_constant_id_list_t` in C.
 * `location` - A field that is a location. This is a `pm_location_t` in C.
-* `location?` - A field that is a location that is optionally present. This is a `pm_location_t` in C, but if the value is not present then the `start` and `end` fields will be `NULL`.
+* `location?` - A field that is a location that is optionally present. This is a `pm_location_t` in C, but if the value is not present then the `length` field will be `0`.
 * `uint8` - A field that is an 8-bit unsigned integer. This is a `uint8_t` in C.
 * `uint32` - A field that is a 32-bit unsigned integer. This is a `uint32_t` in C.
 

--- a/include/prism.h
+++ b/include/prism.h
@@ -143,11 +143,10 @@ PRISM_EXPORTED_FUNCTION void pm_serialize_parse_stream(pm_buffer_t *buffer, void
 /**
  * Serialize the given list of comments to the given buffer.
  *
- * @param parser The parser to serialize.
  * @param list The list of comments to serialize.
  * @param buffer The buffer to serialize to.
  */
-void pm_serialize_comment_list(pm_parser_t *parser, pm_list_t *list, pm_buffer_t *buffer);
+void pm_serialize_comment_list(pm_list_t *list, pm_buffer_t *buffer);
 
 /**
  * Serialize the name of the encoding to the buffer.

--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -257,4 +257,37 @@
     #define PRISM_FALLTHROUGH
 #endif
 
+/**
+ * We need to align nodes in the AST to a pointer boundary so that it can be
+ * safely cast to different node types. Use PRISM_ALIGNAS/PRISM_ALIGNOF to
+ * specify alignment in a compiler-agnostic way.
+ */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L /* C11 or later */
+    #include <stdalign.h>
+
+    /** Specify alignment for a type or variable. */
+    #define PRISM_ALIGNAS(size) alignas(size)
+
+    /** Get the alignment requirement of a type. */
+    #define PRISM_ALIGNOF(type) alignof(type)
+#elif defined(__GNUC__) || defined(__clang__)
+    /** Specify alignment for a type or variable. */
+    #define PRISM_ALIGNAS(size) __attribute__((aligned(size)))
+
+    /** Get the alignment requirement of a type. */
+    #define PRISM_ALIGNOF(type) __alignof__(type)
+#elif defined(_MSC_VER)
+    /** Specify alignment for a type or variable. */
+    #define PRISM_ALIGNAS(size) __declspec(align(size))
+
+    /** Get the alignment requirement of a type. */
+    #define PRISM_ALIGNOF(type) __alignof(type)
+#else
+    /** Void because this platform does not support specifying alignment. */
+    #define PRISM_ALIGNAS(size)
+
+    /** Fallback to sizeof as alignment requirement of a type. */
+    #define PRISM_ALIGNOF(type) sizeof(type)
+#endif
+
 #endif

--- a/include/prism/parser.h
+++ b/include/prism/parser.h
@@ -479,17 +479,11 @@ typedef struct {
     /** The embedded base node. */
     pm_list_node_t node;
 
-    /** A pointer to the start of the key in the source. */
-    const uint8_t *key_start;
+    /** The key of the magic comment. */
+    pm_location_t key;
 
-    /** A pointer to the start of the value in the source. */
-    const uint8_t *value_start;
-
-    /** The length of the key in the source. */
-    uint32_t key_length;
-
-    /** The length of the value in the source. */
-    uint32_t value_length;
+    /** The value of the magic comment. */
+    pm_location_t value;
 } pm_magic_comment_t;
 
 /**

--- a/include/prism/static_literals.h
+++ b/include/prism/static_literals.h
@@ -92,13 +92,14 @@ typedef struct {
  * Add a node to the set of static literals.
  *
  * @param newline_list The list of newline offsets to use to calculate lines.
+ * @param start The start of the source being parsed.
  * @param start_line The line number that the parser starts on.
  * @param literals The set of static literals to add the node to.
  * @param node The node to add to the set.
  * @param replace Whether to replace the previous node if one already exists.
  * @return A pointer to the node that is being overwritten, if there is one.
  */
-pm_node_t * pm_static_literals_add(const pm_newline_list_t *newline_list, int32_t start_line, pm_static_literals_t *literals, pm_node_t *node, bool replace);
+pm_node_t * pm_static_literals_add(const pm_newline_list_t *newline_list, const uint8_t *start, int32_t start_line, pm_static_literals_t *literals, pm_node_t *node, bool replace);
 
 /**
  * Free the internal memory associated with the given static literals set.
@@ -112,10 +113,11 @@ void pm_static_literals_free(pm_static_literals_t *literals);
  *
  * @param buffer The buffer to write the string to.
  * @param newline_list The list of newline offsets to use to calculate lines.
+ * @param start The start of the source being parsed.
  * @param start_line The line number that the parser starts on.
  * @param encoding_name The name of the encoding of the source being parsed.
  * @param node The node to create a string representation of.
  */
-void pm_static_literal_inspect(pm_buffer_t *buffer, const pm_newline_list_t *newline_list, int32_t start_line, const char *encoding_name, const pm_node_t *node);
+void pm_static_literal_inspect(pm_buffer_t *buffer, const pm_newline_list_t *newline_list, const uint8_t *start, int32_t start_line, const char *encoding_name, const pm_node_t *node);
 
 #endif

--- a/include/prism/util/pm_char.h
+++ b/include/prism/util/pm_char.h
@@ -31,10 +31,12 @@ size_t pm_strspn_whitespace(const uint8_t *string, ptrdiff_t length);
  * @param string The string to search.
  * @param length The maximum number of characters to search.
  * @param newline_list The list of newlines to populate.
+ * @param start_offset The offset at which the string occurs in the source, for
+ *   the purpose of tracking newlines.
  * @return The number of characters at the start of the string that are
  *     whitespace.
  */
-size_t pm_strspn_whitespace_newlines(const uint8_t *string, ptrdiff_t length, pm_newline_list_t *newline_list);
+size_t pm_strspn_whitespace_newlines(const uint8_t *string, ptrdiff_t length, pm_newline_list_t *newline_list, uint32_t start_offset);
 
 /**
  * Returns the number of characters at the start of the string that are inline

--- a/include/prism/util/pm_newline_list.h
+++ b/include/prism/util/pm_newline_list.h
@@ -26,9 +26,6 @@
  * sorted/inserted in ascending order.
  */
 typedef struct {
-    /** A pointer to the start of the source string. */
-    const uint8_t *start;
-
     /** The number of offsets in the list. */
     size_t size;
 
@@ -36,7 +33,7 @@ typedef struct {
     size_t capacity;
 
     /** The list of offsets. */
-    size_t *offsets;
+    uint32_t *offsets;
 } pm_newline_list_t;
 
 /**
@@ -55,41 +52,39 @@ typedef struct {
  * allocation of the offsets succeeds, otherwise returns false.
  *
  * @param list The list to initialize.
- * @param start A pointer to the start of the source string.
  * @param capacity The initial capacity of the list.
  * @return True if the allocation of the offsets succeeds, otherwise false.
  */
-bool pm_newline_list_init(pm_newline_list_t *list, const uint8_t *start, size_t capacity);
+bool pm_newline_list_init(pm_newline_list_t *list, size_t capacity);
 
 /**
  * Clear out the newlines that have been appended to the list.
  *
  * @param list The list to clear.
  */
-void
-pm_newline_list_clear(pm_newline_list_t *list);
+void pm_newline_list_clear(pm_newline_list_t *list);
 
 /**
  * Append a new offset to the newline list. Returns true if the reallocation of
  * the offsets succeeds (if one was necessary), otherwise returns false.
  *
  * @param list The list to append to.
- * @param cursor A pointer to the offset to append.
+ * @param cursor The offset to append.
  * @return True if the reallocation of the offsets succeeds (if one was
  *     necessary), otherwise false.
  */
-bool pm_newline_list_append(pm_newline_list_t *list, const uint8_t *cursor);
+bool pm_newline_list_append(pm_newline_list_t *list, uint32_t cursor);
 
 /**
  * Returns the line of the given offset. If the offset is not in the list, the
  * line of the closest offset less than the given offset is returned.
  *
  * @param list The list to search.
- * @param cursor A pointer to the offset to search for.
+ * @param cursor The offset to search for.
  * @param start_line The line to start counting from.
  * @return The line of the given offset.
  */
-int32_t pm_newline_list_line(const pm_newline_list_t *list, const uint8_t *cursor, int32_t start_line);
+int32_t pm_newline_list_line(const pm_newline_list_t *list, uint32_t cursor, int32_t start_line);
 
 /**
  * Returns the line and column of the given offset. If the offset is not in the
@@ -97,11 +92,11 @@ int32_t pm_newline_list_line(const pm_newline_list_t *list, const uint8_t *curso
  * are returned.
  *
  * @param list The list to search.
- * @param cursor A pointer to the offset to search for.
+ * @param cursor The offset to search for.
  * @param start_line The line to start counting from.
  * @return The line and column of the given offset.
  */
-pm_line_column_t pm_newline_list_line_column(const pm_newline_list_t *list, const uint8_t *cursor, int32_t start_line);
+pm_line_column_t pm_newline_list_line_column(const pm_newline_list_t *list, uint32_t cursor, int32_t start_line);
 
 /**
  * Free the internal memory allocated for the newline list.

--- a/lib/prism/translation/parser/compiler.rb
+++ b/lib/prism/translation/parser/compiler.rb
@@ -1767,7 +1767,7 @@ module Prism
             end
           else
             parts =
-              if node.value == ""
+              if node.value_loc.nil?
                 []
               elsif node.value.include?("\n")
                 string_nodes_from_line_continuations(node.unescaped, node.value, node.value_loc.start_offset, node.opening)

--- a/lib/prism/translation/parser/lexer.rb
+++ b/lib/prism/translation/parser/lexer.rb
@@ -18,8 +18,6 @@ module Prism
         # The direct translating of types between the two lexers.
         TYPES = {
           # These tokens should never appear in the output of the lexer.
-          MISSING: nil,
-          NOT_PROVIDED: nil,
           EMBDOC_END: nil,
           EMBDOC_LINE: nil,
 

--- a/lib/prism/translation/ripper.rb
+++ b/lib/prism/translation/ripper.rb
@@ -3152,14 +3152,13 @@ module Prism
       # :foo
       # ^^^^
       def visit_symbol_node(node)
-        if (opening = node.opening)&.match?(/^%s|['"]:?$/)
+        if node.value_loc.nil?
+          bounds(node.location)
+          on_dyna_symbol(on_string_content)
+        elsif (opening = node.opening)&.match?(/^%s|['"]:?$/)
           bounds(node.value_loc)
-          content = on_string_content
-
-          if !(value = node.value).empty?
-            content = on_string_add(content, on_tstring_content(value))
-          end
-
+          content = on_string_add(on_string_content, on_tstring_content(node.value))
+          bounds(node.location)
           on_dyna_symbol(content)
         elsif (closing = node.closing) == ":"
           bounds(node.location)

--- a/rust/ruby-prism-sys/tests/parser_tests.rs
+++ b/rust/ruby-prism-sys/tests/parser_tests.rs
@@ -52,8 +52,8 @@ fn comments_test() {
         assert_eq!((*comment).type_, pm_comment_type_t::PM_COMMENT_INLINE);
 
         let location = {
-            let start = (*comment).location.start.offset_from(parser.start);
-            let end = (*comment).location.end.offset_from(parser.start);
+            let start = (*comment).location.start;
+            let end = (*comment).location.start + (*comment).location.length;
             start..end
         };
         assert_eq!(location, 0..7);
@@ -89,8 +89,8 @@ fn diagnostics_test() {
         );
 
         let location = {
-            let start = (*error).location.start.offset_from(parser.start);
-            let end = (*error).location.end.offset_from(parser.start);
+            let start = (*error).location.start;
+            let end = (*error).location.start + (*error).location.length;
             start..end
         };
         assert_eq!(location, 10..10);

--- a/rust/ruby-prism/build.rs
+++ b/rust/ruby-prism/build.rs
@@ -372,8 +372,8 @@ fn write_node(file: &mut File, flags: &[Flags], node: &Node) -> Result<(), Box<d
             NodeFieldType::OptionalLocation => {
                 writeln!(file, "    pub fn {}(&self) -> Option<Location<'pr>> {{", field.name)?;
                 writeln!(file, "        let pointer: *mut pm_location_t = unsafe {{ &raw mut (*self.pointer).{} }};", field.name)?;
-                writeln!(file, "        let start = unsafe {{ (*pointer).start }};")?;
-                writeln!(file, "        if start.is_null() {{")?;
+                writeln!(file, "        let length = unsafe {{ (*pointer).length }};")?;
+                writeln!(file, "        if length == 0 {{")?;
                 writeln!(file, "            None")?;
                 writeln!(file, "        }} else {{")?;
                 writeln!(file, "            Some(Location::new(self.parser, unsafe {{ &(*pointer) }}))")?;
@@ -605,9 +605,9 @@ impl<'pr> Node<'pr> {{
     /// Panics if the node type cannot be read.
     ///
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    #[allow(clippy::cast_ptr_alignment)]
     pub(crate) fn new(parser: NonNull<pm_parser_t>, node: *mut pm_node_t) -> Self {{
-        match unsafe {{ (*node).type_ }} {{
-"
+        match unsafe {{ (*node).type_ }} {{"
     )?;
 
     for node in &config.nodes {

--- a/snapshots/seattlerb/symbol_empty.txt
+++ b/snapshots/seattlerb/symbol_empty.txt
@@ -8,6 +8,6 @@
         └── @ SymbolNode (location: (1,0)-(1,3))
             ├── flags: newline, static_literal, forced_us_ascii_encoding
             ├── opening_loc: (1,0)-(1,2) = ":'"
-            ├── value_loc: (1,2)-(1,2) = ""
+            ├── value_loc: ∅
             ├── closing_loc: (1,2)-(1,3) = "'"
             └── unescaped: ""

--- a/snapshots/spanning_heredoc_newlines.txt
+++ b/snapshots/spanning_heredoc_newlines.txt
@@ -129,7 +129,7 @@
         │   │       └── @ SymbolNode (location: (17,4)-(20,0))
         │   │           ├── flags: static_literal, forced_us_ascii_encoding
         │   │           ├── opening_loc: (17,4)-(18,0) = "%s\n"
-        │   │           ├── value_loc: (18,0)-(18,0) = ""
+        │   │           ├── value_loc: ∅
         │   │           ├── closing_loc: (19,0)-(20,0) = "\n"
         │   │           └── unescaped: ""
         │   ├── closing_loc: ∅

--- a/snapshots/unparser/corpus/literal/literal.txt
+++ b/snapshots/unparser/corpus/literal/literal.txt
@@ -620,7 +620,7 @@
         ├── @ SymbolNode (location: (48,0)-(48,3))
         │   ├── flags: newline, static_literal
         │   ├── opening_loc: (48,0)-(48,2) = ":\""
-        │   ├── value_loc: (1,0)-(1,0) = ""
+        │   ├── value_loc: ∅
         │   ├── closing_loc: (48,2)-(48,3) = "\""
         │   └── unescaped: ""
         ├── @ RegularExpressionNode (location: (49,0)-(49,5))

--- a/src/static_literals.c
+++ b/src/static_literals.c
@@ -9,6 +9,9 @@ typedef struct {
     /** The list of newline offsets to use to calculate line numbers. */
     const pm_newline_list_t *newline_list;
 
+    /** The start of the source being parsed. */
+    const uint8_t *start;
+
     /** The line number that the parser starts on. */
     int32_t start_line;
 
@@ -353,7 +356,7 @@ pm_compare_regular_expression_nodes(PRISM_ATTRIBUTE_UNUSED const pm_static_liter
  * Add a node to the set of static literals.
  */
 pm_node_t *
-pm_static_literals_add(const pm_newline_list_t *newline_list, int32_t start_line, pm_static_literals_t *literals, pm_node_t *node, bool replace) {
+pm_static_literals_add(const pm_newline_list_t *newline_list, const uint8_t *start, int32_t start_line, pm_static_literals_t *literals, pm_node_t *node, bool replace) {
     switch (PM_NODE_TYPE(node)) {
         case PM_INTEGER_NODE:
         case PM_SOURCE_LINE_NODE:
@@ -361,6 +364,7 @@ pm_static_literals_add(const pm_newline_list_t *newline_list, int32_t start_line
                 &literals->integer_nodes,
                 &(pm_static_literals_metadata_t) {
                     .newline_list = newline_list,
+                    .start = start,
                     .start_line = start_line,
                     .encoding_name = NULL
                 },
@@ -373,6 +377,7 @@ pm_static_literals_add(const pm_newline_list_t *newline_list, int32_t start_line
                 &literals->float_nodes,
                 &(pm_static_literals_metadata_t) {
                     .newline_list = newline_list,
+                    .start = start,
                     .start_line = start_line,
                     .encoding_name = NULL
                 },
@@ -386,6 +391,7 @@ pm_static_literals_add(const pm_newline_list_t *newline_list, int32_t start_line
                 &literals->number_nodes,
                 &(pm_static_literals_metadata_t) {
                     .newline_list = newline_list,
+                    .start = start,
                     .start_line = start_line,
                     .encoding_name = NULL
                 },
@@ -399,6 +405,7 @@ pm_static_literals_add(const pm_newline_list_t *newline_list, int32_t start_line
                 &literals->string_nodes,
                 &(pm_static_literals_metadata_t) {
                     .newline_list = newline_list,
+                    .start = start,
                     .start_line = start_line,
                     .encoding_name = NULL
                 },
@@ -411,6 +418,7 @@ pm_static_literals_add(const pm_newline_list_t *newline_list, int32_t start_line
                 &literals->regexp_nodes,
                 &(pm_static_literals_metadata_t) {
                     .newline_list = newline_list,
+                    .start = start,
                     .start_line = start_line,
                     .encoding_name = NULL
                 },
@@ -423,6 +431,7 @@ pm_static_literals_add(const pm_newline_list_t *newline_list, int32_t start_line
                 &literals->symbol_nodes,
                 &(pm_static_literals_metadata_t) {
                     .newline_list = newline_list,
+                    .start = start,
                     .start_line = start_line,
                     .encoding_name = NULL
                 },
@@ -502,12 +511,12 @@ pm_static_literal_inspect_node(pm_buffer_t *buffer, const pm_static_literals_met
             const double value = ((const pm_float_node_t *) node)->value;
 
             if (PRISM_ISINF(value)) {
-                if (*node->location.start == '-') {
+                if (metadata->start[node->location.start] == '-') {
                     pm_buffer_append_byte(buffer, '-');
                 }
                 pm_buffer_append_string(buffer, "Infinity", 8);
             } else if (value == 0.0) {
-                if (*node->location.start == '-') {
+                if (metadata->start[node->location.start] == '-') {
                     pm_buffer_append_byte(buffer, '-');
                 }
                 pm_buffer_append_string(buffer, "0.0", 3);
@@ -604,11 +613,12 @@ pm_static_literal_inspect_node(pm_buffer_t *buffer, const pm_static_literals_met
  * Create a string-based representation of the given static literal.
  */
 void
-pm_static_literal_inspect(pm_buffer_t *buffer, const pm_newline_list_t *newline_list, int32_t start_line, const char *encoding_name, const pm_node_t *node) {
+pm_static_literal_inspect(pm_buffer_t *buffer, const pm_newline_list_t *newline_list, const uint8_t *start, int32_t start_line, const char *encoding_name, const pm_node_t *node) {
     pm_static_literal_inspect_node(
         buffer,
         &(pm_static_literals_metadata_t) {
             .newline_list = newline_list,
+            .start = start,
             .start_line = start_line,
             .encoding_name = encoding_name
         },

--- a/src/util/pm_char.c
+++ b/src/util/pm_char.c
@@ -83,15 +83,15 @@ pm_strspn_whitespace(const uint8_t *string, ptrdiff_t length) {
  * searching past the given maximum number of characters.
  */
 size_t
-pm_strspn_whitespace_newlines(const uint8_t *string, ptrdiff_t length, pm_newline_list_t *newline_list) {
+pm_strspn_whitespace_newlines(const uint8_t *string, ptrdiff_t length, pm_newline_list_t *newline_list, uint32_t start_offset) {
     if (length <= 0) return 0;
 
-    size_t size = 0;
-    size_t maximum = (size_t) length;
+    uint32_t size = 0;
+    uint32_t maximum = (uint32_t) length;
 
     while (size < maximum && (pm_byte_table[string[size]] & PRISM_CHAR_BIT_WHITESPACE)) {
         if (string[size] == '\n') {
-            pm_newline_list_append(newline_list, string + size);
+            pm_newline_list_append(newline_list, start_offset + size + 1);
         }
 
         size++;

--- a/src/util/pm_newline_list.c
+++ b/src/util/pm_newline_list.c
@@ -5,11 +5,9 @@
  * allocation of the offsets succeeds, otherwise returns false.
  */
 bool
-pm_newline_list_init(pm_newline_list_t *list, const uint8_t *start, size_t capacity) {
-    list->offsets = (size_t *) xcalloc(capacity, sizeof(size_t));
+pm_newline_list_init(pm_newline_list_t *list, size_t capacity) {
+    list->offsets = (uint32_t *) xcalloc(capacity, sizeof(uint32_t));
     if (list->offsets == NULL) return false;
-
-    list->start = start;
 
     // This is 1 instead of 0 because we want to include the first line of the
     // file as having offset 0, which is set because of calloc.
@@ -32,24 +30,20 @@ pm_newline_list_clear(pm_newline_list_t *list) {
  * the offsets succeeds (if one was necessary), otherwise returns false.
  */
 bool
-pm_newline_list_append(pm_newline_list_t *list, const uint8_t *cursor) {
+pm_newline_list_append(pm_newline_list_t *list, uint32_t cursor) {
     if (list->size == list->capacity) {
-        size_t *original_offsets = list->offsets;
+        uint32_t *original_offsets = list->offsets;
 
         list->capacity = (list->capacity * 3) / 2;
-        list->offsets = (size_t *) xcalloc(list->capacity, sizeof(size_t));
+        list->offsets = (uint32_t *) xcalloc(list->capacity, sizeof(uint32_t));
         if (list->offsets == NULL) return false;
 
-        memcpy(list->offsets, original_offsets, list->size * sizeof(size_t));
+        memcpy(list->offsets, original_offsets, list->size * sizeof(uint32_t));
         xfree(original_offsets);
     }
 
-    assert(*cursor == '\n');
-    assert(cursor >= list->start);
-    size_t newline_offset = (size_t) (cursor - list->start + 1);
-
-    assert(list->size == 0 || newline_offset > list->offsets[list->size - 1]);
-    list->offsets[list->size++] = newline_offset;
+    assert(list->size == 0 || cursor > list->offsets[list->size - 1]);
+    list->offsets[list->size++] = cursor;
 
     return true;
 }
@@ -59,21 +53,18 @@ pm_newline_list_append(pm_newline_list_t *list, const uint8_t *cursor) {
  * line of the closest offset less than the given offset is returned.
  */
 int32_t
-pm_newline_list_line(const pm_newline_list_t *list, const uint8_t *cursor, int32_t start_line) {
-    assert(cursor >= list->start);
-    size_t offset = (size_t) (cursor - list->start);
-
+pm_newline_list_line(const pm_newline_list_t *list, uint32_t cursor, int32_t start_line) {
     size_t left = 0;
     size_t right = list->size - 1;
 
     while (left <= right) {
         size_t mid = left + (right - left) / 2;
 
-        if (list->offsets[mid] == offset) {
+        if (list->offsets[mid] == cursor) {
             return ((int32_t) mid) + start_line;
         }
 
-        if (list->offsets[mid] < offset) {
+        if (list->offsets[mid] < cursor) {
             left = mid + 1;
         } else {
             right = mid - 1;
@@ -89,21 +80,18 @@ pm_newline_list_line(const pm_newline_list_t *list, const uint8_t *cursor, int32
  * are returned.
  */
 pm_line_column_t
-pm_newline_list_line_column(const pm_newline_list_t *list, const uint8_t *cursor, int32_t start_line) {
-    assert(cursor >= list->start);
-    size_t offset = (size_t) (cursor - list->start);
-
+pm_newline_list_line_column(const pm_newline_list_t *list, uint32_t cursor, int32_t start_line) {
     size_t left = 0;
     size_t right = list->size - 1;
 
     while (left <= right) {
         size_t mid = left + (right - left) / 2;
 
-        if (list->offsets[mid] == offset) {
+        if (list->offsets[mid] == cursor) {
             return ((pm_line_column_t) { ((int32_t) mid) + start_line, 0 });
         }
 
-        if (list->offsets[mid] < offset) {
+        if (list->offsets[mid] < cursor) {
             left = mid + 1;
         } else {
             right = mid - 1;
@@ -112,7 +100,7 @@ pm_newline_list_line_column(const pm_newline_list_t *list, const uint8_t *cursor
 
     return ((pm_line_column_t) {
         .line = ((int32_t) left) + start_line - 1,
-        .column = (uint32_t) (offset - list->offsets[left - 1])
+        .column = cursor - list->offsets[left - 1]
     });
 }
 

--- a/templates/ext/prism/api_node.c.erb
+++ b/templates/ext/prism/api_node.c.erb
@@ -12,17 +12,12 @@ static VALUE rb_cPrism<%= node.name %>;
 <%- end -%>
 
 static VALUE
-pm_location_new(const pm_parser_t *parser, const uint8_t *start, const uint8_t *end, VALUE source, bool freeze) {
+pm_location_new(const uint32_t start, const uint32_t length, VALUE source, bool freeze) {
     if (freeze) {
-        VALUE location_argv[] = {
-            source,
-            LONG2FIX(start - parser->start),
-            LONG2FIX(end - start)
-        };
-
+        VALUE location_argv[] = { source, LONG2FIX(start), LONG2FIX(length) };
         return rb_obj_freeze(rb_class_new_instance(3, location_argv, rb_cPrismLocation));
     } else {
-        uint64_t value = ((((uint64_t) (start - parser->start)) << 32) | ((uint32_t) (end - start)));
+        uint64_t value = ((((uint64_t) start) << 32) | ((uint64_t) length));
         return ULL2NUM(value);
     }
 }
@@ -30,7 +25,7 @@ pm_location_new(const pm_parser_t *parser, const uint8_t *start, const uint8_t *
 VALUE
 pm_token_new(const pm_parser_t *parser, const pm_token_t *token, rb_encoding *encoding, VALUE source, bool freeze) {
     ID type = rb_intern(pm_token_type_name(token->type));
-    VALUE location = pm_location_new(parser, token->start, token->end, source, freeze);
+    VALUE location = pm_location_new((uint32_t) (token->start - parser->start), (uint32_t) (token->end - token->start), source, freeze);
 
     VALUE slice = rb_enc_str_new((const char *) token->start, token->end - token->start, encoding);
     if (freeze) rb_obj_freeze(slice);
@@ -200,7 +195,7 @@ pm_ast_new(const pm_parser_t *parser, const pm_node_t *node, rb_encoding *encodi
                     argv[1] = ULONG2NUM(node->node_id);
 
                     // location
-                    argv[2] = pm_location_new(parser, node->location.start, node->location.end, source, freeze);
+                    argv[2] = pm_location_new(node->location.start, node->location.length, source, freeze);
 
                     // flags
                     argv[3] = ULONG2NUM(node->flags);
@@ -237,10 +232,10 @@ pm_ast_new(const pm_parser_t *parser, const pm_node_t *node, rb_encoding *encodi
                     if (freeze) rb_obj_freeze(argv[<%= index %>]);
                     <%- when Prism::Template::LocationField -%>
 #line <%= __LINE__ + 1 %> "prism/templates/ext/prism/<%= File.basename(__FILE__) %>"
-                    argv[<%= index %>] = pm_location_new(parser, cast-><%= field.name %>.start, cast-><%= field.name %>.end, source, freeze);
+                    argv[<%= index %>] = pm_location_new(cast-><%= field.name %>.start, cast-><%= field.name %>.length, source, freeze);
                     <%- when Prism::Template::OptionalLocationField -%>
 #line <%= __LINE__ + 1 %> "prism/templates/ext/prism/<%= File.basename(__FILE__) %>"
-                    argv[<%= index %>] = cast-><%= field.name %>.start == NULL ? Qnil : pm_location_new(parser, cast-><%= field.name %>.start, cast-><%= field.name %>.end, source, freeze);
+                    argv[<%= index %>] = cast-><%= field.name %>.length == 0 ? Qnil : pm_location_new(cast-><%= field.name %>.start, cast-><%= field.name %>.length, source, freeze);
                     <%- when Prism::Template::UInt8Field -%>
 #line <%= __LINE__ + 1 %> "prism/templates/ext/prism/<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = UINT2NUM(cast-><%= field.name %>);

--- a/templates/include/prism/ast.h.erb
+++ b/templates/include/prism/ast.h.erb
@@ -46,15 +46,19 @@ typedef struct {
 } pm_token_t;
 
 /**
- * This represents a range of bytes in the source string to which a node or
- * token corresponds.
+ * This struct represents a slice in the source code, defined by an offset and
+ * a length. Note that we have confirmation that we can represent all locations
+ * within Ruby source files using 32-bit integers per:
+ *
+ *     https://bugs.ruby-lang.org/issues/20488#note-1
+ *
  */
 typedef struct {
-    /** A pointer to the start location of the range in the source. */
-    const uint8_t *start;
+    /** The offset of the location from the start of the source. */
+    uint32_t start;
 
-    /** A pointer to the end location of the range in the source. */
-    const uint8_t *end;
+    /** The length of the location. */
+    uint32_t length;
 } pm_location_t;
 
 struct pm_node;
@@ -112,7 +116,7 @@ static const pm_node_flags_t PM_NODE_FLAG_STATIC_LITERAL = 0x2;
 typedef struct pm_node {
     /**
      * This represents the type of the node. It somewhat maps to the nodes that
-     * existed in the original grammar and ripper, but it's not a 1:1 mapping.
+     * existed in the original grammar and ripper, but it is not a 1:1 mapping.
      */
     pm_node_type_t type;
 
@@ -129,7 +133,7 @@ typedef struct pm_node {
     uint32_t node_id;
 
     /**
-     * This is the location of the node in the source. It's a range of bytes
+     * This is the location of the node in the source. It is a range of bytes
      * containing a start and an end.
      */
     pm_location_t location;
@@ -160,6 +164,15 @@ typedef struct pm_node {
  * Return true if the given flag is set on the given node.
  */
 #define PM_NODE_FLAG_P(node_, flag_) ((PM_NODE_FLAGS(node_) & (flag_)) != 0)
+
+/**
+ * The alignment required for a child node within a parent node.
+ */
+#ifdef _MSC_VER
+#define PM_NODE_ALIGNAS __declspec(align(8))
+#else
+#define PM_NODE_ALIGNAS PRISM_ALIGNAS(PRISM_ALIGNOF(void *))
+#endif
 <%- nodes.each do |node| -%>
 
 /**
@@ -182,7 +195,6 @@ typedef struct pm_node {
 typedef struct pm_<%= node.human %> {
     /** The embedded base node. */
     pm_node_t base;
-
 <%- node.fields.each do |field| -%>
 
     /**
@@ -195,7 +207,7 @@ typedef struct pm_<%= node.human %> {
     <%- end -%>
      */
     <%= case field
-    when Prism::Template::NodeField, Prism::Template::OptionalNodeField then "struct #{field.c_type} *#{field.name}"
+    when Prism::Template::NodeField, Prism::Template::OptionalNodeField then "PM_NODE_ALIGNAS struct #{field.c_type} *#{field.name}"
     when Prism::Template::NodeListField then "struct pm_node_list #{field.name}"
     when Prism::Template::ConstantField, Prism::Template::OptionalConstantField then "pm_constant_id_t #{field.name}"
     when Prism::Template::ConstantListField then "pm_constant_id_list_t #{field.name}"

--- a/templates/include/prism/diagnostic.h.erb
+++ b/templates/include/prism/diagnostic.h.erb
@@ -100,25 +100,25 @@ const char * pm_diagnostic_id_human(pm_diagnostic_id_t diag_id);
  * memory for its message.
  *
  * @param list The list to append to.
- * @param start The start of the diagnostic.
- * @param end The end of the diagnostic.
+ * @param start The source offset of the start of the diagnostic.
+ * @param length The length of the diagnostic.
  * @param diag_id The diagnostic ID.
  * @return Whether the diagnostic was successfully appended.
  */
-bool pm_diagnostic_list_append(pm_list_t *list, const uint8_t *start, const uint8_t *end, pm_diagnostic_id_t diag_id);
+bool pm_diagnostic_list_append(pm_list_t *list, uint32_t start, uint32_t length, pm_diagnostic_id_t diag_id);
 
 /**
  * Append a diagnostic to the given list of diagnostics that is using a format
  * string for its message.
  *
  * @param list The list to append to.
- * @param start The start of the diagnostic.
- * @param end The end of the diagnostic.
+ * @param start The source offset of the start of the diagnostic.
+ * @param length The length of the diagnostic.
  * @param diag_id The diagnostic ID.
  * @param ... The arguments to the format string for the message.
  * @return Whether the diagnostic was successfully appended.
  */
-bool pm_diagnostic_list_append_format(pm_list_t *list, const uint8_t *start, const uint8_t *end, pm_diagnostic_id_t diag_id, ...);
+bool pm_diagnostic_list_append_format(pm_list_t *list, uint32_t start, uint32_t length, pm_diagnostic_id_t diag_id, ...);
 
 /**
  * Deallocate the internal state of the given diagnostic list.

--- a/templates/src/diagnostic.c.erb
+++ b/templates/src/diagnostic.c.erb
@@ -447,12 +447,12 @@ pm_diagnostic_level(pm_diagnostic_id_t diag_id) {
  * Append an error to the given list of diagnostic.
  */
 bool
-pm_diagnostic_list_append(pm_list_t *list, const uint8_t *start, const uint8_t *end, pm_diagnostic_id_t diag_id) {
+pm_diagnostic_list_append(pm_list_t *list, uint32_t start, uint32_t length, pm_diagnostic_id_t diag_id) {
     pm_diagnostic_t *diagnostic = (pm_diagnostic_t *) xcalloc(1, sizeof(pm_diagnostic_t));
     if (diagnostic == NULL) return false;
 
     *diagnostic = (pm_diagnostic_t) {
-        .location = { start, end },
+        .location = { .start = start, .length = length },
         .diag_id = diag_id,
         .message = pm_diagnostic_message(diag_id),
         .owned = false,
@@ -468,7 +468,7 @@ pm_diagnostic_list_append(pm_list_t *list, const uint8_t *start, const uint8_t *
  * string for its message.
  */
 bool
-pm_diagnostic_list_append_format(pm_list_t *list, const uint8_t *start, const uint8_t *end, pm_diagnostic_id_t diag_id, ...) {
+pm_diagnostic_list_append_format(pm_list_t *list, uint32_t start, uint32_t length, pm_diagnostic_id_t diag_id, ...) {
     va_list arguments;
     va_start(arguments, diag_id);
 
@@ -485,19 +485,19 @@ pm_diagnostic_list_append_format(pm_list_t *list, const uint8_t *start, const ui
         return false;
     }
 
-    size_t length = (size_t) (result + 1);
-    char *message = (char *) xmalloc(length);
+    size_t message_length = (size_t) (result + 1);
+    char *message = (char *) xmalloc(message_length);
     if (message == NULL) {
         xfree(diagnostic);
         return false;
     }
 
     va_start(arguments, diag_id);
-    vsnprintf(message, length, format, arguments);
+    vsnprintf(message, message_length, format, arguments);
     va_end(arguments);
 
     *diagnostic = (pm_diagnostic_t) {
-        .location = { start, end },
+        .location = { .start = start, .length = length },
         .diag_id = diag_id,
         .message = message,
         .owned = true,

--- a/templates/src/node.c.erb
+++ b/templates/src/node.c.erb
@@ -226,10 +226,8 @@ pm_dump_json_constant(pm_buffer_t *buffer, const pm_parser_t *parser, pm_constan
 }
 
 static void
-pm_dump_json_location(pm_buffer_t *buffer, const pm_parser_t *parser, const pm_location_t *location) {
-    uint32_t start = (uint32_t) (location->start - parser->start);
-    uint32_t end = (uint32_t) (location->end - parser->start);
-    pm_buffer_append_format(buffer, "{\"start\":%" PRIu32 ",\"end\":%" PRIu32 "}", start, end);
+pm_dump_json_location(pm_buffer_t *buffer, const pm_location_t *location) {
+    pm_buffer_append_format(buffer, "{\"start\":%" PRIu32 ",\"length\":%" PRIu32 "}", location->start, location->length);
 }
 
 /**
@@ -243,7 +241,7 @@ pm_dump_json(pm_buffer_t *buffer, const pm_parser_t *parser, const pm_node_t *no
             pm_buffer_append_string(buffer, "{\"type\":\"<%= node.name %>\",\"location\":", <%= node.name.bytesize + 22 %>);
 
             const pm_<%= node.human %>_t *cast = (const pm_<%= node.human %>_t *) node;
-            pm_dump_json_location(buffer, parser, &cast->base.location);
+            pm_dump_json_location(buffer, &cast->base.location);
             <%- [*node.flags, *node.fields].each_with_index do |field, index| -%>
 
             // Dump the <%= field.name %> field
@@ -290,10 +288,10 @@ pm_dump_json(pm_buffer_t *buffer, const pm_parser_t *parser, const pm_node_t *no
             }
             pm_buffer_append_byte(buffer, ']');
             <%- when Prism::Template::LocationField -%>
-            pm_dump_json_location(buffer, parser, &cast-><%= field.name %>);
+            pm_dump_json_location(buffer, &cast-><%= field.name %>);
             <%- when Prism::Template::OptionalLocationField -%>
-            if (cast-><%= field.name %>.start != NULL) {
-                pm_dump_json_location(buffer, parser, &cast-><%= field.name %>);
+            if (cast-><%= field.name %>.length != 0) {
+                pm_dump_json_location(buffer, &cast-><%= field.name %>);
             } else {
                 pm_buffer_append_string(buffer, "null", 4);
             }

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -13,7 +13,7 @@ void pm_prettyprint(void) {}
 static inline void
 prettyprint_location(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm_location_t *location) {
     pm_line_column_t start = pm_newline_list_line_column(&parser->newline_list, location->start, parser->start_line);
-    pm_line_column_t end = pm_newline_list_line_column(&parser->newline_list, location->end, parser->start_line);
+    pm_line_column_t end = pm_newline_list_line_column(&parser->newline_list, location->start + location->length, parser->start_line);
     pm_buffer_append_format(output_buffer, "(%" PRIi32 ",%" PRIu32 ")-(%" PRIi32 ",%" PRIu32 ")", start.line, start.column, end.line, end.column);
 }
 
@@ -106,17 +106,17 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
                 pm_buffer_append_byte(output_buffer, ' ');
                 prettyprint_location(output_buffer, parser, location);
                 pm_buffer_append_string(output_buffer, " = \"", 4);
-                pm_buffer_append_source(output_buffer, location->start, (size_t) (location->end - location->start), PM_BUFFER_ESCAPING_RUBY);
+                pm_buffer_append_source(output_buffer, parser->start + location->start, (size_t) location->length, PM_BUFFER_ESCAPING_RUBY);
                 pm_buffer_append_string(output_buffer, "\"\n", 2);
             <%- when Prism::Template::OptionalLocationField -%>
                 pm_location_t *location = &cast-><%= field.name %>;
-                if (location->start == NULL) {
+                if (location->length == 0) {
                     pm_buffer_append_string(output_buffer, " nil\n", 5);
                 } else {
                     pm_buffer_append_byte(output_buffer, ' ');
                     prettyprint_location(output_buffer, parser, location);
                     pm_buffer_append_string(output_buffer, " = \"", 4);
-                    pm_buffer_append_source(output_buffer, location->start, (size_t) (location->end - location->start), PM_BUFFER_ESCAPING_RUBY);
+                    pm_buffer_append_source(output_buffer, parser->start + location->start, (size_t) location->length, PM_BUFFER_ESCAPING_RUBY);
                     pm_buffer_append_string(output_buffer, "\"\n", 2);
                 }
             <%- when Prism::Template::UInt8Field -%>

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -20,13 +20,9 @@ pm_sizet_to_u32(size_t value) {
 }
 
 static void
-pm_serialize_location(const pm_parser_t *parser, const pm_location_t *location, pm_buffer_t *buffer) {
-    assert(location->start);
-    assert(location->end);
-    assert(location->start <= location->end);
-
-    pm_buffer_append_varuint(buffer, pm_ptrdifft_to_u32(location->start - parser->start));
-    pm_buffer_append_varuint(buffer, pm_ptrdifft_to_u32(location->end - location->start));
+pm_serialize_location(const pm_location_t *location, pm_buffer_t *buffer) {
+    pm_buffer_append_varuint(buffer, location->start);
+    pm_buffer_append_varuint(buffer, location->length);
 }
 
 static void
@@ -77,7 +73,7 @@ pm_serialize_node(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
     <%- if Prism::Template::INCLUDE_NODE_ID -%>
     pm_buffer_append_varuint(buffer, node->node_id);
     <%- end -%>
-    pm_serialize_location(parser, &node->location, buffer);
+    pm_serialize_location(&node->location, buffer);
 
     switch (PM_NODE_TYPE(node)) {
         // We do not need to serialize a ScopeNode ever as
@@ -123,15 +119,15 @@ pm_serialize_node(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
             }
             <%- when Prism::Template::LocationField -%>
             <%- if field.should_be_serialized? -%>
-            pm_serialize_location(parser, &((pm_<%= node.human %>_t *)node)-><%= field.name %>, buffer);
+            pm_serialize_location(&((pm_<%= node.human %>_t *)node)-><%= field.name %>, buffer);
             <%- end -%>
             <%- when Prism::Template::OptionalLocationField -%>
             <%- if field.should_be_serialized? -%>
-            if (((pm_<%= node.human %>_t *)node)-><%= field.name %>.start == NULL) {
+            if (((pm_<%= node.human %>_t *)node)-><%= field.name %>.length == 0) {
                 pm_buffer_append_byte(buffer, 0);
             } else {
                 pm_buffer_append_byte(buffer, 1);
-                pm_serialize_location(parser, &((pm_<%= node.human %>_t *)node)-><%= field.name %>, buffer);
+                pm_serialize_location(&((pm_<%= node.human %>_t *)node)-><%= field.name %>, buffer);
             }
             <%- end -%>
             <%- when Prism::Template::UInt8Field -%>
@@ -169,60 +165,60 @@ pm_serialize_newline_list(pm_newline_list_t *list, pm_buffer_t *buffer) {
 }
 
 static void
-pm_serialize_comment(pm_parser_t *parser, pm_comment_t *comment, pm_buffer_t *buffer) {
+pm_serialize_comment(pm_comment_t *comment, pm_buffer_t *buffer) {
     // serialize type
     pm_buffer_append_byte(buffer, (uint8_t) comment->type);
 
     // serialize location
-    pm_serialize_location(parser, &comment->location, buffer);
+    pm_serialize_location(&comment->location, buffer);
 }
 
 /**
  * Serialize the given list of comments to the given buffer.
  */
 void
-pm_serialize_comment_list(pm_parser_t *parser, pm_list_t *list, pm_buffer_t *buffer) {
+pm_serialize_comment_list(pm_list_t *list, pm_buffer_t *buffer) {
     pm_buffer_append_varuint(buffer, pm_sizet_to_u32(pm_list_size(list)));
 
     pm_comment_t *comment;
     for (comment = (pm_comment_t *) list->head; comment != NULL; comment = (pm_comment_t *) comment->node.next) {
-        pm_serialize_comment(parser, comment, buffer);
+        pm_serialize_comment(comment, buffer);
     }
 }
 
 static void
-pm_serialize_magic_comment(pm_parser_t *parser, pm_magic_comment_t *magic_comment, pm_buffer_t *buffer) {
+pm_serialize_magic_comment(pm_magic_comment_t *magic_comment, pm_buffer_t *buffer) {
     // serialize key location
-    pm_buffer_append_varuint(buffer, pm_ptrdifft_to_u32(magic_comment->key_start - parser->start));
-    pm_buffer_append_varuint(buffer, pm_sizet_to_u32(magic_comment->key_length));
+    pm_buffer_append_varuint(buffer, magic_comment->key.start);
+    pm_buffer_append_varuint(buffer, magic_comment->key.length);
 
     // serialize value location
-    pm_buffer_append_varuint(buffer, pm_ptrdifft_to_u32(magic_comment->value_start - parser->start));
-    pm_buffer_append_varuint(buffer, pm_sizet_to_u32(magic_comment->value_length));
+    pm_buffer_append_varuint(buffer, magic_comment->value.start);
+    pm_buffer_append_varuint(buffer, magic_comment->value.length);
 }
 
 static void
-pm_serialize_magic_comment_list(pm_parser_t *parser, pm_list_t *list, pm_buffer_t *buffer) {
+pm_serialize_magic_comment_list(pm_list_t *list, pm_buffer_t *buffer) {
     pm_buffer_append_varuint(buffer, pm_sizet_to_u32(pm_list_size(list)));
 
     pm_magic_comment_t *magic_comment;
     for (magic_comment = (pm_magic_comment_t *) list->head; magic_comment != NULL; magic_comment = (pm_magic_comment_t *) magic_comment->node.next) {
-        pm_serialize_magic_comment(parser, magic_comment, buffer);
+        pm_serialize_magic_comment(magic_comment, buffer);
     }
 }
 
 static void
 pm_serialize_data_loc(const pm_parser_t *parser, pm_buffer_t *buffer) {
-    if (parser->data_loc.end == NULL) {
+    if (parser->data_loc.length == 0) {
         pm_buffer_append_byte(buffer, 0);
     } else {
         pm_buffer_append_byte(buffer, 1);
-        pm_serialize_location(parser, &parser->data_loc, buffer);
+        pm_serialize_location(&parser->data_loc, buffer);
     }
 }
 
 static void
-pm_serialize_diagnostic(pm_parser_t *parser, pm_diagnostic_t *diagnostic, pm_buffer_t *buffer) {
+pm_serialize_diagnostic(pm_diagnostic_t *diagnostic, pm_buffer_t *buffer) {
     // serialize the type
     pm_buffer_append_varuint(buffer, (uint32_t) diagnostic->diag_id);
 
@@ -232,18 +228,18 @@ pm_serialize_diagnostic(pm_parser_t *parser, pm_diagnostic_t *diagnostic, pm_buf
     pm_buffer_append_string(buffer, diagnostic->message, message_length);
 
     // serialize location
-    pm_serialize_location(parser, &diagnostic->location, buffer);
+    pm_serialize_location(&diagnostic->location, buffer);
 
     pm_buffer_append_byte(buffer, diagnostic->level);
 }
 
 static void
-pm_serialize_diagnostic_list(pm_parser_t *parser, pm_list_t *list, pm_buffer_t *buffer) {
+pm_serialize_diagnostic_list(pm_list_t *list, pm_buffer_t *buffer) {
     pm_buffer_append_varuint(buffer, pm_sizet_to_u32(pm_list_size(list)));
 
     pm_diagnostic_t *diagnostic;
     for (diagnostic = (pm_diagnostic_t *) list->head; diagnostic != NULL; diagnostic = (pm_diagnostic_t *) diagnostic->node.next) {
-        pm_serialize_diagnostic(parser, diagnostic, buffer);
+        pm_serialize_diagnostic(diagnostic, buffer);
     }
 }
 
@@ -263,12 +259,12 @@ pm_serialize_metadata(pm_parser_t *parser, pm_buffer_t *buffer) {
     pm_buffer_append_varsint(buffer, parser->start_line);
     pm_serialize_newline_list(&parser->newline_list, buffer);
 <%- unless Prism::Template::SERIALIZE_ONLY_SEMANTICS_FIELDS -%>
-    pm_serialize_comment_list(parser, &parser->comment_list, buffer);
+    pm_serialize_comment_list(&parser->comment_list, buffer);
 <%- end -%>
-    pm_serialize_magic_comment_list(parser, &parser->magic_comment_list, buffer);
+    pm_serialize_magic_comment_list(&parser->magic_comment_list, buffer);
     pm_serialize_data_loc(parser, buffer);
-    pm_serialize_diagnostic_list(parser, &parser->error_list, buffer);
-    pm_serialize_diagnostic_list(parser, &parser->warning_list, buffer);
+    pm_serialize_diagnostic_list(&parser->error_list, buffer);
+    pm_serialize_diagnostic_list(&parser->warning_list, buffer);
 }
 
 #line <%= __LINE__ + 1 %> "prism/templates/src/<%= File.basename(__FILE__) %>"

--- a/templates/src/token_type.c.erb
+++ b/templates/src/token_type.c.erb
@@ -31,10 +31,6 @@ pm_token_type_human(pm_token_type_t token_type) {
     switch (token_type) {
         case PM_TOKEN_EOF:
             return "end-of-input";
-        case PM_TOKEN_MISSING:
-            return "missing token";
-        case PM_TOKEN_NOT_PROVIDED:
-            return "not provided token";
         case PM_TOKEN_AMPERSAND:
             return "'&'";
         case PM_TOKEN_AMPERSAND_AMPERSAND:

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -45,19 +45,19 @@ module Prism
     def test_unterminated_string_closing
       statement = Prism.parse_statement("'hello")
       assert_equal statement.unescaped, "hello"
-      assert_empty statement.closing
+      assert_nil statement.closing
     end
 
     def test_unterminated_interpolated_string_closing
       statement = Prism.parse_statement('"hello')
       assert_equal statement.unescaped, "hello"
-      assert_empty statement.closing
+      assert_nil statement.closing
     end
 
     def test_unterminated_empty_string_closing
       statement = Prism.parse_statement('"')
       assert_empty statement.unescaped
-      assert_empty statement.closing
+      assert_nil statement.closing
     end
 
     def test_invalid_message_name
@@ -84,7 +84,7 @@ module Prism
 
     def test_incomplete_def_closing_loc
       statement = Prism.parse_statement("def f; 123")
-      assert_empty(statement.end_keyword)
+      assert_nil(statement.end_keyword)
     end
 
     private

--- a/test/prism/result/overlap_test.rb
+++ b/test/prism/result/overlap_test.rb
@@ -33,8 +33,13 @@ module Prism
           queue << child
 
           if compare
-            assert_operator current.location.start_offset, :<=, child.location.start_offset
-            assert_operator current.location.end_offset, :>=, child.location.end_offset
+            assert_operator current.location.start_offset, :<=, child.location.start_offset, -> {
+              "[#{fixture.full_path}] Parent node #{current.class} at #{current.location} does not start before child node #{child.class} at #{child.location}"
+            }
+
+            assert_operator current.location.end_offset, :>=, child.location.end_offset, -> {
+              "[#{fixture.full_path}] Parent node #{current.class} at #{current.location} does not end after child node #{child.class} at #{child.location}"
+            }
           end
         end
       end

--- a/test/prism/result/source_location_test.rb
+++ b/test/prism/result/source_location_test.rb
@@ -935,16 +935,16 @@ module Prism
       node = yield node if block_given?
 
       if expected.begin == 0
-        assert_equal 0, node.location.start_column
+        assert_equal 0, node.location.start_column, "#{kind} start_column"
       end
 
       if expected.end == source.length
-        assert_equal source.split("\n").last.length, node.location.end_column
+        assert_equal source.split("\n").last.length, node.location.end_column, "#{kind} end_column"
       end
 
       assert_kind_of kind, node
-      assert_equal expected.begin, node.location.start_offset
-      assert_equal expected.end, node.location.end_offset
+      assert_equal expected.begin, node.location.start_offset, "#{kind} start_offset"
+      assert_equal expected.end, node.location.end_offset, "#{kind} end_offset"
     end
   end
 end


### PR DESCRIPTION
In the C API, we want to use slices instead of locations in the AST. In this case a "slice" is effectively the same thing as the location, expect it is represented using a 32-bit offset and a 32-bit length. This will cut down on half of the space of all of the locations in the AST.

I am introducing this as a new field type to ease the migration path, so that this can be merged on its own and then fields can be moved one at a time.

Note that from the Ruby/Java/JavaScript side, this is effectively an invisible change. This only impacts the C/Rust side.

Fixes #1566