### PR TITLE
Add CI job to build C sources with various compiler versions and fix array-bounds error with GCC 9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,6 +174,18 @@ jobs:
       env:
         PRISM_BUILD_MINIMAL: "1"
 
+  build-with-various-compilers:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ruby
+        bundler-cache: true
+    - name: Build with various compilers
+      run: bundle exec rake build_in_docker
+
   build-java:
     runs-on: ubuntu-latest
     env:

--- a/Rakefile
+++ b/Rakefile
@@ -79,15 +79,14 @@ end
 
 task :build_in_docker => :templates do
   # Versions from https://github.com/ruby/ruby/blob/master/.github/workflows/compilers.yml
-  compilers = (7..15).map { |v| "gcc-#{v}" }
-  compilers.each do |compiler|
+  versions = (7..15).to_a
+  versions.each do |version|
     dockerfile = <<~DOCKERFILE
-    FROM ghcr.io/ruby/ruby-ci-image:#{compiler}
-    USER root
+    FROM docker.io/library/gcc:#{version}
     ADD . /prism
     WORKDIR /prism
-    RUN #{compiler} --version
-    RUN make CC=#{compiler}
+    RUN gcc --version
+    RUN make SOEXT=so
     DOCKERFILE
     File.write 'Dockerfile', dockerfile
     sh "docker build ."

--- a/Rakefile
+++ b/Rakefile
@@ -76,3 +76,21 @@ namespace :build do
   desc "Build a development version of the gem"
   task dev: ["build:dev_version_set", "build", "build:dev_version_clear"]
 end
+
+task :build_in_docker => :templates do
+  # Versions from https://github.com/ruby/ruby/blob/master/.github/workflows/compilers.yml
+  compilers = (7..15).map { |v| "gcc-#{v}" }
+  compilers.each do |compiler|
+    dockerfile = <<~DOCKERFILE
+    FROM ghcr.io/ruby/ruby-ci-image:#{compiler}
+    USER root
+    ADD . /prism
+    WORKDIR /prism
+    RUN #{compiler} --version
+    RUN make CC=#{compiler}
+    DOCKERFILE
+    File.write 'Dockerfile', dockerfile
+    sh "docker build ."
+    rm 'Dockerfile'
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -83,7 +83,9 @@ task :build_in_docker => :templates do
   versions.each do |version|
     dockerfile = <<~DOCKERFILE
     FROM docker.io/library/gcc:#{version}
-    ADD . /prism
+    COPY Makefile /prism/
+    COPY src /prism/src
+    COPY include /prism/include
     WORKDIR /prism
     RUN gcc --version
     RUN make SOEXT=so

--- a/include/prism/internal/parser.h
+++ b/include/prism/internal/parser.h
@@ -9,6 +9,7 @@
 #include "prism/internal/list.h"
 #include "prism/internal/options.h"
 #include "prism/internal/static_literals.h"
+#include "prism/internal/strpbrk.h"
 
 #include "prism/ast.h"
 #include "prism/line_offset_list.h"
@@ -168,7 +169,7 @@ typedef struct pm_lex_mode {
              * This is the character set that should be used to delimit the
              * tokens within the list.
              */
-            uint8_t breakpoints[11];
+            uint8_t breakpoints[PM_STRPBRK_CACHE_SIZE];
         } list;
 
         struct {
@@ -190,7 +191,7 @@ typedef struct pm_lex_mode {
              * This is the character set that should be used to delimit the
              * tokens within the regular expression.
              */
-            uint8_t breakpoints[7];
+            uint8_t breakpoints[PM_STRPBRK_CACHE_SIZE];
         } regexp;
 
         struct {
@@ -223,7 +224,7 @@ typedef struct pm_lex_mode {
              * This is the character set that should be used to delimit the
              * tokens within the string.
              */
-            uint8_t breakpoints[7];
+            uint8_t breakpoints[PM_STRPBRK_CACHE_SIZE];
         } string;
 
         struct {


### PR DESCRIPTION
From https://github.com/ruby/prism/pull/4051#pullrequestreview-4021612093