### PR TITLE
[rust] add `is_success` and `is_failure` methods for `ParseResult`

### DIFF
--- a/rust/ruby-prism/src/parse_result/mod.rs
+++ b/rust/ruby-prism/src/parse_result/mod.rs
@@ -184,6 +184,20 @@ impl<'pr> ParseResult<'pr> {
     pub fn node(&self) -> Node<'_> {
         Node::new(self.parser, self.node.as_ptr())
     }
+
+    /// Returns true if there were no errors during parsing and false if there
+    /// were.
+    #[must_use]
+    pub fn is_success(&self) -> bool {
+        self.errors().next().is_none()
+    }
+
+    /// Returns true if there were errors during parsing and false if there were
+    /// not.
+    #[must_use]
+    pub fn is_failure(&self) -> bool {
+        !self.is_success()
+    }
 }
 
 impl Drop for ParseResult<'_> {
@@ -193,5 +207,24 @@ impl Drop for ParseResult<'_> {
             pm_parser_free(self.parser.as_ptr());
             drop(Box::from_raw(self.parser.as_ptr()));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parse;
+
+    #[test]
+    fn test_is_success() {
+        let result = parse(b"1 + 1");
+        assert!(result.is_success());
+        assert!(!result.is_failure());
+    }
+
+    #[test]
+    fn test_is_failure() {
+        let result = parse(b"<>");
+        assert!(result.is_failure());
+        assert!(!result.is_success());
     }
 }


### PR DESCRIPTION
## Summary

- Add `is_success()` method to `ParseResult` (Rust equivalent of Ruby's `Result#success?`)
- Add `is_failure()` method to `ParseResult` (Rust equivalent of Ruby's `Result#failure?`)

## Public API Changes

```
+pub fn ruby_prism::ParseResult<'pr>::is_failure(&self) -> bool
+pub fn ruby_prism::ParseResult<'pr>::is_success(&self) -> bool
```

## Test plan

- [x] `bundle exec rake cargo:test`
- [x] `bundle exec rake cargo:lint`