### PR TITLE
Report unterminated construct errors at opening token

### DIFF
--- a/test/prism/errors/block_beginning_with_brace_and_ending_with_end.txt
+++ b/test/prism/errors/block_beginning_with_brace_and_ending_with_end.txt
@@ -1,5 +1,5 @@
 x.each { x end
            ^~~ unexpected 'end', expecting end-of-input
            ^~~ unexpected 'end', ignoring it
-              ^ expected a block beginning with `{` to end with `}`
+       ^ expected a block beginning with `{` to end with `}`
 

--- a/test/prism/errors/command_calls_2.txt
+++ b/test/prism/errors/command_calls_2.txt
@@ -1,5 +1,5 @@
 {a: b c}
-     ^ expected a `}` to close the hash literal
+^ expected a `}` to close the hash literal
       ^ unexpected local variable or method, expecting end-of-input
        ^ unexpected '}', expecting end-of-input
        ^ unexpected '}', ignoring it

--- a/test/prism/errors/command_calls_24.txt
+++ b/test/prism/errors/command_calls_24.txt
@@ -1,5 +1,5 @@
 ->a=b c{}
      ^ expected a `do` keyword or a `{` to open the lambda block
          ^ unexpected end-of-input, assuming it is closing the parent top level context
-         ^ expected a lambda block beginning with `do` to end with `end`
+^~ expected a lambda block beginning with `do` to end with `end`
 

--- a/test/prism/errors/command_calls_25.txt
+++ b/test/prism/errors/command_calls_25.txt
@@ -4,5 +4,5 @@
         ^ unexpected ')', expecting end-of-input
         ^ unexpected ')', ignoring it
            ^ unexpected end-of-input, assuming it is closing the parent top level context
-           ^ expected a lambda block beginning with `do` to end with `end`
+^~ expected a lambda block beginning with `do` to end with `end`
 

--- a/test/prism/errors/heredoc_unterminated.txt
+++ b/test/prism/errors/heredoc_unterminated.txt
@@ -3,7 +3,7 @@ a=>{<<b
     ^~~ unexpected heredoc beginning; expected a key in the hash pattern
       ^ unterminated heredoc; can't find string "b" anywhere before EOF
     ^~~ expected a label as the key in the hash pattern
-       ^ expected a `}` to close the pattern expression
+   ^ expected a `}` to close the pattern expression
        ^ unexpected heredoc ending, expecting end-of-input
        ^ unexpected heredoc ending, ignoring it
 

--- a/test/prism/errors/infix_after_label.txt
+++ b/test/prism/errors/infix_after_label.txt
@@ -1,6 +1,6 @@
 { 'a':.upcase => 1 }
       ^ unexpected '.'; expected a value in the hash literal
-      ^ expected a `}` to close the hash literal
+^ expected a `}` to close the hash literal
                    ^ unexpected '}', expecting end-of-input
                    ^ unexpected '}', ignoring it
 

--- a/test/prism/errors/label_in_interpolated_string.txt
+++ b/test/prism/errors/label_in_interpolated_string.txt
@@ -2,6 +2,7 @@ case    in el""Q
 ^~~~ expected a predicate for a case matching statement
              ^ expected a delimiter after the patterns of an `in` clause
                ^ unexpected constant, expecting end-of-input
+^~~~ expected an `end` to close the `case` statement
  !"""#{in el"":Q
        ^~ unexpected 'in', assuming it is closing the parent 'in' clause
        ^ expected a `}` to close the embedded expression
@@ -10,5 +11,4 @@ case    in el""Q
             ^ cannot parse the string part
     ^~~~~~~~~~~ unexpected label
     ^~~~~~~~~~~ expected a string for concatenation
-               ^ expected an `end` to close the `case` statement
 

--- a/test/prism/errors/pattern_string_key.txt
+++ b/test/prism/errors/pattern_string_key.txt
@@ -1,8 +1,8 @@
 case:a
+^~~~ expected an `end` to close the `case` statement
 in b:"","#{}"
         ^~~~~ expected a label after the `,` in the hash pattern
              ^ expected a pattern expression after the key
              ^ expected a delimiter after the patterns of an `in` clause
              ^ unexpected end-of-input, assuming it is closing the parent top level context
-             ^ expected an `end` to close the `case` statement
 

--- a/test/prism/errors/shadow_args_in_lambda.txt
+++ b/test/prism/errors/shadow_args_in_lambda.txt
@@ -1,5 +1,5 @@
 ->a;b{}
    ^ expected a `do` keyword or a `{` to open the lambda block
        ^ unexpected end-of-input, assuming it is closing the parent top level context
-       ^ expected a lambda block beginning with `do` to end with `end`
+^~ expected a lambda block beginning with `do` to end with `end`
 

--- a/test/prism/errors/unterminated_begin.txt
+++ b/test/prism/errors/unterminated_begin.txt
@@ -1,4 +1,4 @@
 begin
      ^ unexpected end-of-input, assuming it is closing the parent top level context
-     ^ expected an `end` to close the `begin` statement
+^~~~~ expected an `end` to close the `begin` statement
 

--- a/test/prism/errors/unterminated_begin_upcase.txt
+++ b/test/prism/errors/unterminated_begin_upcase.txt
@@ -1,4 +1,4 @@
 BEGIN {
        ^ unexpected end-of-input, assuming it is closing the parent top level context
-       ^ expected a `}` to close the `BEGIN` statement
+      ^ expected a `}` to close the `BEGIN` statement
 

--- a/test/prism/errors/unterminated_block.txt
+++ b/test/prism/errors/unterminated_block.txt
@@ -1,4 +1,4 @@
 foo {
      ^ unexpected end-of-input, assuming it is closing the parent top level context
-     ^ expected a block beginning with `{` to end with `}`
+    ^ expected a block beginning with `{` to end with `}`
 

--- a/test/prism/errors/unterminated_block_do_end.txt
+++ b/test/prism/errors/unterminated_block_do_end.txt
@@ -1,4 +1,4 @@
 foo do
       ^ unexpected end-of-input, assuming it is closing the parent top level context
-      ^ expected a block beginning with `do` to end with `end`
+    ^~ expected a block beginning with `do` to end with `end`
 

--- a/test/prism/errors/unterminated_class.txt
+++ b/test/prism/errors/unterminated_class.txt
@@ -1,4 +1,4 @@
 class Foo
          ^ unexpected end-of-input, assuming it is closing the parent top level context
-         ^ expected an `end` to close the `class` statement
+^~~~~ expected an `end` to close the `class` statement
 

--- a/test/prism/errors/unterminated_def.txt
+++ b/test/prism/errors/unterminated_def.txt
@@ -1,5 +1,5 @@
 def foo
        ^ expected a delimiter to close the parameters
        ^ unexpected end-of-input, assuming it is closing the parent top level context
-       ^ expected an `end` to close the `def` statement
+^~~ expected an `end` to close the `def` statement
 

--- a/test/prism/errors/unterminated_end_upcase.txt
+++ b/test/prism/errors/unterminated_end_upcase.txt
@@ -1,4 +1,4 @@
 END {
      ^ unexpected end-of-input, assuming it is closing the parent top level context
-     ^ expected a `}` to close the `END` statement
+    ^ expected a `}` to close the `END` statement
 

--- a/test/prism/errors/unterminated_for.txt
+++ b/test/prism/errors/unterminated_for.txt
@@ -1,5 +1,5 @@
 for x in y
           ^ unexpected end-of-input; expected a 'do', newline, or ';' after the 'for' loop collection
           ^ unexpected end-of-input, assuming it is closing the parent top level context
-          ^ expected an `end` to close the `for` loop
+^~~ expected an `end` to close the `for` loop
 

--- a/test/prism/errors/unterminated_if.txt
+++ b/test/prism/errors/unterminated_if.txt
@@ -1,5 +1,5 @@
 if true
        ^ expected `then` or `;` or '\n'
        ^ unexpected end-of-input, assuming it is closing the parent top level context
-       ^ expected an `end` to close the conditional clause
+^~ expected an `end` to close the conditional clause
 

--- a/test/prism/errors/unterminated_if_else.txt
+++ b/test/prism/errors/unterminated_if_else.txt
@@ -1,5 +1,5 @@
 if true
+^~ expected an `end` to close the `else` clause
 else
     ^ unexpected end-of-input, assuming it is closing the parent top level context
-    ^ expected an `end` to close the `else` clause
 

--- a/test/prism/errors/unterminated_lambda_brace.txt
+++ b/test/prism/errors/unterminated_lambda_brace.txt
@@ -1,4 +1,4 @@
 -> {
     ^ unexpected end-of-input, assuming it is closing the parent top level context
-    ^ expected a lambda block beginning with `{` to end with `}`
+   ^ expected a lambda block beginning with `{` to end with `}`
 

--- a/test/prism/errors/unterminated_module.txt
+++ b/test/prism/errors/unterminated_module.txt
@@ -1,4 +1,4 @@
 module Foo
           ^ unexpected end-of-input, assuming it is closing the parent top level context
-          ^ expected an `end` to close the `module` statement
+^~~~~~ expected an `end` to close the `module` statement
 

--- a/test/prism/errors/unterminated_pattern_bracket.txt
+++ b/test/prism/errors/unterminated_pattern_bracket.txt
@@ -1,7 +1,7 @@
 case x
+^~~~ expected an `end` to close the `case` statement
 in [1
-     ^ expected a `]` to close the pattern expression
+   ^ expected a `]` to close the pattern expression
      ^ expected a delimiter after the patterns of an `in` clause
      ^ unexpected end-of-input, assuming it is closing the parent top level context
-     ^ expected an `end` to close the `case` statement
 

--- a/test/prism/errors/unterminated_pattern_paren.txt
+++ b/test/prism/errors/unterminated_pattern_paren.txt
@@ -1,7 +1,7 @@
 case x
+^~~~ expected an `end` to close the `case` statement
 in (1
-     ^ expected a `)` to close the pattern expression
+   ^ expected a `)` to close the pattern expression
      ^ expected a delimiter after the patterns of an `in` clause
      ^ unexpected end-of-input, assuming it is closing the parent top level context
-     ^ expected an `end` to close the `case` statement
 

--- a/test/prism/errors/unterminated_until.txt
+++ b/test/prism/errors/unterminated_until.txt
@@ -1,5 +1,5 @@
 until true
           ^ expected a predicate expression for the `until` statement
           ^ unexpected end-of-input, assuming it is closing the parent top level context
-          ^ expected an `end` to close the `until` statement
+^~~~~ expected an `end` to close the `until` statement
 

--- a/test/prism/errors/while_endless_method.txt
+++ b/test/prism/errors/while_endless_method.txt
@@ -1,5 +1,5 @@
 while def f = g do end
                       ^ expected a predicate expression for the `while` statement
                       ^ unexpected end-of-input, assuming it is closing the parent top level context
-                      ^ expected an `end` to close the `while` statement
+^~~~~ expected an `end` to close the `while` statement
 


### PR DESCRIPTION
:wave: We're working on integrating Prism into Sorbet and I would like to propose an improvement to how unterminated construct errors are reported to end users.

This PR adds an `expect1_opening` function that expects a token and attaches the error to the opening token location rather than the current position. This is useful for errors about missing closing tokens, where it could be useful to point to the line with the opening token rather than the end of the file.

For example:

```
def foo
def bar
def baz
       ^ expected an `end` to close the `def` statement
       ^ expected an `end` to close the `def` statement
       ^ expected an `end` to close the `def` statement
```

This would previously produce three identical errors at the end of the file. After this commit, they would be reported at the opening token location:

```
def foo
^~~ expected an `end` to close the `def` statement
def bar
^~~ expected an `end` to close the `def` statement
def baz
^~~ expected an `end` to close the `def` statement
```

This way, end users can see which particular def node is considered unclosed, rather than a seeing a collection of errors all pointing to the end of the file. However, I understand this might be considered less technically correct and potentially less useful in certain situations. In the single-line test examples it might seem preferable to show the error at end-of-input, since that's where the closing token should be, but I think in most practical cases that won't be the case.

## Alternative

An alternative approach might be to add "hints" to errors so the error location remains end-of-input but an additional hint location could point to the opening token. Clients could choose whether to surface the original error location, the hint location, or both. What do you think?

## Tests

As part of this, I added a handful of tests capturing the original behavior which should make it easier to see the effect this proposed change has.