### PR TITLE
[Bug #21831] Fix denominator of rational float literal

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -3962,9 +3962,13 @@ pm_float_node_rational_create(pm_parser_t *parser, const pm_token_t *token) {
     memcpy(digits + (point - start), point + 1, (unsigned long) (end - point - 1));
     pm_integer_parse(&node->numerator, PM_INTEGER_BASE_DEFAULT, digits, digits + length - 1);
 
+    size_t fract_length = 0;
+    for (const uint8_t *fract = point; fract < end; ++fract) {
+        if (*fract != '_') ++fract_length;
+    }
     digits[0] = '1';
-    if (end - point > 1) memset(digits + 1, '0', (size_t) (end - point - 1));
-    pm_integer_parse(&node->denominator, PM_INTEGER_BASE_DEFAULT, digits, digits + (end - point));
+    if (fract_length > 1) memset(digits + 1, '0', fract_length - 1);
+    pm_integer_parse(&node->denominator, PM_INTEGER_BASE_DEFAULT, digits, digits + fract_length);
     xfree(digits);
 
     pm_integers_reduce(&node->numerator, &node->denominator);

--- a/test/prism/result/numeric_value_test.rb
+++ b/test/prism/result/numeric_value_test.rb
@@ -6,16 +6,27 @@ module Prism
   class NumericValueTest < TestCase
     def test_numeric_value
       assert_equal 123, Prism.parse_statement("123").value
+      assert_equal 123, Prism.parse_statement("1_23").value
       assert_equal 3.14, Prism.parse_statement("3.14").value
+      assert_equal 3.14, Prism.parse_statement("3.1_4").value
       assert_equal 42i, Prism.parse_statement("42i").value
+      assert_equal 42i, Prism.parse_statement("4_2i").value
       assert_equal 42.1ri, Prism.parse_statement("42.1ri").value
+      assert_equal 42.1ri, Prism.parse_statement("42.1_0ri").value
       assert_equal 3.14i, Prism.parse_statement("3.14i").value
+      assert_equal 3.14i, Prism.parse_statement("3.1_4i").value
       assert_equal 42r, Prism.parse_statement("42r").value
+      assert_equal 42r, Prism.parse_statement("4_2r").value
       assert_equal 0.5r, Prism.parse_statement("0.5r").value
+      assert_equal 0.5r, Prism.parse_statement("0.5_0r").value
       assert_equal 42ri, Prism.parse_statement("42ri").value
+      assert_equal 42ri, Prism.parse_statement("4_2ri").value
       assert_equal 0.5ri, Prism.parse_statement("0.5ri").value
+      assert_equal 0.5ri, Prism.parse_statement("0.5_0ri").value
       assert_equal 0xFFr, Prism.parse_statement("0xFFr").value
+      assert_equal 0xFFr, Prism.parse_statement("0xF_Fr").value
       assert_equal 0xFFri, Prism.parse_statement("0xFFri").value
+      assert_equal 0xFFri, Prism.parse_statement("0xF_Fri").value
     end
   end
 end


### PR DESCRIPTION
Denominators can contain underscores in fraction part as well as other numeric literals.

[Bug #21831]: https://bugs.ruby-lang.org/issues/21831