### PR TITLE
Add `license` identifier to Rust crates

### DIFF
--- a/rust/ruby-prism-sys/Cargo.toml
+++ b/rust/ruby-prism-sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ruby-prism-sys"
 version = "1.8.0"
 edition = "2021"
+license = "MIT"
 license-file = "../../LICENSE.md"
 repository = "https://github.com/ruby/prism"
 description = "Rust bindings to Ruby's prism parsing library"

--- a/rust/ruby-prism/Cargo.toml
+++ b/rust/ruby-prism/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ruby-prism"
 version = "1.8.0"
 edition = "2021"
+license = "MIT"
 license-file = "../../LICENSE.md"
 repository = "https://github.com/ruby/prism"
 description = "Rustified version of Ruby's prism parsing library"


### PR DESCRIPTION
So that tools like [cargo-about](https://crates.io/crates/cargo-about) can automatically bundle the license for attribution.