### PR TITLE
[ruby-4.0] Bump to v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [1.8.1] - 2026-03-16
+
+### Changed
+
+- Fix `not` binding power in endless methods.
+- Correctly handle `and?` and similar on Ruby 4.0.
+- Fix error message for block/lambda with `...` argument.
+- Fix `in` handling.
+
 ## [1.8.0] - 2026-01-12
 
 ### Added
@@ -18,8 +29,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Fix denominator of rational float literal.
 - Decouple ripper translator from ripper library.
 - Sync Prism::Translation::ParserCurrent with Ruby 4.0.
-
-## [Unreleased]
 
 ## [1.7.0] - 2025-12-18
 
@@ -731,7 +740,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - 🎉 Initial release! 🎉
 
-[unreleased]: https://github.com/ruby/prism/compare/v1.8.0...HEAD
+[unreleased]: https://github.com/ruby/prism/compare/v1.8.1...HEAD
+[1.8.1]: https://github.com/ruby/prism/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/ruby/prism/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/ruby/prism/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/ruby/prism/compare/v1.5.2...v1.6.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    prism (1.8.0)
+    prism (1.8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/ext/prism/extension.h
+++ b/ext/prism/extension.h
@@ -1,7 +1,7 @@
 #ifndef PRISM_EXT_NODE_H
 #define PRISM_EXT_NODE_H
 
-#define EXPECTED_PRISM_VERSION "1.8.0"
+#define EXPECTED_PRISM_VERSION "1.8.1"
 
 #include <ruby.h>
 #include <ruby/encoding.h>

--- a/gemfiles/2.7/Gemfile.lock
+++ b/gemfiles/2.7/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    prism (1.8.0)
+    prism (1.8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/3.0/Gemfile.lock
+++ b/gemfiles/3.0/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    prism (1.8.0)
+    prism (1.8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/3.1/Gemfile.lock
+++ b/gemfiles/3.1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    prism (1.8.0)
+    prism (1.8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/3.2/Gemfile.lock
+++ b/gemfiles/3.2/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    prism (1.8.0)
+    prism (1.8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/3.3/Gemfile.lock
+++ b/gemfiles/3.3/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    prism (1.8.0)
+    prism (1.8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/3.4/Gemfile.lock
+++ b/gemfiles/3.4/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    prism (1.8.0)
+    prism (1.8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/4.0/Gemfile.lock
+++ b/gemfiles/4.0/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    prism (1.8.0)
+    prism (1.8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/4.1/Gemfile.lock
+++ b/gemfiles/4.1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    prism (1.8.0)
+    prism (1.8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/include/prism/version.h
+++ b/include/prism/version.h
@@ -19,11 +19,11 @@
 /**
  * The patch version of the Prism library as an int.
  */
-#define PRISM_VERSION_PATCH 0
+#define PRISM_VERSION_PATCH 1
 
 /**
  * The version of the Prism library as a constant string.
  */
-#define PRISM_VERSION "1.8.0"
+#define PRISM_VERSION "1.8.1"
 
 #endif

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruby/prism",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Prism Ruby parser",
   "type": "module",
   "main": "src/index.js",

--- a/prism.gemspec
+++ b/prism.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "prism"
-  spec.version = "1.8.0"
+  spec.version = "1.8.1"
   spec.authors = ["Shopify"]
   spec.email = ["ruby@shopify.com"]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ruby-prism"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "ruby-prism-sys",
  "serde",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "ruby-prism-sys"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bindgen",
  "cc",

--- a/rust/ruby-prism-sys/Cargo.toml
+++ b/rust/ruby-prism-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-prism-sys"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 license-file = "../../LICENSE.md"
 repository = "https://github.com/ruby/prism"

--- a/rust/ruby-prism-sys/tests/utils_tests.rs
+++ b/rust/ruby-prism-sys/tests/utils_tests.rs
@@ -12,7 +12,7 @@ fn version_test() {
         CStr::from_ptr(version)
     };
 
-    assert_eq!(&cstring.to_string_lossy(), "1.8.0");
+    assert_eq!(&cstring.to_string_lossy(), "1.8.1");
 }
 
 #[test]

--- a/rust/ruby-prism/Cargo.toml
+++ b/rust/ruby-prism/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-prism"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 license-file = "../../LICENSE.md"
 repository = "https://github.com/ruby/prism"
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dependencies]
-ruby-prism-sys = { version = "1.8.0", path = "../ruby-prism-sys" }
+ruby-prism-sys = { version = "1.8.1", path = "../ruby-prism-sys" }
 
 [features]
 default = ["vendored"]

--- a/templates/java/org/prism/Loader.java.erb
+++ b/templates/java/org/prism/Loader.java.erb
@@ -102,7 +102,7 @@ public class Loader {
 
         expect((byte) 1, "prism major version does not match");
         expect((byte) 8, "prism minor version does not match");
-        expect((byte) 0, "prism patch version does not match");
+        expect((byte) 1, "prism patch version does not match");
 
         expect((byte) 1, "Loader.java requires no location fields in the serialized output");
 

--- a/templates/javascript/src/deserialize.js.erb
+++ b/templates/javascript/src/deserialize.js.erb
@@ -2,7 +2,7 @@ import * as nodes from "./nodes.js";
 
 const MAJOR_VERSION = 1;
 const MINOR_VERSION = 8;
-const PATCH_VERSION = 0;
+const PATCH_VERSION = 1;
 
 // The DataView getFloat64 function takes an optional second argument that
 // specifies whether the number is little-endian or big-endian. It does not

--- a/templates/lib/prism/serialize.rb.erb
+++ b/templates/lib/prism/serialize.rb.erb
@@ -14,7 +14,7 @@ module Prism
 
     # The patch version of prism that we are expecting to find in the serialized
     # strings.
-    PATCH_VERSION = 0
+    PATCH_VERSION = 1
 
     # Deserialize the dumped output from a request to parse or parse_file.
     #


### PR DESCRIPTION
This PR makes a Prism v1.8.1 release to be included in the Ruby 4.0.2 release.