### PR TITLE
Fix unescaped backtick in documentation

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -374,7 +374,7 @@ tokens:
   - name: AMPERSAND_EQUAL
     comment: "&="
   - name: BACKTICK
-    comment: "`"
+    comment: "\\`"
   - name: BACK_REFERENCE
     comment: "a back reference"
   - name: BANG


### PR DESCRIPTION
On my machine(doxygen 1.16.1) the documentation task fails with:

```
include/prism/ast.h:8111: error: Reached end of file while
still searching closing '`' of a verbatim block starting at line 8080
```