### PR TITLE
Fix UTF-8 code units to match the number of bytes

### DIFF
--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -189,6 +189,8 @@ module Prism
     #--
     #: (Integer byte_offset, Encoding encoding) -> Integer
     def code_units_offset(byte_offset, encoding)
+      return byte_offset if encoding == Encoding::UTF_8
+
       byteslice = (source.byteslice(0, byte_offset) or raise).encode(encoding, invalid: :replace, undef: :replace)
 
       if encoding == Encoding::UTF_16LE || encoding == Encoding::UTF_16BE
@@ -250,6 +252,14 @@ module Prism
   #   has not yet been implemented.
   #
   class CodeUnitsCache
+    # Counter used for UTF-8, where one code unit equals one byte.
+    class UTF8Counter # :nodoc:
+      #: (Integer byte_offset, Integer byte_length) -> Integer
+      def count(byte_offset, byte_length)
+        byte_length
+      end
+    end
+
     class UTF16Counter # :nodoc:
       # @rbs @source: String
       # @rbs @encoding: Encoding
@@ -266,7 +276,10 @@ module Prism
       end
     end
 
-    class LengthCounter # :nodoc:
+    # Counter used for UTF-32, where one code unit equals one code point and
+    # matches String#length. Also used as a best-effort fallback for any other
+    # encoding that does not have a dedicated counter.
+    class UTF32Counter # :nodoc:
       # @rbs @source: String
       # @rbs @encoding: Encoding
 
@@ -282,10 +295,10 @@ module Prism
       end
     end
 
-    private_constant :UTF16Counter, :LengthCounter
+    private_constant :UTF8Counter, :UTF16Counter, :UTF32Counter
 
     # @rbs @source: String
-    # @rbs @counter: UTF16Counter | LengthCounter
+    # @rbs @counter: UTF8Counter | UTF16Counter | UTF32Counter
     # @rbs @cache: Hash[Integer, Integer]
     # @rbs @offsets: Array[Integer]
 
@@ -295,10 +308,13 @@ module Prism
     def initialize(source, encoding)
       @source = source
       @counter =
-        if encoding == Encoding::UTF_16LE || encoding == Encoding::UTF_16BE
+        case encoding
+        when Encoding::UTF_8
+          UTF8Counter.new
+        when Encoding::UTF_16LE, Encoding::UTF_16BE
           UTF16Counter.new(source, encoding)
         else
-          LengthCounter.new(source, encoding)
+          UTF32Counter.new(source, encoding)
         end
 
       @cache = {} #: Hash[Integer, Integer]

--- a/rbi/generated/prism/parse_result.rbi
+++ b/rbi/generated/prism/parse_result.rbi
@@ -143,6 +143,12 @@ module Prism
   #   introduce some kind of LRU cache to limit the number of entries, but this
   #   has not yet been implemented.
   class CodeUnitsCache
+    # Counter used for UTF-8, where one code unit equals one byte.
+    class UTF8Counter
+      sig { params(byte_offset: Integer, byte_length: Integer).returns(Integer) }
+      def count(byte_offset, byte_length); end
+    end
+
     class UTF16Counter
       sig { params(source: String, encoding: Encoding).void }
       def initialize(source, encoding); end
@@ -151,7 +157,10 @@ module Prism
       def count(byte_offset, byte_length); end
     end
 
-    class LengthCounter
+    # Counter used for UTF-32, where one code unit equals one code point and
+    # matches String#length. Also used as a best-effort fallback for any other
+    # encoding that does not have a dedicated counter.
+    class UTF32Counter
       sig { params(source: String, encoding: Encoding).void }
       def initialize(source, encoding); end
 

--- a/sig/generated/prism/parse_result.rbs
+++ b/sig/generated/prism/parse_result.rbs
@@ -169,6 +169,12 @@ module Prism
   #   introduce some kind of LRU cache to limit the number of entries, but this
   #   has not yet been implemented.
   class CodeUnitsCache
+    # Counter used for UTF-8, where one code unit equals one byte.
+    class UTF8Counter
+      # : (Integer byte_offset, Integer byte_length) -> Integer
+      def count: (Integer byte_offset, Integer byte_length) -> Integer
+    end
+
     class UTF16Counter
       @source: String
 
@@ -181,7 +187,10 @@ module Prism
       def count: (Integer byte_offset, Integer byte_length) -> Integer
     end
 
-    class LengthCounter
+    # Counter used for UTF-32, where one code unit equals one code point and
+    # matches String#length. Also used as a best-effort fallback for any other
+    # encoding that does not have a dedicated counter.
+    class UTF32Counter
       @source: String
 
       @encoding: Encoding
