### PR TITLE
Remove explicit rbs dependency

### DIFF
--- a/gemfiles/2.7/Gemfile
+++ b/gemfiles/2.7/Gemfile
@@ -10,6 +10,5 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "rbs"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/2.7/Gemfile.lock
+++ b/gemfiles/2.7/Gemfile.lock
@@ -16,7 +16,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    rbs (3.1.3)
     ruby_parser (3.21.1)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -33,7 +32,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  rbs
   ruby_parser
   test-unit
 

--- a/gemfiles/3.0/Gemfile
+++ b/gemfiles/3.0/Gemfile
@@ -10,7 +10,6 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "rbs"
 gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/3.0/Gemfile.lock
+++ b/gemfiles/3.0/Gemfile.lock
@@ -7,7 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    logger (1.7.0)
     mini_portile2 (2.8.9)
     nokogiri (1.17.2)
       mini_portile2 (~> 2.8.2)
@@ -21,8 +20,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    rbs (3.6.1)
-      logger
     ruby_memcheck (3.0.1)
       nokogiri
     ruby_parser (3.21.1)
@@ -41,7 +38,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  rbs
   ruby_memcheck
   ruby_parser
   test-unit

--- a/gemfiles/3.1/Gemfile
+++ b/gemfiles/3.1/Gemfile
@@ -10,7 +10,6 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "rbs"
 gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/3.1/Gemfile.lock
+++ b/gemfiles/3.1/Gemfile.lock
@@ -7,7 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    logger (1.7.0)
     mini_portile2 (2.8.9)
     nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
@@ -21,8 +20,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    rbs (3.10.2)
-      logger
     ruby_memcheck (3.0.1)
       nokogiri
     ruby_parser (3.21.1)
@@ -41,7 +38,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  rbs
   ruby_memcheck
   ruby_parser
   test-unit

--- a/gemfiles/3.2/Gemfile
+++ b/gemfiles/3.2/Gemfile
@@ -10,7 +10,6 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "rbs"
 gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/3.2/Gemfile.lock
+++ b/gemfiles/3.2/Gemfile.lock
@@ -7,7 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    logger (1.7.0)
     mini_portile2 (2.8.9)
     nokogiri (1.19.0)
       mini_portile2 (~> 2.8.2)
@@ -21,8 +20,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    rbs (3.10.2)
-      logger
     ruby_memcheck (3.0.1)
       nokogiri
     ruby_parser (3.22.0)
@@ -41,7 +38,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  rbs
   ruby_memcheck
   ruby_parser
   test-unit

--- a/gemfiles/3.3/Gemfile
+++ b/gemfiles/3.3/Gemfile
@@ -10,7 +10,6 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "rbs"
 gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/3.3/Gemfile.lock
+++ b/gemfiles/3.3/Gemfile.lock
@@ -7,7 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    logger (1.7.0)
     mini_portile2 (2.8.9)
     nokogiri (1.19.0)
       mini_portile2 (~> 2.8.2)
@@ -21,8 +20,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    rbs (3.10.2)
-      logger
     ruby_memcheck (3.0.1)
       nokogiri
     ruby_parser (3.22.0)
@@ -41,7 +38,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  rbs
   ruby_memcheck
   ruby_parser
   test-unit

--- a/gemfiles/3.4/Gemfile
+++ b/gemfiles/3.4/Gemfile
@@ -10,7 +10,6 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "rbs"
 gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/3.4/Gemfile.lock
+++ b/gemfiles/3.4/Gemfile.lock
@@ -7,7 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    logger (1.7.0)
     mini_portile2 (2.8.9)
     nokogiri (1.19.0)
       mini_portile2 (~> 2.8.2)
@@ -21,8 +20,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    rbs (3.10.2)
-      logger
     ruby_memcheck (3.0.1)
       nokogiri
     ruby_parser (3.22.0)
@@ -41,7 +38,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  rbs
   ruby_memcheck
   ruby_parser
   test-unit

--- a/gemfiles/4.0/Gemfile
+++ b/gemfiles/4.0/Gemfile
@@ -11,7 +11,6 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "rbs"
 gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/4.0/Gemfile.lock
+++ b/gemfiles/4.0/Gemfile.lock
@@ -8,7 +8,6 @@ GEM
   specs:
     ast (2.4.3)
     ffi (1.17.3)
-    logger (1.7.0)
     mini_portile2 (2.8.9)
     nokogiri (1.19.0)
       mini_portile2 (~> 2.8.2)
@@ -22,8 +21,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    rbs (3.10.2)
-      logger
     ruby_memcheck (3.0.1)
       nokogiri
     ruby_parser (3.22.0)
@@ -43,7 +40,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  rbs
   ruby_memcheck
   ruby_parser
   test-unit

--- a/gemfiles/4.1/Gemfile
+++ b/gemfiles/4.1/Gemfile
@@ -11,7 +11,6 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "rbs"
 gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/4.1/Gemfile.lock
+++ b/gemfiles/4.1/Gemfile.lock
@@ -8,7 +8,6 @@ GEM
   specs:
     ast (2.4.3)
     ffi (1.17.3)
-    logger (1.7.0)
     mini_portile2 (2.8.9)
     nokogiri (1.19.0)
       mini_portile2 (~> 2.8.2)
@@ -22,8 +21,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    rbs (3.10.2)
-      logger
     ruby_memcheck (3.0.1)
       nokogiri
     ruby_parser (3.22.0)
@@ -43,7 +40,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  rbs
   ruby_memcheck
   ruby_parser
   test-unit

--- a/gemfiles/typecheck/Gemfile
+++ b/gemfiles/typecheck/Gemfile
@@ -6,7 +6,6 @@ gem "minitest"
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "rbs"
 gem "ruby_parser"
 gem "sorbet", "<= 0.6.12666" # until tapioca is bumped
 gem "steep", ">= 1.7.0.dev.1"

--- a/gemfiles/typecheck/Gemfile.lock
+++ b/gemfiles/typecheck/Gemfile.lock
@@ -131,7 +131,6 @@ DEPENDENCIES
   parser
   rake
   rake-compiler
-  rbs
   ruby_parser
   sorbet (<= 0.6.12666)
   steep (>= 1.7.0.dev.1)


### PR DESCRIPTION
We don't actually use it. For typechecking, it's just a transitive dependency of tapioca/steep