### PR TITLE
[Feature #22108] Computed hash keys with (expr): syntax

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -13679,7 +13679,9 @@ parse_assocs(pm_parser_t *parser, pm_static_literals_t *literals, pm_node_t *nod
                 pm_hash_key_static_literals_add(parser, literals, key);
 
                 pm_token_t operator = { 0 };
-                if (!pm_symbol_node_label_p(parser, key)) {
+                if (PM_NODE_TYPE_P(key, PM_PARENTHESES_NODE) && (parser->start + key->location.start + key->location.length) == parser->current.start && accept1(parser, PM_TOKEN_COLON)) {
+                    // Computed hash key (expr): — no => needed
+                } else if (!pm_symbol_node_label_p(parser, key)) {
                     expect1(parser, PM_TOKEN_EQUAL_GREATER, PM_ERR_HASH_ROCKET);
                     operator = parser->previous;
                 }


### PR DESCRIPTION
Add support for computed property keys in hash literals:

```ruby
h = { (expression): value }
```

In parse_assocs, when the default case encounters a PM_PARENTHESES_NODE key followed by PM_TOKEN_COLON with no intervening space, treat it as a computed hash key association.

This is the PRISM counterpart to:
 * ruby/ruby#17299 (which implements the same syntax in the CRuby parse.y parser)

(Potetentially) obsoleted by:
 * https://github.com/ruby/prism/pull/4134


Assisted-by: OpenCode 1.17.3 (opencode/big-pickle)