### PR TITLE
Handle String-like and IO-like objects for Ripper.sexp

### DIFF
--- a/lib/prism/translation/ripper.rb
+++ b/lib/prism/translation/ripper.rb
@@ -480,7 +480,17 @@ module Prism
 
       # Create a new Translation::Ripper object with the given source.
       def initialize(source, filename = "(ripper)", lineno = 1)
-        @source = source
+        if source.is_a?(IO)
+          @source = source.read
+        elsif source.respond_to?(:gets)
+          @source = +""
+          while line = source.gets
+            @source << line
+          end
+        else
+          @source = source.to_str
+        end
+
         @filename = filename
         @lineno = lineno
         @column = 0

--- a/test/prism/ruby/ripper_test.rb
+++ b/test/prism/ruby/ripper_test.rb
@@ -145,6 +145,36 @@ module Prism
       assert_equal(Ripper.tokenize(source), Translation::Ripper.tokenize(source))
     end
 
+    def test_sexp_coercion
+      string_like = Object.new
+      def string_like.to_str
+        "a"
+      end
+      assert_equal Ripper.sexp(string_like), Translation::Ripper.sexp(string_like)
+
+      File.open(__FILE__) do |file1|
+        File.open(__FILE__) do |file2|
+          assert_equal Ripper.sexp(file1), Translation::Ripper.sexp(file2)
+        end
+      end
+
+      File.open(__FILE__) do |file1|
+        File.open(__FILE__) do |file2|
+          object1_with_gets = Object.new
+          object1_with_gets.define_singleton_method(:gets) do
+            file1.gets
+          end
+
+          object2_with_gets = Object.new
+          object2_with_gets.define_singleton_method(:gets) do
+            file2.gets
+          end
+
+          assert_equal Ripper.sexp(object1_with_gets), Translation::Ripper.sexp(object2_with_gets)
+        end
+      end
+    end
+
     # Check that the hardcoded values don't change without us noticing.
     def test_internals
       actual = Translation::Ripper.constants.select { |name| name.start_with?("EXPR_") }.sort


### PR DESCRIPTION
* RSpec relies on this in https://github.com/rspec/rspec/blob/rspec-support-v3.13.6/rspec-support/lib/rspec/support/source.rb#L57 which is given an RSpec::Support::EncodedString.
* CI failure caused by this on truffleruby: https://github.com/sporkmonger/addressable/actions/runs/21457707372/job/61802608154#step:7:14