### PR TITLE
Fix Sorbet RBI for Parser35 alias to Parser40

### DIFF
--- a/rbi/prism/translation/parser35.rbi
+++ b/rbi/prism/translation/parser35.rbi
@@ -1,4 +1,3 @@
 # typed: strict
 
-class Prism::Translation::Parser35 < Prism::Translation::Parser
-end
+Prism::Translation::Parser35 = Prism::Translation::Parser40


### PR DESCRIPTION
Hello. I'm a maintainer for Homebrew. Our latest bundler Dependabot PR added Prism 1.7.0 to our Gemfile.lock. Running Sorbet identified an error related to aliasing Parser35 to Parser40 with the change from Ruby 3.5.0 to 4.0.0. This PR removes the class in favor of just an alias.

```
sorbet/rbi/gems/prism@1.7.0.rbi:15758: Cannot initialize the class `Parser35` by constant assignment https://srb.help/4022
       15758 |Prism::Translation::Parser35 = Prism::Translation::Parser40
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    sorbet/rbi/gems/prism@1.7.0.rbi:15759: Previously defined as a class here
       15759 |class Prism::Translation::Parser35 < Prism::Translation::Parser; end
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  Note:
    Sorbet does not allow treating constant assignments as class or module definitions,
    even if the initializer computes a `Module` object at runtime. See the docs for more.
Errors: 1
```


