### PR TITLE
Correctly apply rdoc prerequisite

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -44,8 +44,6 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v6
-      - name: Template source files
-        run: bundle exec rake templates
       - name: Build with RDoc
         run: bundle exec rake rdoc
       - name: Build with Doxygen

--- a/rakelib/rdoc.rake
+++ b/rakelib/rdoc.rake
@@ -29,5 +29,5 @@ end
 %w[rdoc rerdoc rdoc:coverage].each do |name|
   # rdoc:coverage available in rdoc as a default gem since ruby 3.3 only
   next unless Rake::Task.task_defined?(name)
-  Rake::Task[name].enhance(["compile"])
+  Rake::Task[name].prerequisites.unshift("compile")
 end


### PR DESCRIPTION
I thought this didn't actually work but it seems it is necessary this way. Unclear why `enhance` worked for the docs workflow but not for pages