### PR TITLE
Implement noblock for the ripper/ruby_parser translator

### DIFF
--- a/lib/prism/translation/ripper.rb
+++ b/lib/prism/translation/ripper.rb
@@ -2623,6 +2623,13 @@ module Prism
         on_var_ref(on_kw("nil"))
       end
 
+      # def foo(&nil); end
+      #         ^^^^
+      def visit_no_block_parameter_node(node)
+        bounds(node.location)
+        on_blockarg(:nil)
+      end
+
       # def foo(**nil); end
       #         ^^^^^
       def visit_no_keywords_parameter_node(node)

--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -1152,6 +1152,12 @@ module Prism
           s(node, :nil)
         end
 
+        # def foo(&nil); end
+        #         ^^^^
+        def visit_no_block_parameter_node(node)
+          :"&nil"
+        end
+
         # def foo(**nil); end
         #         ^^^^^
         def visit_no_keywords_parameter_node(node)

--- a/test/prism/ruby/ripper_test.rb
+++ b/test/prism/ruby/ripper_test.rb
@@ -40,9 +40,6 @@ module Prism
     # https://bugs.ruby-lang.org/issues/21669
     incorrect << "4.1/void_value.txt"
 
-    # https://bugs.ruby-lang.org/issues/19979
-    incorrect << "4.1/noblock.txt"
-
     # Skip these tests that we haven't implemented yet.
     omitted_sexp_raw = [
       "bom_leading_space.txt",


### PR DESCRIPTION
In ripper, compared to `**nil` it is not a new event