### PR TITLE
Prism::ParseResult#continuable?

### DIFF
--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -938,6 +938,78 @@ module Prism
       !success?
     end
 
+    # Returns true if the parsed source is an incomplete expression that could
+    # become valid with additional input. This is useful for REPL contexts (such
+    # as IRB) where the user may be entering a multi-line expression one line at
+    # a time and the implementation needs to determine whether to wait for more
+    # input or to evaluate what has been entered so far.
+    #
+    # Concretely, this returns true when every error present is caused by the
+    # parser reaching the end of the input before a construct was closed (e.g.
+    # an unclosed string, array, block, or keyword), and returns false when any
+    # error is caused by a token that makes the input structurally invalid
+    # regardless of what might follow (e.g. a stray `end`, `]`, or `)` with no
+    # matching opener).
+    #
+    # Examples:
+    #
+    #     Prism.parse("1 + [").continuable?      #=> true  (unclosed array)
+    #     Prism.parse("1 + ]").continuable?      #=> false (stray ])
+    #     Prism.parse("tap do").continuable?     #=> true  (unclosed block)
+    #     Prism.parse("end.tap do").continuable? #=> false (stray end)
+    #
+    #--
+    #: () -> bool
+    def continuable?
+      return false if errors.empty?
+
+      offset = source.source.bytesize
+      errors.all? { |error| CONTINUABLE.include?(error.type) || error.location.start_offset == offset }
+    end
+
+    # The set of error types whose location the parser places at the opening
+    # token of an unclosed construct rather than at the end of the source. These
+    # errors always indicate incomplete input regardless of their byte position,
+    # so they are checked by type rather than by location.
+    #--
+    #: Array[Symbol]
+    CONTINUABLE = %i[
+      begin_term
+      begin_upcase_term
+      block_param_pipe_term
+      block_term_brace
+      block_term_end
+      case_missing_conditions
+      case_term
+      class_term
+      conditional_term
+      conditional_term_else
+      def_term
+      embdoc_term
+      end_upcase_term
+      for_term
+      hash_term
+      heredoc_term
+      lambda_term_brace
+      lambda_term_end
+      list_i_lower_term
+      list_i_upper_term
+      list_w_lower_term
+      list_w_upper_term
+      module_term
+      regexp_term
+      rescue_term
+      string_interpolated_term
+      string_literal_eof
+      symbol_term_dynamic
+      symbol_term_interpolated
+      until_term
+      while_term
+      xstring_term
+    ].freeze
+
+    private_constant :CONTINUABLE
+
     # Create a code units cache for the given encoding.
     #--
     #: (Encoding encoding) -> _CodeUnitsCache

--- a/rbi/generated/prism/parse_result.rbi
+++ b/rbi/generated/prism/parse_result.rbi
@@ -579,6 +579,35 @@ module Prism
     sig { returns(T::Boolean) }
     def failure?; end
 
+    # Returns true if the parsed source is an incomplete expression that could
+    # become valid with additional input. This is useful for REPL contexts (such
+    # as IRB) where the user may be entering a multi-line expression one line at
+    # a time and the implementation needs to determine whether to wait for more
+    # input or to evaluate what has been entered so far.
+    #
+    # Concretely, this returns true when every error present is caused by the
+    # parser reaching the end of the input before a construct was closed (e.g.
+    # an unclosed string, array, block, or keyword), and returns false when any
+    # error is caused by a token that makes the input structurally invalid
+    # regardless of what might follow (e.g. a stray `end`, `]`, or `)` with no
+    # matching opener).
+    #
+    # Examples:
+    #
+    #     Prism.parse("1 + [").continuable?      #=> true  (unclosed array)
+    #     Prism.parse("1 + ]").continuable?      #=> false (stray ])
+    #     Prism.parse("tap do").continuable?     #=> true  (unclosed block)
+    #     Prism.parse("end.tap do").continuable? #=> false (stray end)
+    #
+    sig { returns(T::Boolean) }
+    def continuable?; end
+
+    # The set of error types whose location the parser places at the opening
+    # token of an unclosed construct rather than at the end of the source. These
+    # errors always indicate incomplete input regardless of their byte position,
+    # so they are checked by type rather than by location.
+    CONTINUABLE = T.let(nil, T.untyped)
+
     # Create a code units cache for the given encoding.
     sig { params(encoding: Encoding).returns(T.untyped) }
     def code_units_cache(encoding); end

