### PR TITLE
Recompile when config.yml changes

### DIFF
--- a/ext/prism/depend
+++ b/ext/prism/depend
@@ -1,0 +1,2 @@
+$(OBJS): $(HDRS) $(ruby_headers)
+$(OBJS): $(srcdir)/../../config.yml

--- a/prism.gemspec
+++ b/prism.gemspec
@@ -42,6 +42,8 @@ Gem::Specification.new do |spec|
     "docs/serialization.md",
     "docs/testing.md",
     "ext/prism/api_node.c",
+    "ext/prism/depend",
+    "ext/prism/extconf.rb",
     "ext/prism/extension.c",
     "ext/prism/extension.h",
     "include/prism.h",


### PR DESCRIPTION
* Fixes https://github.com/ruby/prism/issues/3931.
* The first line is the default one, we want to keep that default dependency too.
* Some docs about this: https://docs.ruby-lang.org/en/4.0/MakeMakefile.html