### PR TITLE
Fix `sexp_processor` gem reference

### DIFF
--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -4,7 +4,7 @@
 begin
   require "sexp"
 rescue LoadError
-  warn(%q{Error: Unable to load sexp. Add `gem "sexp"` to your Gemfile.})
+  warn(%q{Error: Unable to load sexp. Add `gem "sexp_processor"` to your Gemfile.})
   exit(1)
 end
 


### PR DESCRIPTION
Followup to https://github.com/ruby/prism/pull/3800

It's https://rubygems.org/gems/sexp_processor, not https://rubygems.org/gems/sexp