### PR TITLE
Fix CI caused by bundler issue

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: ruby
         bundler-cache: true
 
     - name: Build library

--- a/.github/workflows/cpp-bindings.yml
+++ b/.github/workflows/cpp-bindings.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: head
+          ruby-version: ruby
           bundler-cache: true
       - name: Compile prism
         run: bundle exec rake compile

--- a/.github/workflows/cruby-bindings.yml
+++ b/.github/workflows/cruby-bindings.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up latest ruby head
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: head
+          ruby-version: ruby
           bundler: none
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.3"
+        ruby-version: ruby
         bundler-cache: true
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: ruby
           bundler-cache: true
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/java-wasm-bindings.yml
+++ b/.github/workflows/java-wasm-bindings.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: head
+          ruby-version: ruby
           bundler-cache: true
 
       - name: rake templates

--- a/.github/workflows/javascript-bindings.yml
+++ b/.github/workflows/javascript-bindings.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: head
+          ruby-version: ruby
           bundler-cache: true
 
       - name: rake templates

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.4"
+        ruby-version: ruby
         bundler-cache: true
     - name: Lint
       run: bundle exec rake lint
@@ -49,7 +49,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.4"
+        ruby-version: ruby
         bundler-cache: true
     - name: Check Sorbet
       run: bundle exec rake typecheck:tapioca typecheck:sorbet
@@ -73,7 +73,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: ruby
         bundler-cache: true
     - name: Run Ruby tests
       run: bundle exec rake
@@ -133,7 +133,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: ruby
         bundler-cache: true
     - name: Run Ruby tests
       run: bundle exec rake compile_no_debug test
@@ -153,7 +153,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: ruby
         bundler-cache: true
     - name: Run Ruby tests
       run: bundle exec rake
@@ -167,7 +167,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: ruby
         bundler-cache: true
     - name: Run Ruby tests
       run: bundle exec rake compile_minimal test
@@ -219,7 +219,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: ruby
         bundler-cache: true
     - name: Lex ruby/ruby
       run: bundle exec rake lex:ruby
@@ -231,7 +231,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: ruby
         bundler-cache: true
     - name: Lex discourse/discourse
       run: bundle exec rake lex:discourse
@@ -243,7 +243,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: ruby
         bundler-cache: true
     - name: Lex Top 100 Gems
       run: bundle exec rake lex:topgems
@@ -258,6 +258,8 @@ jobs:
 
   memcheck:
     runs-on: ubuntu-24.04
+    env:
+      BUNDLER_VERSION: '0' # https://github.com/ruby/ruby/pull/16909
     steps:
     - uses: actions/checkout@v6
     - name: Install valgrind
@@ -278,7 +280,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: ruby
         bundler-cache: true
     - run: bundle config --local frozen false
     - run: bundle exec rake build:dev
@@ -355,7 +357,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: ruby
         bundler-cache: true
     - name: Run build with gcc-analyzer enabled
       run: |
@@ -368,7 +370,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: ruby
         bundler-cache: true
     - name: Install clang-analyzer
       run: sudo apt-get install -y clang-tools

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: ruby
           bundler-cache: true
 
       - uses: rust-lang/crates-io-auth-action@v1

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: ruby
           bundler-cache: true
 
       - name: Publish to RubyGems

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: ruby
           bundler-cache: true
 
       - name: Set up node

--- a/.github/workflows/rust-bindings.yml
+++ b/.github/workflows/rust-bindings.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4
+          ruby-version: ruby
           bundler-cache: true
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4
+          ruby-version: ruby
           bundler-cache: true
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
@@ -90,7 +90,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4
+          ruby-version: ruby
           bundler-cache: true
       - name: rake cargo:build
         run: bundle exec rake cargo:build


### PR DESCRIPTION
Current latest released bundler is incompatible with ruby-head, I want to fix that in https://github.com/ruby/ruby/pull/16909. This makes CI green again.

Many jobs used ruby-head but I don't think they actually need that. I only left tests and memcheck against ruby-head, the others all just use the latest released ruby now.