### PR TITLE
Sync `Prism::Translation::ParserCurrent` with Ruby 4.0

### DIFF
--- a/lib/prism/translation/parser_current.rb
+++ b/lib/prism/translation/parser_current.rb
@@ -16,7 +16,7 @@ module Prism
       ParserCurrent = Parser41
     else
       # Keep this in sync with released Ruby.
-      parser = Parser34
+      parser = Parser40
       major, minor, _patch = Gem::Version.new(RUBY_VERSION).segments
       warn "warning: `Prism::Translation::Current` is loading #{parser.name}, " \
            "but you are running #{major}.#{minor}."


### PR DESCRIPTION
This PR updates the fallback version for `Prism::Translation::ParserCurrent` from 3.4 to 4.0.

Currently, the fallback resolves to `Parser34`, as shown below:

```console
$ ruby -v -rprism -rprism/translation/parser_current -e 'p Prism::Translation::ParserCurrent'
ruby 3.0.7p220 (2024-04-23 revision 724a071175) [x86_64-darwin23]
warning: `Prism::Translation::Current` is loading Prism::Translation::Parser34, but you are running 3.0.
Prism::Translation::Parser34
```

Following the comment "Keep this in sync with released Ruby.", it seems like the right time to set this to Ruby 4.0, which is scheduled for release this week.