### PR TITLE
Update bundler in the main gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "rake-compiler"
 gem "ruby_parser"
 gem "test-unit"
 
-platforms :mri, :mswin, :mingw, :x64_mingw do
+platforms :mri, :windows do
   gem "ffi"
   gem "irb"
   gem "ruby_memcheck"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,4 +81,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.5.16
+  4.0.4


### PR DESCRIPTION
Every time I run `bundle exec rake`, I get warnings about duplicate constants. This is solved in newer bundler versions:

```
/home/user/.rbenv/versions/4.0.0/lib/ruby/gems/4.0.0/gems/bundler-2.5.16/lib/bundler/rubygems_ext.rb:290: warning: already initialized constant Gem::Platform::JAVA
/home/user/.rbenv/versions/4.0.0/lib/ruby/4.0.0/rubygems/platform.rb:279: warning: previous definition of JAVA was here
and many more
```

Bundler 4 requires ruby 3.2 but erb since 5.0 already imposes the same constraint.

Bundler now warns about using mswin etc. Should use windows instead.