### PR TITLE
Follow repo move from oracle/truffleruby to truffleruby/truffleruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Prism has been integrated into the majority of Ruby runtimes, many libraries, an
 * [JRuby](https://github.com/jruby/jruby/pull/8103) (via Java)
 * [Natalie](https://github.com/natalie-lang/natalie/pull/1213) (via C++ and Ruby)
 * [Opal](https://github.com/opal/opal/pull/2642) (via Ruby and WASM)
-* [TruffleRuby](https://github.com/oracle/truffleruby/issues/3117) (via Java)
+* [TruffleRuby](https://github.com/truffleruby/truffleruby/issues/3117) (via Java)
 
 ### Libraries
 

--- a/docs/build_system.md
+++ b/docs/build_system.md
@@ -58,12 +58,12 @@ prism's `Makefile` is not used at all in CRuby. Instead, CRuby's `Makefile` is u
 
 ### Building prism as part of TruffleRuby
 
-[This script](https://github.com/oracle/truffleruby/blob/master/tool/import-prism.sh) imports prism sources in TruffleRuby.
+[This script](https://github.com/truffleruby/truffleruby/blob/master/tool/import-prism.sh) imports prism sources in TruffleRuby.
 The script generates the templates when importing.
 
 Then when `mx build` builds TruffleRuby and the `prism` mx project inside, it runs `make`.
 
-Then the `prism bindings` mx project is built, which contains the [bindings](https://github.com/oracle/truffleruby/blob/vm-24.1.1/src/main/c/yarp_bindings/src/yarp_bindings.c)
+Then the `prism bindings` mx project is built, which contains the [bindings](https://github.com/truffleruby/truffleruby/blob/vm-24.1.1/src/main/c/yarp_bindings/src/yarp_bindings.c)
 and links to `libprism.a` (to avoid exporting symbols, so no conflict when installing the prism gem).
 
 ### Building prism as part of JRuby

--- a/docs/cruby_compilation.md
+++ b/docs/cruby_compilation.md
@@ -1,6 +1,6 @@
 # Compiling Prism's AST
 
-One important class of consumers of Prism's AST is compilers. Currently [CRuby](https://github.com/ruby/ruby), [JRuby](https://github.com/jruby/jruby), [TruffleRuby](https://github.com/oracle/truffleruby), and [Natalie](https://github.com/natalie-lang/natalie) have all built compilation code on top of Prism's AST.
+One important class of consumers of Prism's AST is compilers. Currently [CRuby](https://github.com/ruby/ruby), [JRuby](https://github.com/jruby/jruby), [TruffleRuby](https://github.com/truffleruby/truffleruby), and [Natalie](https://github.com/natalie-lang/natalie) have all built compilation code on top of Prism's AST.
 
 This document will describe, at a high level, how CRuby's compilation of Prism's AST works.
 

--- a/include/prism.h
+++ b/include/prism.h
@@ -314,7 +314,7 @@ PRISM_EXPORTED_FUNCTION pm_string_query_t pm_string_query_method_name(const uint
  * dependencies. It is currently being integrated into
  * [CRuby](https://github.com/ruby/ruby),
  * [JRuby](https://github.com/jruby/jruby),
- * [TruffleRuby](https://github.com/oracle/truffleruby),
+ * [TruffleRuby](https://github.com/truffleruby/truffleruby),
  * [Sorbet](https://github.com/sorbet/sorbet), and
  * [Syntax Tree](https://github.com/ruby-syntax-tree/syntax_tree).
  *


### PR DESCRIPTION
The redirect from GitHub works but since I see Prism code in many places I'd prefer if those URLs reference the resolved repository on GitHub.