### PR TITLE
Fix multibyte non-alphanumeric chars for bare percent string literals

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -11094,6 +11094,7 @@ parser_lex(pm_parser_t *parser) {
                         if (!parser->encoding->alnum_char(parser->current.end, parser->end - parser->current.end)) {
                             if (*parser->current.end >= 0x80) {
                                 pm_parser_err_current(parser, PM_ERR_INVALID_PERCENT);
+                                goto lex_next_token;
                             }
 
                             const uint8_t delimiter = pm_lex_percent_delimiter(parser);

--- a/test/prism/errors/alnum_delimiters_10.txt
+++ b/test/prism/errors/alnum_delimiters_10.txt
@@ -1,0 +1,4 @@
+%â
+^ unknown type of %string
+â
+

--- a/test/prism/errors/alnum_delimiters_11.txt
+++ b/test/prism/errors/alnum_delimiters_11.txt
@@ -1,0 +1,4 @@
+%💎
+^ unknown type of %string
+💎
+


### PR DESCRIPTION
Fixes #4130

Alphanumerics are correctly handled in the check below by simply discarding the `%`.
The same was not true for the other types, which caused some assumption to no longer hold.