### PR TITLE
various fixes for RubyParser

### DIFF
--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -1562,7 +1562,7 @@ module Prism
 
         # Create a new compiler with the given options.
         def copy_compiler(in_def: self.in_def, in_pattern: self.in_pattern)
-          Compiler.new(file, in_def: in_def, in_pattern: in_pattern)
+          self.class.new(file, in_def: in_def, in_pattern: in_pattern)
         end
 
         # Create a new Sexp object from the given prism node and arguments.
@@ -1624,7 +1624,6 @@ module Prism
         end
       end
 
-      private_constant :Compiler
       attr_accessor :scopes # :nodoc:
 
       def initialize scopes:nil # :nodoc:
@@ -1677,7 +1676,7 @@ module Prism
         end
 
         result.attach_comments!
-        result.value.accept(Compiler.new(filepath))
+        result.value.accept(self.class::Compiler.new(filepath))
       end
     end
   end

--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -1625,17 +1625,23 @@ module Prism
       end
 
       private_constant :Compiler
+      attr_accessor :scopes # :nodoc:
+
+      def initialize scopes:nil # :nodoc:
+        super()
+        self.scopes = [scopes] if scopes
+      end
 
       # Parse the given source and translate it into the seattlerb/ruby_parser
       # gem's Sexp format.
       def parse(source, filepath = "(string)")
-        translate(Prism.parse(source, filepath: filepath, partial_script: true), filepath)
+        translate(Prism.parse(source, filepath: filepath, partial_script: true, scopes: scopes), filepath)
       end
 
       # Parse the given file and translate it into the seattlerb/ruby_parser
       # gem's Sexp format.
       def parse_file(filepath)
-        translate(Prism.parse_file(filepath, partial_script: true), filepath)
+        translate(Prism.parse_file(filepath, partial_script: true, scopes: scopes), filepath)
       end
 
       # Parse the give file and translate it into the
@@ -1649,14 +1655,14 @@ module Prism
       class << self
         # Parse the given source and translate it into the seattlerb/ruby_parser
         # gem's Sexp format.
-        def parse(source, filepath = "(string)")
-          new.parse(source, filepath)
+        def parse(source, filepath = "(string)", scopes: nil)
+          new(scopes: scopes).parse(source, filepath)
         end
 
         # Parse the given file and translate it into the seattlerb/ruby_parser
         # gem's Sexp format.
-        def parse_file(filepath)
-          new.parse_file(filepath)
+        def parse_file(filepath, scopes: nil)
+          new(scopes: scopes).parse_file(filepath)
         end
       end
 

--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # :markup: markdown
 
+require "timeout"
+
 begin
   require "sexp"
 rescue LoadError

--- a/rakelib/seattlerb.rake
+++ b/rakelib/seattlerb.rake
@@ -65,7 +65,9 @@ namespace :seattlerb do
 
       def assert_parse(source, _)
         entry = caller.find { _1.include?("test_ruby_parser.rb") }
-        name = entry[/\d+:in `(?:block (?:\(\d+ levels\) )?in )?(?:assert_|test_|<module:)?(.+?)\>?'/, 1]
+
+        name = entry[/\d+:in [`'](?:block (?:\(\d+ levels\) )?in )?(?:assert_|test_|<module:)?(.+?)\>?'/, 1]
+                 .sub(/^Test.+#(?:test|assert)_/, '') # 4.x backtrace incl class
 
         COLLECTED[name] << source
         super


### PR DESCRIPTION
See individual commits for details.

One thing this doesn't have is the ACTUAL fixes I want for parser changes, because that would cause failures in the tests against RubyParser.

Is there a plan for how to deal with drift if I'm hoping to EOL RubyParser? Add them to `known_failures`?

Also, it looks like an import hasn't been for some time, and maybe the last one was done against git and not against a release... I'm hesitant to add/change those files as I'm not sure I'm doing the process correctly:

```
$ git clean -qf -- test/prism/fixtures ; rake seattlerb:import
```
