### PR TITLE
Apply path excludes to `pull_request` target

### DIFF
--- a/.github/workflows/cpp-bindings.yml
+++ b/.github/workflows/cpp-bindings.yml
@@ -2,7 +2,7 @@ name: C++ bindings
 
 on:
   push:
-    paths:
+    paths: &paths
       - ".github/workflows/cpp-bindings.yml"
       - "include/"
       - "src/"
@@ -12,6 +12,7 @@ on:
       - main
       - ruby-4.0
   pull_request:
+    paths: *paths
 
 jobs:
   test:

--- a/.github/workflows/java-wasm-bindings.yml
+++ b/.github/workflows/java-wasm-bindings.yml
@@ -2,7 +2,7 @@ name: Java WASM bindings
 
 on:
   push:
-    paths:
+    paths: &paths
       - ".github/workflows/java-wasm-bindings.yml"
       - "include/"
       - "src/"
@@ -13,6 +13,7 @@ on:
       - main
       - ruby-4.0
   pull_request:
+    paths: *paths
 
 jobs:
   build-wasm:

--- a/.github/workflows/javascript-bindings.yml
+++ b/.github/workflows/javascript-bindings.yml
@@ -2,7 +2,7 @@ name: JavaScript bindings
 
 on:
   push:
-    paths:
+    paths: &paths
       - ".github/workflows/javascript-bindings.yml"
       - "include/"
       - "src/"
@@ -11,6 +11,7 @@ on:
       - main
       - ruby-4.0
   pull_request:
+    paths: *paths
 
 jobs:
   build:

--- a/.github/workflows/rust-bindings.yml
+++ b/.github/workflows/rust-bindings.yml
@@ -2,7 +2,7 @@ name: Rust bindings
 
 on:
   push:
-    paths:
+    paths: &paths
       - ".github/workflows/rust-bindings.yml"
       - "include/"
       - "src/"
@@ -12,6 +12,7 @@ on:
       - main
       - ruby-4.0
   pull_request:
+    paths: *paths
 
 env:
   RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
`push` is for push only. We can use anchors instead of duplicating the value, since github supports them now