### PR TITLE
Use the terminology "column in bytes/characters/code units"

### DIFF
--- a/include/prism/util/pm_newline_list.h
+++ b/include/prism/util/pm_newline_list.h
@@ -46,7 +46,7 @@ typedef struct {
     /** The line number. */
     int32_t line;
 
-    /** The column number. */
+    /** The column in bytes. */
     uint32_t column;
 } pm_line_column_t;
 

--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -103,7 +103,7 @@ module Prism
       offsets[find_line(byte_offset) + 1] || source.bytesize
     end
 
-    # Return the column number for the given byte offset.
+    # Return the column in bytes for the given byte offset.
     def column(byte_offset)
       byte_offset - line_start(byte_offset)
     end
@@ -113,7 +113,7 @@ module Prism
       (source.byteslice(0, byte_offset) or raise).length
     end
 
-    # Return the column number in characters for the given byte offset.
+    # Return the column in characters for the given byte offset.
     def character_column(byte_offset)
       character_offset(byte_offset) - character_offset(line_start(byte_offset))
     end
@@ -146,7 +146,7 @@ module Prism
       CodeUnitsCache.new(source, encoding)
     end
 
-    # Returns the column number in code units for the given encoding for the
+    # Returns the column in code units for the given encoding for the
     # given byte offset.
     def code_units_column(byte_offset, encoding)
       code_units_offset(byte_offset, encoding) - code_units_offset(line_start(byte_offset), encoding)
@@ -253,7 +253,7 @@ module Prism
       byte_offset
     end
 
-    # Return the column number in characters for the given byte offset.
+    # Return the column in characters for the given byte offset.
     def character_column(byte_offset)
       byte_offset - line_start(byte_offset)
     end
@@ -428,19 +428,19 @@ module Prism
       source.line(end_offset)
     end
 
-    # The column number in bytes where this location starts from the start of
+    # The column in bytes where this location starts from the start of
     # the line.
     def start_column
       source.column(start_offset)
     end
 
-    # The column number in characters where this location ends from the start of
+    # The column in characters where this location ends from the start of
     # the line.
     def start_character_column
       source.character_column(start_offset)
     end
 
-    # The column number in code units of the given encoding where this location
+    # The column in code units of the given encoding where this location
     # starts from the start of the line.
     def start_code_units_column(encoding = Encoding::UTF_16LE)
       source.code_units_column(start_offset, encoding)
@@ -452,19 +452,19 @@ module Prism
       cache[start_offset] - cache[source.line_start(start_offset)]
     end
 
-    # The column number in bytes where this location ends from the start of the
+    # The column in bytes where this location ends from the start of the
     # line.
     def end_column
       source.column(end_offset)
     end
 
-    # The column number in characters where this location ends from the start of
+    # The column in characters where this location ends from the start of
     # the line.
     def end_character_column
       source.character_column(end_offset)
     end
 
-    # The column number in code units of the given encoding where this location
+    # The column in code units of the given encoding where this location
     # ends from the start of the line.
     def end_code_units_column(encoding = Encoding::UTF_16LE)
       source.code_units_column(end_offset, encoding)

--- a/lib/prism/translation/ripper.rb
+++ b/lib/prism/translation/ripper.rb
@@ -475,7 +475,7 @@ module Prism
       # The current line number of the parser.
       attr_reader :lineno
 
-      # The current column number of the parser.
+      # The current column in bytes of the parser.
       attr_reader :column
 
       # Create a new Translation::Ripper object with the given source.

--- a/templates/lib/prism/dot_visitor.rb.erb
+++ b/templates/lib/prism/dot_visitor.rb.erb
@@ -169,7 +169,7 @@ module Prism
       "Node_#{node.object_id}"
     end
 
-    # Inspect a location to display the start and end line and column numbers.
+    # Inspect a location to display the start and end line and columns in bytes.
     def location_inspect(location)
       "(#{location.start_line},#{location.start_column})-(#{location.end_line},#{location.end_column})"
     end


### PR DESCRIPTION
* Consistent and clear.
* Avoids the confusion that "column number" might be understood as a column in an editor starting at 1 (they all start at 0).

From https://github.com/ruby/prism/pull/3877#discussion_r2733633671