@@ -195,7 +204,7 @@ module Prism
 
     @source: String
 
-    @counter: UTF16Counter | LengthCounter
+    @counter: UTF8Counter | UTF16Counter | UTF32Counter
 
     @cache: Hash[Integer, Integer]
 

--- a/test/prism/ruby/location_test.rb
+++ b/test/prism/ruby/location_test.rb
@@ -73,7 +73,7 @@ module Prism
       assert_equal 0, location.start_code_units_offset(Encoding::UTF_16LE)
       assert_equal 0, location.start_code_units_offset(Encoding::UTF_32LE)
 
-      assert_equal 1, location.end_code_units_offset(Encoding::UTF_8)
+      assert_equal 4, location.end_code_units_offset(Encoding::UTF_8)
       assert_equal 2, location.end_code_units_offset(Encoding::UTF_16LE)
       assert_equal 1, location.end_code_units_offset(Encoding::UTF_32LE)
 
@@ -81,37 +81,37 @@ module Prism
       assert_equal 0, location.start_code_units_column(Encoding::UTF_16LE)
       assert_equal 0, location.start_code_units_column(Encoding::UTF_32LE)
 
-      assert_equal 1, location.end_code_units_column(Encoding::UTF_8)
+      assert_equal 4, location.end_code_units_column(Encoding::UTF_8)
       assert_equal 2, location.end_code_units_column(Encoding::UTF_16LE)
       assert_equal 1, location.end_code_units_column(Encoding::UTF_32LE)
 
       # second 😀
       location = program.statements.body.first.arguments.arguments.first.location
 
-      assert_equal 4, location.start_code_units_offset(Encoding::UTF_8)
+      assert_equal 7, location.start_code_units_offset(Encoding::UTF_8)
       assert_equal 5, location.start_code_units_offset(Encoding::UTF_16LE)
       assert_equal 4, location.start_code_units_offset(Encoding::UTF_32LE)
 
-      assert_equal 5, location.end_code_units_offset(Encoding::UTF_8)
+      assert_equal 11, location.end_code_units_offset(Encoding::UTF_8)
       assert_equal 7, location.end_code_units_offset(Encoding::UTF_16LE)
       assert_equal 5, location.end_code_units_offset(Encoding::UTF_32LE)
 
-      assert_equal 4, location.start_code_units_column(Encoding::UTF_8)
+      assert_equal 7, location.start_code_units_column(Encoding::UTF_8)
       assert_equal 5, location.start_code_units_column(Encoding::UTF_16LE)
       assert_equal 4, location.start_code_units_column(Encoding::UTF_32LE)
 
-      assert_equal 5, location.end_code_units_column(Encoding::UTF_8)
+      assert_equal 11, location.end_code_units_column(Encoding::UTF_8)
       assert_equal 7, location.end_code_units_column(Encoding::UTF_16LE)
       assert_equal 5, location.end_code_units_column(Encoding::UTF_32LE)
 
       # first 😍
       location = program.statements.body.last.name_loc
 
-      assert_equal 6, location.start_code_units_offset(Encoding::UTF_8)
+      assert_equal 12, location.start_code_units_offset(Encoding::UTF_8)
       assert_equal 8, location.start_code_units_offset(Encoding::UTF_16LE)
       assert_equal 6, location.start_code_units_offset(Encoding::UTF_32LE)
 
-      assert_equal 7, location.end_code_units_offset(Encoding::UTF_8)
+      assert_equal 16, location.end_code_units_offset(Encoding::UTF_8)
       assert_equal 10, location.end_code_units_offset(Encoding::UTF_16LE)
       assert_equal 7, location.end_code_units_offset(Encoding::UTF_32LE)
 
@@ -119,26 +119,26 @@ module Prism
       assert_equal 0, location.start_code_units_column(Encoding::UTF_16LE)
       assert_equal 0, location.start_code_units_column(Encoding::UTF_32LE)
 
-      assert_equal 1, location.end_code_units_column(Encoding::UTF_8)
+      assert_equal 4, location.end_code_units_column(Encoding::UTF_8)
       assert_equal 2, location.end_code_units_column(Encoding::UTF_16LE)
       assert_equal 1, location.end_code_units_column(Encoding::UTF_32LE)
 
       # second 😍
       location = program.statements.body.last.value.location
 
-      assert_equal 12, location.start_code_units_offset(Encoding::UTF_8)
+      assert_equal 21, location.start_code_units_offset(Encoding::UTF_8)
       assert_equal 15, location.start_code_units_offset(Encoding::UTF_16LE)
       assert_equal 12, location.start_code_units_offset(Encoding::UTF_32LE)
 
