### PR TITLE
[rust] add support for accesing the list of line offsets

### DIFF
--- a/rust/ruby-prism/src/lib.rs
+++ b/rust/ruby-prism/src/lib.rs
@@ -66,6 +66,27 @@ mod tests {
     }
 
     #[test]
+    fn line_offsets_test() {
+        let source = "";
+        let result = parse(source.as_ref());
+
+        let expected: [u32; 1] = [0];
+        assert_eq!(expected, result.line_offsets());
+
+        let source = "1 + 1";
+        let result = parse(source.as_ref());
+
+        let expected: [u32; 1] = [0];
+        assert_eq!(expected, result.line_offsets());
+
+        let source = "begin\n1 + 1\n2 + 2\nend";
+        let result = parse(source.as_ref());
+
+        let expected: [u32; 4] = [0, 6, 12, 18];
+        assert_eq!(expected, result.line_offsets());
+    }
+
+    #[test]
     fn magic_comments_test() {
         use crate::MagicComment;
 

--- a/rust/ruby-prism/src/parse_result/mod.rs
+++ b/rust/ruby-prism/src/parse_result/mod.rs
@@ -119,6 +119,15 @@ impl<'pr> ParseResult<'pr> {
         &self.source[start..end]
     }
 
+    /// Returns a slice containing the offsets of the start of each line in the source string
+    /// that was parsed.
+    #[must_use]
+    pub fn line_offsets(&self) -> &'pr [u32] {
+        unsafe {
+            let list = &(*self.parser.as_ptr()).line_offsets;
+            std::slice::from_raw_parts(list.offsets, list.size)
+        }
+    }
     /// Returns an iterator that can be used to iterate over the errors in the
     /// parse result.
     #[must_use]


### PR DESCRIPTION
As per subject.  `rubyfmt` spends a non-trivial amount of time figuring out where the newlines are in the source string, and since the parser already has this information, it seems silly to have to recompute it.

I'm glad I wrote tests, though, because the implementation seems surprising to me -- I don't think I ever would have expected the list to contain offsets for newlines that aren't actually present in the source string.  I guess it's too late to change the contract here?  (I considered making this code return `list[1..]`, but I think the consistency between it and the C implementation is more important; happy to reconsider or to get the underlying library changed.)

cc @reese