### PR TITLE
Reject modifier conditionals in `if`/`unless` predicates

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -15486,7 +15486,7 @@ parse_conditional(pm_parser_t *parser, pm_context_t context, size_t opening_newl
     pm_token_t keyword = parser->previous;
     pm_token_t then_keyword = { 0 };
 
-    pm_node_t *predicate = parse_predicate(parser, PM_BINDING_POWER_MODIFIER, context, &then_keyword, (uint16_t) (depth + 1));
+    pm_node_t *predicate = parse_predicate(parser, PM_BINDING_POWER_MODIFIER + 1, context, &then_keyword, (uint16_t) (depth + 1));
     pm_statements_node_t *statements = NULL;
 
     if (!match3(parser, PM_TOKEN_KEYWORD_ELSIF, PM_TOKEN_KEYWORD_ELSE, PM_TOKEN_KEYWORD_END)) {
@@ -15524,7 +15524,7 @@ parse_conditional(pm_parser_t *parser, pm_context_t context, size_t opening_newl
             pm_token_t elsif_keyword = parser->current;
             parser_lex(parser);
 
-            pm_node_t *predicate = parse_predicate(parser, PM_BINDING_POWER_MODIFIER, PM_CONTEXT_ELSIF, &then_keyword, (uint16_t) (depth + 1));
+            pm_node_t *predicate = parse_predicate(parser, PM_BINDING_POWER_MODIFIER + 1, PM_CONTEXT_ELSIF, &then_keyword, (uint16_t) (depth + 1));
             pm_accepts_block_stack_push(parser, true);
 
             pm_statements_node_t *statements = parse_statements(parser, PM_CONTEXT_ELSIF, (uint16_t) (depth + 1));

--- a/src/prism.c
+++ b/src/prism.c
@@ -15486,7 +15486,7 @@ parse_conditional(pm_parser_t *parser, pm_context_t context, size_t opening_newl
     pm_token_t keyword = parser->previous;
     pm_token_t then_keyword = { 0 };
 
-    pm_node_t *predicate = parse_predicate(parser, PM_BINDING_POWER_MODIFIER + 1, context, &then_keyword, (uint16_t) (depth + 1));
+    pm_node_t *predicate = parse_predicate(parser, PM_BINDING_POWER_COMPOSITION, context, &then_keyword, (uint16_t) (depth + 1));
     pm_statements_node_t *statements = NULL;
 
     if (!match3(parser, PM_TOKEN_KEYWORD_ELSIF, PM_TOKEN_KEYWORD_ELSE, PM_TOKEN_KEYWORD_END)) {
@@ -15524,7 +15524,7 @@ parse_conditional(pm_parser_t *parser, pm_context_t context, size_t opening_newl
             pm_token_t elsif_keyword = parser->current;
             parser_lex(parser);
 
-            pm_node_t *predicate = parse_predicate(parser, PM_BINDING_POWER_MODIFIER + 1, PM_CONTEXT_ELSIF, &then_keyword, (uint16_t) (depth + 1));
+            pm_node_t *predicate = parse_predicate(parser, PM_BINDING_POWER_COMPOSITION, PM_CONTEXT_ELSIF, &then_keyword, (uint16_t) (depth + 1));
             pm_accepts_block_stack_push(parser, true);
 
             pm_statements_node_t *statements = parse_statements(parser, PM_CONTEXT_ELSIF, (uint16_t) (depth + 1));

--- a/test/prism/errors/modifier_conditional_in_predicate.txt
+++ b/test/prism/errors/modifier_conditional_in_predicate.txt
@@ -1,0 +1,12 @@
+if a if b then end
+     ^~ expected `then` or `;` or '\n'
+     ^~ unexpected 'if', ignoring it
+          ^~~~ unexpected 'then', expecting end-of-input
+          ^~~~ unexpected 'then', ignoring it
+
+unless a unless b then end
+         ^~~~~~ expected `then` or `;` or '\n'
+         ^~~~~~ unexpected 'unless', ignoring it
+                  ^~~~ unexpected 'then', expecting end-of-input
+                  ^~~~ unexpected 'then', ignoring it
+


### PR DESCRIPTION
Fixes [Bug #22089](https://bugs.ruby-lang.org/issues/22089).

Prism accepted a statement modifier (`if`/`unless`/`while`/`until`) in an `if`/`unless`/`elsif` condition, while parse.y rejects it.

```ruby
if a if b then end   # parse.y: SyntaxError, Prism: accepted
```

Those conditions were parsed with a binding-power floor of `PM_BINDING_POWER_MODIFIER`. That floor is inclusive: statement modifiers have left binding power `PM_BINDING_POWER_MODIFIER`, so they were consumed as part of the condition. `while`/`until` conditions already use `PM_BINDING_POWER_COMPOSITION` and reject this syntax.

This raises the floor to `PM_BINDING_POWER_MODIFIER + 1`, which keeps `and`/`or` and tighter operators in the condition but excludes statement modifiers, matching parse.y.

`while`/`until` use `PM_BINDING_POWER_COMPOSITION` for the same effect because there is currently no precedence between `MODIFIER` and `COMPOSITION`. I used `PM_BINDING_POWER_MODIFIER + 1` to match the existing `+ 1` floor idiom (`PM_BINDING_POWER_DEFINED + 1`, `PM_BINDING_POWER_MATCH + 1`) and state the boundary directly. I can switch this to `PM_BINDING_POWER_COMPOSITION` if keeping the paths aligned is preferred.

Added an error fixture under `test/prism/errors/`.