### PR TITLE
Fix CI path excludes

### DIFF
--- a/.github/workflows/cpp-bindings.yml
+++ b/.github/workflows/cpp-bindings.yml
@@ -4,9 +4,9 @@ on:
   push:
     paths: &paths
       - ".github/workflows/cpp-bindings.yml"
-      - "include/"
-      - "src/"
-      - "cpp/"
+      - "include/**"
+      - "src/**"
+      - "cpp/**"
       - "*akefile*"
     branches:
       - main

--- a/.github/workflows/java-wasm-bindings.yml
+++ b/.github/workflows/java-wasm-bindings.yml
@@ -4,11 +4,11 @@ on:
   push:
     paths: &paths
       - ".github/workflows/java-wasm-bindings.yml"
-      - "include/"
-      - "src/"
+      - "include/**"
+      - "src/**"
       - "*akefile*"
-      - "java/"
-      - "java/wasm/"
+      - "java/**"
+      - "java/wasm/**"
     branches:
       - main
       - ruby-4.0

--- a/.github/workflows/javascript-bindings.yml
+++ b/.github/workflows/javascript-bindings.yml
@@ -4,8 +4,8 @@ on:
   push:
     paths: &paths
       - ".github/workflows/javascript-bindings.yml"
-      - "include/"
-      - "src/"
+      - "include/**"
+      - "src/**"
       - "*akefile*"
     branches:
       - main

--- a/.github/workflows/rust-bindings.yml
+++ b/.github/workflows/rust-bindings.yml
@@ -4,9 +4,9 @@ on:
   push:
     paths: &paths
       - ".github/workflows/rust-bindings.yml"
-      - "include/"
-      - "src/"
-      - "rust/"
+      - "include/**"
+      - "src/**"
+      - "rust/**"
       - "*akefile*"
     branches:
       - main

--- a/java/wasm/pom.xml
+++ b/java/wasm/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby-complete</artifactId>
-      <version>10.1.0.0</version>
+      <version>10.0.5.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
They need wildcards, otherwise they don't match.
Previously it always ran on PRs but in https://github.com/ruby/ruby-prism/commit/c4d202dc4866d6f03cc6cbda083a8950c6e6e42e I also applied it to PRs.
That means that previously it didn't run on main only.

This fixes this.