### PR TITLE
Make `ruby_memcheck` optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -259,7 +259,8 @@ jobs:
   memcheck:
     runs-on: ubuntu-24.04
     env:
-      BUNDLER_VERSION: '0' # https://github.com/ruby/ruby/pull/16909
+      BUNDLE_WITH: 'memcheck'
+      BUNDLER_VERSION: '0'
     steps:
     - uses: actions/checkout@v7
     - name: Install valgrind

--- a/Gemfile
+++ b/Gemfile
@@ -15,16 +15,13 @@ gem "test-unit"
 platforms :mri, :windows do
   gem "ffi"
   gem "irb"
-  gem "ruby_memcheck"
   gem "rdoc"
+
+  group :memcheck, optional: true do
+    gem "ruby_memcheck"
+  end
 end
 
 gem "onigmo", platforms: :ruby
-
-# Until a nokogiri release includes sparklemotion/nokogiri#3530, aarch64-mingw-ucrt
-# source-builds of libxml2 fail in libtool. Pin to main on that platform only.
-if RUBY_PLATFORM =~ /aarch64.*mingw/
-  gem "nokogiri", github: "sparklemotion/nokogiri", branch: "main"
-end
 
 gem "lrama"

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -46,16 +46,17 @@ return if RUBY_ENGINE == "jruby" || RUBY_ENGINE == "truffleruby"
 # Don't bother trying to configure memcheck on old versions of Ruby.
 return if RUBY_VERSION < "3.0"
 
-# Only attempt to configure memcheck if the gem is installed.
-begin
-  require "ruby_memcheck"
-rescue LoadError
-  return
-end
-
 namespace :test do
-  RubyMemcheck.config(use_only_ruby_free_at_exit: false)
-  RubyMemcheck::TestTask.new(valgrind_internal: :compile, &config)
+  begin
+    require "ruby_memcheck"
+    RubyMemcheck.config(use_only_ruby_free_at_exit: false)
+    RubyMemcheck::TestTask.new(valgrind_internal: :compile, &config)
+  rescue LoadError
+    task :valgrind_internal do
+      puts "\e[31mruby_memcheck gem not available. Try running with BUNDLE_WITH=memcheck\e[0m"
+      exit 1
+    end
+  end
 
   # Hide test:valgrind_internal from rake -T
   Rake::Task["test:valgrind_internal"].clear_comments


### PR DESCRIPTION
It consistently fails CI when nokogiri tries to install from source. But those steps don't actually need it and the nokogiri version with this fix is still quite a long while out.

Also bumps bundler to remove a workaround.