### PR TITLE
Fix extra doc docmment

### DIFF
--- a/ext/prism/extension.c
+++ b/ext/prism/extension.c
@@ -1606,8 +1606,6 @@ Init_prism(void) {
     rb_ext_ractor_safe(true);
 #endif
 
-    /* Grab up references to all of the constants that we are going to need to
-     * reference throughout this extension. */
     rb_cPrism = rb_define_module("Prism");
     rb_cPrismNode = rb_define_class_under(rb_cPrism, "Node", rb_cObject);
     rb_cPrismSource = rb_define_class_under(rb_cPrism, "Source", rb_cObject);


### PR DESCRIPTION
https://github.com/ruby/prism/commit/9df2a21995764880c6d27213e2c7960f2232c879 changed the comment style

Now rdoc picks this up. The comment doesn't say much, seems fine to just remove

<img width="1087" height="584" alt="grafik" src="https://github.com/user-attachments/assets/ff5554c3-3713-4a9e-a4f9-ad220f307eb6" />
