### PR TITLE
Add `keyword_loc` to `ForwardingSuperNode`

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2627,6 +2627,14 @@ nodes:
           end
   - name: ForwardingSuperNode
     fields:
+      - name: keyword_loc
+        type: location
+        comment: |
+          super
+          ^^^^^
+
+          super { 123 }
+          ^^^^^
       - name: block
         type: node?
         kind: BlockNode

--- a/rbi/generated/prism/dsl.rbi
+++ b/rbi/generated/prism/dsl.rbi
@@ -294,8 +294,8 @@ module Prism
     def forwarding_parameter_node(source: T.unsafe(nil), node_id: T.unsafe(nil), location: T.unsafe(nil), flags: T.unsafe(nil)); end
 
     # Create a new ForwardingSuperNode node.
-    sig { params(source: Source, node_id: Integer, location: Location, flags: Integer, block: ::T.nilable(BlockNode)).returns(ForwardingSuperNode) }
-    def forwarding_super_node(source: T.unsafe(nil), node_id: T.unsafe(nil), location: T.unsafe(nil), flags: T.unsafe(nil), block: T.unsafe(nil)); end
+    sig { params(source: Source, node_id: Integer, location: Location, flags: Integer, keyword_loc: Location, block: ::T.nilable(BlockNode)).returns(ForwardingSuperNode) }
+    def forwarding_super_node(source: T.unsafe(nil), node_id: T.unsafe(nil), location: T.unsafe(nil), flags: T.unsafe(nil), keyword_loc: T.unsafe(nil), block: T.unsafe(nil)); end
 
     # Create a new GlobalVariableAndWriteNode node.
     sig { params(source: Source, node_id: Integer, location: Location, flags: Integer, name: Symbol, name_loc: Location, operator_loc: Location, value: Node).returns(GlobalVariableAndWriteNode) }

--- a/rbi/generated/prism/node.rbi
+++ b/rbi/generated/prism/node.rbi
@@ -5755,8 +5755,8 @@ module Prism
   # If it has any other arguments, it would be a `SuperNode` instead.
   class ForwardingSuperNode < Node
     # Initialize a new ForwardingSuperNode node.
-    sig { params(source: Source, node_id: Integer, location: Location, flags: Integer, block: ::T.nilable(BlockNode)).void }
-    def initialize(source, node_id, location, flags, block); end
+    sig { params(source: Source, node_id: Integer, location: Location, flags: Integer, keyword_loc: Location, block: ::T.nilable(BlockNode)).void }
+    def initialize(source, node_id, location, flags, keyword_loc, block); end
 
     # See Node.accept.
     sig { override.params(visitor: Visitor).returns(::T.untyped) }
@@ -5780,8 +5780,8 @@ module Prism
     def comment_targets; end
 
     # Creates a copy of self with the given fields, using self as the template.
-    sig { params(node_id: Integer, location: Location, flags: Integer, block: ::T.nilable(BlockNode)).returns(ForwardingSuperNode) }
-    def copy(node_id: T.unsafe(nil), location: T.unsafe(nil), flags: T.unsafe(nil), block: T.unsafe(nil)); end
+    sig { params(node_id: Integer, location: Location, flags: Integer, keyword_loc: Location, block: ::T.nilable(BlockNode)).returns(ForwardingSuperNode) }
+    def copy(node_id: T.unsafe(nil), location: T.unsafe(nil), flags: T.unsafe(nil), keyword_loc: T.unsafe(nil), block: T.unsafe(nil)); end
 
     sig { override.returns(T::Array[::T.nilable(Node)]) }
     def deconstruct; end
@@ -5800,9 +5800,26 @@ module Prism
     sig { override.returns(String) }
     def inspect; end
 
+    # super
+    # ^^^^^
+    #
+    # super { 123 }
+    # ^^^^^
+    sig { returns(Location) }
+    def keyword_loc; end
+
+    # Save the keyword_loc location using the given saved source so that
+    # it can be retrieved later.
+    sig { params(repository: ::T.untyped).returns(Relocation::Entry) }
+    def save_keyword_loc(repository); end
+
     # All other arguments are forwarded as normal, except the original block is replaced with the new block.
     sig { returns(::T.nilable(BlockNode)) }
     def block; end
+
+    # Slice the location of keyword_loc from the source.
+    sig { returns(String) }
+    def keyword; end
 
     sig { params(other: ::T.untyped).returns(::T.nilable(T::Boolean)) }
     def ===(other); end

--- a/sig/generated/prism/dsl.rbs
+++ b/sig/generated/prism/dsl.rbs
@@ -355,8 +355,8 @@ module Prism
 
     # Create a new ForwardingSuperNode node.
     # --
-    # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?block: BlockNode?) -> ForwardingSuperNode
-    def forwarding_super_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?block: BlockNode?) -> ForwardingSuperNode
+    # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?block: BlockNode?) -> ForwardingSuperNode
+    def forwarding_super_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?block: BlockNode?) -> ForwardingSuperNode
 
     # Create a new GlobalVariableAndWriteNode node.
     # --

--- a/sig/generated/prism/node.rbs
+++ b/sig/generated/prism/node.rbs
@@ -8403,10 +8403,12 @@ module Prism
   class ForwardingSuperNode < Node
     @block: BlockNode?
 
