### PR TITLE
Fix locations for invalid syntax when using `expect1_opening`

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -12438,7 +12438,7 @@ expect1_opening(pm_parser_t *parser, pm_token_type_t type, pm_diagnostic_id_t di
 
     pm_parser_err(parser, opening->start, opening->end, diag_id);
 
-    parser->previous.start = opening->end;
+    parser->previous.start = parser->previous.end;
     parser->previous.type = PM_TOKEN_MISSING;
 }
 

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -82,6 +82,11 @@ module Prism
       assert_empty result.errors
     end
 
+    def test_incomplete_def_closing_loc
+      statement = Prism.parse_statement("def f; 123")
+      assert_empty(statement.end_keyword)
+    end
+
     private
 
     def assert_errors(filepath, version)


### PR DESCRIPTION
Followup to https://github.com/ruby/prism/pull/3827

It sets the start to the opening but it should instead just continue on as usual.
Fixes https://github.com/ruby/prism/issues/3851

Notice how the AST actually contains "123" in both the body and end keyword.