### PR TITLE
Bump jruby

### DIFF
--- a/java/wasm/perf-test/test
+++ b/java/wasm/perf-test/test
@@ -45,7 +45,6 @@ public class test {
         "META-INF/jruby.home/lib/ruby/stdlib/rubygems.rb",
         "META-INF/jruby.home/lib/ruby/stdlib/rbconfig.rb",
         "jruby/kernel/rbconfig.rb",
-        "META-INF/jruby.home/lib/ruby/stdlib/rubygems/compatibility.rb",
         "META-INF/jruby.home/lib/ruby/stdlib/rubygems/defaults.rb",
         "META-INF/jruby.home/lib/ruby/stdlib/rubygems/deprecate.rb",
         "META-INF/jruby.home/lib/ruby/stdlib/rubygems/errors.rb",

--- a/java/wasm/pom.xml
+++ b/java/wasm/pom.xml
@@ -60,8 +60,8 @@
     </dependency>
     <dependency>
       <groupId>org.jruby</groupId>
-      <artifactId>jruby-complete</artifactId>
-      <version>10.0.5.0</version>
+      <artifactId>jruby</artifactId>
+      <version>10.1.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/wasm/src/test/java/org/jruby/parser/prism/JRubyTest.java
+++ b/java/wasm/src/test/java/org/jruby/parser/prism/JRubyTest.java
@@ -41,7 +41,6 @@ public class JRubyTest {
         "META-INF/jruby.home/lib/ruby/stdlib/rubygems.rb",
         "META-INF/jruby.home/lib/ruby/stdlib/rbconfig.rb",
         "jruby/kernel/rbconfig.rb",
-        "META-INF/jruby.home/lib/ruby/stdlib/rubygems/compatibility.rb",
         "META-INF/jruby.home/lib/ruby/stdlib/rubygems/defaults.rb",
         "META-INF/jruby.home/lib/ruby/stdlib/rubygems/deprecate.rb",
         "META-INF/jruby.home/lib/ruby/stdlib/rubygems/errors.rb",


### PR DESCRIPTION
`jruby-complete` is being replaced by `jruby` https://github.com/jruby/jruby/pull/9512

For https://github.com/ruby/prism/issues/4123