### PR TITLE
Prism parser maven 0.0.3

### DIFF
--- a/java/api/pom.xml
+++ b/java/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ruby-lang</groupId>
     <artifactId>prism-parser</artifactId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>0.0.3</version>
   </parent>
 
   <artifactId>prism-parser-api</artifactId>

--- a/java/api/pom.xml
+++ b/java/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ruby-lang</groupId>
     <artifactId>prism-parser</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>prism-parser-api</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.ruby-lang</groupId>
   <artifactId>prism-parser</artifactId>
-  <version>0.0.3-SNAPSHOT</version>
+  <version>0.0.3</version>
   <packaging>pom</packaging>
   <name>Java Prism</name>
   <description>Java API for the Prism Ruby language parser</description>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.ruby-lang</groupId>
   <artifactId>prism-parser</artifactId>
-  <version>0.0.3</version>
+  <version>0.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Java Prism</name>
   <description>Java API for the Prism Ruby language parser</description>

--- a/java/wasm/pom.xml
+++ b/java/wasm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ruby-lang</groupId>
     <artifactId>prism-parser</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>prism-parser-wasm</artifactId>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.ruby-lang</groupId>
       <artifactId>prism-parser-api</artifactId>
-      <version>0.0.3</version>
+      <version>0.0.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>

--- a/java/wasm/pom.xml
+++ b/java/wasm/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <chicory.version>1.7.5</chicory.version>
-    <redline.version>0.0.2</redline.version>
+    <redline.version>0.0.3</redline.version>
   </properties>
 
   <dependencyManagement>

--- a/java/wasm/pom.xml
+++ b/java/wasm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ruby-lang</groupId>
     <artifactId>prism-parser</artifactId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>0.0.3</version>
   </parent>
 
   <artifactId>prism-parser-wasm</artifactId>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.ruby-lang</groupId>
       <artifactId>prism-parser-api</artifactId>
-      <version>0.0.3-SNAPSHOT</version>
+      <version>0.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>


### PR DESCRIPTION
This release just updates some transitive dependencies:

* chicory-redline to 0.0.3 to update its dependency on jffi.