### PR TITLE
Skip dependabot for typecheck

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,13 +26,10 @@ updates:
       - '/gemfiles/3.4'
       - '/gemfiles/4.0'
       - '/gemfiles/4.1'
-      - '/gemfiles/typecheck'
+      # - '/gemfiles/typecheck'
     schedule:
       interval: 'weekly'
     groups:
       ruby-deps:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "sorbet"
-      - dependency-name: "tapioca"


### PR DESCRIPTION
Instead of continuously adding to the list, let's just skip the directory for now.

https://github.com/ruby/prism/pull/4086#issuecomment-4283681202