### PR TITLE
Use a stable version for cargo lint

### DIFF
--- a/.github/workflows/rust-bindings.yml
+++ b/.github/workflows/rust-bindings.yml
@@ -51,8 +51,6 @@ jobs:
 
   lint:
     name: cargo:lint
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -64,7 +62,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: "1.91.1"
           components: clippy, rustfmt
       - uses: actions/cache@v5
         with:


### PR DESCRIPTION
When a new rust version releases, CI shouldn't fail because of new rules