### PR TITLE
Add xfree_sized and xrealloc_sized

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -24,6 +24,7 @@ OUTPUT_DIRECTORY       = doc
 JAVADOC_AUTOBRIEF      = YES
 OPTIMIZE_OUTPUT_FOR_C  = YES
 INPUT                  = src src/util include include/prism include/prism/util
+EXCLUDE                = include/prism/debug_allocator.h
 HTML_OUTPUT            = c
 SORT_MEMBER_DOCS       = NO
 GENERATE_LATEX         = NO

--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -413,7 +413,7 @@ dump(int argc, VALUE *argv, VALUE self) {
     if (options.freeze) rb_obj_freeze(value);
 
 #ifdef PRISM_BUILD_DEBUG
-    xfree(dup);
+    xfree_sized(dup, length);
 #endif
 
     pm_string_free(&input);
@@ -929,7 +929,7 @@ parse(int argc, VALUE *argv, VALUE self) {
     VALUE value = parse_input(&input, &options);
 
 #ifdef PRISM_BUILD_DEBUG
-    xfree(dup);
+    xfree_sized(dup, length);
 #endif
 
     pm_string_free(&input);

--- a/include/prism/debug_allocator.h
+++ b/include/prism/debug_allocator.h
@@ -1,0 +1,99 @@
+/**
+ * @file debug_allocator.h
+ *
+ * Decorate allocation function to ensure sizes are correct.
+ */
+#ifndef PRISM_DEBUG_ALLOCATOR_H
+#define PRISM_DEBUG_ALLOCATOR_H
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static inline void *
+pm_debug_malloc(size_t size)
+{
+    size_t *memory = xmalloc(size + sizeof(size_t));
+    memory[0] = size;
+    return memory + 1;
+}
+
+static inline void *
+pm_debug_calloc(size_t nmemb, size_t size)
+{
+    size_t total_size = nmemb * size;
+    void *ptr = pm_debug_malloc(total_size);
+    memset(ptr, 0, total_size);
+    return ptr;
+}
+
+static inline void *
+pm_debug_realloc(void *ptr, size_t size)
+{
+    if (ptr == NULL) {
+        return pm_debug_malloc(size);
+    }
+
+    size_t *memory = (size_t *)ptr;
+    void *raw_memory = memory - 1;
+    memory = (size_t *)xrealloc(raw_memory, size + sizeof(size_t));
+    memory[0] = size;
+    return memory + 1;
+}
+
+static inline void
+pm_debug_free(void *ptr)
+{
+    if (ptr != NULL) {
+        size_t *memory = (size_t *)ptr;
+        xfree(memory - 1);
+    }
+}
+
+static inline void
+pm_debug_free_sized(void *ptr, size_t old_size)
+{
+    if (ptr != NULL) {
+        size_t *memory = (size_t *)ptr;
+        if (old_size != memory[-1]) {
+            fprintf(stderr, "[BUG] buffer %p was allocated with size %lu but freed with size %lu\n", ptr, memory[-1], old_size);
+            abort();
+        }
+        xfree_sized(memory - 1, old_size + sizeof(size_t));
+    }
+}
+
+static inline void *
+pm_debug_realloc_sized(void *ptr, size_t size, size_t old_size)
+{
+    if (ptr == NULL) {
+        if (old_size != 0) {
+            fprintf(stderr, "[BUG] realloc_sized called with NULL pointer and old size %lu\n", old_size);
+            abort();
+        }
+        return pm_debug_malloc(size);
+    }
+
+    size_t *memory = (size_t *)ptr;
+    if (old_size != memory[-1]) {
+        fprintf(stderr, "[BUG] buffer %p was allocated with size %lu but realloced with size %lu\n", ptr, memory[-1], old_size);
+        abort();
+    }
+    return pm_debug_realloc(ptr, size);
+}
+
+#undef xmalloc
+#undef xrealloc
+#undef xcalloc
+#undef xfree
+#undef xrealloc_sized
+#undef xfree_sized
+
+#define xmalloc          pm_debug_malloc
+#define xrealloc         pm_debug_realloc
+#define xcalloc          pm_debug_calloc
+#define xfree            pm_debug_free
+#define xrealloc_sized   pm_debug_realloc_sized
+#define xfree_sized      pm_debug_free_sized
+
+#endif

--- a/include/prism/defines.h
+++ b/include/prism/defines.h
@@ -161,10 +161,12 @@
  * ```
  * #ifndef PRISM_XALLOCATOR_H
  * #define PRISM_XALLOCATOR_H
- * #define xmalloc      my_malloc
- * #define xrealloc     my_realloc
- * #define xcalloc      my_calloc
- * #define xfree        my_free
+ * #define xmalloc          my_malloc
+ * #define xrealloc         my_realloc
+ * #define xcalloc          my_calloc
+ * #define xfree            my_free
+ * #define xrealloc_sized   my_realloc_sized // (optional)
+ * #define xfree_sized      my_free_sized    // (optional)
  * #endif
  * ```
  */
@@ -202,6 +204,28 @@
          */
         #define xfree free
     #endif
+#endif
+
+#ifndef xfree_sized
+/**
+ * The free_sized function that should be used. This can be overridden with the
+ * PRISM_XALLOCATOR define.
+ * If not defined, defaults to calling xfree.
+ */
+    #define xfree_sized(p, s) xfree(((void)(s), (p)))
+#endif
+
+#ifndef xrealloc_sized
+/**
+ * The xrealloc_sized function that should be used. This can be overridden with the
+ * PRISM_XALLOCATOR define.
+ * If not defined, defaults to calling xrealloc.
+ */
+    #define xrealloc_sized(p, ns, os) xrealloc((p), ((void)(os), (ns)))
+#endif
+
+#ifdef PRISM_BUILD_DEBUG
+    #include "prism/debug_allocator.h"
 #endif
 
 /**

--- a/prism.gemspec
+++ b/prism.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
     "ext/prism/extension.h",
     "include/prism.h",
     "include/prism/ast.h",
+    "include/prism/debug_allocator.h",
     "include/prism/defines.h",
     "include/prism/diagnostic.h",
     "include/prism/encoding.h",

--- a/src/options.c
+++ b/src/options.c
@@ -226,10 +226,10 @@ pm_options_free(pm_options_t *options) {
             pm_string_free(&scope->locals[local_index]);
         }
 
-        xfree(scope->locals);
+        xfree_sized(scope->locals, scope->locals_count * sizeof(pm_string_t));
     }
 
-    xfree(options->scopes);
+    xfree_sized(options->scopes, options->scopes_count * sizeof(pm_options_scope_t));
 }
 
 /**

--- a/src/static_literals.c
+++ b/src/static_literals.c
@@ -183,7 +183,7 @@ pm_node_hash_insert(pm_node_hash_t *hash, const pm_static_literals_metadata_t *m
         }
 
         // Finally, free the old node list and update the hash.
-        xfree(hash->nodes);
+        xfree_sized(hash->nodes, hash->capacity * sizeof(pm_node_t *));
         hash->nodes = new_nodes;
         hash->capacity = new_capacity;
     }
@@ -221,7 +221,7 @@ pm_node_hash_insert(pm_node_hash_t *hash, const pm_static_literals_metadata_t *m
  */
 static void
 pm_node_hash_free(pm_node_hash_t *hash) {
-    if (hash->capacity > 0) xfree(hash->nodes);
+    if (hash->capacity > 0) xfree_sized(hash->nodes, hash->capacity * sizeof(pm_node_t *));
 }
 
 /**

--- a/src/util/pm_buffer.c
+++ b/src/util/pm_buffer.c
@@ -50,6 +50,7 @@ pm_buffer_length(const pm_buffer_t *buffer) {
 static inline bool
 pm_buffer_append_length(pm_buffer_t *buffer, size_t length) {
     size_t next_length = buffer->length + length;
+    const size_t original_capacity = buffer->capacity;
 
     if (next_length > buffer->capacity) {
         if (buffer->capacity == 0) {
@@ -60,7 +61,7 @@ pm_buffer_append_length(pm_buffer_t *buffer, size_t length) {
             buffer->capacity *= 2;
         }
 
-        buffer->value = xrealloc(buffer->value, buffer->capacity);
+        buffer->value = xrealloc_sized(buffer->value, buffer->capacity, original_capacity);
         if (buffer->value == NULL) return false;
     }
 
@@ -353,5 +354,5 @@ pm_buffer_insert(pm_buffer_t *buffer, size_t index, const char *value, size_t le
  */
 void
 pm_buffer_free(pm_buffer_t *buffer) {
-    xfree(buffer->value);
+    xfree_sized(buffer->value, buffer->capacity);
 }

--- a/src/util/pm_line_offset_list.c
+++ b/src/util/pm_line_offset_list.c
@@ -39,7 +39,7 @@ pm_line_offset_list_append(pm_line_offset_list_t *list, uint32_t cursor) {
         if (list->offsets == NULL) return false;
 
         memcpy(list->offsets, original_offsets, list->size * sizeof(uint32_t));
-        xfree(original_offsets);
+        xfree_sized(original_offsets, list->size * sizeof(uint32_t));
     }
 
     assert(list->size == 0 || cursor > list->offsets[list->size - 1]);
@@ -109,5 +109,5 @@ pm_line_offset_list_line_column(const pm_line_offset_list_t *list, uint32_t curs
  */
 void
 pm_line_offset_list_free(pm_line_offset_list_t *list) {
-    xfree(list->offsets);
+    xfree_sized(list->offsets, list->capacity * sizeof(uint32_t));
 }

--- a/src/util/pm_list.c
+++ b/src/util/pm_list.c
@@ -41,7 +41,7 @@ pm_list_free(pm_list_t *list) {
 
     while (node != NULL) {
         next = node->next;
-        xfree(node);
+        xfree_sized(node, sizeof(pm_list_node_t));
         node = next;
     }
 

--- a/src/util/pm_string.c
+++ b/src/util/pm_string.c
@@ -71,9 +71,10 @@ pm_string_file_handle_open(pm_string_file_handle_t *handle, const char *filepath
     int length = MultiByteToWideChar(CP_UTF8, 0, filepath, -1, NULL, 0);
     if (length == 0) return PM_STRING_INIT_ERROR_GENERIC;
 
-    handle->path = xmalloc(sizeof(WCHAR) * ((size_t) length));
+    const size_t path_size = sizeof(WCHAR) * ((size_t) length);
+    handle->path = xmalloc(path_size);
     if ((handle->path == NULL) || (MultiByteToWideChar(CP_UTF8, 0, filepath, -1, handle->path, length) == 0)) {
-        xfree(handle->path);
+        xfree_sized(handle->path, path_size);
         return PM_STRING_INIT_ERROR_GENERIC;
     }
 
@@ -88,7 +89,7 @@ pm_string_file_handle_open(pm_string_file_handle_t *handle, const char *filepath
             }
         }
 
-        xfree(handle->path);
+        xfree_sized(handle->path, path_size);
         return result;
     }
 
@@ -215,7 +216,7 @@ pm_string_file_init(pm_string_t *string, const char *filepath) {
     if (result != PM_STRING_INIT_SUCCESS) return result;
 
     // Get the file size.
-    DWORD file_size = GetFileSize(handle.file, NULL);
+    const DWORD file_size = GetFileSize(handle.file, NULL);
     if (file_size == INVALID_FILE_SIZE) {
         pm_string_file_handle_close(&handle);
         return PM_STRING_INIT_ERROR_GENERIC;
@@ -245,7 +246,7 @@ pm_string_file_init(pm_string_t *string, const char *filepath) {
 
     // Check the number of bytes read
     if (bytes_read != file_size) {
-        xfree(source);
+        xfree_sized(source, file_size);
         pm_string_file_handle_close(&handle);
         return PM_STRING_INIT_ERROR_GENERIC;
     }
@@ -281,7 +282,7 @@ pm_string_file_init(pm_string_t *string, const char *filepath) {
         return PM_STRING_INIT_SUCCESS;
     }
 
-    size_t length = (size_t) size;
+    const size_t length = (size_t) size;
     uint8_t *source = xmalloc(length);
     if (source == NULL) {
         close(fd);
@@ -292,7 +293,7 @@ pm_string_file_init(pm_string_t *string, const char *filepath) {
     close(fd);
 
     if (bytes_read == -1) {
-        xfree(source);
+        xfree_sized(source, length);
         return PM_STRING_INIT_ERROR_GENERIC;
     }
 

--- a/templates/ext/prism/api_node.c.erb
+++ b/templates/ext/prism/api_node.c.erb
@@ -113,7 +113,7 @@ pm_node_stack_pop(pm_node_stack_node_t **stack) {
     const pm_node_t *visit = current->visit;
 
     *stack = current->prev;
-    xfree(current);
+    xfree_sized(current, sizeof(pm_node_stack_node_t));
 
     return visit;
 }

--- a/templates/src/diagnostic.c.erb
+++ b/templates/src/diagnostic.c.erb
@@ -488,7 +488,7 @@ pm_diagnostic_list_append_format(pm_list_t *list, uint32_t start, uint32_t lengt
     size_t message_length = (size_t) (result + 1);
     char *message = (char *) xmalloc(message_length);
     if (message == NULL) {
-        xfree(diagnostic);
+        xfree_sized(diagnostic, sizeof(pm_diagnostic_t));
         return false;
     }
 
@@ -519,7 +519,7 @@ pm_diagnostic_list_free(pm_list_t *list) {
         pm_diagnostic_t *next = (pm_diagnostic_t *) node->node.next;
 
         if (node->owned) xfree((void *) node->message);
-        xfree(node);
+        xfree_sized(node, sizeof(pm_diagnostic_t));
 
         node = next;
     }

--- a/templates/src/node.c.erb
+++ b/templates/src/node.c.erb
@@ -32,7 +32,11 @@ pm_node_list_grow(pm_node_list_t *list, size_t size) {
         next_capacity = double_capacity;
     }
 
-    pm_node_t **nodes = (pm_node_t **) xrealloc(list->nodes, sizeof(pm_node_t *) * next_capacity);
+    pm_node_t **nodes = (pm_node_t **) xrealloc_sized(
+      list->nodes,
+      sizeof(pm_node_t *) * next_capacity,
+      sizeof(pm_node_t *) * list->capacity
+    );
     if (nodes == NULL) return false;
 
     list->nodes = nodes;
@@ -79,7 +83,7 @@ pm_node_list_concat(pm_node_list_t *list, pm_node_list_t *other) {
 void
 pm_node_list_free(pm_node_list_t *list) {
     if (list->capacity > 0) {
-        xfree(list->nodes);
+        xfree_sized(list->nodes, sizeof(pm_node_t *) * list->capacity);
         *list = (pm_node_list_t) { 0 };
     }
 }
@@ -132,6 +136,7 @@ pm_node_destroy(pm_parser_t *parser, pm_node_t *node) {
             <%- raise -%>
             <%- end -%>
             <%- end -%>
+            xfree_sized(node, sizeof(pm_<%= node.human %>_t));
             break;
         }
         <%- end -%>
@@ -140,7 +145,6 @@ pm_node_destroy(pm_parser_t *parser, pm_node_t *node) {
             assert(false && "unreachable");
             break;
     }
-    xfree(node);
 }
 
 /**


### PR DESCRIPTION
### Context

Ruby internals have had a `ruby_sized_xfree` function for a very longtime. Until recently it was just used to feed the freed size into the GC statistics, to allow it to be smarter as of when to trigger.

However C23 does introduce `free_sized`: https://en.cppreference.com/w/c/memory/free_sized.html, which when used allow allocator to either deallocate faster or be more secure by aborting when the size doesn't match.

It is however important to note that passing an incorrect size is undefined behavior, so the allocator could just as well leak or crash.

Very recently `glibc 2.43` added support for `free_sized`: https://sourceware.org/pipermail/libc-announce/2026/000052.html, and other common allocators like `jemalloc` have supported it for years.
However if the allocator doesn't support it, it's easily shimed with a simple macro that discard the size.

The last few days I've changed a majority of `xfree` calls inside MRI to use `ruby_sized_xfree`, and added some debug checks inside it to ensure the passed size is correct, and that surfaced a few minor bugs (mostly strings losing a few bytes of capacity when switching between encodings). (e.g. https://github.com/ruby/ruby/pull/16010)

Now most of Ruby's own codebase have been converted, and most of the remaining unsized frees are within `prism` and similarly vendored codebases. I haven't yet hooked MRI to the allocator, for now it's still only used for GC statistics.

### `xrealloc_sized`

I'm not sure why, but C23 standard doesn't defined `realloc_sized`, but similarly Ruby had `ruby_sized_xrealloc` for a while, and I think it does make a lot of sense for that purpose given realloc is essentially `malloc + free`.

### Proposal

I'd like to also convert Prism to use sized frees as well, so that when compiled inside Ruby it can use `ruby_sized_xfree`, hence play better with the GC and potentially benefit from C23 `free_sized` performance benefits in the future.

In this PR I implemented debug checks for the allocator sizes, and converted a few call sites to the new API, as well as added a couple convenience macros that make using `free_sized` much easier.

A side benefit of these debug checks is that if you accidentally use raw `free` or raw `malloc`, it will blow up.

If there is interest from the maintainers, I can convert the rest of the prism codebase.
