### PR TITLE
Fix lexing for unterminated strings/heredocs etc.

### DIFF
--- a/test/prism/errors/unterminated_heredoc_and_embexpr.txt
+++ b/test/prism/errors/unterminated_heredoc_and_embexpr.txt
@@ -1,0 +1,11 @@
+<<A+B
+  ^ unterminated heredoc; can't find string "A" anywhere before EOF
+   ^ unexpected '+', ignoring it
+  ^ unterminated heredoc; can't find string "A" anywhere before EOF
+#{C
+   ^ unexpected heredoc ending; expected an argument
+   ^ unexpected heredoc ending, expecting end-of-input
+   ^ unexpected heredoc ending, ignoring it
+   ^ unexpected end-of-input, assuming it is closing the parent top level context
+^ expected a `}` to close the embedded expression
+

--- a/test/prism/errors/unterminated_heredoc_and_embexpr_2.txt
+++ b/test/prism/errors/unterminated_heredoc_and_embexpr_2.txt
@@ -1,0 +1,9 @@
+<<A+B
+  ^ unterminated heredoc; can't find string "A" anywhere before EOF
+#{C + "#{"}
+           ^ unterminated string meets end of file
+           ^ unexpected end-of-input, assuming it is closing the parent top level context
+           ^ expected a `}` to close the embedded expression
+      ^ unterminated string; expected a closing delimiter for the interpolated string
+           ^ expected a `}` to close the embedded expression
+

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -87,6 +87,28 @@ module Prism
       assert_nil(statement.end_keyword)
     end
 
+    def test_unclosed_interpolation
+      statement = Prism.parse_statement("\"\#{")
+      assert_equal('"', statement.opening)
+      assert_nil(statement.closing)
+
+      assert_equal(1, statement.parts.count)
+      assert_equal('#{', statement.parts[0].opening)
+      assert_equal("", statement.parts[0].closing)
+      assert_nil(statement.parts[0].statements)
+    end
+
+    def test_unclosed_heredoc_and_interpolation
+      statement = Prism.parse_statement("<<D\n\#{")
+      assert_equal("<<D", statement.opening)
+      assert_nil(statement.closing)
+
+      assert_equal(1, statement.parts.count)
+      assert_equal('#{', statement.parts[0].opening)
+      assert_equal("", statement.parts[0].closing)
+      assert_nil(statement.parts[0].statements)
+    end
+
     private
 
     def assert_errors(filepath, version)


### PR DESCRIPTION
When we hit EOF and still have lex modes left, it means some content was unterminated. Heredocs specifically have logic that needs to happen when the body finished lexing. If we don't reset the mode back to how it was before, it will not continue lexing at the correct place.

Followup to https://github.com/ruby/prism/pull/3918. We can't call into `parser_lex` since it resets token locations. So I went back to `goto`.

Closes https://github.com/ruby/prism/issues/3911