-      assert_equal 13, location.end_code_units_offset(Encoding::UTF_8)
+      assert_equal 25, location.end_code_units_offset(Encoding::UTF_8)
       assert_equal 17, location.end_code_units_offset(Encoding::UTF_16LE)
       assert_equal 13, location.end_code_units_offset(Encoding::UTF_32LE)
 
-      assert_equal 6, location.start_code_units_column(Encoding::UTF_8)
+      assert_equal 9, location.start_code_units_column(Encoding::UTF_8)
       assert_equal 7, location.start_code_units_column(Encoding::UTF_16LE)
       assert_equal 6, location.start_code_units_column(Encoding::UTF_32LE)
 
-      assert_equal 7, location.end_code_units_column(Encoding::UTF_8)
+      assert_equal 13, location.end_code_units_column(Encoding::UTF_8)
       assert_equal 9, location.end_code_units_column(Encoding::UTF_16LE)
       assert_equal 7, location.end_code_units_column(Encoding::UTF_32LE)
     end
@@ -157,7 +157,7 @@ module Prism
       assert_equal 0, location.cached_start_code_units_offset(utf16_cache)
       assert_equal 0, location.cached_start_code_units_offset(utf32_cache)
 
-      assert_equal 1, location.cached_end_code_units_offset(utf8_cache)
+      assert_equal 4, location.cached_end_code_units_offset(utf8_cache)
       assert_equal 2, location.cached_end_code_units_offset(utf16_cache)
       assert_equal 1, location.cached_end_code_units_offset(utf32_cache)
 
@@ -165,26 +165,26 @@ module Prism
       assert_equal 0, location.cached_start_code_units_column(utf16_cache)
       assert_equal 0, location.cached_start_code_units_column(utf32_cache)
 
-      assert_equal 1, location.cached_end_code_units_column(utf8_cache)
+      assert_equal 4, location.cached_end_code_units_column(utf8_cache)
       assert_equal 2, location.cached_end_code_units_column(utf16_cache)
       assert_equal 1, location.cached_end_code_units_column(utf32_cache)
 
       # second 😀
       location = result.value.statements.body.first.arguments.arguments.first.location
 
-      assert_equal 4, location.cached_start_code_units_offset(utf8_cache)
+      assert_equal 7, location.cached_start_code_units_offset(utf8_cache)
       assert_equal 5, location.cached_start_code_units_offset(utf16_cache)
       assert_equal 4, location.cached_start_code_units_offset(utf32_cache)
 
-      assert_equal 5, location.cached_end_code_units_offset(utf8_cache)
+      assert_equal 11, location.cached_end_code_units_offset(utf8_cache)
       assert_equal 7, location.cached_end_code_units_offset(utf16_cache)
       assert_equal 5, location.cached_end_code_units_offset(utf32_cache)
 
-      assert_equal 4, location.cached_start_code_units_column(utf8_cache)
+      assert_equal 7, location.cached_start_code_units_column(utf8_cache)
       assert_equal 5, location.cached_start_code_units_column(utf16_cache)
       assert_equal 4, location.cached_start_code_units_column(utf32_cache)
 
-      assert_equal 5, location.cached_end_code_units_column(utf8_cache)
+      assert_equal 11, location.cached_end_code_units_column(utf8_cache)
       assert_equal 7, location.cached_end_code_units_column(utf16_cache)
       assert_equal 5, location.cached_end_code_units_column(utf32_cache)
     end
@@ -200,7 +200,7 @@ module Prism
       assert_equal "😀".b.to_sym, receiver.name
 
       location = receiver.location
-      assert_equal 1, location.end_code_units_column(Encoding::UTF_8)
+      assert_equal 4, location.end_code_units_column(Encoding::UTF_8)
       assert_equal 2, location.end_code_units_column(Encoding::UTF_16LE)
       assert_equal 1, location.end_code_units_column(Encoding::UTF_32LE)
     end


### PR DESCRIPTION
I was seeing some weird results for UTF-8 in the Ruby LSP and I realized we actually made a mistake when implementing the code unit offsets. The idea is for this method to return code units (not code points!). That means:

- UTF-32: number of characters
- UTF-16: the weird code unit count with 1/2 byte characters being length 1 and 3/4 byte characters length 2
- UTF-8: **number of bytes**

[Spec reference](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#positionEncodingKind): see the comments above each position encoding kind.

We are actually not returning the number of bytes, but the string length, which is incorrect. It's easy to see the mistake in the tests: the location of an emoji (4 bytes) was 1 before (single character).

This PR makes sure that we're returning the number of bytes for UTF-8, which is the amount expected for code units.

Basically, I added a UTF-8 counter that just returns the number of bytes and tried to ensure naming consistency across the counters.