### PR TITLE
Silence clippy

### DIFF
--- a/rust/ruby-prism-sys/src/lib.rs
+++ b/rust/ruby-prism-sys/src/lib.rs
@@ -26,6 +26,7 @@
 #[allow(non_upper_case_globals)]
 #[allow(unused_qualifications)]
 #[allow(clippy::missing_const_for_fn)]
+#[allow(clippy::use_self)]
 mod bindings {
     // In `build.rs`, we use `bindgen` to generate bindings based on C headers
     // and `libprism`. Here is where we pull in those bindings and make


### PR DESCRIPTION
It's generated code

```
 error: unnecessary structure name repetition
    --> /home/runner/work/prism/prism/rust/target/debug/build/ruby-prism-sys-c00cbfa68640095d/out/bindings.rs:2303:26
     |
2303 |     pub subsequent: *mut pm_rescue_node,
     |                          ^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#use_self
     = note: `-D clippy::use-self` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::use_self)]`

error: unnecessary structure name repetition
    --> /home/runner/work/prism/prism/rust/target/debug/build/ruby-prism-sys-c00cbfa68640095d/out/bindings.rs:2582:20
     |
2582 |     pub next: *mut pm_list_node,
     |                    ^^^^^^^^^^^^ help: use the applicable keyword: `Self`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#use_self

error: unnecessary structure name repetition
    --> /home/runner/work/prism/prism/rust/target/debug/build/ruby-prism-sys-c00cbfa68640095d/out/bindings.rs:2712:20
     |
2712 |     pub prev: *mut pm_lex_mode,
     |                    ^^^^^^^^^^^ help: use the applicable keyword: `Self`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#use_self

error: unnecessary structure name repetition
    --> /home/runner/work/prism/prism/rust/target/debug/build/ruby-prism-sys-c00cbfa68640095d/out/bindings.rs:2775:20
     |
2775 |     pub prev: *mut pm_context_node,
     |                    ^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#use_self

error: unnecessary structure name repetition
    --> /home/runner/work/prism/prism/rust/target/debug/build/ruby-prism-sys-c00cbfa68640095d/out/bindings.rs:2845:24
     |
2845 |     pub previous: *mut pm_scope,
     |                        ^^^^^^^^ help: use the applicable keyword: `Self`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#use_self
```