### PR TITLE
Fix `Prism.parse_comments` locations for FFI backend

### DIFF
--- a/include/prism/internal/serialize.h
+++ b/include/prism/internal/serialize.h
@@ -15,6 +15,11 @@
 #ifndef PRISM_EXCLUDE_SERIALIZATION
 
 /*
+ * Serialize the given list of offsets to the given buffer.
+ */
+void pm_serialize_line_offset_list(pm_line_offset_list_t *list, pm_buffer_t *buffer);
+
+/*
  * Serialize the given list of comments to the given buffer.
  */
 void pm_serialize_comment_list(pm_list_t *list, pm_buffer_t *buffer);

--- a/src/prism.c
+++ b/src/prism.c
@@ -22933,6 +22933,7 @@ pm_serialize_parse_comments(pm_buffer_t *buffer, const uint8_t *source, size_t s
     pm_serialize_header(buffer);
     pm_serialize_encoding(parser.encoding, buffer);
     pm_buffer_append_varsint(buffer, parser.start_line);
+    pm_serialize_line_offset_list(&parser.line_offsets, buffer);
     pm_serialize_comment_list(&parser.comment_list, buffer);
 
     pm_parser_cleanup(&parser);

--- a/templates/lib/prism/serialize.rb.erb
+++ b/templates/lib/prism/serialize.rb.erb
@@ -135,8 +135,10 @@ module Prism
                    loader.load_header
                    loader.load_encoding
       start_line = loader.load_varsint
+      offsets    = loader.load_line_offsets(freeze)
 
       source.replace_start_line(start_line)
+      source.replace_offsets(offsets)
 
       result =     loader.load_comments(freeze)
       raise unless loader.eof?

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -156,7 +156,10 @@ pm_serialize_node(pm_parser_t *parser, pm_node_t *node, pm_buffer_t *buffer) {
     }
 }
 
-static void
+/*
+ * Serialize the given list of offsets to the given buffer.
+ */
+void
 pm_serialize_line_offset_list(pm_line_offset_list_t *list, pm_buffer_t *buffer) {
     uint32_t size = pm_sizet_to_u32(list->size);
     pm_buffer_append_varuint(buffer, size);

--- a/test/prism/api/parse_comments_test.rb
+++ b/test/prism/api/parse_comments_test.rb
@@ -9,6 +9,8 @@ module Prism
 
       assert_kind_of Array, comments
       assert_equal 1, comments.length
+      assert_equal 1, comments[0].location.start_line
+      assert_equal "# foo", comments[0].slice
     end
 
     def test_parse_file_comments


### PR DESCRIPTION
Offsets are not serialized but the locations require them to work correctly.

`start_line` returned 0 previously.