### PR TITLE
Fix stack-use-after-return with unterminated heredocs

### DIFF
--- a/src/prism.c
+++ b/src/prism.c
@@ -19816,6 +19816,18 @@ parse_expression_prefix(pm_parser_t *parser, pm_binding_power_t binding_power, u
                 }
             }
 
+            /* If a missing terminator left this heredoc's lex mode on the
+             * stack, it still points at our stack-local common_whitespace.
+             * Clear the pointer so that subsequent lexing cannot read from
+             * this function's dead stack frame. */
+            pm_lex_mode_t *whitespace_mode = parser->lex_modes.current;
+            do {
+                if (whitespace_mode->mode == PM_LEX_HEREDOC && whitespace_mode->as.heredoc.common_whitespace == &common_whitespace) {
+                    whitespace_mode->as.heredoc.common_whitespace = NULL;
+                }
+                whitespace_mode = whitespace_mode->prev;
+            } while (whitespace_mode != NULL);
+
             if (match1(parser, PM_TOKEN_STRING_BEGIN)) {
                 return parse_strings(parser, node, false, (uint16_t) (depth + 1));
             }


### PR DESCRIPTION
This fixes a stack-use-after-return found while fuzzing mruby, which vendors Prism as its compiler.

Reproduction (24 bytes, minimized from a clusterfuzz testcase):

```ruby
`#{r{<<~0
#{{i}w<<0
0
}
```

Parsing this source under valgrind, or ASan with `detect_stack_use_after_return=1`, reports reads of a dead stack frame in `parser_lex`:

```
READ of size 8 at ... thread T0
    #0 parser_lex src/prism.c (heredoc common_whitespace check)
    #1 parse_string_part
    #2 parse_expression_prefix
    ...
Address ... is located in stack of thread T0 in frame parse_expression_prefix
    'common_whitespace' <== Memory access is inside this variable
```

Cause: the `PM_TOKEN_HEREDOC_START` handler in `parse_expression_prefix` stores the address of its stack-local `common_whitespace` into the heredoc lex mode so that the lexer can report the common leading whitespace back to the parser. On well-formed input the lex mode is popped when `PM_TOKEN_HEREDOC_END` is lexed, before the handler returns. When the terminator is missing, however, `expect1_heredoc_term` only records an error and does not pop the lex mode, so the stored pointer outlives the handler's stack frame. Subsequent lexing, still in heredoc mode, then dereferences the dangling pointer at the `common_whitespace` checks in `parser_lex`.

Fix: before leaving the handler, walk the lex mode stack and clear any `common_whitespace` pointer that still points at the handler's local. The lexer already guards the pointer against NULL, so this degrades gracefully; the dedent width is lost, but the source is a syntax error at that point anyway.

I verified the fix with valgrind and ASan on the v1.9.0 sources vendored in mruby, and the same code is present on main.