### PR TITLE
[rust] add `Location` line/column and chop methods

### DIFF
--- a/rust/ruby-prism-sys/build/main.rs
+++ b/rust/ruby-prism-sys/build/main.rs
@@ -116,6 +116,7 @@ fn generate_bindings(ruby_include_path: &Path) -> bindgen::Bindings {
         // Structs
         .allowlist_type("pm_comment_t")
         .allowlist_type("pm_diagnostic_t")
+        .allowlist_type("pm_line_column_t")
         .allowlist_type("pm_list_t")
         .allowlist_type("pm_magic_comment_t")
         .allowlist_type("pm_node_t")
@@ -140,6 +141,8 @@ fn generate_bindings(ruby_include_path: &Path) -> bindgen::Bindings {
         // Functions
         .allowlist_function("pm_list_empty_p")
         .allowlist_function("pm_list_free")
+        .allowlist_function("pm_newline_list_line")
+        .allowlist_function("pm_newline_list_line_column")
         .allowlist_function("pm_node_destroy")
         .allowlist_function("pm_pack_parse")
         .allowlist_function("pm_parse")

--- a/rust/ruby-prism/src/lib.rs
+++ b/rust/ruby-prism/src/lib.rs
@@ -161,6 +161,47 @@ mod tests {
     }
 
     #[test]
+    fn location_line_column_test() {
+        let source = "foo\nbar\nbaz";
+        let result = parse(source.as_ref());
+
+        let node = result.node();
+        let program = node.as_program_node().unwrap();
+        let statements = program.statements().body();
+        let mut iter = statements.iter();
+        let _foo = iter.next().unwrap();
+        let bar = iter.next().unwrap();
+        let baz = iter.next().unwrap();
+
+        let bar_loc = bar.location();
+        assert_eq!(bar_loc.start_line(), 2);
+        assert_eq!(bar_loc.end_line(), 2);
+        assert_eq!(bar_loc.start_column(), 0);
+        assert_eq!(bar_loc.end_column(), 3);
+
+        let baz_loc = baz.location();
+        assert_eq!(baz_loc.start_line(), 3);
+        assert_eq!(baz_loc.end_line(), 3);
+        assert_eq!(baz_loc.start_column(), 0);
+        assert_eq!(baz_loc.end_column(), 3);
+    }
+
+    #[test]
+    fn test_chop() {
+        let result = parse(b"foo");
+        let mut location = result.node().as_program_node().unwrap().location();
+
+        assert_eq!(location.chop().as_slice(), b"fo");
+        assert_eq!(location.chop().chop().chop().as_slice(), b"");
+
+        // Check that we don't go negative.
+        for _ in 0..10 {
+            location = location.chop();
+        }
+        assert_eq!(location.as_slice(), b"");
+    }
+
+    #[test]
     fn visitor_test() {
         use super::{visit_interpolated_regular_expression_node, visit_regular_expression_node, InterpolatedRegularExpressionNode, RegularExpressionNode, Visit};
 


### PR DESCRIPTION
## Summary

- Add `start_line()` method to `Location` (Rust equivalent of Ruby's `Location#start_line`)
- Add `end_line()` method to `Location` (Rust equivalent of Ruby's `Location#end_line`)
- Add `start_column()` method to `Location` (Rust equivalent of Ruby's `Location#start_column`)
- Add `end_column()` method to `Location` (Rust equivalent of Ruby's `Location#end_column`)
- Add `chop()` method to `Location` (Rust equivalent of Ruby's `Location#chop`)

These methods use the C API `pm_newline_list_line_column` function to compute line and column numbers.

## Public API Changes

```
Removed items from the public API
=================================
(none)

Changed items in the public API
===============================
(none)

Added items to the public API
=============================
+pub const fn ruby_prism::Location<'pr>::chop(&self) -> Self
+pub fn ruby_prism::Location<'pr>::end_column(&self) -> u32
+pub fn ruby_prism::Location<'pr>::end_line(&self) -> i32
+pub fn ruby_prism::Location<'pr>::start_column(&self) -> u32
+pub fn ruby_prism::Location<'pr>::start_line(&self) -> i32
```

## Test plan

- [x] `bundle exec rake cargo:test`
- [x] `bundle exec rake cargo:lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)