### PR TITLE
Bound the leading-zero skip in pm_integer_parse

### DIFF
--- a/src/integer.c
+++ b/src/integer.c
@@ -503,7 +503,7 @@ pm_integer_parse(pm_integer_t *integer, pm_integer_base_t base, const uint8_t *s
     uint32_t multiplier = 10;
     switch (base) {
         case PM_INTEGER_BASE_DEFAULT:
-            while (*start == '0') start++; // 01 -> 1
+            while (start < end && *start == '0') start++; // 01 -> 1
             break;
         case PM_INTEGER_BASE_BINARY:
             start += 2; // 0b


### PR DESCRIPTION
## Problem

`pm_integer_parse()` skips leading zeros in the `PM_INTEGER_BASE_DEFAULT` branch without checking `end`:

```c
case PM_INTEGER_BASE_DEFAULT:
    while (*start == '0') start++; // 01 -> 1
```

For an all-zero input this reads one byte past the range. The `if (start >= end) return;` below it comes too late; the loop has already dereferenced the byte at `end`.

`pm_float_node_rational_create()` reaches it. It allocates `length` bytes for the mantissa, writes only `length - 1` of them because the decimal point is squeezed out, and passes `end = digits + length - 1`. So the byte the skip lands on is not merely one-past-the-end, it is uninitialized heap:

```
$ valgrind ./parse +0.0r
Conditional jump or move depends on uninitialised value(s)
   at pm_integer_parse (integer.c:506)
   by pm_float_node_rational_create (prism.c:3963)
   by parse_expression_prefix (prism.c:17898)
```

A leading `+` is needed to make the mantissa buffer long enough for the skip to reach the uninitialized byte, so `+0.0r` reports while `0.0r` does not.

## Fix

Bound the loop, matching what `PM_INTEGER_BASE_DECIMAL` and `PM_INTEGER_BASE_UNKNOWN` already do with `(end - start) > 1`.

The parsed value does not change: `start >= end` returns 0 either way. I confirmed the same harness reports the read before the patch and is clean after, with `value=0` in both cases.

Found by an mruby fuzzer testcase.