### PR TITLE
Ignore tapioca for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,4 @@ updates:
           - "*"
     ignore:
       - dependency-name: "sorbet"
+      - dependency-name: "tapioca"


### PR DESCRIPTION
Ref https://github.com/ruby/prism/pull/4034

rbs 4.0 has been released and now it resolves differently
But we have to wait on steep to release it's new version first before we can make use of this to properly work