### PR TITLE
Release prism Maven artifacts v0.0.2

### DIFF
--- a/java/api/pom.xml
+++ b/java/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ruby-lang</groupId>
     <artifactId>prism-parser</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>prism-parser-api</artifactId>

--- a/java/api/pom.xml
+++ b/java/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ruby-lang</groupId>
     <artifactId>prism-parser</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.2</version>
   </parent>
 
   <artifactId>prism-parser-api</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.ruby-lang</groupId>
   <artifactId>prism-parser</artifactId>
-  <version>0.0.2</version>
+  <version>0.0.3-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Java Prism</name>
   <description>Java API for the Prism Ruby language parser</description>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.ruby-lang</groupId>
   <artifactId>prism-parser</artifactId>
-  <version>0.0.2-SNAPSHOT</version>
+  <version>0.0.2</version>
   <packaging>pom</packaging>
   <name>Java Prism</name>
   <description>Java API for the Prism Ruby language parser</description>

--- a/java/wasm/pom.xml
+++ b/java/wasm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ruby-lang</groupId>
     <artifactId>prism-parser</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>prism-parser-wasm</artifactId>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.ruby-lang</groupId>
       <artifactId>prism-parser-api</artifactId>
-      <version>0.0.2</version>
+      <version>0.0.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>

--- a/java/wasm/pom.xml
+++ b/java/wasm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ruby-lang</groupId>
     <artifactId>prism-parser</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.2</version>
   </parent>
 
   <artifactId>prism-parser-wasm</artifactId>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.ruby-lang</groupId>
       <artifactId>prism-parser-api</artifactId>
-      <version>0.0.2-SNAPSHOT</version>
+      <version>0.0.2</version>
     </dependency>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>


### PR DESCRIPTION
Just version bumps here. Still not sure how to handle Maven releases with main locked down.