### PR TITLE
Add irb to the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "test-unit"
 
 platforms :mri, :mswin, :mingw, :x64_mingw do
   gem "ffi"
+  gem "irb"
   gem "parser"
   gem "ruby_memcheck"
   gem "ruby_parser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,11 @@ GEM
     date (3.5.1)
     erb (6.0.1)
     ffi (1.17.3)
+    io-console (0.8.2)
+    irb (1.16.0)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     mini_portile2 (2.8.9)
     nokogiri (1.19.0)
       mini_portile2 (~> 2.8.2)
@@ -20,6 +25,9 @@ GEM
       ast (~> 2.4.1)
       racc
     power_assert (3.0.1)
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
     psych (5.3.1)
       date
       stringio
@@ -31,6 +39,8 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    reline (0.6.3)
+      io-console (~> 0.5)
     ruby_memcheck (3.0.1)
       nokogiri
     ruby_parser (3.22.0)
@@ -48,6 +58,7 @@ PLATFORMS
 DEPENDENCIES
   benchmark-ips
   ffi
+  irb
   onigmo
   parser
   prism!


### PR DESCRIPTION
On ruby 4.0.0, it is not a default gem anymore, which means you can't do `bundle exec irb`