### PR TITLE
[ruby-4.0] Specify a tag for npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -42,5 +42,17 @@ jobs:
       - name: Update npm
         run: npm install -g npm@latest
 
-      - run: npm publish
+      - name: Determine npm tag
+        id: npm-tag
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./javascript/package.json').version")
+          LATEST_VERSION=$(npm view @ruby/prism version 2>/dev/null || echo "0.0.0")
+          if npx semver "$PACKAGE_VERSION" -r ">$LATEST_VERSION"; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            MINOR=$(echo "$PACKAGE_VERSION" | cut -d. -f1,2)
+            echo "tag=v$MINOR" >> "$GITHUB_OUTPUT"
+          fi
+
+      - run: npm publish --tag ${{ steps.npm-tag.outputs.tag }}
         working-directory: javascript


### PR DESCRIPTION
This is an attempt to fix the Prism v1.8.1 release on npm https://github.com/ruby/prism/actions/runs/23169365809/job/67317398366.