### PR TITLE
Update redline and release 0.0.4 of Java API

### DIFF
--- a/java/api/pom.xml
+++ b/java/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ruby-lang</groupId>
     <artifactId>prism-parser</artifactId>
-    <version>0.0.4-SNAPSHOT</version>
+    <version>0.0.4</version>
   </parent>
 
   <artifactId>prism-parser-api</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.ruby-lang</groupId>
   <artifactId>prism-parser</artifactId>
-  <version>0.0.4-SNAPSHOT</version>
+  <version>0.0.4</version>
   <packaging>pom</packaging>
   <name>Java Prism</name>
   <description>Java API for the Prism Ruby language parser</description>

--- a/java/wasm/pom.xml
+++ b/java/wasm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ruby-lang</groupId>
     <artifactId>prism-parser</artifactId>
-    <version>0.0.4-SNAPSHOT</version>
+    <version>0.0.4</version>
   </parent>
 
   <artifactId>prism-parser-wasm</artifactId>
@@ -15,7 +15,7 @@
 
   <properties>
     <chicory.version>1.7.5</chicory.version>
-    <redline.version>0.0.4</redline.version>
+    <redline.version>0.0.5</redline.version>
   </properties>
 
   <dependencyManagement>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.ruby-lang</groupId>
       <artifactId>prism-parser-api</artifactId>
-      <version>0.0.4-SNAPSHOT</version>
+      <version>0.0.4</version>
     </dependency>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>


### PR DESCRIPTION
This release just includes updates from main up to today plus a move to chicory-redline 0.0.5 to permanently resolve a dependency conflict in JRuby.

See https://github.com/roastedroot/chicory-redline/pull/20 for the change to redline.

This release blocks JRuby 10.1.1.0 from updating other dependencies due to this conflict. See https://github.com/jruby/jruby/pull/9511 for that update.