### PR TITLE
Remove rubyvm: keyword argument from Prism.find

### DIFF
--- a/lib/prism.rb
+++ b/lib/prism.rb
@@ -90,9 +90,9 @@ module Prism
   # an exact match. On other implementations, it falls back to best-effort
   # matching by source location line number.
   #--
-  #: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable, ?rubyvm: bool) -> Node?
-  def self.find(callable, rubyvm: !!defined?(RubyVM))
-    NodeFind.find(callable, rubyvm)
+  #: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
+  def self.find(callable)
+    NodeFind.find(callable)
   end
 
   # @rbs!

--- a/lib/prism/node_find.rb
+++ b/lib/prism/node_find.rb
@@ -14,11 +14,11 @@ module Prism
   module NodeFind # :nodoc:
     # Find the node for the given callable or backtrace location.
     #--
-    #: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable, bool rubyvm) -> Node?
-    def self.find(callable, rubyvm)
+    #: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
+    def self.find(callable)
       case callable
       when Proc
-        if rubyvm
+        if defined?(::RubyVM)
           RubyVMCallableFind.new.find(callable)
         elsif callable.lambda?
           LineLambdaFind.new.find(callable)
@@ -26,13 +26,13 @@ module Prism
           LineProcFind.new.find(callable)
         end
       when Method, UnboundMethod
-        if rubyvm
+        if defined?(::RubyVM)
           RubyVMCallableFind.new.find(callable)
         else
           LineMethodFind.new.find(callable)
         end
       when Thread::Backtrace::Location
-        if rubyvm
+        if defined?(::RubyVM)
           RubyVMBacktraceLocationFind.new.find(callable)
         else
           LineBacktraceLocationFind.new.find(callable)

--- a/rbi/generated/prism.rbi
+++ b/rbi/generated/prism.rbi
@@ -27,8 +27,8 @@ module Prism
   # returns the Prism node representing it. On CRuby, this uses node_id for
   # an exact match. On other implementations, it falls back to best-effort
   # matching by source location line number.
-  sig { params(callable: ::T.any(Method, UnboundMethod, Proc, Thread::Backtrace::Location), rubyvm: T::Boolean).returns(::T.nilable(Node)) }
-  def self.find(callable, rubyvm: T.unsafe(nil)); end
+  sig { params(callable: ::T.any(Method, UnboundMethod, Proc, Thread::Backtrace::Location)).returns(::T.nilable(Node)) }
+  def self.find(callable); end
 
   VERSION = T.let(nil, String)
   BACKEND = T.let(nil, Symbol)

--- a/rbi/generated/prism/node_find.rbi
+++ b/rbi/generated/prism/node_find.rbi
@@ -10,8 +10,8 @@ module Prism
   # pay for its definition.
   module NodeFind
     # Find the node for the given callable or backtrace location.
-    sig { params(callable: ::T.any(Method, UnboundMethod, Proc, Thread::Backtrace::Location), rubyvm: T::Boolean).returns(::T.nilable(Node)) }
-    def self.find(callable, rubyvm); end
+    sig { params(callable: ::T.any(Method, UnboundMethod, Proc, Thread::Backtrace::Location)).returns(::T.nilable(Node)) }
+    def self.find(callable); end
 
     # Base class that handles parsing a file.
     class Find

--- a/sig/generated/prism.rbs
+++ b/sig/generated/prism.rbs
@@ -37,8 +37,8 @@ module Prism
   # an exact match. On other implementations, it falls back to best-effort
   # matching by source location line number.
   # --
-  # : (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable, ?rubyvm: bool) -> Node?
-  def self.find: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable, ?rubyvm: bool) -> Node?
+  # : (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
+  def self.find: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
 
   VERSION: String
 

--- a/sig/generated/prism/node_find.rbs
+++ b/sig/generated/prism/node_find.rbs
@@ -11,8 +11,8 @@ module Prism
   module NodeFind
     # Find the node for the given callable or backtrace location.
     # --
-    # : (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable, bool rubyvm) -> Node?
-    def self.find: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable, bool rubyvm) -> Node?
+    # : (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
+    def self.find: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
 
     # Base class that handles parsing a file.
     class Find

--- a/test/prism/ruby/find_test.rb
+++ b/test/prism/ruby/find_test.rb
@@ -143,42 +143,42 @@ module Prism
       assert_def_node Prism.find(Fixtures::MultipleOnLine.method(:second)), :second
     end
 
-    # === Fallback (line-based) tests via rubyvm: false ===
+    # === Fallback (line-based) tests ===
 
     def test_fallback_simple_method
-      assert_def_node Prism.find(Fixtures::Methods.instance_method(:simple_method), rubyvm: false), :simple_method
+      assert_def_node NodeFind::LineMethodFind.new.find(Fixtures::Methods.instance_method(:simple_method)), :simple_method
     end
 
     def test_fallback_singleton_method
-      assert_def_node Prism.find(Fixtures::Methods.method(:singleton_method_fixture), rubyvm: false), :singleton_method_fixture
+      assert_def_node NodeFind::LineMethodFind.new.find(Fixtures::Methods.method(:singleton_method_fixture)), :singleton_method_fixture
     end
 
     def test_fallback_lambda
-      node = Prism.find(Fixtures::Procs::SIMPLE_LAMBDA, rubyvm: false)
+      node = NodeFind::LineLambdaFind.new.find(Fixtures::Procs::SIMPLE_LAMBDA)
       assert_instance_of LambdaNode, node
     end
 
     def test_fallback_proc
-      node = Prism.find(Fixtures::Procs::SIMPLE_PROC, rubyvm: false)
+      node = NodeFind::LineProcFind.new.find(Fixtures::Procs::SIMPLE_PROC)
       assert_instance_of CallNode, node
       assert node.block.is_a?(BlockNode)
     end
 
     def test_fallback_define_method
-      node = Prism.find(Fixtures::DefineMethod.instance_method(:dynamic), rubyvm: false)
+      node = NodeFind::LineMethodFind.new.find(Fixtures::DefineMethod.instance_method(:dynamic))
       assert_instance_of CallNode, node
       assert node.block.is_a?(BlockNode)
     end
 
     def test_fallback_for_loop
-      node = Prism.find(Fixtures::ForLoop::FOR_PROC, rubyvm: false)
+      node = NodeFind::LineProcFind.new.find(Fixtures::ForLoop::FOR_PROC)
       assert_instance_of ForNode, node
     end
 
     def test_fallback_backtrace_location
       location = zero_division_location
       assert_not_nil location
-      node = Prism.find(location, rubyvm: false)
+      node = NodeFind::LineBacktraceLocationFind.new.find(location)
       assert_not_nil node
       assert_equal location.lineno, node.location.start_line
     end


### PR DESCRIPTION
Remove the `rubyvm:` keyword argument from `Prism.find`. The internal dispatch already checks `defined?(::RubyVM)`, so exposing this as a public parameter seems unnecessary. Removing it makes the API cleaner and makes it straightforward to test each `Find` implementation directly using the concrete classes.

~Additionally, unified `LineMethodFind`, `LineLambdaFind`, and `LineProcFind` into a single `LineCallableFind` class, since they share the same structure (parse file, match by start line).~