### PR TITLE
Support `version: "nearest"`.

### DIFF
--- a/include/prism/options.h
+++ b/include/prism/options.h
@@ -82,7 +82,10 @@ typedef void (*pm_options_shebang_callback_t)(struct pm_options *options, const 
  * parse in the same way as a specific version of CRuby would have.
  */
 typedef enum {
-    /** If an explicit version is not provided, the current version of prism will be used. */
+    /**
+     * If an explicit version is not provided, the current version of prism will
+     * be used.
+     */
     PM_OPTIONS_VERSION_UNSET = 0,
 
     /** The vendored version of prism in CRuby 3.3.x. */
@@ -452,6 +455,9 @@ PRISM_EXPORTED_FUNCTION void pm_options_free(pm_options_t *options);
  * | ----- | ------------------------- |
  * | `0`   | use the latest version of prism |
  * | `1`   | use the version of prism that is vendored in CRuby 3.3.0 |
+ * | `2`   | use the version of prism that is vendored in CRuby 3.4.0 |
+ * | `3`   | use the version of prism that is vendored in CRuby 4.0.0 |
+ * | `4`   | use the version of prism that is vendored in CRuby 4.1.0 |
  *
  * Each scope is laid out as follows:
  *

--- a/lib/prism/ffi.rb
+++ b/lib/prism/ffi.rb
@@ -423,10 +423,26 @@ module Prism
 
     # Return the value that should be dumped for the version option.
     def dump_options_version(version)
-      current = version == "current"
+      checking =
+        case version
+        when "current"
+          RUBY_VERSION
+        when "latest"
+          nil
+        when "nearest"
+          if RUBY_VERSION <= "3.3"
+            "3.3"
+          elsif RUBY_VERSION >= "4.1"
+            "4.1"
+          else
+            RUBY_VERSION
+          end
+        else
+          version
+        end
 
-      case current ? RUBY_VERSION : version
-      when nil, "latest"
+      case checking
+      when nil
         0 # Handled in pm_parser_init
       when /\A3\.3(\.\d+)?\z/
         1
@@ -437,7 +453,7 @@ module Prism
       when /\A4\.1(\.\d+)?\z/
         4
       else
-        if current
+        if version == "current"
           raise CurrentVersionError, RUBY_VERSION
         else
           raise ArgumentError, "invalid version: #{version}"


### PR DESCRIPTION
This clamps to supported versions based on the current Ruby version.

Fixes #3885