### PR TITLE
Correctly handle `and?` and similar on ruby 4.0

### DIFF
--- a/snapshots/4.0/leading_logical.txt
+++ b/snapshots/4.0/leading_logical.txt
@@ -1,10 +1,10 @@
-@ ProgramNode (location: (1,0)-(21,5))
+@ ProgramNode (location: (1,0)-(15,4))
 ├── flags: ∅
 ├── locals: []
 └── statements:
-    @ StatementsNode (location: (1,0)-(21,5))
+    @ StatementsNode (location: (1,0)-(15,4))
     ├── flags: ∅
-    └── body: (length: 8)
+    └── body: (length: 4)
         ├── @ AndNode (location: (1,0)-(3,4))
         │   ├── flags: newline
         │   ├── left:
@@ -62,50 +62,22 @@
         │   │   ├── flags: static_literal, decimal
         │   │   └── value: 3
         │   └── operator_loc: (11,0)-(11,3) = "and"
-        ├── @ OrNode (location: (13,0)-(15,4))
-        │   ├── flags: newline
-        │   ├── left:
-        │   │   @ OrNode (location: (13,0)-(14,4))
-        │   │   ├── flags: ∅
-        │   │   ├── left:
-        │   │   │   @ IntegerNode (location: (13,0)-(13,1))
-        │   │   │   ├── flags: static_literal, decimal
-        │   │   │   └── value: 1
-        │   │   ├── right:
-        │   │   │   @ IntegerNode (location: (14,3)-(14,4))
-        │   │   │   ├── flags: static_literal, decimal
-        │   │   │   └── value: 2
-        │   │   └── operator_loc: (14,0)-(14,2) = "or"
-        │   ├── right:
-        │   │   @ IntegerNode (location: (15,3)-(15,4))
-        │   │   ├── flags: static_literal, decimal
-        │   │   └── value: 3
-        │   └── operator_loc: (15,0)-(15,2) = "or"
-        ├── @ IntegerNode (location: (17,0)-(17,1))
-        │   ├── flags: newline, static_literal, decimal
-        │   └── value: 1
-        ├── @ CallNode (location: (18,0)-(18,6))
-        │   ├── flags: newline, variable_call, ignore_visibility
-        │   ├── receiver: ∅
-        │   ├── call_operator_loc: ∅
-        │   ├── name: :andfoo
-        │   ├── message_loc: (18,0)-(18,6) = "andfoo"
-        │   ├── opening_loc: ∅
-        │   ├── arguments: ∅
-        │   ├── closing_loc: ∅
-        │   ├── equal_loc: ∅
-        │   └── block: ∅
-        ├── @ IntegerNode (location: (20,0)-(20,1))
-        │   ├── flags: newline, static_literal, decimal
-        │   └── value: 2
-        └── @ CallNode (location: (21,0)-(21,5))
-            ├── flags: newline, variable_call, ignore_visibility
-            ├── receiver: ∅
-            ├── call_operator_loc: ∅
-            ├── name: :orfoo
-            ├── message_loc: (21,0)-(21,5) = "orfoo"
-            ├── opening_loc: ∅
-            ├── arguments: ∅
-            ├── closing_loc: ∅
-            ├── equal_loc: ∅
-            └── block: ∅
+        └── @ OrNode (location: (13,0)-(15,4))
+            ├── flags: newline
+            ├── left:
+            │   @ OrNode (location: (13,0)-(14,4))
+            │   ├── flags: ∅
+            │   ├── left:
+            │   │   @ IntegerNode (location: (13,0)-(13,1))
+            │   │   ├── flags: static_literal, decimal
+            │   │   └── value: 1
+            │   ├── right:
+            │   │   @ IntegerNode (location: (14,3)-(14,4))
+            │   │   ├── flags: static_literal, decimal
+            │   │   └── value: 2
+            │   └── operator_loc: (14,0)-(14,2) = "or"
+            ├── right:
+            │   @ IntegerNode (location: (15,3)-(15,4))
+            │   ├── flags: static_literal, decimal
+            │   └── value: 3
+            └── operator_loc: (15,0)-(15,2) = "or"

