### PR TITLE
Correct constant pool bucket type logic

### DIFF
--- a/src/util/pm_constant_pool.c
+++ b/src/util/pm_constant_pool.c
@@ -264,7 +264,7 @@ pm_constant_pool_insert(pm_constant_pool_t *pool, const uint8_t *start, size_t l
                 // constant and replace it with the shared constant.
                 xfree((void *) constant->start);
                 constant->start = start;
-                bucket->type = (unsigned int) (PM_CONSTANT_POOL_BUCKET_DEFAULT & 0x3);
+                bucket->type = (unsigned int) (type & 0x3);
             }
 
             return bucket->id;


### PR DESCRIPTION
When replacing an owned constant by a different type (constant or shared) replace with the correct type instead of defaulting to shared.

Fixes #3788