### PR TITLE
Define RubyParser::SyntaxError so we don't have to require ruby_parser anymore

### DIFF
--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -2,10 +2,15 @@
 # :markup: markdown
 
 begin
-  require "ruby_parser"
+  require "sexp"
 rescue LoadError
-  warn(%q{Error: Unable to load ruby_parser. Add `gem "ruby_parser"` to your Gemfile.})
+  warn(%q{Error: Unable to load sexp. Add `gem "sexp"` to your Gemfile.})
   exit(1)
+end
+
+class RubyParser # :nodoc:
+  class SyntaxError < RuntimeError # :nodoc:
+  end
 end
 
 module Prism


### PR DESCRIPTION
I'd rather there be no require whatesoever as the SyntaxError class
there is basic af... but this guard should do the trick.
