### PR TITLE
Check host_os rather than RUBY_PLATFORM

### DIFF
--- a/ext/prism/extconf.rb
+++ b/ext/prism/extconf.rb
@@ -50,7 +50,7 @@ def make(env, target)
   Dir.chdir(File.expand_path("../..", __dir__)) do
     system(
       env,
-      RbConfig::CONFIG['host_os'].match?(/openbsd|freebsd/) ? "gmake" : "make",
+      RbConfig::CONFIG['host_os'].match?(/openbsd|freebsd/i) ? "gmake" : "make",
       target,
       exception: true
     )

--- a/ext/prism/extconf.rb
+++ b/ext/prism/extconf.rb
@@ -50,7 +50,7 @@ def make(env, target)
   Dir.chdir(File.expand_path("../..", __dir__)) do
     system(
       env,
-      RUBY_PLATFORM.match?(/openbsd|freebsd/) ? "gmake" : "make",
+      RbConfig::CONFIG['host_os'].match?(/openbsd|freebsd/) ? "gmake" : "make",
       target,
       exception: true
     )


### PR DESCRIPTION
RUBY_PLATFORM has been "java" on JRuby since the mid 2000s, so use "host_os" from RbConfig::CONFIG to compare the host platform.

This fixes installs on FreeBSD and OpenBSD which need to use gmake instead of make.

cc @jeremyevans who ran into this upgrading minitest while running JRuby on OpenBSD. Please confirm!