### PR TITLE
Use align keywords instead of the header

### DIFF
--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -263,13 +263,11 @@
  * specify alignment in a compiler-agnostic way.
  */
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L /* C11 or later */
-    #include <stdalign.h>
-
     /** Specify alignment for a type or variable. */
-    #define PRISM_ALIGNAS(size) alignas(size)
+    #define PRISM_ALIGNAS _Alignas
 
     /** Get the alignment requirement of a type. */
-    #define PRISM_ALIGNOF(type) alignof(type)
+    #define PRISM_ALIGNOF _Alignof
 #elif defined(__GNUC__) || defined(__clang__)
     /** Specify alignment for a type or variable. */
     #define PRISM_ALIGNAS(size) __attribute__((aligned(size)))


### PR DESCRIPTION
OpenBSD is advertising to the preprocessor that it supports C11 but does not include the stdalign.h header. We do not actually need the header, since we can just use the keywords.