### PR TITLE
[ruby-4.0] Fix an error on npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -51,7 +51,7 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           else
             MINOR=$(echo "$PACKAGE_VERSION" | cut -d. -f1,2)
-            echo "tag=v$MINOR" >> "$GITHUB_OUTPUT"
+            echo "tag=stable-$MINOR" >> "$GITHUB_OUTPUT"
           fi
 
       - run: npm publish --tag ${{ steps.npm-tag.outputs.tag }}


### PR DESCRIPTION
$ Run npm publish --tag v1.8

npm error Tag name must not be a valid SemVer range: v1.8
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-03-16T22_57_22_956Z-debug-0.log
Error: Process completed with exit code 1.

https://github.com/ruby/prism/actions/runs/23169830009/job/67318860180