### PR TITLE
Temporarily disable ibm runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
       shell: bash
 
   build-ibm:
-    if: github.repository == 'ruby/prism'
+    if: github.repository == 'ruby/prism' && false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
They are currently broken and take everything else down with them.

https://github.com/IBM/actionspz/issues/75