### PR TITLE
Clarify the documentation of -x, it always searches a shebang that includes "ruby"

### DIFF
--- a/include/prism/options.h
+++ b/include/prism/options.h
@@ -103,7 +103,7 @@ static const uint8_t PM_OPTIONS_COMMAND_LINE_P = 0x10;
 
 /**
  * A bit representing whether or not the command line -x option was set. -x
- * searches the input file for a shebang that matches the current Ruby engine.
+ * searches the input file for a shebang that includes "ruby".
  */
 static const uint8_t PM_OPTIONS_COMMAND_LINE_X = 0x20;
 

--- a/src/prism.c
+++ b/src/prism.c
@@ -22280,8 +22280,8 @@ parse_program(pm_parser_t *parser) {
 
 /**
  * A vendored version of strnstr that is used to find a substring within a
- * string with a given length. This function is used to search for the Ruby
- * engine name within a shebang when the -x option is passed to Ruby.
+ * string with a given length. This function is used to search for "ruby"
+ * within a shebang when the -x option is passed to Ruby.
  *
  * The only modification that we made here is that we don't do NULL byte checks
  * because we know the little parameter will not have a NULL byte and we allow


### PR DESCRIPTION
See https://github.com/ruby/prism/blob/5172b2a0843f67d5fa9bd462ef0b84f88392d412/src/prism.c#L22503-L22506