### PR TITLE
add `extern "C"` wrappers to `prism.h` when using C++

### DIFF
--- a/include/prism.h
+++ b/include/prism.h
@@ -6,6 +6,10 @@
 #ifndef PRISM_H
 #define PRISM_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "prism/defines.h"
 #include "prism/util/pm_buffer.h"
 #include "prism/util/pm_char.h"
@@ -402,5 +406,9 @@ PRISM_EXPORTED_FUNCTION pm_string_query_t pm_string_query_method_name(const uint
  * }
  * ```
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
The Prism integration for Sorbet has a non-trivial number of `#include "prism.h"` that need to be wrapped in `extern "C"`.  Usually the library's headers take care of this wrapping, which is what this PR implements.

(Sorbet has one `#include` of a non-`prism.h` file, but I don't think it's worth wrapping every individual header, and the lone instance in Sorbet is easy to change to a different header.)