### PR TITLE
Optimize ripper translator token sorting

### DIFF
--- a/lib/prism/lex_compat.rb
+++ b/lib/prism/lex_compat.rb
@@ -802,8 +802,12 @@ module Prism
       # Drop the EOF token from the list
       tokens = tokens[0...-1]
 
-      # We sort by location to compare against Ripper's output
-      tokens.sort_by!(&:location)
+      # We sort by location because Ripper.lex sorts.
+      # Manually implemented instead of `sort_by!(&:location)` for performance.
+      tokens.sort_by! do |token|
+        line, column = token.location
+        source.line_to_byte_offset(line) + column
+      end
 
       # Add :on_sp tokens
       tokens = add_on_sp_tokens(tokens, source, result.data_loc, bom, eof_token)


### PR DESCRIPTION
With the benchmark from https://github.com/ruby/prism/commit/2ea81398cc6f776dca686125847dbf9b0af58c16 Prism is:
* 1.33x slower before
* 1.07x slower after