### PR TITLE
Use explicit npm dist-tag to allow publishing older versions

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -42,5 +42,17 @@ jobs:
       - name: Update npm
         run: npm install -g npm@latest
 
-      - run: npm publish
+      - name: Determine npm tag
+        id: npm-tag
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./javascript/package.json').version")
+          LATEST_VERSION=$(npm view @ruby/prism version 2>/dev/null || echo "0.0.0")
+          if npx semver "$PACKAGE_VERSION" -r ">$LATEST_VERSION"; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            MINOR=$(echo "$PACKAGE_VERSION" | cut -d. -f1,2)
+            echo "tag=stable-$MINOR" >> "$GITHUB_OUTPUT"
+          fi
+
+      - run: npm publish --tag ${{ steps.npm-tag.outputs.tag }}
         working-directory: javascript


### PR DESCRIPTION
## Description

When publishing a backport release (e.g. 1.8.1) after a newer version (e.g. 1.9.0) already exists on npm, `npm publish` fails because it tries to move the `latest` tag to a lower version. Fix this by comparing the package version against the current `latest` on npm and using a `stable-X.Y` dist-tag for older releases.

## Background

This has already been merged to ruby-4.0 branch to fix the npm release failure for Prism v1.8.1. However, I want to merge this to main as well to make sure we have this fix in future stable versions.

Ideally, I would like to call the npm tag `ruby-4.0` to clarify it's the latest Prism version for Ruby 4.0. But a git tag push is not necessarily associated to a particular branch, so I thought it's not straightforward for GitHub Actions to figure out which branch (like `ruby-4.0`) a release tag came from. For example, when a tag is pushed before puhsing the same thing to ruby-4.0 branch, the release workflow should still work.