### PR TITLE
[rust] Expose `start` offsets for `Location`

### DIFF
--- a/rust/ruby-prism/src/lib.rs
+++ b/rust/ruby-prism/src/lib.rs
@@ -465,6 +465,7 @@ mod tests {
 
         assert_eq!(slice, "222");
         assert_eq!(6, location.start);
+        assert_eq!(location.start, location.start());
         assert_eq!(9, location.end());
 
         let recv_loc = plus.receiver().unwrap().location();

--- a/rust/ruby-prism/src/parse_result/mod.rs
+++ b/rust/ruby-prism/src/parse_result/mod.rs
@@ -44,6 +44,12 @@ impl<'pr> Location<'pr> {
         }
     }
 
+    /// Returns the start offset from the beginning of the parsed source.
+    #[must_use]
+    pub const fn start(&self) -> u32 {
+        self.start
+    }
+
     /// Returns the end offset from the beginning of the parsed source.
     #[must_use]
     pub const fn end(&self) -> u32 {


### PR DESCRIPTION
#3772 replaced `end_offset()` with `end()` for `Location`, but there's no corresponding `start()` method to replace `start_offset`. (We could alternatively make the `start` attribute `pub` instead of `pub(crate)`, but exposing both as methods keeps some consistency.)