### PR TITLE
Better ripper event tests / handful of compatibility fixes

### DIFF
--- a/lib/prism/translation/ripper.rb
+++ b/lib/prism/translation/ripper.rb
@@ -2359,6 +2359,8 @@ module Prism
                 visit(node.parameters.parameters)
               end
 
+            visit_all(node.parameters.locals)
+
             if node.parameters.opening_loc.nil?
               params
             else

--- a/test/prism/ruby/ripper_test.rb
+++ b/test/prism/ruby/ripper_test.rb
@@ -135,7 +135,7 @@ module Prism
       end
     end
 
-    UNSUPPORTED_EVENTS = %i[backtick comma heredoc_beg heredoc_end ident ignored_nl kw label_end lbrace lbracket lparen nl op rbrace rbracket rparen semicolon sp symbeg tstring_beg tstring_end words_sep ignored_sp]
+    UNSUPPORTED_EVENTS = %i[backtick comma heredoc_beg heredoc_end ignored_nl kw label_end lbrace lbracket lparen nl op rbrace rbracket rparen semicolon sp symbeg tstring_beg tstring_end words_sep ignored_sp]
     SUPPORTED_EVENTS = Translation::Ripper::EVENTS - UNSUPPORTED_EVENTS
 
     module Events


### PR DESCRIPTION
Currently the events are not very well tested, now it compares against the full test suite. Also includes a handful of fixes for better compat that I discovered during this.

For the event excludes, most are not implemented at all like `on_comma` and others have many failures I didn't check out yet like `on_words_sep`. The test excludes are for implemented events that just have a few incompatibilities here and there.

Eventually I want to implement currently unimplemented types like `on_tstring_begin` which yard for example uses. Seems like that should be possible.