### PR TITLE
Fix missing Ripper doc caused by shim with `:nodoc:`

### DIFF
--- a/lib/prism/translation/ripper/shim.rb
+++ b/lib/prism/translation/ripper/shim.rb
@@ -2,4 +2,6 @@
 
 # This writes the prism ripper translation into the Ripper constant so that
 # users can transparently use Ripper without any changes.
-Ripper = Prism::Translation::Ripper # :nodoc:
+# :stopdoc:
+Ripper = Prism::Translation::Ripper
+# :startdoc:


### PR DESCRIPTION
This fixes the missing Ripper documentation, which currently returns 404 Not Found:

<img width="407" height="102" alt="image" src="https://github.com/user-attachments/assets/09442d4c-275d-4873-a8dc-ba00e5067f23" />

https://docs.ruby-lang.org/en/master/Ripper.html

We need to use `:stopdoc:`/`startdoc:` instead of `:nodoc:` to ignore the shim markup.

See also https://ruby.github.io/rdoc/doc/markup_reference/rdoc_rdoc.html#directives

> [!NOTE]
> This PR is thanks to @st0012's [advice](https://x.com/_st0012/status/2048765110966247579?s=20). 😃 