### PR TITLE
Use less `visit_token` in the ripper translator

### DIFF
--- a/lib/prism/translation/ripper.rb
+++ b/lib/prism/translation/ripper.rb
@@ -1088,7 +1088,7 @@ module Prism
           on_blockarg(nil)
         else
           bounds(node.name_loc)
-          name = visit_token(node.name.to_s)
+          name = on_ident(node.name.to_s)
 
           bounds(node.location)
           on_blockarg(name)
@@ -1303,7 +1303,7 @@ module Prism
           receiver = visit(node.receiver)
 
           bounds(node.call_operator_loc)
-          call_operator = visit_token(node.call_operator)
+          call_operator = visit_call_operator(node.call_operator)
 
           message =
             if node.message_loc.nil?
@@ -1414,7 +1414,7 @@ module Prism
         receiver = visit(node.receiver)
 
         bounds(node.call_operator_loc)
-        call_operator = visit_token(node.call_operator)
+        call_operator = visit_call_operator(node.call_operator)
 
         bounds(node.message_loc)
         message = visit_token(node.message)
@@ -1436,7 +1436,7 @@ module Prism
         receiver = visit(node.receiver)
 
         bounds(node.call_operator_loc)
-        call_operator = visit_token(node.call_operator)
+        call_operator = visit_call_operator(node.call_operator)
 
         bounds(node.message_loc)
         message = visit_token(node.message)
@@ -1458,7 +1458,7 @@ module Prism
         receiver = visit(node.receiver)
 
         bounds(node.call_operator_loc)
-        call_operator = visit_token(node.call_operator)
+        call_operator = visit_call_operator(node.call_operator)
 
         bounds(node.message_loc)
         message = visit_token(node.message)
@@ -1492,7 +1492,7 @@ module Prism
           receiver = visit(node.receiver)
 
           bounds(node.call_operator_loc)
-          call_operator = visit_token(node.call_operator)
+          call_operator = visit_call_operator(node.call_operator)
 
           bounds(node.message_loc)
           message = visit_token(node.message)
@@ -1604,9 +1604,6 @@ module Prism
 
       # @@foo = 1
       # ^^^^^^^^^
-      #
-      # @@foo, @@bar = 1
-      # ^^^^^  ^^^^^
       def visit_class_variable_write_node(node)
         bounds(node.name_loc)
         target = on_var_field(on_cvar(node.name.to_s))
@@ -1678,9 +1675,6 @@ module Prism
 
       # Foo = 1
       # ^^^^^^^
-      #
-      # Foo, Bar = 1
-      # ^^^  ^^^
       def visit_constant_write_node(node)
         bounds(node.name_loc)
         target = on_var_field(on_const(node.name.to_s))
@@ -1773,9 +1767,6 @@ module Prism
 
       # Foo::Bar = 1
       # ^^^^^^^^^^^^
-      #
-      # Foo::Foo, Bar::Bar = 1
-      # ^^^^^^^^  ^^^^^^^^
       def visit_constant_path_write_node(node)
         target = visit_constant_path_write_node_target(node.target)
 
@@ -1873,7 +1864,7 @@ module Prism
         operator =
           if !node.operator_loc.nil?
             bounds(node.operator_loc)
-            visit_token(node.operator)
+            node.operator == "." ? on_period(".") : on_op("::")
           end
 
         bounds(node.name_loc)
@@ -2188,9 +2179,6 @@ module Prism
 
       # $foo = 1
       # ^^^^^^^^
-      #
-      # $foo, $bar = 1
-      # ^^^^  ^^^^
       def visit_global_variable_write_node(node)
         bounds(node.name_loc)
         target = on_var_field(on_gvar(node.name.to_s))
@@ -3152,7 +3140,7 @@ module Prism
       #         ^^^^^^^
       def visit_optional_parameter_node(node)
         bounds(node.name_loc)
-        name = visit_token(node.name.to_s)
+        name = on_ident(node.name.to_s)
 
         bounds(node.operator_loc)
         on_op("=")
@@ -3473,7 +3461,7 @@ module Prism
           on_rest_param(nil)
         else
           bounds(node.name_loc)
-          on_rest_param(visit_token(node.name.to_s))
+          on_rest_param(on_ident(node.name.to_s))
         end
       end
 
@@ -4073,6 +4061,11 @@ module Prism
         else
           on_ident(token)
         end
+      end
+
+      # Visit either `.`, `&.`, or `::`.
+      def visit_call_operator(token)
+        token == "." ? on_period(token) : on_op(token)
       end
 
       # Visit a node that represents a number. We need to explicitly handle the

--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -394,9 +394,6 @@ module Prism
 
         # @@foo = 1
         # ^^^^^^^^^
-        #
-        # @@foo, @@bar = 1
-        # ^^^^^  ^^^^^
         def visit_class_variable_write_node(node)
           s(node, class_variable_write_type, node.name, visit_write_value(node.value))
         end
@@ -651,9 +648,6 @@ module Prism
 
         # $foo = 1
         # ^^^^^^^^
-        #
-        # $foo, $bar = 1
-        # ^^^^  ^^^^
         def visit_global_variable_write_node(node)
           s(node, :gasgn, node.name, visit_write_value(node.value))
         end
@@ -799,9 +793,6 @@ module Prism
 
         # @foo = 1
         # ^^^^^^^^
-        #
-        # @foo, @bar = 1
-        # ^^^^  ^^^^
         def visit_instance_variable_write_node(node)
           s(node, :iasgn, node.name, visit_write_value(node.value))
         end
@@ -1013,9 +1004,6 @@ module Prism
 
         # foo = 1
         # ^^^^^^^
-        #
-        # foo, bar = 1
-        # ^^^  ^^^
         def visit_local_variable_write_node(node)
           s(node, :lasgn, node.name, visit_write_value(node.value))
         end


### PR DESCRIPTION
The ripper translator is a good resource when porting ripper usage over to prism

A few places use `visit_token` when it can be more specific. A call operator for example can ever only be one of three things. A positional argument can only ever be a identifier (no constant, no global, etc.)

Also removes some stale comments. There are `*_TargetNode` for these now.