--- a/snapshots/and_or_with_suffix.txt
+++ b/snapshots/and_or_with_suffix.txt
@@ -1,0 +1,139 @@
+@ ProgramNode (location: (1,0)-(17,5))
+├── flags: ∅
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (1,0)-(17,5))
+    ├── flags: ∅
+    └── body: (length: 12)
+        ├── @ CallNode (location: (1,0)-(1,3))
+        │   ├── flags: newline, variable_call, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :foo
+        │   ├── message_loc: (1,0)-(1,3) = "foo"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── block: ∅
+        ├── @ CallNode (location: (2,0)-(2,4))
+        │   ├── flags: newline, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :and?
+        │   ├── message_loc: (2,0)-(2,4) = "and?"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── block: ∅
+        ├── @ CallNode (location: (4,0)-(4,3))
+        │   ├── flags: newline, variable_call, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :foo
+        │   ├── message_loc: (4,0)-(4,3) = "foo"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── block: ∅
+        ├── @ CallNode (location: (5,0)-(5,3))
+        │   ├── flags: newline, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :or?
+        │   ├── message_loc: (5,0)-(5,3) = "or?"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── block: ∅
+        ├── @ CallNode (location: (7,0)-(7,3))
+        │   ├── flags: newline, variable_call, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :foo
+        │   ├── message_loc: (7,0)-(7,3) = "foo"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── block: ∅
+        ├── @ CallNode (location: (8,0)-(8,4))
+        │   ├── flags: newline, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :and!
+        │   ├── message_loc: (8,0)-(8,4) = "and!"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── block: ∅
+        ├── @ CallNode (location: (10,0)-(10,3))
+        │   ├── flags: newline, variable_call, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :foo
+        │   ├── message_loc: (10,0)-(10,3) = "foo"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── block: ∅
+        ├── @ CallNode (location: (11,0)-(11,3))
+        │   ├── flags: newline, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :or!
+        │   ├── message_loc: (11,0)-(11,3) = "or!"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── block: ∅
+        ├── @ CallNode (location: (13,0)-(13,3))
+        │   ├── flags: newline, variable_call, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :foo
+        │   ├── message_loc: (13,0)-(13,3) = "foo"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── block: ∅
+        ├── @ CallNode (location: (14,0)-(14,6))
+        │   ├── flags: newline, variable_call, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :andbar
+        │   ├── message_loc: (14,0)-(14,6) = "andbar"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── block: ∅
+        ├── @ CallNode (location: (16,0)-(16,3))
+        │   ├── flags: newline, variable_call, ignore_visibility
+        │   ├── receiver: ∅
+        │   ├── call_operator_loc: ∅
+        │   ├── name: :foo
+        │   ├── message_loc: (16,0)-(16,3) = "foo"
+        │   ├── opening_loc: ∅
+        │   ├── arguments: ∅
+        │   ├── closing_loc: ∅
+        │   ├── equal_loc: ∅
+        │   └── block: ∅
+        └── @ CallNode (location: (17,0)-(17,5))
+            ├── flags: newline, variable_call, ignore_visibility
+            ├── receiver: ∅
+            ├── call_operator_loc: ∅
+            ├── name: :orbar
+            ├── message_loc: (17,0)-(17,5) = "orbar"
+            ├── opening_loc: ∅
+            ├── arguments: ∅
+            ├── closing_loc: ∅
+            ├── equal_loc: ∅
+            └── block: ∅

