### PR TITLE
Implement `on_label_end` for ripper

### DIFF
--- a/lib/prism/translation/ripper.rb
+++ b/lib/prism/translation/ripper.rb
@@ -22,7 +22,6 @@ module Prism
     # - on_comma
     # - on_ignored_nl
     # - on_ignored_sp
-    # - on_label_end
     # - on_nl
     # - on_operator_ambiguous
     # - on_semicolon
@@ -3633,7 +3632,13 @@ module Prism
         end
 
         result = yield
-        return result if assoc
+        if assoc
+          if node.closing != ":"
+            bounds(node.closing_loc)
+            on_label_end(node.closing)
+          end
+          return result
+        end
 
         if is_heredoc
           bounds(node.closing_loc)

--- a/test/prism/ruby/ripper_test.rb
+++ b/test/prism/ruby/ripper_test.rb
@@ -139,11 +139,11 @@ module Prism
       end
     end
 
-    UNSUPPORTED_EVENTS = %i[comma ignored_nl label_end nl semicolon sp ignored_sp]
+    UNSUPPORTED_EVENTS = %i[comma ignored_nl nl semicolon sp ignored_sp]
     # Events that are currently not emitted
     SUPPORTED_EVENTS = Translation::Ripper::EVENTS - UNSUPPORTED_EVENTS
     # Events that assert against their line/column
-    CHECK_LOCATION_EVENTS = %i[kw op lbrace rbrace lbracket rbracket lparen rparen words_sep]
+    CHECK_LOCATION_EVENTS = %i[kw op lbrace rbrace lbracket rbracket lparen rparen words_sep label_end]
 
     module Events
       attr_reader :events


### PR DESCRIPTION
It is emitted for string-like symbols only