### PR TITLE
Fix npm publish workflow (untested)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -43,3 +43,4 @@ jobs:
         run: npm install -g npm@latest
 
       - run: npm publish
+        working-directory: javascript


### PR DESCRIPTION
Last one didn't work out:
```
Run npm publish
npm warn Unknown user config "always-auth". This will stop working in the next major version of npm.
npm error code ENOENT
npm error syscall open
npm error path /home/runner/work/prism/prism/package.json
npm error errno -2
npm error enoent Could not read package.json: Error: ENOENT: no such file or directory, open '/home/runner/work/prism/prism/package.json'
npm error enoent This is related to npm not being able to find a file.
npm error enoent
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-10-16T12_44_21_684Z-debug-0.log
```

Rust also failed, because the crate already existed on crates.io with that version. I'm assuming that had nothing to do with the workflow.