--- a/src/prism.c
+++ b/src/prism.c
@@ -10034,8 +10034,21 @@ parser_lex(pm_parser_t *parser) {
                                 following && (
                                     (peek_at(parser, following) == '&' && peek_at(parser, following + 1) == '&') ||
                                     (peek_at(parser, following) == '|' && peek_at(parser, following + 1) == '|') ||
-                                    (peek_at(parser, following) == 'a' && peek_at(parser, following + 1) == 'n' && peek_at(parser, following + 2) == 'd' && !char_is_identifier(parser, following + 3, parser->end - (following + 3))) ||
-                                    (peek_at(parser, following) == 'o' && peek_at(parser, following + 1) == 'r' && !char_is_identifier(parser, following + 2, parser->end - (following + 2)))
+                                    (
+                                        peek_at(parser, following) == 'a' &&
+                                        peek_at(parser, following + 1) == 'n' &&
+                                        peek_at(parser, following + 2) == 'd' &&
+                                        peek_at(parser, next_content + 3) != '!' &&
+                                        peek_at(parser, next_content + 3) != '?' &&
+                                        !char_is_identifier(parser, following + 3, parser->end - (following + 3))
+                                    ) ||
+                                    (
+                                        peek_at(parser, following) == 'o' &&
+                                        peek_at(parser, following + 1) == 'r' &&
+                                        peek_at(parser, next_content + 2) != '!' &&
+                                        peek_at(parser, next_content + 2) != '?' &&
+                                        !char_is_identifier(parser, following + 2, parser->end - (following + 2))
+                                    )
                                 )
                             ) {
                                 if (!lexed_comment) parser_lex_ignored_newline(parser);
@@ -10106,6 +10119,8 @@ parser_lex(pm_parser_t *parser) {
                                 peek_at(parser, next_content) == 'a' &&
                                 peek_at(parser, next_content + 1) == 'n' &&
                                 peek_at(parser, next_content + 2) == 'd' &&
+                                peek_at(parser, next_content + 3) != '!' &&
+                                peek_at(parser, next_content + 3) != '?' &&
                                 !char_is_identifier(parser, next_content + 3, parser->end - (next_content + 3))
                             ) {
                                 if (!lexed_comment) parser_lex_ignored_newline(parser);
@@ -10122,6 +10137,8 @@ parser_lex(pm_parser_t *parser) {
                             if (
                                 peek_at(parser, next_content) == 'o' &&
                                 peek_at(parser, next_content + 1) == 'r' &&
+                                peek_at(parser, next_content + 2) != '!' &&
+                                peek_at(parser, next_content + 2) != '?' &&
                                 !char_is_identifier(parser, next_content + 2, parser->end - (next_content + 2))
                             ) {
                                 if (!lexed_comment) parser_lex_ignored_newline(parser);

--- a/test/prism/fixtures/4.0/leading_logical.txt
+++ b/test/prism/fixtures/4.0/leading_logical.txt
@@ -14,8 +14,3 @@ and 3
 or 2
 or 3
 
-1
-andfoo
-
-2
-orfoo

--- a/test/prism/fixtures/and_or_with_suffix.txt
+++ b/test/prism/fixtures/and_or_with_suffix.txt
@@ -1,0 +1,17 @@
+foo
+and?
+
+foo
+or?
+
+foo
+and!
+
+foo
+or!
+
+foo
+andbar
+
+foo
+orbar

--- a/test/prism/ruby/ripper_test.rb
+++ b/test/prism/ruby/ripper_test.rb
@@ -37,6 +37,13 @@ module Prism
       ]
     end
 
+    if RUBY_VERSION.start_with?("4.")
+      incorrect += [
+        # https://bugs.ruby-lang.org/issues/21945
+        "and_or_with_suffix.txt",
+      ]
+    end
+
     # https://bugs.ruby-lang.org/issues/21669
     incorrect << "4.1/void_value.txt"
     # https://bugs.ruby-lang.org/issues/19107


### PR DESCRIPTION
It gets confused for syntax introduced in https://bugs.ruby-lang.org/issues/20925 But it actually should be a plain method call.
`!`/`?` are not valid as part of an identifier, methods however allow them as the last character.

Fixes [[Bug #21946]](https://bugs.ruby-lang.org/issues/21946)