### PR TITLE
Fully handle unreferencing a block exit

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -12533,7 +12533,10 @@ pm_node_unreference_each(const pm_node_t *node, void *data) {
                         );
                     }
                     parser->current_block_exits->size--;
-                    return false;
+
+                    /* Note returning true here because these nodes could have
+                     * arguments that are themselves block exits. */
+                    return true;
                 }
 
                 index++;


### PR DESCRIPTION
If a block exit has a further block exit in its subtree, we need to keep recursing.

Fixes #3783