### PR TITLE
Improve Ripper compatibiliy layer and emit :on_embexpr_end for unmatched closing brace

### DIFF
--- a/lib/prism/lex_compat.rb
+++ b/lib/prism/lex_compat.rb
@@ -846,6 +846,8 @@ module Prism
 
       cache = Translation::Ripper::LineAndColumnCache.new(source)
 
+      brace_depth = 0
+
       tokens.each do |token|
         # Skip missing heredoc ends.
         next if token[1] == :on_heredoc_end && token[2] == ""
@@ -853,6 +855,24 @@ module Prism
         # Add :on_sp tokens.
         line, column = token[0]
         start_offset = source.byte_offset(line, column)
+
+        # Replicate a Ripper quirk where exactly the first unmatched closing
+        # brace is emitted as :on_embexpr_end, and any subsequent ones are :on_rbrace.
+        #
+        # Track brace nesting depth to handle unmatched closing braces.
+        # :on_lbrace (hashes/blocks), :on_embexpr_beg (interpolation), and :on_tlambeg (lambdas)
+        # all start a curly brace context balanced by a closing }.
+        case token[1]
+        when :on_lbrace, :on_embexpr_beg, :on_tlambeg
+          brace_depth += 1
+        when :on_rbrace
+          if brace_depth == 0
+            token = [token[0], :on_embexpr_end, token[2], prev_token_state]
+          end
+          brace_depth -= 1
+        when :on_embexpr_end
+          brace_depth -= 1
+        end
 
         # Ripper reports columns on line 1 without counting the BOM, so we
         # adjust to get the real offset

--- a/test/prism/ruby/ripper_test.rb
+++ b/test/prism/ruby/ripper_test.rb
@@ -219,6 +219,14 @@ module Prism
       assert_equal(Ripper.lex('if;)'), Translation::Ripper.lex('if;)'))
     end
 
+    def test_unmatched_braces
+      assert_ripper_lex("} }")
+      assert_ripper_lex("{ b: 1 } }")
+      assert_ripper_lex("[].each { } }")
+      assert_ripper_lex('"#{1}" }')
+      assert_ripper_lex("-> { } }")
+    end
+
     def test_tokenize
       source = "foo;1;BAZ"
       assert_equal(Ripper.tokenize(source), Translation::Ripper.tokenize(source))


### PR DESCRIPTION
Changes:
- emit `:on_embexpr_end` for the first unmatched `}`

### Rationale

Ripper contains a scanner quirk that tokenizes the first unmatched closing curly brace (` }`) as `:on_embexpr_end` rather than `:on_rbrace`. Because Prism did not replicate this behavior, Haml attribute parsing (which relies on this quirk to balance braces) failed with an `Haml::SyntaxError: Unbalanced brackets` error.

Right now the [Haml](https://github.com/haml/haml/actions/runs/29104951164/job/86402984390) and [Sinatra](https://github.com/sinatra/sinatra/actions/runs/28933677569/job/85838673722) tests fail on TruffleRuby on CI. This patch fixes the specs (checked locally).

cc @eregon 

### Examples (before the fix)

Ripper:

```
Ripper.lex("a(:class => :header}")
=>
[[[1, 0], :on_ident, "a", CMDARG],
 [[1, 1], :on_lparen, "(", BEG|LABEL],
 [[1, 2], :on_symbeg, ":", FNAME],
 [[1, 3], :on_kw, "class", ENDFN],
 [[1, 8], :on_sp, " ", END],
 [[1, 9], :on_op, "=>", BEG],
 [[1, 11], :on_sp, " ", BEG],
 [[1, 12], :on_symbeg, ":", FNAME],
 [[1, 13], :on_ident, "header", ENDFN],
 [[1, 19], :on_embexpr_end, "}", END]]
```

Prism:

```
Prism.lex_compat("a(:class => :header}")
=>
#<Prism::LexCompat::Result:0x00000001280bc948
 @comments=[],
 @data_loc=nil,
 @errors=
  [#<Prism::ParseError @type=:argument_term_paren @message="unexpected '}'; expected a `)` to close the arguments" @location=#<Prism::Location @start_offset=19 @length=1 start_line=1> @level=:syntax>,
   #<Prism::ParseError @type=:expect_eol_after_statement @message="unexpected '}', expecting end-of-input" @location=#<Prism::Location @start_offset=19 @length=1 start_line=1> @level=:syntax>,
   #<Prism::ParseError @type=:unexpected_token_ignore @message="unexpected '}', ignoring it" @location=#<Prism::Location @start_offset=19 @length=1 start_line=1> @level=:syntax>],
 @magic_comments=[],
 @source=#<Prism::ASCIISource:0x00000001280d9d18 @offsets=[0], @source="a(:class => :header}", @start_line=1>,
 @value=
  [[[1, 0], :on_ident, "a", CMDARG],
   [[1, 1], :on_lparen, "(", BEG|LABEL],
   [[1, 2], :on_symbeg, ":", FNAME],
   [[1, 3], :on_kw, "class", ENDFN],
   [[1, 8], :on_sp, " ", ENDFN],
   [[1, 9], :on_op, "=>", BEG],
   [[1, 11], :on_sp, " ", BEG],
   [[1, 12], :on_symbeg, ":", FNAME],
   [[1, 13], :on_ident, "header", ENDFN],
   [[1, 19], :on_rbrace, "}", END]],
 @warnings=[]>
```

### The Haml use case

When rendering a Haml tag with attributes (e.g., `%h1{:class => :header} Hello World`), Haml needs to parse and extract the attributes hash. It does this by temporarily replacing the leading  `{` with a dummy method call prefix `a(`, transforming it into `a(:class => :header}`.

It then tokenizes this string using `Ripper.lex` to balance the brackets and extract the attributes hash. Since the opening `{` was replaced with `(`, the closing `}` is  unmatched.

https://github.com/haml/haml/blob/08808371860b7289af6ef23f328ae42f81a19afc/lib/haml/parser.rb#L686-L692