--- a/sig/generated/prism/parse_result.rbs
+++ b/sig/generated/prism/parse_result.rbs
@@ -669,6 +669,36 @@ module Prism
     # : () -> bool
     def failure?: () -> bool
 
+    # Returns true if the parsed source is an incomplete expression that could
+    # become valid with additional input. This is useful for REPL contexts (such
+    # as IRB) where the user may be entering a multi-line expression one line at
+    # a time and the implementation needs to determine whether to wait for more
+    # input or to evaluate what has been entered so far.
+    #
+    # Concretely, this returns true when every error present is caused by the
+    # parser reaching the end of the input before a construct was closed (e.g.
+    # an unclosed string, array, block, or keyword), and returns false when any
+    # error is caused by a token that makes the input structurally invalid
+    # regardless of what might follow (e.g. a stray `end`, `]`, or `)` with no
+    # matching opener).
+    #
+    # Examples:
+    #
+    #     Prism.parse("1 + [").continuable?      #=> true  (unclosed array)
+    #     Prism.parse("1 + ]").continuable?      #=> false (stray ])
+    #     Prism.parse("tap do").continuable?     #=> true  (unclosed block)
+    #     Prism.parse("end.tap do").continuable? #=> false (stray end)
+    #
+    # --
+    # : () -> bool
+    def continuable?: () -> bool
+
+    # The set of error types whose location the parser places at the opening
+    # token of an unclosed construct rather than at the end of the source. These
+    # errors always indicate incomplete input regardless of their byte position,
+    # so they are checked by type rather than by location.
+    CONTINUABLE: untyped
+
     # Create a code units cache for the given encoding.
     # --
     # : (Encoding encoding) -> _CodeUnitsCache

--- a/test/prism/errors_test.rb
+++ b/test/prism/errors_test.rb
@@ -109,6 +109,41 @@ module Prism
       assert_nil(statement.parts[0].statements)
     end
 
+    def test_continuable
+      # Valid input is not continuable (nothing to continue).
+      refute_predicate Prism.parse("1 + 1"), :continuable?
+      refute_predicate Prism.parse(""), :continuable?
+
+      # Stray closing tokens make input non-continuable regardless of what
+      # follows (matches the feature-request examples exactly).
+      refute_predicate Prism.parse("1 + ]"), :continuable?
+      refute_predicate Prism.parse("end.tap do"), :continuable?
+
+      # Unclosed constructs are continuable.
+      assert_predicate Prism.parse("1 + ["), :continuable?
+      assert_predicate Prism.parse("tap do"), :continuable?
+
+      # Unclosed keywords.
+      assert_predicate Prism.parse("def foo"), :continuable?
+      assert_predicate Prism.parse("class Foo"), :continuable?
+      assert_predicate Prism.parse("module Foo"), :continuable?
+      assert_predicate Prism.parse("if true"), :continuable?
+      assert_predicate Prism.parse("while true"), :continuable?
+      assert_predicate Prism.parse("begin"), :continuable?
+      assert_predicate Prism.parse("for x in [1]"), :continuable?
+
+      # Unclosed delimiters.
+      assert_predicate Prism.parse("{"), :continuable?
+      assert_predicate Prism.parse("foo("), :continuable?
+      assert_predicate Prism.parse('"hello'), :continuable?
+      assert_predicate Prism.parse("'hello"), :continuable?
+      assert_predicate Prism.parse("<<~HEREDOC\nhello"), :continuable?
+
+      # A mix: stray end plus an unclosed block is not continuable because the
+      # stray end cannot be fixed by appending more input.
+      refute_predicate Prism.parse("end\ntap do"), :continuable?
+    end
+
     private
 
     def assert_errors(filepath, version)


### PR DESCRIPTION
An API to determine if more input could fix the existing syntax errors. Fixes #3530