### PR TITLE
Add escaping for doxygen

### DIFF
--- a/templates/include/prism/ast.h.erb
+++ b/templates/include/prism/ast.h.erb
@@ -22,7 +22,7 @@
  */
 typedef enum pm_token_type {
 <%- tokens.each do |token| -%>
-    /** <%= token.comment %> */
+    /** <%= Prism::Template::Doxygen.verbatim(token.comment) %> */
     PM_TOKEN_<%= token.name %><%= " = #{token.value}" if token.value %>,
 
 <%- end -%>

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -49,6 +49,14 @@ module Prism
       end
     end
 
+    # This module contains methods for escaping characters in Doxygen comments.
+    module Doxygen
+      # Similar to /verbatim ... /endverbatim but doesn't wrap the result in a code block.
+      def self.verbatim(value)
+        value.gsub(/[\.*%!`#<>_+-]/, '\\\\\0')
+      end
+    end
+
     # A comment attached to a field or node.
     class ConfigComment
       attr_reader :value


### PR DESCRIPTION
Many characters have special meaning and break formatting

Before:
<img width="884" height="582" alt="grafik" src="https://github.com/user-attachments/assets/424ab0db-ce96-44f6-972c-60be3407a3d9" />

After:
<img width="861" height="556" alt="grafik" src="https://github.com/user-attachments/assets/a0ce1951-bff8-4ff7-9f7d-2c9dfda7ec53" />

@byroot can you check if this fixes https://github.com/ruby/prism/pull/3895 for you? It doesn't break when I run it locally even though I use the same version as you.