### PR TITLE
add a `pm_arena_reset` API method

### DIFF
--- a/include/prism/util/pm_arena.h
+++ b/include/prism/util/pm_arena.h
@@ -79,6 +79,19 @@ void * pm_arena_zalloc(pm_arena_t *arena, size_t size, size_t alignment);
 void * pm_arena_memdup(pm_arena_t *arena, const void *src, size_t size, size_t alignment);
 
 /**
+ * Resets the arena.  If no memory has been allocated from this arena, this
+ * call is a no-op.
+ *
+ * Otherwise, a single block is retained and other blocks are freed.
+ *
+ * After this call, all pointers returned by pm_arena_alloc and
+ * pm_arena_zalloc are invalid.
+ *
+ * @param arena The arena to reset.
+ */
+void pm_arena_reset(pm_arena_t *arena);
+
+/**
  * Free all blocks in the arena. After this call, all pointers returned by
  * pm_arena_alloc and pm_arena_zalloc are invalid.
  *

--- a/src/util/pm_arena.c
+++ b/src/util/pm_arena.c
@@ -88,18 +88,42 @@ pm_arena_memdup(pm_arena_t *arena, const void *src, size_t size, size_t alignmen
     return dst;
 }
 
-/**
- * Free all blocks in the arena.
- */
 void
-pm_arena_free(pm_arena_t *arena) {
-    pm_arena_block_t *block = arena->current;
-
+free_blocks(pm_arena_block_t *block) {
     while (block != NULL) {
         pm_arena_block_t *prev = block->prev;
         xfree_sized(block, PM_ARENA_BLOCK_SIZE(block->capacity));
         block = prev;
     }
+}
+
+/**
+ * Free all but one block in the arena and mark the block as freshly allocated.
+ *
+ * Does nothing if the arena has never been used.
+ */
+void
+pm_arena_reset(pm_arena_t *arena) {
+    pm_arena_block_t *block = arena->current;
+
+    if (block == NULL) {
+        return;
+    }
+
+    free_blocks(block->prev);
+
+    block->prev = NULL;
+    block->used = 0;
+
+    arena->block_count = 1;
+}
+
+/**
+ * Free all blocks in the arena.
+ */
+void
+pm_arena_free(pm_arena_t *arena) {
+    free_blocks(arena->current);
 
     *arena = (pm_arena_t) { 0 };
 }


### PR DESCRIPTION
This PR is half commit-as-is, half starting point for discussion.

We have some Rust analysis programs that parse a bunch of Ruby files in one go.  The way things are currently structured, the arena used for one file and parse needs to be completely freed, and the next file needs to start reallocating blocks out of a completely fresh arena.  These new blocks may or may not be the same blocks, and if the files are sufficiently large, we need to repeatedly allocate multiple blocks for each file.  I think the same thing is true for something like Sorbet parsing a bunch of files in one go.  But `pm_arena_t` doesn't offer any API functions that would let you reset the state of the allocator.

It seems like it'd be useful to try and re-use arenas between parsing calls: we could immediately start reusing the biggest chunk of memory allocated thus far, and we don't need to waste time repeatedly allocating blocks of memory and freeing them.  Hence this PR to add `pm_arena_reset` to almost, but not quite, completely reset the arena so it can be reused.

I know of at least one precedent for this kind of API: the `bumpalo` Rust crate offers [`Bump#reset`](https://docs.rs/bumpalo/3.20.2/bumpalo/struct.Bump.html#method.reset) which does exactly the same thing offered here.  [GNU's obstacks](https://gcc.gnu.org/onlinedocs/libiberty/Obstacks.html) are not quite the same thing as arena allocation, but they do allow you to reuse an obstack in roughly the same way.  I imagine there are other instances, but those are the two I know about.

Full disclosure: I have no stats backing it up that this would actually be faster or be so much faster that it's worthwhile having the extra code in Prism.

This PR would either require followon PRs to figure out what the Rust-side API would look like (e.g. do we need/want to `PRISM_EXPORTED_FUNCTION` `pm_arena_reset`?  how does the `ruby_prism::parse` method need to change, or what does an additional API look like?  etc.), or would require some iteration, assuming that it's accepted in the first place.