### PR TITLE
[Feature #22111] Non-symbolic hash keys with expr-colon syntax

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -13680,8 +13680,12 @@ parse_assocs(pm_parser_t *parser, pm_static_literals_t *literals, pm_node_t *nod
 
                 pm_token_t operator = { 0 };
                 if (!pm_symbol_node_label_p(parser, key)) {
-                    expect1(parser, PM_TOKEN_EQUAL_GREATER, PM_ERR_HASH_ROCKET);
-                    operator = parser->previous;
+                    if (accept1(parser, PM_TOKEN_COLON)) {
+                        operator = parser->previous;
+                    } else {
+                        expect1(parser, PM_TOKEN_EQUAL_GREATER, PM_ERR_HASH_ROCKET);
+                        operator = parser->previous;
+                    }
                 }
 
                 pm_node_t *value = parse_value_expression(parser, PM_BINDING_POWER_DEFINED, PM_PARSE_ACCEPTS_DO_BLOCK, PM_ERR_HASH_VALUE, (uint16_t) (depth + 1));


### PR DESCRIPTION
Add support for computed property keys via expr-colon syntax:

```ruby
h = { expr : value }
```

In parse_assocs, when pm_symbol_node_label_p returns false for a key node and the following token is PM_TOKEN_COLON, treat it as a computed hash key association rather than a label.

This is the PRISM counterpart to:
 * ruby/ruby/pull/17299 (which implements the same syntax via a grammar rule in parse.y)


Assisted-by: OpenCode 1.17.3 (opencode/big-pickle)