### PR TITLE
Fix typo for big-endian JS bindings

### DIFF
--- a/templates/javascript/src/deserialize.js.erb
+++ b/templates/javascript/src/deserialize.js.erb
@@ -14,7 +14,7 @@ const LITTLE_ENDIAN = (() => {
 
   if (uint8[0] === 0x44) {
     return true;
-  } else if (uInt8[0] === 0x11) {
+  } else if (uint8[0] === 0x11) {
     return false;
   } else {
     throw new Error("Mixed endianness");


### PR DESCRIPTION
Fixes #4109