### PR TITLE
remove `ruby_memcheck` from version gemfiles

### DIFF
--- a/gemfiles/3.0/Gemfile
+++ b/gemfiles/3.0/Gemfile
@@ -10,6 +10,5 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/3.0/Gemfile.lock
+++ b/gemfiles/3.0/Gemfile.lock
@@ -7,10 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    mini_portile2 (2.8.9)
-    nokogiri (1.17.2)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     onigmo (0.1.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)
@@ -20,8 +16,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    ruby_memcheck (3.0.1)
-      nokogiri
     ruby_parser (3.21.1)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -38,7 +32,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  ruby_memcheck
   ruby_parser
   test-unit
 

--- a/gemfiles/3.1/Gemfile
+++ b/gemfiles/3.1/Gemfile
@@ -10,6 +10,5 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/3.1/Gemfile.lock
+++ b/gemfiles/3.1/Gemfile.lock
@@ -7,10 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    mini_portile2 (2.8.9)
-    nokogiri (1.18.10)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     onigmo (0.1.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)
@@ -20,8 +16,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    ruby_memcheck (3.0.1)
-      nokogiri
     ruby_parser (3.21.1)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -38,7 +32,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  ruby_memcheck
   ruby_parser
   test-unit
 

--- a/gemfiles/3.2/Gemfile
+++ b/gemfiles/3.2/Gemfile
@@ -10,6 +10,5 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/3.2/Gemfile.lock
+++ b/gemfiles/3.2/Gemfile.lock
@@ -7,10 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    mini_portile2 (2.8.9)
-    nokogiri (1.19.0)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     onigmo (0.1.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)
@@ -20,8 +16,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    ruby_memcheck (3.0.1)
-      nokogiri
     ruby_parser (3.22.0)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -38,7 +32,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  ruby_memcheck
   ruby_parser
   test-unit
 

--- a/gemfiles/3.3/Gemfile
+++ b/gemfiles/3.3/Gemfile
@@ -10,6 +10,5 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/3.3/Gemfile.lock
+++ b/gemfiles/3.3/Gemfile.lock
@@ -7,10 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    mini_portile2 (2.8.9)
-    nokogiri (1.19.0)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     onigmo (0.1.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)
@@ -20,8 +16,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    ruby_memcheck (3.0.1)
-      nokogiri
     ruby_parser (3.22.0)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -38,7 +32,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  ruby_memcheck
   ruby_parser
   test-unit
 

--- a/gemfiles/3.4/Gemfile
+++ b/gemfiles/3.4/Gemfile
@@ -10,6 +10,5 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/3.4/Gemfile.lock
+++ b/gemfiles/3.4/Gemfile.lock
@@ -7,10 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    mini_portile2 (2.8.9)
-    nokogiri (1.19.0)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     onigmo (0.1.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)
@@ -20,8 +16,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    ruby_memcheck (3.0.1)
-      nokogiri
     ruby_parser (3.22.0)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -38,7 +32,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  ruby_memcheck
   ruby_parser
   test-unit
 

--- a/gemfiles/4.0/Gemfile
+++ b/gemfiles/4.0/Gemfile
@@ -6,11 +6,9 @@ ruby "~> 4.0.0"
 
 gemspec path: "../.."
 
-gem "ffi"
 gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/4.0/Gemfile.lock
+++ b/gemfiles/4.0/Gemfile.lock
@@ -7,11 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    ffi (1.17.3)
-    mini_portile2 (2.8.9)
-    nokogiri (1.19.0)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     onigmo (0.1.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)
@@ -21,8 +16,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    ruby_memcheck (3.0.1)
-      nokogiri
     ruby_parser (3.22.0)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -34,13 +27,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ffi
   onigmo
   parser
   prism!
   rake
   rake-compiler
-  ruby_memcheck
   ruby_parser
   test-unit
 

--- a/gemfiles/4.1/Gemfile
+++ b/gemfiles/4.1/Gemfile
@@ -11,6 +11,5 @@ gem "onigmo", platforms: :ruby
 gem "parser"
 gem "rake-compiler"
 gem "rake"
-gem "ruby_memcheck"
 gem "ruby_parser"
 gem "test-unit"

--- a/gemfiles/4.1/Gemfile.lock
+++ b/gemfiles/4.1/Gemfile.lock
@@ -8,10 +8,6 @@ GEM
   specs:
     ast (2.4.3)
     ffi (1.17.3)
-    mini_portile2 (2.8.9)
-    nokogiri (1.19.0)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     onigmo (0.1.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)
@@ -21,8 +17,6 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.1)
       rake
-    ruby_memcheck (3.0.1)
-      nokogiri
     ruby_parser (3.22.0)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -40,7 +34,6 @@ DEPENDENCIES
   prism!
   rake
   rake-compiler
-  ruby_memcheck
   ruby_parser
   test-unit
 

--- a/gemfiles/typecheck/Gemfile
+++ b/gemfiles/typecheck/Gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "minitest"
 gem "parser"
 gem "rake-compiler"
 gem "rake"

--- a/gemfiles/typecheck/Gemfile.lock
+++ b/gemfiles/typecheck/Gemfile.lock
@@ -127,7 +127,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  minitest
   parser
   rake
   rake-compiler


### PR DESCRIPTION
It's not used and there is not much point in running against older ruby versions.
Also remove minitest dep from typechecking.