+    @keyword_loc: Location
+
     # Initialize a new ForwardingSuperNode node.
     # --
-    # : (Source source, Integer node_id, Location location, Integer flags, BlockNode? block) -> void
-    def initialize: (Source source, Integer node_id, Location location, Integer flags, BlockNode? block) -> void
+    # : (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, BlockNode? block) -> void
+    def initialize: (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, BlockNode? block) -> void
 
     # See Node.accept.
     # --
@@ -8440,8 +8442,8 @@ module Prism
     #
     # Creates a copy of self with the given fields, using self as the template.
     # --
-    # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?block: BlockNode?) -> ForwardingSuperNode
-    def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?block: BlockNode?) -> ForwardingSuperNode
+    # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?block: BlockNode?) -> ForwardingSuperNode
+    def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?block: BlockNode?) -> ForwardingSuperNode
 
     alias deconstruct child_nodes
 
@@ -8461,6 +8463,26 @@ module Prism
     # : () -> String
     def inspect: () -> String
 
+    # :category: Locations
+    # :call-seq:
+    #   keyword_loc -> Location
+    #
+    # super
+    # ^^^^^
+    #
+    # super { 123 }
+    # ^^^^^
+    # --
+    # : () -> Location
+    def keyword_loc: () -> Location
+
+    # :category: Repository
+    # Save the keyword_loc location using the given saved source so that
+    # it can be retrieved later.
+    # --
+    # : (_Repository repository) -> Relocation::Entry
+    def save_keyword_loc: (_Repository repository) -> Relocation::Entry
+
     # :call-seq:
     #   block -> BlockNode | nil
     #
@@ -8468,6 +8490,14 @@ module Prism
     # --
     # : () -> BlockNode?
     def block: () -> BlockNode?
+
+    # :call-seq:
+    #   keyword -> String
+    #
+    # Slice the location of keyword_loc from the source.
+    # --
+    # : () -> String
+    def keyword: () -> String
 
     # : (untyped other) -> boolish
     def ===: (untyped other) -> boolish

--- a/snapshots/super.txt
+++ b/snapshots/super.txt
@@ -7,6 +7,7 @@
     └── body: (length: 9)
         ├── @ ForwardingSuperNode (location: (1,0)-(1,5))
         │   ├── flags: newline
+        │   ├── keyword_loc: (1,0)-(1,5) = "super"
         │   └── block: ∅
         ├── @ SuperNode (location: (3,0)-(3,7))
         │   ├── flags: newline
@@ -83,6 +84,7 @@
         │       └── operator_loc: (11,6)-(11,7) = "&"
         ├── @ ForwardingSuperNode (location: (13,0)-(13,8))
         │   ├── flags: newline
+        │   ├── keyword_loc: (13,0)-(13,5) = "super"
         │   └── block:
         │       @ BlockNode (location: (13,6)-(13,8))
         │       ├── flags: ∅

--- a/snapshots/unparser/corpus/literal/super.txt
+++ b/snapshots/unparser/corpus/literal/super.txt
@@ -7,6 +7,7 @@
     └── body: (length: 11)
         ├── @ ForwardingSuperNode (location: (1,0)-(1,5))
         │   ├── flags: newline
+        │   ├── keyword_loc: (1,0)-(1,5) = "super"
         │   └── block: ∅
         ├── @ SuperNode (location: (2,0)-(2,7))
         │   ├── flags: newline
@@ -170,6 +171,7 @@
         │   └── block: ∅
         ├── @ ForwardingSuperNode (location: (10,0)-(12,1))
         │   ├── flags: newline
+        │   ├── keyword_loc: (10,0)-(10,5) = "super"
         │   └── block:
         │       @ BlockNode (location: (10,6)-(12,1))
         │       ├── flags: ∅

--- a/snapshots/whitequark/super_block.txt
+++ b/snapshots/whitequark/super_block.txt
@@ -7,6 +7,7 @@
     └── body: (length: 2)
         ├── @ ForwardingSuperNode (location: (1,0)-(1,12))
         │   ├── flags: newline
+        │   ├── keyword_loc: (1,0)-(1,5) = "super"
         │   └── block:
         │       @ BlockNode (location: (1,6)-(1,12))
         │       ├── flags: ∅

--- a/snapshots/whitequark/zsuper.txt
+++ b/snapshots/whitequark/zsuper.txt
@@ -7,4 +7,5 @@
     └── body: (length: 1)
         └── @ ForwardingSuperNode (location: (1,0)-(1,5))
             ├── flags: newline
+            ├── keyword_loc: (1,0)-(1,5) = "super"
             └── block: ∅

--- a/src/prism.c
+++ b/src/prism.c
@@ -4379,6 +4379,7 @@ pm_forwarding_super_node_create(pm_parser_t *parser, const pm_token_t *token, pm
         ++parser->node_id,
         0,
         (block == NULL) ? PM_LOCATION_INIT_TOKEN(parser, token) : PM_LOCATION_INIT_TOKEN_NODE(parser, token, block),
+        PM_LOCATION_INIT_TOKEN(parser, token),
         block
     );
 }


### PR DESCRIPTION
They can take a block and so the keyword location is not always the entirety of the node. You can get it by constructing a location that is just the first 5 characters but why not have it be provided by prism?