### PR TITLE
Use each_line to avoid allocating array

### DIFF
--- a/lib/prism/lex_compat.rb
+++ b/lib/prism/lex_compat.rb
@@ -659,13 +659,14 @@ module Prism
             IgnoreStateToken.new([[lineno, column], event, value, lex_state])
           when :on_words_sep
             # Ripper emits one token each per line.
-            lines = value.lines
-            lines[0...-1].each do |whitespace|
-              tokens << Token.new([[lineno, column], event, whitespace, lex_state])
-              lineno += 1
-              column = 0
+            value.each_line.with_index do |line, index|
+              if index > 0
+                lineno += 1
+                column = 0
+              end
+              tokens << Token.new([[lineno, column], event, line, lex_state])
             end
-            Token.new([[lineno, column], event, lines.last, lex_state])
+            tokens.pop
           when :on_regexp_end
             # On regex end, Ripper scans and then sets end state, so the ripper
             # lexed output is begin, when it should be end. prism sets lex state


### PR DESCRIPTION
Though very unlikely, it could potentially allocate a large array of whitespace.