### PR TITLE
Set "trailing" on the comment node

### DIFF
--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -471,9 +471,12 @@ parser_location(const pm_parser_t *parser, VALUE source, bool freeze, const uint
  */
 static inline VALUE
 parser_comment(const pm_parser_t *parser, VALUE source, bool freeze, const pm_comment_t *comment) {
-    VALUE argv[] = { PARSER_LOCATION_LOC(parser, source, freeze, comment->location) };
+    VALUE argv[] = {
+        comment->trailing ? Qtrue : Qfalse,
+        PARSER_LOCATION_LOC(parser, source, freeze, comment->location)
+    };
     VALUE type = (comment->type == PM_COMMENT_EMBDOC) ? rb_cPrismEmbDocComment : rb_cPrismInlineComment;
-    return rb_class_new_instance_freeze(1, argv, type, freeze);
+    return rb_class_new_instance_freeze(2, argv, type, freeze);
 }
 
 /**

--- a/include/prism/parser.h
+++ b/include/prism/parser.h
@@ -467,6 +467,8 @@ typedef struct pm_comment {
 
     /** The type of comment that we've found. */
     pm_comment_type_t type;
+
+    bool trailing;
 } pm_comment_t;
 
 /**

--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -513,8 +513,15 @@ module Prism
     # The location of this comment in the source.
     attr_reader :location
 
+    # Returns true if this comment happens on the same line as other code and
+    # false if the comment is by itself.
+    def trailing?
+      @trailing
+    end
+
     # Create a new comment object with the given location.
-    def initialize(location)
+    def initialize(trailing, location)
+      @trailing = trailing
       @location = location
     end
 
@@ -532,12 +539,6 @@ module Prism
   # InlineComment objects are the most common. They correspond to comments in
   # the source file like this one that start with #.
   class InlineComment < Comment
-    # Returns true if this comment happens on the same line as other code and
-    # false if the comment is by itself.
-    def trailing?
-      !location.start_line_slice.strip.empty?
-    end
-
     # Returns a string representation of this comment.
     def inspect
       "#<Prism::InlineComment @location=#{location.inspect}>"
@@ -547,11 +548,6 @@ module Prism
   # EmbDocComment objects correspond to comments that are surrounded by =begin
   # and =end.
   class EmbDocComment < Comment
-    # This can only be true for inline comments.
-    def trailing?
-      false
-    end
-
     # Returns a string representation of this comment.
     def inspect
       "#<Prism::EmbDocComment @location=#{location.inspect}>"

--- a/templates/lib/prism/serialize.rb.erb
+++ b/templates/lib/prism/serialize.rb.erb
@@ -295,8 +295,8 @@ module Prism
           Array.new(load_varuint) do
             comment =
               case load_varuint
-              when 0 then InlineComment.new(load_location_object(freeze))
-              when 1 then EmbDocComment.new(load_location_object(freeze))
+              when 0 then InlineComment.new(load_boolean, load_location_object(freeze))
+              when 1 then EmbDocComment.new(load_boolean, load_location_object(freeze))
               end
 
             comment.freeze if freeze
@@ -448,6 +448,10 @@ module Prism
 
         value = -value if negative
         value
+      end
+
+      def load_boolean
+        io.getbyte != 0
       end
 
       def load_double

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -173,6 +173,9 @@ pm_serialize_comment(pm_parser_t *parser, pm_comment_t *comment, pm_buffer_t *bu
     // serialize type
     pm_buffer_append_byte(buffer, (uint8_t) comment->type);
 
+    // serialize trailing
+    pm_buffer_append_byte(buffer, (uint8_t) comment->trailing);
+
     // serialize location
     pm_serialize_location(parser, &comment->location, buffer);
 }


### PR DESCRIPTION
Comment nodes can know if they are trailing comments by looking at the previous token.  If we set this on the comment object then we don't need to look at source slices when attaching comments