### PR TITLE
Remove now unneeded rdoc private annotations

### DIFF
--- a/lib/prism.rb
+++ b/lib/prism.rb
@@ -43,7 +43,7 @@ module Prism
   # Raised when requested to parse as the currently running Ruby version but Prism has no support for it.
   class CurrentVersionError < ArgumentError
     # Initialize a new exception for the given ruby version string.
-    #--
+    #
     #: (String version) -> void
     def initialize(version)
       message = +"invalid version: Requested to parse as `version: 'current'`; "
@@ -69,7 +69,7 @@ module Prism
   # resembles the return value of Ripper.lex.
   #
   # For supported options, see Prism.parse.
-  #--
+  #
   #: (String source, **untyped options) -> LexCompat::Result
   def self.lex_compat(source, **options)
     LexCompat.new(source, **options).result # steep:ignore
@@ -79,7 +79,7 @@ module Prism
   #   load(source, serialized, freeze) -> ParseResult
   #
   # Load the serialized AST using the source as a reference into a tree.
-  #--
+  #
   #: (String source, String serialized, ?bool freeze) -> ParseResult
   def self.load(source, serialized, freeze = false)
     Serialize.load_parse(source, serialized, freeze)
@@ -89,7 +89,7 @@ module Prism
   # returns the Prism node representing it. On CRuby, this uses node_id for
   # an exact match. On other implementations, it falls back to best-effort
   # matching by source location line number.
-  #--
+  #
   #: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
   def self.find(callable)
     NodeFind.find(callable)

--- a/lib/prism/desugar_compiler.rb
+++ b/lib/prism/desugar_compiler.rb
@@ -22,7 +22,7 @@ module Prism
     end
 
     # Desugar `x &&= y` to `x && x = y`
-    #--
+    #
     #: () -> node
     def compile
       and_node(
@@ -59,7 +59,7 @@ module Prism
     end
 
     # Desugar `x ||= y` to `defined?(x) ? x : x = y`
-    #--
+    #
     #: () -> node
     def compile
       if_node(
@@ -116,7 +116,7 @@ module Prism
     end
 
     # Desugar `x += y` to `x = x + y`
-    #--
+    #
     #: () -> node
     def compile
       binary_operator_loc = node.binary_operator_loc.chop
@@ -166,7 +166,7 @@ module Prism
     end
 
     # Desugar `x ||= y` to `x || x = y`
-    #--
+    #
     #: () -> node
     def compile
       or_node(
@@ -300,7 +300,7 @@ module Prism
     # becomes
     #
     # `@@foo && @@foo = bar`
-    #--
+    #
     #: (ClassVariableAndWriteNode node) -> node
     def visit_class_variable_and_write_node(node)
       node.desugar
@@ -311,7 +311,7 @@ module Prism
     # becomes
     #
     # `defined?(@@foo) ? @@foo : @@foo = bar`
-    #--
+    #
     #: (ClassVariableOrWriteNode node) -> node
     def visit_class_variable_or_write_node(node)
       node.desugar
@@ -322,7 +322,7 @@ module Prism
     # becomes
     #
     # `@@foo = @@foo + bar`
-    #--
+    #
     #: (ClassVariableOperatorWriteNode node) -> node
     def visit_class_variable_operator_write_node(node)
       node.desugar
@@ -333,7 +333,7 @@ module Prism
     # becomes
     #
     # `Foo && Foo = bar`
-    #--
+    #
     #: (ConstantAndWriteNode node) -> node
     def visit_constant_and_write_node(node)
       node.desugar
@@ -344,7 +344,7 @@ module Prism
     # becomes
     #
     # `defined?(Foo) ? Foo : Foo = bar`
-    #--
+    #
     #: (ConstantOrWriteNode node) -> node
     def visit_constant_or_write_node(node)
       node.desugar
@@ -355,7 +355,7 @@ module Prism
     # becomes
     #
     # `Foo = Foo + bar`
-    #--
+    #
     #: (ConstantOperatorWriteNode node) -> node
     def visit_constant_operator_write_node(node)
       node.desugar
@@ -366,7 +366,7 @@ module Prism
     # becomes
     #
     # `$foo && $foo = bar`
-    #--
+    #
     #: (GlobalVariableAndWriteNode node) -> node
     def visit_global_variable_and_write_node(node)
       node.desugar
@@ -377,7 +377,7 @@ module Prism
     # becomes
     #
     # `defined?($foo) ? $foo : $foo = bar`
-    #--
+    #
     #: (GlobalVariableOrWriteNode node) -> node
     def visit_global_variable_or_write_node(node)
       node.desugar
@@ -388,7 +388,7 @@ module Prism
     # becomes
     #
     # `$foo = $foo + bar`
-    #--
+    #
     #: (GlobalVariableOperatorWriteNode node) -> node
     def visit_global_variable_operator_write_node(node)
       node.desugar
@@ -399,7 +399,7 @@ module Prism
     # becomes
     #
     # `@foo && @foo = bar`
-    #--
+    #
     #: (InstanceVariableAndWriteNode node) -> node
     def visit_instance_variable_and_write_node(node)
       node.desugar
@@ -410,7 +410,7 @@ module Prism
     # becomes
     #
     # `@foo || @foo = bar`
-    #--
+    #
     #: (InstanceVariableOrWriteNode node) -> node
     def visit_instance_variable_or_write_node(node)
       node.desugar
@@ -421,7 +421,7 @@ module Prism
     # becomes
     #
     # `@foo = @foo + bar`
-    #--
+    #
     #: (InstanceVariableOperatorWriteNode node) -> node
     def visit_instance_variable_operator_write_node(node)
       node.desugar
@@ -432,7 +432,7 @@ module Prism
     # becomes
     #
     # `foo && foo = bar`
-    #--
+    #
     #: (LocalVariableAndWriteNode node) -> node
     def visit_local_variable_and_write_node(node)
       node.desugar
@@ -443,7 +443,7 @@ module Prism
     # becomes
     #
     # `foo || foo = bar`
-    #--
+    #
     #: (LocalVariableOrWriteNode node) -> node
     def visit_local_variable_or_write_node(node)
       node.desugar
@@ -454,7 +454,7 @@ module Prism
     # becomes
     #
     # `foo = foo + bar`
-    #--
+    #
     #: (LocalVariableOperatorWriteNode node) -> node
     def visit_local_variable_operator_write_node(node)
       node.desugar

--- a/lib/prism/lex_compat.rb
+++ b/lib/prism/lex_compat.rb
@@ -48,7 +48,7 @@ module Prism
       attr_reader :value #: Array[lex_compat_token]
 
       # Create a new lex compat result object with the given values.
-      #--
+      #
       #: (Array[lex_compat_token] value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
       def initialize(value, comments, magic_comments, data_loc, errors, warnings, continuable, source)
         @value = value
@@ -56,7 +56,7 @@ module Prism
       end
 
       # Implement the hash pattern matching interface for Result.
-      #--
+      #
       #: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
       def deconstruct_keys(keys) # :nodoc:
         super.merge!(value: value)
@@ -572,7 +572,7 @@ module Prism
 
       # Here we will split between the two types of heredocs and return the
       # object that will store their tokens.
-      #--
+      #
       #: (lex_compat_token opening) -> (PlainHeredoc | DashHeredoc | DedentingHeredoc)
       def self.build(opening)
         case opening[2][2]

--- a/lib/prism/node_ext.rb
+++ b/lib/prism/node_ext.rb
@@ -25,7 +25,7 @@ module Prism
   module RegularExpressionOptions # :nodoc:
     # Returns a numeric value that represents the flags that were used to create
     # the regular expression.
-    #--
+    #
     #: (Integer flags) -> Integer
     def self.options(flags)
       o = 0
@@ -41,7 +41,7 @@ module Prism
   class InterpolatedMatchLastLineNode < Node
     # Returns a numeric value that represents the flags that were used to create
     # the regular expression.
-    #--
+    #
     #: () -> Integer
     def options
       RegularExpressionOptions.options(flags)
@@ -51,7 +51,7 @@ module Prism
   class InterpolatedRegularExpressionNode < Node
     # Returns a numeric value that represents the flags that were used to create
     # the regular expression.
-    #--
+    #
     #: () -> Integer
     def options
       RegularExpressionOptions.options(flags)
@@ -61,7 +61,7 @@ module Prism
   class MatchLastLineNode < Node
     # Returns a numeric value that represents the flags that were used to create
     # the regular expression.
-    #--
+    #
     #: () -> Integer
     def options
       RegularExpressionOptions.options(flags)
@@ -71,7 +71,7 @@ module Prism
   class RegularExpressionNode < Node
     # Returns a numeric value that represents the flags that were used to create
     # the regular expression.
-    #--
+    #
     #: () -> Integer
     def options
       RegularExpressionOptions.options(flags)
@@ -82,7 +82,7 @@ module Prism
 
   module HeredocQuery # :nodoc:
     # Returns true if this node was represented as a heredoc in the source code.
-    #--
+    #
     #: (String? opening) -> bool?
     def self.heredoc?(opening)
       # @type self: InterpolatedStringNode | InterpolatedXStringNode | StringNode | XStringNode
@@ -92,7 +92,7 @@ module Prism
 
   class InterpolatedStringNode < Node
     # Returns true if this node was represented as a heredoc in the source code.
-    #--
+    #
     #: () -> bool?
     def heredoc?
       HeredocQuery.heredoc?(opening)
@@ -101,7 +101,7 @@ module Prism
 
   class InterpolatedXStringNode < Node
     # Returns true if this node was represented as a heredoc in the source code.
-    #--
+    #
     #: () -> bool?
     def heredoc?
       HeredocQuery.heredoc?(opening)
@@ -110,7 +110,7 @@ module Prism
 
   class StringNode < Node
     # Returns true if this node was represented as a heredoc in the source code.
-    #--
+    #
     #: () -> bool?
     def heredoc?
       HeredocQuery.heredoc?(opening)
@@ -118,7 +118,7 @@ module Prism
 
     # Occasionally it's helpful to treat a string as if it were interpolated so
     # that there's a consistent interface for working with strings.
-    #--
+    #
     #: () -> InterpolatedStringNode
     def to_interpolated
       InterpolatedStringNode.new(
@@ -135,7 +135,7 @@ module Prism
 
   class XStringNode < Node
     # Returns true if this node was represented as a heredoc in the source code.
-    #--
+    #
     #: () -> bool?
     def heredoc?
       HeredocQuery.heredoc?(opening)
@@ -143,7 +143,7 @@ module Prism
 
     # Occasionally it's helpful to treat a string as if it were interpolated so
     # that there's a consistent interface for working with strings.
-    #--
+    #
     #: () -> InterpolatedXStringNode
     def to_interpolated
       InterpolatedXStringNode.new(
@@ -162,7 +162,7 @@ module Prism
 
   class ImaginaryNode < Node
     # Returns the value of the node as a Ruby Complex.
-    #--
+    #
     #: () -> Complex
     def value
       Complex(0, numeric.value)
@@ -171,7 +171,7 @@ module Prism
 
   class RationalNode < Node
     # Returns the value of the node as a Ruby Rational.
-    #--
+    #
     #: () -> Rational
     def value
       Rational(numerator, denominator)
@@ -181,14 +181,14 @@ module Prism
   class ConstantReadNode < Node
     # Returns the list of parts for the full name of this constant.
     # For example: [:Foo]
-    #--
+    #
     #: () -> Array[Symbol]
     def full_name_parts
       [name]
     end
 
     # Returns the full name of this constant. For example: "Foo"
-    #--
+    #
     #: () -> String
     def full_name
       name.to_s
@@ -198,14 +198,14 @@ module Prism
   class ConstantWriteNode < Node
     # Returns the list of parts for the full name of this constant.
     # For example: [:Foo]
-    #--
+    #
     #: () -> Array[Symbol]
     def full_name_parts
       [name]
     end
 
     # Returns the full name of this constant. For example: "Foo"
-    #--
+    #
     #: () -> String
     def full_name
       name.to_s
@@ -228,7 +228,7 @@ module Prism
 
     # Returns the list of parts for the full name of this constant path.
     # For example: [:Foo, :Bar]
-    #--
+    #
     #: () -> Array[Symbol]
     def full_name_parts
       parts = [] #: Array[Symbol]
@@ -252,7 +252,7 @@ module Prism
     end
 
     # Returns the full name of this constant path. For example: "Foo::Bar"
-    #--
+    #
     #: () -> String
     def full_name
       full_name_parts.join("::")
@@ -262,7 +262,7 @@ module Prism
   class ConstantPathTargetNode < Node
     # Returns the list of parts for the full name of this constant path.
     # For example: [:Foo, :Bar]
-    #--
+    #
     #: () -> Array[Symbol]
     def full_name_parts
       parts =
@@ -284,7 +284,7 @@ module Prism
     end
 
     # Returns the full name of this constant path. For example: "Foo::Bar"
-    #--
+    #
     #: () -> String
     def full_name
       full_name_parts.join("::")
@@ -294,14 +294,14 @@ module Prism
   class ConstantTargetNode < Node
     # Returns the list of parts for the full name of this constant.
     # For example: [:Foo]
-    #--
+    #
     #: () -> Array[Symbol]
     def full_name_parts
       [name]
     end
 
     # Returns the full name of this constant. For example: "Foo"
-    #--
+    #
     #: () -> String
     def full_name
       name.to_s
@@ -310,7 +310,7 @@ module Prism
 
   class ParametersNode < Node
     # Mirrors the Method#parameters method.
-    #--
+    #
     #: () -> Array[[Symbol, Symbol] | [Symbol]]
     def signature
       names = [] #: Array[[Symbol, Symbol] | [Symbol]]
@@ -379,7 +379,7 @@ module Prism
     # can be any amount of space between the message and the = sign. However,
     # sometimes you want the location of the full message including the inner
     # space and the = sign. This method provides that.
-    #--
+    #
     #: () -> Location?
     def full_message_loc
       attribute_write? ? message_loc&.adjoin("=") : message_loc

--- a/lib/prism/node_find.rb
+++ b/lib/prism/node_find.rb
@@ -13,7 +13,7 @@ module Prism
   # pay for its definition.
   module NodeFind # :nodoc:
     # Find the node for the given callable or backtrace location.
-    #--
+    #
     #: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
     def self.find(callable)
       case callable
@@ -47,7 +47,7 @@ module Prism
       private
 
       # Parse the given file path, returning a ParseResult or nil.
-      #--
+      #
       #: (String? file) -> ParseResult?
       def parse_file(file)
         return unless file && File.readable?(file)
@@ -60,7 +60,7 @@ module Prism
     # from the instruction sequence.
     class RubyVMCallableFind < Find
       # Find the node for the given callable using the ISeq node_id.
-      #--
+      #
       #: (Method | UnboundMethod | Proc callable) -> Node?
       def find(callable)
         return unless (source_location = callable.source_location)
@@ -78,7 +78,7 @@ module Prism
     # from the backtrace location.
     class RubyVMBacktraceLocationFind < Find
       # Find the node for the given backtrace location using node_id.
-      #--
+      #
       #: (Thread::Backtrace::Location location) -> Node?
       def find(location)
         file = location.absolute_path || location.path
@@ -95,7 +95,7 @@ module Prism
     # matching. Used on non-CRuby implementations.
     class LineMethodFind < Find
       # Find the node for the given method by matching on name and line.
-      #--
+      #
       #: (Method | UnboundMethod callable) -> Node?
       def find(callable)
         return unless (source_location = callable.source_location)
@@ -121,7 +121,7 @@ module Prism
     # on non-CRuby implementations.
     class LineLambdaFind < Find
       # Find the node for the given lambda by matching on line.
-      #--
+      #
       #: (Proc callable) -> Node?
       def find(callable)
         return unless (source_location = callable.source_location)
@@ -146,7 +146,7 @@ module Prism
     # matching. Used on non-CRuby implementations.
     class LineProcFind < Find
       # Find the node for the given proc by matching on line.
-      #--
+      #
       #: (Proc callable) -> Node?
       def find(callable)
         return unless (source_location = callable.source_location)
@@ -171,7 +171,7 @@ module Prism
     # line matching. Used on non-CRuby implementations.
     class LineBacktraceLocationFind < Find
       # Find the node for the given backtrace location by matching on line.
-      #--
+      #
       #: (Thread::Backtrace::Location location) -> Node?
       def find(location)
         file = location.absolute_path || location.path

--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -28,7 +28,7 @@ module Prism
     # can be calculated by iterating through the source code and recording the
     # byte offset whenever a newline character is encountered.  The first
     # element is always 0 to mark the first line.
-    #--
+    #
     #: (String source, Integer start_line, Array[Integer] offsets) -> Source
     def self.for(source, start_line, offsets)
       if source.ascii_only?
@@ -62,7 +62,7 @@ module Prism
     # The list of newline byte offsets in the source code. When initialized from
     # the C extension, this may be a packed binary string of uint32_t values
     # that is lazily unpacked on first access.
-    #--
+    #
     #: () -> Array[Integer]
     def offsets
       offsets = @offsets
@@ -73,7 +73,7 @@ module Prism
     # Create a new source object with the given source code. The offsets
     # parameter can be either an Array of Integer byte offsets or a packed
     # binary string of uint32_t values (from the C extension).
-    #--
+    #
     #: (String source, Integer start_line, Array[Integer] | String offsets) -> void
     def initialize(source, start_line, offsets)
       @source = source
@@ -82,14 +82,14 @@ module Prism
     end
 
     # Replace the value of start_line with the given value.
-    #--
+    #
     #: (Integer start_line) -> void
     def replace_start_line(start_line)
       @start_line = start_line
     end
 
     # Replace the value of offsets with the given value.
-    #--
+    #
     #: (Array[Integer] offsets) -> void
     def replace_offsets(offsets)
       @offsets = offsets
@@ -97,14 +97,14 @@ module Prism
 
     # Returns the encoding of the source code, which is set by parameters to the
     # parser or by the encoding magic comment.
-    #--
+    #
     #: () -> Encoding
     def encoding
       source.encoding
     end
 
     # Returns the lines of the source code as an array of strings.
-    #--
+    #
     #: () -> Array[String]
     def lines
       source.lines
@@ -112,14 +112,14 @@ module Prism
 
     # Perform a byteslice on the source code using the given byte offset and
     # byte length.
-    #--
+    #
     #: (Integer byte_offset, Integer length) -> String
     def slice(byte_offset, length)
       source.byteslice(byte_offset, length) or raise
     end
 
     # Converts the line number and column in bytes to a byte offset.
-    #--
+    #
     #: (Integer line, Integer column) -> Integer
     def byte_offset(line, column)
       normal = line - @start_line
@@ -131,7 +131,7 @@ module Prism
 
     # Binary search through the offsets to find the line number for the given
     # byte offset.
-    #--
+    #
     #: (Integer byte_offset) -> Integer
     def line(byte_offset)
       start_line + find_line(byte_offset)
@@ -139,7 +139,7 @@ module Prism
 
     # Return the byte offset of the start of the line corresponding to the given
     # byte offset.
-    #--
+    #
     #: (Integer byte_offset) -> Integer
     def line_start(byte_offset)
       offsets[find_line(byte_offset)]
@@ -147,28 +147,28 @@ module Prism
 
     # Returns the byte offset of the end of the line corresponding to the given
     # byte offset.
-    #--
+    #
     #: (Integer byte_offset) -> Integer
     def line_end(byte_offset)
       offsets[find_line(byte_offset) + 1] || source.bytesize
     end
 
     # Return the column in bytes for the given byte offset.
-    #--
+    #
     #: (Integer byte_offset) -> Integer
     def column(byte_offset)
       byte_offset - line_start(byte_offset)
     end
 
     # Return the character offset for the given byte offset.
-    #--
+    #
     #: (Integer byte_offset) -> Integer
     def character_offset(byte_offset)
       (source.byteslice(0, byte_offset) or raise).length
     end
 
     # Return the column in characters for the given byte offset.
-    #--
+    #
     #: (Integer byte_offset) -> Integer
     def character_column(byte_offset)
       character_offset(byte_offset) - character_offset(line_start(byte_offset))
@@ -186,7 +186,7 @@ module Prism
     # possible that the given byte offset will not occur on a character
     # boundary. Second, it's possible that the source code will contain a
     # character that has no equivalent in the given encoding.
-    #--
+    #
     #: (Integer byte_offset, Encoding encoding) -> Integer
     def code_units_offset(byte_offset, encoding)
       return byte_offset if encoding == Encoding::UTF_8
@@ -202,7 +202,7 @@ module Prism
 
     # Generate a cache that targets a specific encoding for calculating code
     # unit offsets.
-    #--
+    #
     #: (Encoding encoding) -> CodeUnitsCache
     def code_units_cache(encoding)
       CodeUnitsCache.new(source, encoding)
@@ -210,14 +210,14 @@ module Prism
 
     # Returns the column in code units for the given encoding for the
     # given byte offset.
-    #--
+    #
     #: (Integer byte_offset, Encoding encoding) -> Integer
     def code_units_column(byte_offset, encoding)
       code_units_offset(byte_offset, encoding) - code_units_offset(line_start(byte_offset), encoding)
     end
 
     # Freeze this object and the objects it contains.
-    #--
+    #
     #: () -> void
     def deep_freeze
       source.freeze
@@ -227,7 +227,7 @@ module Prism
 
     # Binary search through the offsets to find the index for the given
     # byte offset.
-    #--
+    #
     #: (Integer byte_offset) -> Integer
     def find_line(byte_offset) # :nodoc:
       index = offsets.bsearch_index { |offset| offset > byte_offset } || offsets.length
@@ -301,7 +301,7 @@ module Prism
     # @rbs @offsets: Array[Integer]
 
     # Initialize a new cache with the given source and encoding.
-    #--
+    #
     #: (String source, Encoding encoding) -> void
     def initialize(source, encoding)
       @source = source
@@ -320,7 +320,7 @@ module Prism
     end
 
     # Retrieve the code units offset from the given byte offset.
-    #--
+    #
     #: (Integer byte_offset) -> Integer
     def [](byte_offset)
       @cache[byte_offset] ||=
@@ -348,14 +348,14 @@ module Prism
   # at that point we will treat everything as single-byte characters.
   class ASCIISource < Source
     # Return the character offset for the given byte offset.
-    #--
+    #
     #: (Integer byte_offset) -> Integer
     def character_offset(byte_offset)
       byte_offset
     end
 
     # Return the column in characters for the given byte offset.
-    #--
+    #
     #: (Integer byte_offset) -> Integer
     def character_column(byte_offset)
       byte_offset - line_start(byte_offset)
@@ -367,7 +367,7 @@ module Prism
     # This method is tested with UTF-8, UTF-16, and UTF-32. If there is the
     # concept of code units that differs from the number of characters in other
     # encodings, it is not captured here.
-    #--
+    #
     #: (Integer byte_offset, Encoding encoding) -> Integer
     def code_units_offset(byte_offset, encoding)
       byte_offset
@@ -376,7 +376,7 @@ module Prism
     # Returns a cache that is the identity function in order to maintain the
     # same interface. We can do this because code units are always equivalent to
     # byte offsets for ASCII-only sources.
-    #--
+    #
     #: (Encoding encoding) -> _CodeUnitsCache
     def code_units_cache(encoding)
       ->(byte_offset) { byte_offset }
@@ -385,7 +385,7 @@ module Prism
     # Specialized version of `code_units_column` that does not depend on
     # `code_units_offset`, which is a more expensive operation. This is
     # essentially the same as `Prism::Source#column`.
-    #--
+    #
     #: (Integer byte_offset, Encoding encoding) -> Integer
     def code_units_column(byte_offset, encoding)
       byte_offset - line_start(byte_offset)
@@ -411,7 +411,7 @@ module Prism
 
     # Create a new location object with the given source, start byte offset, and
     # byte length.
-    #--
+    #
     #: (Source source, Integer start_offset, Integer length) -> void
     def initialize(source, start_offset, length)
       @source = source
@@ -427,14 +427,14 @@ module Prism
 
     # These are the comments that are associated with this location that exist
     # before the start of this location.
-    #--
+    #
     #: () -> Array[Comment]
     def leading_comments
       @leading_comments ||= []
     end
 
     # Attach a comment to the leading comments of this location.
-    #--
+    #
     #: (Comment comment) -> void
     def leading_comment(comment)
       leading_comments << comment
@@ -442,14 +442,14 @@ module Prism
 
     # These are the comments that are associated with this location that exist
     # after the end of this location.
-    #--
+    #
     #: () -> Array[Comment]
     def trailing_comments
       @trailing_comments ||= []
     end
 
     # Attach a comment to the trailing comments of this location.
-    #--
+    #
     #: (Comment comment) -> void
     def trailing_comment(comment)
       trailing_comments << comment
@@ -457,42 +457,42 @@ module Prism
 
     # Returns all comments that are associated with this location (both leading
     # and trailing comments).
-    #--
+    #
     #: () -> Array[Comment]
     def comments
       [*@leading_comments, *@trailing_comments] #: Array[Comment]
     end
 
     # Create a new location object with the given options.
-    #--
+    #
     #: (?source: Source, ?start_offset: Integer, ?length: Integer) -> Location
     def copy(source: self.source, start_offset: self.start_offset, length: self.length)
       Location.new(source, start_offset, length)
     end
 
     # Returns a new location that is the result of chopping off the last byte.
-    #--
+    #
     #: () -> Location
     def chop
       copy(length: length == 0 ? length : length - 1)
     end
 
     # Returns a string representation of this location.
-    #--
+    #
     #: () -> String
     def inspect # :nodoc:
       "#<Prism::Location @start_offset=#{@start_offset} @length=#{@length} start_line=#{start_line}>"
     end
 
     # Returns all of the lines of the source code associated with this location.
-    #--
+    #
     #: () -> Array[String]
     def source_lines
       source.lines
     end
 
     # The source code that this location represents.
-    #--
+    #
     #: () -> String
     def slice
       source.slice(start_offset, length)
@@ -501,7 +501,7 @@ module Prism
     # The source code that this location represents starting from the beginning
     # of the line that this location starts on to the end of the line that this
     # location ends on.
-    #--
+    #
     #: () -> String
     def slice_lines
       line_start = source.line_start(start_offset)
@@ -511,14 +511,14 @@ module Prism
 
     # The character offset from the beginning of the source where this location
     # starts.
-    #--
+    #
     #: () -> Integer
     def start_character_offset
       source.character_offset(start_offset)
     end
 
     # The offset from the start of the file in code units of the given encoding.
-    #--
+    #
     #: (Encoding encoding) -> Integer
     def start_code_units_offset(encoding = Encoding::UTF_16LE)
       source.code_units_offset(start_offset, encoding)
@@ -526,14 +526,14 @@ module Prism
 
     # The start offset from the start of the file in code units using the given
     # cache to fetch or calculate the value.
-    #--
+    #
     #: (_CodeUnitsCache cache) -> Integer
     def cached_start_code_units_offset(cache)
       cache[start_offset]
     end
 
     # The byte offset from the beginning of the source where this location ends.
-    #--
+    #
     #: () -> Integer
     def end_offset
       start_offset + length
@@ -541,14 +541,14 @@ module Prism
 
     # The character offset from the beginning of the source where this location
     # ends.
-    #--
+    #
     #: () -> Integer
     def end_character_offset
       source.character_offset(end_offset)
     end
 
     # The offset from the start of the file in code units of the given encoding.
-    #--
+    #
     #: (Encoding encoding) -> Integer
     def end_code_units_offset(encoding = Encoding::UTF_16LE)
       source.code_units_offset(end_offset, encoding)
@@ -556,21 +556,21 @@ module Prism
 
     # The end offset from the start of the file in code units using the given
     # cache to fetch or calculate the value.
-    #--
+    #
     #: (_CodeUnitsCache cache) -> Integer
     def cached_end_code_units_offset(cache)
       cache[end_offset]
     end
 
     # The line number where this location starts.
-    #--
+    #
     #: () -> Integer
     def start_line
       source.line(start_offset)
     end
 
     # The content of the line where this location starts before this location.
-    #--
+    #
     #: () -> String
     def start_line_slice
       offset = source.line_start(start_offset)
@@ -578,7 +578,7 @@ module Prism
     end
 
     # The line number where this location ends.
-    #--
+    #
     #: () -> Integer
     def end_line
       source.line(end_offset)
@@ -586,7 +586,7 @@ module Prism
 
     # The column in bytes where this location starts from the start of
     # the line.
-    #--
+    #
     #: () -> Integer
     def start_column
       source.column(start_offset)
@@ -594,7 +594,7 @@ module Prism
 
     # The column in characters where this location ends from the start of
     # the line.
-    #--
+    #
     #: () -> Integer
     def start_character_column
       source.character_column(start_offset)
@@ -602,7 +602,7 @@ module Prism
 
     # The column in code units of the given encoding where this location
     # starts from the start of the line.
-    #--
+    #
     #: (?Encoding encoding) -> Integer
     def start_code_units_column(encoding = Encoding::UTF_16LE)
       source.code_units_column(start_offset, encoding)
@@ -610,7 +610,7 @@ module Prism
 
     # The start column in code units using the given cache to fetch or calculate
     # the value.
-    #--
+    #
     #: (_CodeUnitsCache cache) -> Integer
     def cached_start_code_units_column(cache)
       cache[start_offset] - cache[source.line_start(start_offset)]
@@ -618,7 +618,7 @@ module Prism
 
     # The column in bytes where this location ends from the start of the
     # line.
-    #--
+    #
     #: () -> Integer
     def end_column
       source.column(end_offset)
@@ -626,7 +626,7 @@ module Prism
 
     # The column in characters where this location ends from the start of
     # the line.
-    #--
+    #
     #: () -> Integer
     def end_character_column
       source.character_column(end_offset)
@@ -634,7 +634,7 @@ module Prism
 
     # The column in code units of the given encoding where this location
     # ends from the start of the line.
-    #--
+    #
     #: (?Encoding encoding) -> Integer
     def end_code_units_column(encoding = Encoding::UTF_16LE)
       source.code_units_column(end_offset, encoding)
@@ -642,28 +642,28 @@ module Prism
 
     # The end column in code units using the given cache to fetch or calculate
     # the value.
-    #--
+    #
     #: (_CodeUnitsCache cache) -> Integer
     def cached_end_code_units_column(cache)
       cache[end_offset] - cache[source.line_start(end_offset)]
     end
 
     # Implement the hash pattern matching interface for Location.
-    #--
+    #
     #: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys(keys) # :nodoc:
       { start_offset: start_offset, end_offset: end_offset }
     end
 
     # Implement the pretty print interface for Location.
-    #--
+    #
     #: (PP q) -> void
     def pretty_print(q) # :nodoc:
       q.text("(#{start_line},#{start_column})-(#{end_line},#{end_column})")
     end
 
     # Returns true if the given other location is equal to this location.
-    #--
+    #
     #: (untyped other) -> bool
     def ==(other)
       Location === other &&
@@ -674,7 +674,7 @@ module Prism
     # Returns a new location that stretches from this location to the given
     # other location. Raises an error if this location is not before the other
     # location or if they don't share the same source.
-    #--
+    #
     #: (Location other) -> Location
     def join(other)
       raise "Incompatible sources" if source != other.source
@@ -686,7 +686,7 @@ module Prism
     # Join this location with the first occurrence of the string in the source
     # that occurs after this location on the same line, and return the new
     # location. This will raise an error if the string does not exist.
-    #--
+    #
     #: (String string) -> Location
     def adjoin(string)
       line_suffix = source.slice(end_offset, source.line_end(end_offset) - end_offset)
@@ -705,21 +705,21 @@ module Prism
     attr_reader :location #: Location
 
     # Create a new comment object with the given location.
-    #--
+    #
     #: (Location location) -> void
     def initialize(location)
       @location = location
     end
 
     # Implement the hash pattern matching interface for Comment.
-    #--
+    #
     #: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys(keys) # :nodoc:
       { location: location }
     end
 
     # Returns the content of the comment by slicing it from the source code.
-    #--
+    #
     #: () -> String
     def slice
       location.slice
@@ -728,7 +728,7 @@ module Prism
     # Returns true if this comment happens on the same line as other code and
     # false if the comment is by itself. This can only be true for inline
     # comments and should be false for block comments.
-    #--
+    #
     #: () -> bool
     def trailing?
       raise NotImplementedError, "trailing? is not implemented for #{self.class}"
@@ -740,14 +740,14 @@ module Prism
   class InlineComment < Comment
     # Returns true if this comment happens on the same line as other code and
     # false if the comment is by itself.
-    #--
+    #
     #: () -> bool
     def trailing?
       !location.start_line_slice.strip.empty?
     end
 
     # Returns a string representation of this comment.
-    #--
+    #
     #: () -> String
     def inspect # :nodoc:
       "#<Prism::InlineComment @location=#{location.inspect}>"
@@ -758,14 +758,14 @@ module Prism
   # and =end.
   class EmbDocComment < Comment
     # Returns false. This can only be true for inline comments.
-    #--
+    #
     #: () -> bool
     def trailing?
       false
     end
 
     # Returns a string representation of this comment.
-    #--
+    #
     #: () -> String
     def inspect # :nodoc:
       "#<Prism::EmbDocComment @location=#{location.inspect}>"
@@ -781,7 +781,7 @@ module Prism
     attr_reader :value_loc #: Location
 
     # Create a new magic comment object with the given key and value locations.
-    #--
+    #
     #: (Location key_loc, Location value_loc) -> void
     def initialize(key_loc, value_loc)
       @key_loc = key_loc
@@ -789,28 +789,28 @@ module Prism
     end
 
     # Returns the key of the magic comment by slicing it from the source code.
-    #--
+    #
     #: () -> String
     def key
       key_loc.slice
     end
 
     # Returns the value of the magic comment by slicing it from the source code.
-    #--
+    #
     #: () -> String
     def value
       value_loc.slice
     end
 
     # Implement the hash pattern matching interface for MagicComment.
-    #--
+    #
     #: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys(keys) # :nodoc:
       { key_loc: key_loc, value_loc: value_loc }
     end
 
     # Returns a string representation of this magic comment.
-    #--
+    #
     #: () -> String
     def inspect # :nodoc:
       "#<Prism::MagicComment @key=#{key.inspect} @value=#{value.inspect}>"
@@ -833,7 +833,7 @@ module Prism
     attr_reader :level #: Symbol
 
     # Create a new error object with the given message and location.
-    #--
+    #
     #: (Symbol type, String message, Location location, Symbol level) -> void
     def initialize(type, message, location, level)
       @type = type
@@ -843,14 +843,14 @@ module Prism
     end
 
     # Implement the hash pattern matching interface for ParseError.
-    #--
+    #
     #: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys(keys) # :nodoc:
       { type: type, message: message, location: location, level: level }
     end
 
     # Returns a string representation of this error.
-    #--
+    #
     #: () -> String
     def inspect # :nodoc:
       "#<Prism::ParseError @type=#{@type.inspect} @message=#{@message.inspect} @location=#{@location.inspect} @level=#{@level.inspect}>"
@@ -873,7 +873,7 @@ module Prism
     attr_reader :level #: Symbol
 
     # Create a new warning object with the given message and location.
-    #--
+    #
     #: (Symbol type, String message, Location location, Symbol level) -> void
     def initialize(type, message, location, level)
       @type = type
@@ -883,14 +883,14 @@ module Prism
     end
 
     # Implement the hash pattern matching interface for ParseWarning.
-    #--
+    #
     #: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys(keys) # :nodoc:
       { type: type, message: message, location: location, level: level }
     end
 
     # Returns a string representation of this warning.
-    #--
+    #
     #: () -> String
     def inspect # :nodoc:
       "#<Prism::ParseWarning @type=#{@type.inspect} @message=#{@message.inspect} @location=#{@location.inspect} @level=#{@level.inspect}>"
@@ -922,7 +922,7 @@ module Prism
     attr_reader :source #: Source
 
     # Create a new result object with the given values.
-    #--
+    #
     #: (Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
     def initialize(comments, magic_comments, data_loc, errors, warnings, continuable, source)
       @comments = comments
@@ -935,14 +935,14 @@ module Prism
     end
 
     # Implement the hash pattern matching interface for Result.
-    #--
+    #
     #: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys(keys) # :nodoc:
       { comments: comments, magic_comments: magic_comments, data_loc: data_loc, errors: errors, warnings: warnings }
     end
 
     # Returns the encoding of the source code that was parsed.
-    #--
+    #
     #: () -> Encoding
     def encoding
       source.encoding
@@ -950,7 +950,7 @@ module Prism
 
     # Returns true if there were no errors during parsing and false if there
     # were.
-    #--
+    #
     #: () -> bool
     def success?
       errors.empty?
@@ -958,7 +958,7 @@ module Prism
 
     # Returns true if there were errors during parsing and false if there were
     # not.
-    #--
+    #
     #: () -> bool
     def failure?
       !success?
@@ -984,14 +984,13 @@ module Prism
     #     Prism.parse("tap do").continuable?     #=> true  (unclosed block)
     #     Prism.parse("end.tap do").continuable? #=> false (stray end)
     #
-    #--
     #: () -> bool
     def continuable?
       @continuable
     end
 
     # Create a code units cache for the given encoding.
-    #--
+    #
     #: (Encoding encoding) -> _CodeUnitsCache
     def code_units_cache(encoding)
       source.code_units_cache(encoding)
@@ -1012,7 +1011,7 @@ module Prism
     attr_reader :value #: ProgramNode
 
     # Create a new parse result object with the given values.
-    #--
+    #
     #: (ProgramNode value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
     def initialize(value, comments, magic_comments, data_loc, errors, warnings, continuable, source)
       @value = value
@@ -1020,14 +1019,14 @@ module Prism
     end
 
     # Implement the hash pattern matching interface for ParseResult.
-    #--
+    #
     #: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys(keys) # :nodoc:
       super.merge!(value: value)
     end
 
     # Attach the list of comments to their respective locations in the tree.
-    #--
+    #
     #: () -> void
     def attach_comments!
       Comments.new(self).attach! # steep:ignore
@@ -1035,7 +1034,7 @@ module Prism
 
     # Walk the tree and mark nodes that are on a new line, loosely emulating
     # the behavior of CRuby's `:line` tracepoint event.
-    #--
+    #
     #: () -> void
     def mark_newlines!
       value.accept(Newlines.new(source.offsets.size)) # steep:ignore
@@ -1043,7 +1042,7 @@ module Prism
 
     # Returns a string representation of the syntax tree with the errors
     # displayed inline.
-    #--
+    #
     #: () -> String
     def errors_format
       Errors.new(self).format
@@ -1056,7 +1055,7 @@ module Prism
     attr_reader :value #: Array[Token]
 
     # Create a new lex result object with the given values.
-    #--
+    #
     #: (Array[Token] value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
     def initialize(value, comments, magic_comments, data_loc, errors, warnings, continuable, source)
       @value = value
@@ -1064,7 +1063,7 @@ module Prism
     end
 
     # Implement the hash pattern matching interface for LexResult.
-    #--
+    #
     #: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys(keys) # :nodoc:
       super.merge!(value: value)
@@ -1078,7 +1077,7 @@ module Prism
     attr_reader :value #: [ProgramNode, Array[Token]]
 
     # Create a new parse lex result object with the given values.
-    #--
+    #
     #: ([ProgramNode, Array[Token]] value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
     def initialize(value, comments, magic_comments, data_loc, errors, warnings, continuable, source)
       @value = value
@@ -1086,7 +1085,7 @@ module Prism
     end
 
     # Implement the hash pattern matching interface for ParseLexResult.
-    #--
+    #
     #: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys(keys) # :nodoc:
       super.merge!(value: value)
@@ -1108,7 +1107,7 @@ module Prism
     # @rbs @location: Location | Integer
 
     # Create a new token object with the given type, value, and location.
-    #--
+    #
     #: (Source source, Symbol type, String value, Location | Integer location, Integer state) -> void
     def initialize(source, type, value, location, state)
       @source = source
@@ -1119,14 +1118,14 @@ module Prism
     end
 
     # Implement the hash pattern matching interface for Token.
-    #--
+    #
     #: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys(keys) # :nodoc:
       { type: type, value: value, location: location }
     end
 
     # A Location object representing the location of this token in the source.
-    #--
+    #
     #: () -> Location
     def location
       location = @location
@@ -1135,7 +1134,7 @@ module Prism
     end
 
     # Implement the pretty print interface for Token.
-    #--
+    #
     #: (PP q) -> void
     def pretty_print(q) # :nodoc:
       q.group do
@@ -1152,7 +1151,7 @@ module Prism
     end
 
     # Returns true if the given other token is equal to this token.
-    #--
+    #
     #: (untyped other) -> bool
     def ==(other)
       Token === other &&
@@ -1161,7 +1160,7 @@ module Prism
     end
 
     # Returns a string representation of this token.
-    #--
+    #
     #: () -> String
     def inspect # :nodoc:
       location
@@ -1169,7 +1168,7 @@ module Prism
     end
 
     # Freeze this object and the objects it contains.
-    #--
+    #
     #: () -> void
     def deep_freeze
       value.freeze
@@ -1214,7 +1213,7 @@ module Prism
     attr_reader :forwarding #: Array[Symbol]
 
     # Create a new scope object with the given locals and forwarding.
-    #--
+    #
     #: (Array[Symbol] locals, Array[Symbol] forwarding) -> void
     def initialize(locals, forwarding)
       @locals = locals
@@ -1225,7 +1224,7 @@ module Prism
   # Create a new scope with the given locals and forwarding options that is
   # suitable for passing into one of the Prism.* methods that accepts the
   # `scopes` option.
-  #--
+  #
   #: (?locals: Array[Symbol], ?forwarding: Array[Symbol]) -> Scope
   def self.scope(locals: [], forwarding: [])
     Scope.new(locals, forwarding)

--- a/lib/prism/parse_result/comments.rb
+++ b/lib/prism/parse_result/comments.rb
@@ -109,7 +109,7 @@ module Prism
 
       # Create a new Comments object that will attach comments to the given
       # parse result.
-      #--
+      #
       #: (ParseResult parse_result) -> void
       def initialize(parse_result)
         @parse_result = parse_result
@@ -117,7 +117,7 @@ module Prism
 
       # Attach the comments to their respective locations in the tree by
       # mutating the parse result.
-      #--
+      #
       #: () -> void
       def attach!
         parse_result.comments.each do |comment|
@@ -146,7 +146,7 @@ module Prism
 
       # Responsible for finding the nearest targets to the given comment within
       # the context of the given encapsulating node.
-      #--
+      #
       #: (node node, Comment comment) -> [_CommentTarget?, _CommentTarget?, _CommentTarget?]
       def nearest_targets(node, comment)
         comment_start = comment.location.start_offset

--- a/lib/prism/parse_result/errors.rb
+++ b/lib/prism/parse_result/errors.rb
@@ -14,14 +14,14 @@ module Prism
       attr_reader :parse_result #: ParseResult
 
       # Initialize a new set of errors from the given parse result.
-      #--
+      #
       #: (ParseResult parse_result) -> void
       def initialize(parse_result)
         @parse_result = parse_result
       end
 
       # Formats the errors in a human-readable way and return them as a string.
-      #--
+      #
       #: () -> String
       def format
         error_lines = {} #: Hash[Integer, Array[ParseError]]

--- a/lib/prism/parse_result/newlines.rb
+++ b/lib/prism/parse_result/newlines.rb
@@ -31,14 +31,14 @@ module Prism
       # @rbs @lines: Array[bool]
 
       # Create a new Newlines visitor with the given newline offsets.
-      #--
+      #
       #: (Integer lines) -> void
       def initialize(lines)
         @lines = Array.new(1 + lines, false)
       end
 
       # Permit block nodes to mark newlines within themselves.
-      #--
+      #
       #: (BlockNode node) -> void
       def visit_block_node(node)
         old_lines = @lines
@@ -52,7 +52,7 @@ module Prism
       end
 
       # Permit lambda nodes to mark newlines within themselves.
-      #--
+      #
       #: (LambdaNode node) -> void
       def visit_lambda_node(node)
         old_lines = @lines
@@ -66,7 +66,7 @@ module Prism
       end
 
       # Mark if nodes as newlines.
-      #--
+      #
       #: (IfNode node) -> void
       def visit_if_node(node)
         node.newline_flag!(@lines)
@@ -74,7 +74,7 @@ module Prism
       end
 
       # Mark unless nodes as newlines.
-      #--
+      #
       #: (UnlessNode node) -> void
       def visit_unless_node(node)
         node.newline_flag!(@lines)
@@ -82,7 +82,7 @@ module Prism
       end
 
       # Permit statements lists to mark newlines within themselves.
-      #--
+      #
       #: (StatementsNode node) -> void
       def visit_statements_node(node)
         node.body.each do |child|

--- a/lib/prism/pattern.rb
+++ b/lib/prism/pattern.rb
@@ -43,7 +43,7 @@ module Prism
     class CompilationError < StandardError
       # Create a new CompilationError with the given representation of the node
       # that caused the error.
-      #--
+      #
       #: (String repr) -> void
       def initialize(repr) # :nodoc:
         super(<<~ERROR)
@@ -66,7 +66,7 @@ module Prism
 
     # Create a new pattern with the given query. The query should be a string
     # containing a Ruby pattern matching expression.
-    #--
+    #
     #: (String query) -> void
     def initialize(query)
       @query = query
@@ -75,7 +75,7 @@ module Prism
 
     # Compile the query into a callable object that can be used to match against
     # nodes.
-    #--
+    #
     #: () -> Proc
     def compile
       result = Prism.parse("case nil\nin #{query}\nend")
@@ -93,7 +93,7 @@ module Prism
     # pattern. If a block is given, it will be called with each node that
     # matches the pattern. If no block is given, an enumerator will be returned
     # that will yield each node that matches the pattern.
-    #--
+    #
     #: (node root) -> Enumerator[node, void]
     #: (node root) { (node) -> void } -> void
     def scan(root, &blk)
@@ -112,7 +112,7 @@ module Prism
 
     # Shortcut for combining two procs into one that returns true if both return
     # true.
-    #--
+    #
     #: (Proc left, Proc right) -> Proc
     def combine_and(left, right) # :nodoc:
       ->(other) { left.call(other) && right.call(other) }
@@ -120,7 +120,7 @@ module Prism
 
     # Shortcut for combining two procs into one that returns true if either
     # returns true.
-    #--
+    #
     #: (Proc left, Proc right) -> Proc
     def combine_or(left, right) # :nodoc:
       ->(other) { left.call(other) || right.call(other) }
@@ -129,14 +129,14 @@ module Prism
     # Raise an error because the given node is not supported. Note purposefully
     # not typing this method since it is a no return method that Steep does not
     # understand.
-    #--
+    #
     #: (node node) -> bot
     def compile_error(node) # :nodoc:
       raise CompilationError, node.inspect
     end
 
     # in [foo, bar, baz]
-    #--
+    #
     #: (ArrayPatternNode node) -> Proc
     def compile_array_pattern_node(node) # :nodoc:
       compile_error(node) if !node.rest.nil? || node.posts.any?
@@ -163,14 +163,14 @@ module Prism
     end
 
     # in foo | bar
-    #--
+    #
     #: (AlternationPatternNode node) -> Proc
     def compile_alternation_pattern_node(node) # :nodoc:
       combine_or(compile_node(node.left), compile_node(node.right))
     end
 
     # in Prism::ConstantReadNode
-    #--
+    #
     #: (ConstantPathNode node) -> Proc
     def compile_constant_path_node(node) # :nodoc:
       parent = node.parent
@@ -187,14 +187,14 @@ module Prism
 
     # in ConstantReadNode
     # in String
-    #--
+    #
     #: (ConstantReadNode node) -> Proc
     def compile_constant_read_node(node) # :nodoc:
       compile_constant_name(node, node.name)
     end
 
     # Compile a name associated with a constant.
-    #--
+    #
     #: ((ConstantPathNode | ConstantReadNode) node, Symbol name) -> Proc
     def compile_constant_name(node, name) # :nodoc:
       if Prism.const_defined?(name, false)
@@ -212,7 +212,7 @@ module Prism
 
     # in InstanceVariableReadNode[name: Symbol]
     # in { name: Symbol }
-    #--
+    #
     #: (HashPatternNode node) -> Proc
     def compile_hash_pattern_node(node) # :nodoc:
       compile_error(node) if node.rest
@@ -247,14 +247,14 @@ module Prism
     end
 
     # in nil
-    #--
+    #
     #: (NilNode node) -> Proc
     def compile_nil_node(node) # :nodoc:
       ->(attribute) { attribute.nil? }
     end
 
     # in /foo/
-    #--
+    #
     #: (RegularExpressionNode node) -> Proc
     def compile_regular_expression_node(node) # :nodoc:
       regexp = Regexp.new(node.unescaped, node.closing[1..])
@@ -264,7 +264,7 @@ module Prism
 
     # in ""
     # in "foo"
-    #--
+    #
     #: (StringNode node) -> Proc
     def compile_string_node(node) # :nodoc:
       string = node.unescaped
@@ -274,7 +274,7 @@ module Prism
 
     # in :+
     # in :foo
-    #--
+    #
     #: (SymbolNode node) -> Proc
     def compile_symbol_node(node) # :nodoc:
       symbol = node.unescaped.to_sym
@@ -284,7 +284,7 @@ module Prism
 
     # Compile any kind of node. Dispatch out to the individual compilation
     # methods based on the type of node.
-    #--
+    #
     #: (node node) -> Proc
     def compile_node(node) # :nodoc:
       case node

--- a/lib/prism/relocation.rb
+++ b/lib/prism/relocation.rb
@@ -54,7 +54,7 @@ module Prism
       # @rbs @values: Hash[Symbol, untyped]?
 
       # Initialize a new entry with the given repository.
-      #--
+      #
       #: (Repository repository) -> void
       def initialize(repository)
         @repository = repository
@@ -62,49 +62,49 @@ module Prism
       end
 
       # Fetch the filepath of the value.
-      #--
+      #
       #: () -> String
       def filepath
         fetch_value(:filepath)
       end
 
       # Fetch the start line of the value.
-      #--
+      #
       #: () -> Integer
       def start_line
         fetch_value(:start_line)
       end
 
       # Fetch the end line of the value.
-      #--
+      #
       #: () -> Integer
       def end_line
         fetch_value(:end_line)
       end
 
       # Fetch the start byte offset of the value.
-      #--
+      #
       #: () -> Integer
       def start_offset
         fetch_value(:start_offset)
       end
 
       # Fetch the end byte offset of the value.
-      #--
+      #
       #: () -> Integer
       def end_offset
         fetch_value(:end_offset)
       end
 
       # Fetch the start character offset of the value.
-      #--
+      #
       #: () -> Integer
       def start_character_offset
         fetch_value(:start_character_offset)
       end
 
       # Fetch the end character offset of the value.
-      #--
+      #
       #: () -> Integer
       def end_character_offset
         fetch_value(:end_character_offset)
@@ -112,7 +112,7 @@ module Prism
 
       # Fetch the start code units offset of the value, for the encoding that
       # was configured on the repository.
-      #--
+      #
       #: () -> Integer
       def start_code_units_offset
         fetch_value(:start_code_units_offset)
@@ -120,35 +120,35 @@ module Prism
 
       # Fetch the end code units offset of the value, for the encoding that was
       # configured on the repository.
-      #--
+      #
       #: () -> Integer
       def end_code_units_offset
         fetch_value(:end_code_units_offset)
       end
 
       # Fetch the start byte column of the value.
-      #--
+      #
       #: () -> Integer
       def start_column
         fetch_value(:start_column)
       end
 
       # Fetch the end byte column of the value.
-      #--
+      #
       #: () -> Integer
       def end_column
         fetch_value(:end_column)
       end
 
       # Fetch the start character column of the value.
-      #--
+      #
       #: () -> Integer
       def start_character_column
         fetch_value(:start_character_column)
       end
 
       # Fetch the end character column of the value.
-      #--
+      #
       #: () -> Integer
       def end_character_column
         fetch_value(:end_character_column)
@@ -156,7 +156,7 @@ module Prism
 
       # Fetch the start code units column of the value, for the encoding that
       # was configured on the repository.
-      #--
+      #
       #: () -> Integer
       def start_code_units_column
         fetch_value(:start_code_units_column)
@@ -164,28 +164,28 @@ module Prism
 
       # Fetch the end code units column of the value, for the encoding that was
       # configured on the repository.
-      #--
+      #
       #: () -> Integer
       def end_code_units_column
         fetch_value(:end_code_units_column)
       end
 
       # Fetch the leading comments of the value.
-      #--
+      #
       #: () -> Array[CommentsField::Comment]
       def leading_comments
         fetch_value(:leading_comments)
       end
 
       # Fetch the trailing comments of the value.
-      #--
+      #
       #: () -> Array[CommentsField::Comment]
       def trailing_comments
         fetch_value(:trailing_comments)
       end
 
       # Fetch the leading and trailing comments of the value.
-      #--
+      #
       #: () -> Array[CommentsField::Comment]
       def comments
         [*leading_comments, *trailing_comments]
@@ -194,7 +194,7 @@ module Prism
       # Reify the values on this entry with the given values. This is an
       # internal-only API that is called from the repository when it is time to
       # reify the values.
-      #--
+      #
       #: (entry_values values) -> void
       def reify!(values) # :nodoc:
         @repository = nil
@@ -204,7 +204,7 @@ module Prism
       private
 
       # Fetch a value from the entry, raising an error if it is missing.
-      #--
+      #
       #: (Symbol name) -> entry_value
       def fetch_value(name)
         values.fetch(name) do
@@ -214,7 +214,7 @@ module Prism
       end
 
       # Return the values from the repository, reifying them if necessary.
-      #--
+      #
       #: () -> entry_values
       def values
         @values || (@repository&.reify!; @values) #: entry_values
@@ -227,21 +227,21 @@ module Prism
       attr_reader :value #: untyped
 
       # Initialize the source with the given value.
-      #--
+      #
       #: (untyped value) -> void
       def initialize(value)
         @value = value
       end
 
       # Reparse the value and return the parse result.
-      #--
+      #
       #: () -> ParseResult
       def result
         raise NotImplementedError, "Subclasses must implement #result"
       end
 
       # Create a code units cache for the given encoding.
-      #--
+      #
       #: (Encoding encoding) -> _CodeUnitsCache
       def code_units_cache(encoding)
         result.code_units_cache(encoding)
@@ -251,7 +251,7 @@ module Prism
     # A source that is represented by a file path.
     class SourceFilepath < Source
       # Reparse the file and return the parse result.
-      #--
+      #
       #: () -> ParseResult
       def result
         Prism.parse_file(value)
@@ -261,7 +261,7 @@ module Prism
     # A source that is represented by a string.
     class SourceString < Source
       # Reparse the string and return the parse result.
-      #--
+      #
       #: () -> ParseResult
       def result
         Prism.parse(value)
@@ -274,14 +274,14 @@ module Prism
       attr_reader :value #: String
 
       # Initialize a new field with the given file path.
-      #--
+      #
       #: (String value) -> void
       def initialize(value)
         @value = value
       end
 
       # Fetch the file path.
-      #--
+      #
       #: (_Value _value) -> entry_values
       def fields(_value)
         { filepath: value }
@@ -291,7 +291,7 @@ module Prism
     # A field representing the start and end lines.
     class LinesField
       # Fetches the start and end line of a value.
-      #--
+      #
       #: (_Value value) -> entry_values
       def fields(value)
         { start_line: value.start_line, end_line: value.end_line }
@@ -301,7 +301,7 @@ module Prism
     # A field representing the start and end byte offsets.
     class OffsetsField
       # Fetches the start and end byte offset of a value.
-      #--
+      #
       #: (_Value value) -> entry_values
       def fields(value)
         { start_offset: value.start_offset, end_offset: value.end_offset }
@@ -311,7 +311,7 @@ module Prism
     # A field representing the start and end character offsets.
     class CharacterOffsetsField
       # Fetches the start and end character offset of a value.
-      #--
+      #
       #: (_Value value) -> entry_values
       def fields(value)
         {
@@ -333,7 +333,7 @@ module Prism
       # @rbs @cache: _CodeUnitsCache?
 
       # Initialize a new field with the associated repository and encoding.
-      #--
+      #
       #: (Repository repository, Encoding encoding) -> void
       def initialize(repository, encoding)
         @repository = repository
@@ -343,7 +343,7 @@ module Prism
 
       # Fetches the start and end code units offset of a value for a particular
       # encoding.
-      #--
+      #
       #: (_Value value) -> entry_values
       def fields(value)
         {
@@ -355,7 +355,7 @@ module Prism
       private
 
       # Lazily create a code units cache for the associated encoding.
-      #--
+      #
       #: () -> _CodeUnitsCache
       def cache
         @cache ||= repository.code_units_cache(encoding)
@@ -365,7 +365,7 @@ module Prism
     # A field representing the start and end byte columns.
     class ColumnsField
       # Fetches the start and end byte column of a value.
-      #--
+      #
       #: (_Value value) -> entry_values
       def fields(value)
         { start_column: value.start_column, end_column: value.end_column }
@@ -375,7 +375,7 @@ module Prism
     # A field representing the start and end character columns.
     class CharacterColumnsField
       # Fetches the start and end character column of a value.
-      #--
+      #
       #: (_Value value) -> entry_values
       def fields(value)
         {
@@ -398,7 +398,7 @@ module Prism
       # @rbs @cache: _CodeUnitsCache?
 
       # Initialize a new field with the associated repository and encoding.
-      #--
+      #
       #: (Repository repository, Encoding encoding) -> void
       def initialize(repository, encoding)
         @repository = repository
@@ -408,7 +408,7 @@ module Prism
 
       # Fetches the start and end code units column of a value for a particular
       # encoding.
-      #--
+      #
       #: (_Value value) -> entry_values
       def fields(value)
         {
@@ -420,7 +420,7 @@ module Prism
       private
 
       # Lazily create a code units cache for the associated encoding.
-      #--
+      #
       #: () -> _CodeUnitsCache
       def cache
         @cache ||= repository.code_units_cache(encoding)
@@ -445,7 +445,7 @@ module Prism
       private
 
       # Create comment objects from the given values.
-      #--
+      #
       #: (entry_value values) -> Array[Comment]
       def comments(values)
         values.map { |value| Comment.new(value.slice) }
@@ -455,7 +455,7 @@ module Prism
     # A field representing the leading comments.
     class LeadingCommentsField < CommentsField
       # Fetches the leading comments of a value.
-      #--
+      #
       #: (_Value value) -> entry_values
       def fields(value)
         { leading_comments: comments(value.leading_comments) }
@@ -465,7 +465,7 @@ module Prism
     # A field representing the trailing comments.
     class TrailingCommentsField < CommentsField
       # Fetches the trailing comments of a value.
-      #--
+      #
       #: (_Value value) -> entry_values
       def fields(value)
         { trailing_comments: comments(value.trailing_comments) }
@@ -491,7 +491,7 @@ module Prism
       attr_reader :entries #: Hash[Integer, Hash[Symbol, Entry]]
 
       # Initialize a new repository with the given source.
-      #--
+      #
       #: (Source source) -> void
       def initialize(source)
         @source = source
@@ -500,14 +500,14 @@ module Prism
       end
 
       # Create a code units cache for the given encoding from the source.
-      #--
+      #
       #: (Encoding encoding) -> _CodeUnitsCache
       def code_units_cache(encoding)
         source.code_units_cache(encoding)
       end
 
       # Configure the filepath field for this repository and return self.
-      #--
+      #
       #: () -> self
       def filepath
         raise ConfigurationError, "Can only specify filepath for a filepath source" unless source.is_a?(SourceFilepath)
@@ -515,14 +515,14 @@ module Prism
       end
 
       # Configure the lines field for this repository and return self.
-      #--
+      #
       #: () -> self
       def lines
         field(:lines, LinesField.new)
       end
 
       # Configure the offsets field for this repository and return self.
-      #--
+      #
       #: () -> self
       def offsets
         field(:offsets, OffsetsField.new)
@@ -530,7 +530,7 @@ module Prism
 
       # Configure the character offsets field for this repository and return
       # self.
-      #--
+      #
       #: () -> self
       def character_offsets
         field(:character_offsets, CharacterOffsetsField.new)
@@ -538,14 +538,14 @@ module Prism
 
       # Configure the code unit offsets field for this repository for a specific
       # encoding and return self.
-      #--
+      #
       #: (Encoding encoding) -> self
       def code_unit_offsets(encoding)
         field(:code_unit_offsets, CodeUnitOffsetsField.new(self, encoding))
       end
 
       # Configure the columns field for this repository and return self.
-      #--
+      #
       #: () -> self
       def columns
         field(:columns, ColumnsField.new)
@@ -553,7 +553,7 @@ module Prism
 
       # Configure the character columns field for this repository and return
       # self.
-      #--
+      #
       #: () -> self
       def character_columns
         field(:character_columns, CharacterColumnsField.new)
@@ -561,7 +561,7 @@ module Prism
 
       # Configure the code unit columns field for this repository for a specific
       # encoding and return self.
-      #--
+      #
       #: (Encoding encoding) -> self
       def code_unit_columns(encoding)
         field(:code_unit_columns, CodeUnitColumnsField.new(self, encoding))
@@ -569,7 +569,7 @@ module Prism
 
       # Configure the leading comments field for this repository and return
       # self.
-      #--
+      #
       #: () -> self
       def leading_comments
         field(:leading_comments, LeadingCommentsField.new)
@@ -577,7 +577,7 @@ module Prism
 
       # Configure the trailing comments field for this repository and return
       # self.
-      #--
+      #
       #: () -> self
       def trailing_comments
         field(:trailing_comments, TrailingCommentsField.new)
@@ -585,7 +585,7 @@ module Prism
 
       # Configure both the leading and trailing comment fields for this
       # repository and return self.
-      #--
+      #
       #: () -> self
       def comments
         leading_comments.trailing_comments
@@ -594,7 +594,7 @@ module Prism
       # This method is called from nodes and locations when they want to enter
       # themselves into the repository. It it internal-only and meant to be
       # called from the #save* APIs.
-      #--
+      #
       #: (Integer node_id, Symbol field_name) -> Entry
       def enter(node_id, field_name) # :nodoc:
         entry = Entry.new(self)
@@ -605,7 +605,7 @@ module Prism
       # This method is called from the entries in the repository when they need
       # to reify their values. It is internal-only and meant to be called from
       # the various value APIs.
-      #--
+      #
       #: () -> void
       def reify! # :nodoc:
         result = source.result
@@ -639,7 +639,7 @@ module Prism
 
       # Append the given field to the repository and return the repository so
       # that these calls can be chained.
-      #--
+      #
       #: (Symbol name, _Field) -> self
       def field(name, value)
         raise ConfigurationError, "Cannot specify multiple #{name} fields" if @fields.key?(name)
@@ -649,14 +649,14 @@ module Prism
     end
 
     # Create a new repository for the given filepath.
-    #--
+    #
     #: (String value) -> Repository
     def self.filepath(value)
       Repository.new(SourceFilepath.new(value))
     end
 
     # Create a new repository for the given string.
-    #--
+    #
     #: (String value) -> Repository
     def self.string(value)
       Repository.new(SourceString.new(value))

--- a/lib/prism/string_query.rb
+++ b/lib/prism/string_query.rb
@@ -16,28 +16,28 @@ module Prism
     attr_reader :string #: String
 
     # Initialize a new query with the given string.
-    #--
+    #
     #: (String string) -> void
     def initialize(string)
       @string = string
     end
 
     # Whether or not this string is a valid local variable name.
-    #--
+    #
     #: () -> bool
     def local?
       StringQuery.local?(string)
     end
 
     # Whether or not this string is a valid constant name.
-    #--
+    #
     #: () -> bool
     def constant?
       StringQuery.constant?(string)
     end
 
     # Whether or not this string is a valid method name.
-    #--
+    #
     #: () -> bool
     def method_name?
       StringQuery.method_name?(string)

--- a/rakelib/typecheck.rake
+++ b/rakelib/typecheck.rake
@@ -30,7 +30,8 @@ namespace :typecheck do
             # break when RDoc private starts
             break
           when /\A:/
-            # skip RBS type annotations
+            # skip RBS type annotations and remove preceeding empty line
+            comments.pop if comments.last&.text&.empty?
           else
             comments << RBI::Comment.new(line)
           end

--- a/rbi/generated/prism/lex_compat.rbi
+++ b/rbi/generated/prism/lex_compat.rbi
@@ -130,7 +130,6 @@ module Prism
         # As tokens are coming in, we track the minimum amount of common leading
         # whitespace on plain string content tokens. This allows us to later
         # remove that amount of whitespace from the beginning of each line.
-        #
         sig { params(token: [[Integer, Integer], Symbol, String, ::T.untyped]).void }
         def <<(token); end
 

--- a/rbi/generated/prism/parse_result.rbi
+++ b/rbi/generated/prism/parse_result.rbi
@@ -612,7 +612,6 @@ module Prism
     #     Prism.parse("1 + ]").continuable?      #=> false (stray ])
     #     Prism.parse("tap do").continuable?     #=> true  (unclosed block)
     #     Prism.parse("end.tap do").continuable? #=> false (stray end)
-    #
     sig { returns(T::Boolean) }
     def continuable?; end
 

--- a/rbi/generated/prism/relocation.rbi
+++ b/rbi/generated/prism/relocation.rbi
@@ -257,7 +257,6 @@ module Prism
         attr_reader :slice
 
         # Initialize a new comment with the given slice.
-        #
         sig { params(slice: String).void }
         def initialize(slice); end
       end

--- a/sig/generated/prism.rbs
+++ b/sig/generated/prism.rbs
@@ -8,7 +8,7 @@ module Prism
   # Raised when requested to parse as the currently running Ruby version but Prism has no support for it.
   class CurrentVersionError < ArgumentError
     # Initialize a new exception for the given ruby version string.
-    # --
+    #
     # : (String version) -> void
     def initialize: (String version) -> void
   end
@@ -20,7 +20,7 @@ module Prism
   # resembles the return value of Ripper.lex.
   #
   # For supported options, see Prism.parse.
-  # --
+  #
   # : (String source, **untyped options) -> LexCompat::Result
   def self.lex_compat: (String source, **untyped options) -> LexCompat::Result
 
@@ -28,7 +28,7 @@ module Prism
   #   load(source, serialized, freeze) -> ParseResult
   #
   # Load the serialized AST using the source as a reference into a tree.
-  # --
+  #
   # : (String source, String serialized, ?bool freeze) -> ParseResult
   def self.load: (String source, String serialized, ?bool freeze) -> ParseResult
 
@@ -36,7 +36,7 @@ module Prism
   # returns the Prism node representing it. On CRuby, this uses node_id for
   # an exact match. On other implementations, it falls back to best-effort
   # matching by source location line number.
-  # --
+  #
   # : (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
   def self.find: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
 

--- a/sig/generated/prism/compiler.rbs
+++ b/sig/generated/prism/compiler.rbs
@@ -19,17 +19,17 @@ module Prism
   #     # => [:program, [[[:call, [[:integer], [:arguments, [[:integer]]]]]]]]
   class Compiler < Visitor
     # Visit an individual node.
-    # --
+    #
     # : (node?) -> untyped
     def visit: (node?) -> untyped
 
     # Visit a list of nodes.
-    # --
+    #
     # : (Array[node?]) -> untyped
     def visit_all: (Array[node?]) -> untyped
 
     # Visit the child nodes of the given node.
-    # --
+    #
     # : (node) -> Array[untyped]
     def visit_child_nodes: (node) -> Array[untyped]
 

--- a/sig/generated/prism/desugar_compiler.rbs
+++ b/sig/generated/prism/desugar_compiler.rbs
@@ -18,7 +18,7 @@ module Prism
     def initialize: (ClassVariableAndWriteNode | ConstantAndWriteNode | GlobalVariableAndWriteNode | InstanceVariableAndWriteNode | LocalVariableAndWriteNode node, Source default_source, Symbol read_class, Symbol write_class, **untyped arguments) -> void
 
     # Desugar `x &&= y` to `x && x = y`
-    # --
+    #
     # : () -> node
     def compile: () -> node
   end
@@ -40,7 +40,7 @@ module Prism
     def initialize: (ClassVariableOrWriteNode | ConstantOrWriteNode | GlobalVariableOrWriteNode node, Source default_source, Symbol read_class, Symbol write_class, **untyped arguments) -> void
 
     # Desugar `x ||= y` to `defined?(x) ? x : x = y`
-    # --
+    #
     # : () -> node
     def compile: () -> node
   end
@@ -62,7 +62,7 @@ module Prism
     def initialize: (ClassVariableOperatorWriteNode | ConstantOperatorWriteNode | GlobalVariableOperatorWriteNode | InstanceVariableOperatorWriteNode | LocalVariableOperatorWriteNode node, Source default_source, Symbol read_class, Symbol write_class, **untyped arguments) -> void
 
     # Desugar `x += y` to `x = x + y`
-    # --
+    #
     # : () -> node
     def compile: () -> node
   end
@@ -84,7 +84,7 @@ module Prism
     def initialize: (InstanceVariableOrWriteNode | LocalVariableOrWriteNode node, Source default_source, Symbol read_class, Symbol write_class, **untyped arguments) -> void
 
     # Desugar `x ||= y` to `x || x = y`
-    # --
+    #
     # : () -> node
     def compile: () -> node
   end
@@ -172,7 +172,7 @@ module Prism
     # becomes
     #
     # `@@foo && @@foo = bar`
-    # --
+    #
     # : (ClassVariableAndWriteNode node) -> node
     def visit_class_variable_and_write_node: (ClassVariableAndWriteNode node) -> node
 
@@ -181,7 +181,7 @@ module Prism
     # becomes
     #
     # `defined?(@@foo) ? @@foo : @@foo = bar`
-    # --
+    #
     # : (ClassVariableOrWriteNode node) -> node
     def visit_class_variable_or_write_node: (ClassVariableOrWriteNode node) -> node
 
@@ -190,7 +190,7 @@ module Prism
     # becomes
     #
     # `@@foo = @@foo + bar`
-    # --
+    #
     # : (ClassVariableOperatorWriteNode node) -> node
     def visit_class_variable_operator_write_node: (ClassVariableOperatorWriteNode node) -> node
 
@@ -199,7 +199,7 @@ module Prism
     # becomes
     #
     # `Foo && Foo = bar`
-    # --
+    #
     # : (ConstantAndWriteNode node) -> node
     def visit_constant_and_write_node: (ConstantAndWriteNode node) -> node
 
@@ -208,7 +208,7 @@ module Prism
     # becomes
     #
     # `defined?(Foo) ? Foo : Foo = bar`
-    # --
+    #
     # : (ConstantOrWriteNode node) -> node
     def visit_constant_or_write_node: (ConstantOrWriteNode node) -> node
 
@@ -217,7 +217,7 @@ module Prism
     # becomes
     #
     # `Foo = Foo + bar`
-    # --
+    #
     # : (ConstantOperatorWriteNode node) -> node
     def visit_constant_operator_write_node: (ConstantOperatorWriteNode node) -> node
 
@@ -226,7 +226,7 @@ module Prism
     # becomes
     #
     # `$foo && $foo = bar`
-    # --
+    #
     # : (GlobalVariableAndWriteNode node) -> node
     def visit_global_variable_and_write_node: (GlobalVariableAndWriteNode node) -> node
 
@@ -235,7 +235,7 @@ module Prism
     # becomes
     #
     # `defined?($foo) ? $foo : $foo = bar`
-    # --
+    #
     # : (GlobalVariableOrWriteNode node) -> node
     def visit_global_variable_or_write_node: (GlobalVariableOrWriteNode node) -> node
 
@@ -244,7 +244,7 @@ module Prism
     # becomes
     #
     # `$foo = $foo + bar`
-    # --
+    #
     # : (GlobalVariableOperatorWriteNode node) -> node
     def visit_global_variable_operator_write_node: (GlobalVariableOperatorWriteNode node) -> node
 
@@ -253,7 +253,7 @@ module Prism
     # becomes
     #
     # `@foo && @foo = bar`
-    # --
+    #
     # : (InstanceVariableAndWriteNode node) -> node
     def visit_instance_variable_and_write_node: (InstanceVariableAndWriteNode node) -> node
 
@@ -262,7 +262,7 @@ module Prism
     # becomes
     #
     # `@foo || @foo = bar`
-    # --
+    #
     # : (InstanceVariableOrWriteNode node) -> node
     def visit_instance_variable_or_write_node: (InstanceVariableOrWriteNode node) -> node
 
@@ -271,7 +271,7 @@ module Prism
     # becomes
     #
     # `@foo = @foo + bar`
-    # --
+    #
     # : (InstanceVariableOperatorWriteNode node) -> node
     def visit_instance_variable_operator_write_node: (InstanceVariableOperatorWriteNode node) -> node
 
@@ -280,7 +280,7 @@ module Prism
     # becomes
     #
     # `foo && foo = bar`
-    # --
+    #
     # : (LocalVariableAndWriteNode node) -> node
     def visit_local_variable_and_write_node: (LocalVariableAndWriteNode node) -> node
 
@@ -289,7 +289,7 @@ module Prism
     # becomes
     #
     # `foo || foo = bar`
-    # --
+    #
     # : (LocalVariableOrWriteNode node) -> node
     def visit_local_variable_or_write_node: (LocalVariableOrWriteNode node) -> node
 
@@ -298,7 +298,7 @@ module Prism
     # becomes
     #
     # `foo = foo + bar`
-    # --
+    #
     # : (LocalVariableOperatorWriteNode node) -> node
     def visit_local_variable_operator_write_node: (LocalVariableOperatorWriteNode node) -> node
   end

--- a/sig/generated/prism/dispatcher.rbs
+++ b/sig/generated/prism/dispatcher.rbs
@@ -38,23 +38,23 @@ module Prism
     attr_reader listeners: Hash[Symbol, Array[untyped]]
 
     # Initialize a new dispatcher.
-    # --
+    #
     # : () -> void
     def initialize: () -> void
 
     # Register a listener for one or more events.
-    # --
+    #
     # : (untyped, *Symbol) -> void
     def register: (untyped, *Symbol) -> void
 
     # Register all public methods of a listener that match the pattern
     # `on_<node_name>_(enter|leave)`.
-    # --
+    #
     # : (untyped) -> void
     def register_public_methods: (untyped) -> void
 
     # Register a listener for the given events.
-    # --
+    #
     # : (untyped, Array[Symbol]) -> void
     private def register_events: (untyped, Array[Symbol]) -> void
 
@@ -62,7 +62,7 @@ module Prism
     alias dispatch visit
 
     # Dispatches a single event for `node` to all registered listeners.
-    # --
+    #
     # : (node node) -> void
     def dispatch_once: (node node) -> void
 
@@ -529,762 +529,762 @@ module Prism
       def initialize: (Hash[Symbol, Array[untyped]] listeners) -> void
 
       # Dispatch enter and leave events for AliasGlobalVariableNode nodes.
-      # --
+      #
       # : (AliasGlobalVariableNode node) -> void
       def visit_alias_global_variable_node: (AliasGlobalVariableNode node) -> void
 
       # Dispatch enter and leave events for AliasMethodNode nodes.
-      # --
+      #
       # : (AliasMethodNode node) -> void
       def visit_alias_method_node: (AliasMethodNode node) -> void
 
       # Dispatch enter and leave events for AlternationPatternNode nodes.
-      # --
+      #
       # : (AlternationPatternNode node) -> void
       def visit_alternation_pattern_node: (AlternationPatternNode node) -> void
 
       # Dispatch enter and leave events for AndNode nodes.
-      # --
+      #
       # : (AndNode node) -> void
       def visit_and_node: (AndNode node) -> void
 
       # Dispatch enter and leave events for ArgumentsNode nodes.
-      # --
+      #
       # : (ArgumentsNode node) -> void
       def visit_arguments_node: (ArgumentsNode node) -> void
 
       # Dispatch enter and leave events for ArrayNode nodes.
-      # --
+      #
       # : (ArrayNode node) -> void
       def visit_array_node: (ArrayNode node) -> void
 
       # Dispatch enter and leave events for ArrayPatternNode nodes.
-      # --
+      #
       # : (ArrayPatternNode node) -> void
       def visit_array_pattern_node: (ArrayPatternNode node) -> void
 
       # Dispatch enter and leave events for AssocNode nodes.
-      # --
+      #
       # : (AssocNode node) -> void
       def visit_assoc_node: (AssocNode node) -> void
 
       # Dispatch enter and leave events for AssocSplatNode nodes.
-      # --
+      #
       # : (AssocSplatNode node) -> void
       def visit_assoc_splat_node: (AssocSplatNode node) -> void
 
       # Dispatch enter and leave events for BackReferenceReadNode nodes.
-      # --
+      #
       # : (BackReferenceReadNode node) -> void
       def visit_back_reference_read_node: (BackReferenceReadNode node) -> void
 
       # Dispatch enter and leave events for BeginNode nodes.
-      # --
+      #
       # : (BeginNode node) -> void
       def visit_begin_node: (BeginNode node) -> void
 
       # Dispatch enter and leave events for BlockArgumentNode nodes.
-      # --
+      #
       # : (BlockArgumentNode node) -> void
       def visit_block_argument_node: (BlockArgumentNode node) -> void
 
       # Dispatch enter and leave events for BlockLocalVariableNode nodes.
-      # --
+      #
       # : (BlockLocalVariableNode node) -> void
       def visit_block_local_variable_node: (BlockLocalVariableNode node) -> void
 
       # Dispatch enter and leave events for BlockNode nodes.
-      # --
+      #
       # : (BlockNode node) -> void
       def visit_block_node: (BlockNode node) -> void
 
       # Dispatch enter and leave events for BlockParameterNode nodes.
-      # --
+      #
       # : (BlockParameterNode node) -> void
       def visit_block_parameter_node: (BlockParameterNode node) -> void
 
       # Dispatch enter and leave events for BlockParametersNode nodes.
-      # --
+      #
       # : (BlockParametersNode node) -> void
       def visit_block_parameters_node: (BlockParametersNode node) -> void
 
       # Dispatch enter and leave events for BreakNode nodes.
-      # --
+      #
       # : (BreakNode node) -> void
       def visit_break_node: (BreakNode node) -> void
 
       # Dispatch enter and leave events for CallAndWriteNode nodes.
-      # --
+      #
       # : (CallAndWriteNode node) -> void
       def visit_call_and_write_node: (CallAndWriteNode node) -> void
 
       # Dispatch enter and leave events for CallNode nodes.
-      # --
+      #
       # : (CallNode node) -> void
       def visit_call_node: (CallNode node) -> void
 
       # Dispatch enter and leave events for CallOperatorWriteNode nodes.
-      # --
+      #
       # : (CallOperatorWriteNode node) -> void
       def visit_call_operator_write_node: (CallOperatorWriteNode node) -> void
 
       # Dispatch enter and leave events for CallOrWriteNode nodes.
-      # --
+      #
       # : (CallOrWriteNode node) -> void
       def visit_call_or_write_node: (CallOrWriteNode node) -> void
 
       # Dispatch enter and leave events for CallTargetNode nodes.
-      # --
+      #
       # : (CallTargetNode node) -> void
       def visit_call_target_node: (CallTargetNode node) -> void
 
       # Dispatch enter and leave events for CapturePatternNode nodes.
-      # --
+      #
       # : (CapturePatternNode node) -> void
       def visit_capture_pattern_node: (CapturePatternNode node) -> void
 
       # Dispatch enter and leave events for CaseMatchNode nodes.
-      # --
+      #
       # : (CaseMatchNode node) -> void
       def visit_case_match_node: (CaseMatchNode node) -> void
 
       # Dispatch enter and leave events for CaseNode nodes.
-      # --
+      #
       # : (CaseNode node) -> void
       def visit_case_node: (CaseNode node) -> void
 
       # Dispatch enter and leave events for ClassNode nodes.
-      # --
+      #
       # : (ClassNode node) -> void
       def visit_class_node: (ClassNode node) -> void
 
       # Dispatch enter and leave events for ClassVariableAndWriteNode nodes.
-      # --
+      #
       # : (ClassVariableAndWriteNode node) -> void
       def visit_class_variable_and_write_node: (ClassVariableAndWriteNode node) -> void
 
       # Dispatch enter and leave events for ClassVariableOperatorWriteNode nodes.
-      # --
+      #
       # : (ClassVariableOperatorWriteNode node) -> void
       def visit_class_variable_operator_write_node: (ClassVariableOperatorWriteNode node) -> void
 
       # Dispatch enter and leave events for ClassVariableOrWriteNode nodes.
-      # --
+      #
       # : (ClassVariableOrWriteNode node) -> void
       def visit_class_variable_or_write_node: (ClassVariableOrWriteNode node) -> void
 
       # Dispatch enter and leave events for ClassVariableReadNode nodes.
-      # --
+      #
       # : (ClassVariableReadNode node) -> void
       def visit_class_variable_read_node: (ClassVariableReadNode node) -> void
 
       # Dispatch enter and leave events for ClassVariableTargetNode nodes.
-      # --
+      #
       # : (ClassVariableTargetNode node) -> void
       def visit_class_variable_target_node: (ClassVariableTargetNode node) -> void
 
       # Dispatch enter and leave events for ClassVariableWriteNode nodes.
-      # --
+      #
       # : (ClassVariableWriteNode node) -> void
       def visit_class_variable_write_node: (ClassVariableWriteNode node) -> void
 
       # Dispatch enter and leave events for ConstantAndWriteNode nodes.
-      # --
+      #
       # : (ConstantAndWriteNode node) -> void
       def visit_constant_and_write_node: (ConstantAndWriteNode node) -> void
 
       # Dispatch enter and leave events for ConstantOperatorWriteNode nodes.
-      # --
+      #
       # : (ConstantOperatorWriteNode node) -> void
       def visit_constant_operator_write_node: (ConstantOperatorWriteNode node) -> void
 
       # Dispatch enter and leave events for ConstantOrWriteNode nodes.
-      # --
+      #
       # : (ConstantOrWriteNode node) -> void
       def visit_constant_or_write_node: (ConstantOrWriteNode node) -> void
 
       # Dispatch enter and leave events for ConstantPathAndWriteNode nodes.
-      # --
+      #
       # : (ConstantPathAndWriteNode node) -> void
       def visit_constant_path_and_write_node: (ConstantPathAndWriteNode node) -> void
 
       # Dispatch enter and leave events for ConstantPathNode nodes.
-      # --
+      #
       # : (ConstantPathNode node) -> void
       def visit_constant_path_node: (ConstantPathNode node) -> void
 
       # Dispatch enter and leave events for ConstantPathOperatorWriteNode nodes.
-      # --
+      #
       # : (ConstantPathOperatorWriteNode node) -> void
       def visit_constant_path_operator_write_node: (ConstantPathOperatorWriteNode node) -> void
 
       # Dispatch enter and leave events for ConstantPathOrWriteNode nodes.
-      # --
+      #
       # : (ConstantPathOrWriteNode node) -> void
       def visit_constant_path_or_write_node: (ConstantPathOrWriteNode node) -> void
 
       # Dispatch enter and leave events for ConstantPathTargetNode nodes.
-      # --
+      #
       # : (ConstantPathTargetNode node) -> void
       def visit_constant_path_target_node: (ConstantPathTargetNode node) -> void
 
       # Dispatch enter and leave events for ConstantPathWriteNode nodes.
-      # --
+      #
       # : (ConstantPathWriteNode node) -> void
       def visit_constant_path_write_node: (ConstantPathWriteNode node) -> void
 
       # Dispatch enter and leave events for ConstantReadNode nodes.
-      # --
+      #
       # : (ConstantReadNode node) -> void
       def visit_constant_read_node: (ConstantReadNode node) -> void
 
       # Dispatch enter and leave events for ConstantTargetNode nodes.
-      # --
+      #
       # : (ConstantTargetNode node) -> void
       def visit_constant_target_node: (ConstantTargetNode node) -> void
 
       # Dispatch enter and leave events for ConstantWriteNode nodes.
-      # --
+      #
       # : (ConstantWriteNode node) -> void
       def visit_constant_write_node: (ConstantWriteNode node) -> void
 
       # Dispatch enter and leave events for DefNode nodes.
-      # --
+      #
       # : (DefNode node) -> void
       def visit_def_node: (DefNode node) -> void
 
       # Dispatch enter and leave events for DefinedNode nodes.
-      # --
+      #
       # : (DefinedNode node) -> void
       def visit_defined_node: (DefinedNode node) -> void
 
       # Dispatch enter and leave events for ElseNode nodes.
-      # --
+      #
       # : (ElseNode node) -> void
       def visit_else_node: (ElseNode node) -> void
 
       # Dispatch enter and leave events for EmbeddedStatementsNode nodes.
-      # --
+      #
       # : (EmbeddedStatementsNode node) -> void
       def visit_embedded_statements_node: (EmbeddedStatementsNode node) -> void
 
       # Dispatch enter and leave events for EmbeddedVariableNode nodes.
-      # --
+      #
       # : (EmbeddedVariableNode node) -> void
       def visit_embedded_variable_node: (EmbeddedVariableNode node) -> void
 
       # Dispatch enter and leave events for EnsureNode nodes.
-      # --
+      #
       # : (EnsureNode node) -> void
       def visit_ensure_node: (EnsureNode node) -> void
 
       # Dispatch enter and leave events for ErrorRecoveryNode nodes.
-      # --
+      #
       # : (ErrorRecoveryNode node) -> void
       def visit_error_recovery_node: (ErrorRecoveryNode node) -> void
 
       # Dispatch enter and leave events for FalseNode nodes.
-      # --
+      #
       # : (FalseNode node) -> void
       def visit_false_node: (FalseNode node) -> void
 
       # Dispatch enter and leave events for FindPatternNode nodes.
-      # --
+      #
       # : (FindPatternNode node) -> void
       def visit_find_pattern_node: (FindPatternNode node) -> void
 
       # Dispatch enter and leave events for FlipFlopNode nodes.
-      # --
+      #
       # : (FlipFlopNode node) -> void
       def visit_flip_flop_node: (FlipFlopNode node) -> void
 
       # Dispatch enter and leave events for FloatNode nodes.
-      # --
+      #
       # : (FloatNode node) -> void
       def visit_float_node: (FloatNode node) -> void
 
       # Dispatch enter and leave events for ForNode nodes.
-      # --
+      #
       # : (ForNode node) -> void
       def visit_for_node: (ForNode node) -> void
 
       # Dispatch enter and leave events for ForwardingArgumentsNode nodes.
-      # --
+      #
       # : (ForwardingArgumentsNode node) -> void
       def visit_forwarding_arguments_node: (ForwardingArgumentsNode node) -> void
 
       # Dispatch enter and leave events for ForwardingParameterNode nodes.
-      # --
+      #
       # : (ForwardingParameterNode node) -> void
       def visit_forwarding_parameter_node: (ForwardingParameterNode node) -> void
 
       # Dispatch enter and leave events for ForwardingSuperNode nodes.
-      # --
+      #
       # : (ForwardingSuperNode node) -> void
       def visit_forwarding_super_node: (ForwardingSuperNode node) -> void
 
       # Dispatch enter and leave events for GlobalVariableAndWriteNode nodes.
-      # --
+      #
       # : (GlobalVariableAndWriteNode node) -> void
       def visit_global_variable_and_write_node: (GlobalVariableAndWriteNode node) -> void
 
       # Dispatch enter and leave events for GlobalVariableOperatorWriteNode nodes.
-      # --
+      #
       # : (GlobalVariableOperatorWriteNode node) -> void
       def visit_global_variable_operator_write_node: (GlobalVariableOperatorWriteNode node) -> void
 
       # Dispatch enter and leave events for GlobalVariableOrWriteNode nodes.
-      # --
+      #
       # : (GlobalVariableOrWriteNode node) -> void
       def visit_global_variable_or_write_node: (GlobalVariableOrWriteNode node) -> void
 
       # Dispatch enter and leave events for GlobalVariableReadNode nodes.
-      # --
+      #
       # : (GlobalVariableReadNode node) -> void
       def visit_global_variable_read_node: (GlobalVariableReadNode node) -> void
 
       # Dispatch enter and leave events for GlobalVariableTargetNode nodes.
-      # --
+      #
       # : (GlobalVariableTargetNode node) -> void
       def visit_global_variable_target_node: (GlobalVariableTargetNode node) -> void
 
       # Dispatch enter and leave events for GlobalVariableWriteNode nodes.
-      # --
+      #
       # : (GlobalVariableWriteNode node) -> void
       def visit_global_variable_write_node: (GlobalVariableWriteNode node) -> void
 
       # Dispatch enter and leave events for HashNode nodes.
-      # --
+      #
       # : (HashNode node) -> void
       def visit_hash_node: (HashNode node) -> void
 
       # Dispatch enter and leave events for HashPatternNode nodes.
-      # --
+      #
       # : (HashPatternNode node) -> void
       def visit_hash_pattern_node: (HashPatternNode node) -> void
 
       # Dispatch enter and leave events for IfNode nodes.
-      # --
+      #
       # : (IfNode node) -> void
       def visit_if_node: (IfNode node) -> void
 
       # Dispatch enter and leave events for ImaginaryNode nodes.
-      # --
+      #
       # : (ImaginaryNode node) -> void
       def visit_imaginary_node: (ImaginaryNode node) -> void
 
       # Dispatch enter and leave events for ImplicitNode nodes.
-      # --
+      #
       # : (ImplicitNode node) -> void
       def visit_implicit_node: (ImplicitNode node) -> void
 
       # Dispatch enter and leave events for ImplicitRestNode nodes.
-      # --
+      #
       # : (ImplicitRestNode node) -> void
       def visit_implicit_rest_node: (ImplicitRestNode node) -> void
 
       # Dispatch enter and leave events for InNode nodes.
-      # --
+      #
       # : (InNode node) -> void
       def visit_in_node: (InNode node) -> void
 
       # Dispatch enter and leave events for IndexAndWriteNode nodes.
-      # --
+      #
       # : (IndexAndWriteNode node) -> void
       def visit_index_and_write_node: (IndexAndWriteNode node) -> void
 
       # Dispatch enter and leave events for IndexOperatorWriteNode nodes.
-      # --
+      #
       # : (IndexOperatorWriteNode node) -> void
       def visit_index_operator_write_node: (IndexOperatorWriteNode node) -> void
 
       # Dispatch enter and leave events for IndexOrWriteNode nodes.
-      # --
+      #
       # : (IndexOrWriteNode node) -> void
       def visit_index_or_write_node: (IndexOrWriteNode node) -> void
 
       # Dispatch enter and leave events for IndexTargetNode nodes.
-      # --
+      #
       # : (IndexTargetNode node) -> void
       def visit_index_target_node: (IndexTargetNode node) -> void
 
       # Dispatch enter and leave events for InstanceVariableAndWriteNode nodes.
-      # --
+      #
       # : (InstanceVariableAndWriteNode node) -> void
       def visit_instance_variable_and_write_node: (InstanceVariableAndWriteNode node) -> void
 
       # Dispatch enter and leave events for InstanceVariableOperatorWriteNode nodes.
-      # --
+      #
       # : (InstanceVariableOperatorWriteNode node) -> void
       def visit_instance_variable_operator_write_node: (InstanceVariableOperatorWriteNode node) -> void
 
       # Dispatch enter and leave events for InstanceVariableOrWriteNode nodes.
-      # --
+      #
       # : (InstanceVariableOrWriteNode node) -> void
       def visit_instance_variable_or_write_node: (InstanceVariableOrWriteNode node) -> void
 
       # Dispatch enter and leave events for InstanceVariableReadNode nodes.
-      # --
+      #
       # : (InstanceVariableReadNode node) -> void
       def visit_instance_variable_read_node: (InstanceVariableReadNode node) -> void
 
       # Dispatch enter and leave events for InstanceVariableTargetNode nodes.
-      # --
+      #
       # : (InstanceVariableTargetNode node) -> void
       def visit_instance_variable_target_node: (InstanceVariableTargetNode node) -> void
 
       # Dispatch enter and leave events for InstanceVariableWriteNode nodes.
-      # --
+      #
       # : (InstanceVariableWriteNode node) -> void
       def visit_instance_variable_write_node: (InstanceVariableWriteNode node) -> void
 
       # Dispatch enter and leave events for IntegerNode nodes.
-      # --
+      #
       # : (IntegerNode node) -> void
       def visit_integer_node: (IntegerNode node) -> void
 
       # Dispatch enter and leave events for InterpolatedMatchLastLineNode nodes.
-      # --
+      #
       # : (InterpolatedMatchLastLineNode node) -> void
       def visit_interpolated_match_last_line_node: (InterpolatedMatchLastLineNode node) -> void
 
       # Dispatch enter and leave events for InterpolatedRegularExpressionNode nodes.
-      # --
+      #
       # : (InterpolatedRegularExpressionNode node) -> void
       def visit_interpolated_regular_expression_node: (InterpolatedRegularExpressionNode node) -> void
 
       # Dispatch enter and leave events for InterpolatedStringNode nodes.
-      # --
+      #
       # : (InterpolatedStringNode node) -> void
       def visit_interpolated_string_node: (InterpolatedStringNode node) -> void
 
       # Dispatch enter and leave events for InterpolatedSymbolNode nodes.
-      # --
+      #
       # : (InterpolatedSymbolNode node) -> void
       def visit_interpolated_symbol_node: (InterpolatedSymbolNode node) -> void
 
       # Dispatch enter and leave events for InterpolatedXStringNode nodes.
-      # --
+      #
       # : (InterpolatedXStringNode node) -> void
       def visit_interpolated_x_string_node: (InterpolatedXStringNode node) -> void
 
       # Dispatch enter and leave events for ItLocalVariableReadNode nodes.
-      # --
+      #
       # : (ItLocalVariableReadNode node) -> void
       def visit_it_local_variable_read_node: (ItLocalVariableReadNode node) -> void
 
       # Dispatch enter and leave events for ItParametersNode nodes.
-      # --
+      #
       # : (ItParametersNode node) -> void
       def visit_it_parameters_node: (ItParametersNode node) -> void
 
       # Dispatch enter and leave events for KeywordHashNode nodes.
-      # --
+      #
       # : (KeywordHashNode node) -> void
       def visit_keyword_hash_node: (KeywordHashNode node) -> void
 
       # Dispatch enter and leave events for KeywordRestParameterNode nodes.
-      # --
+      #
       # : (KeywordRestParameterNode node) -> void
       def visit_keyword_rest_parameter_node: (KeywordRestParameterNode node) -> void
 
       # Dispatch enter and leave events for LambdaNode nodes.
-      # --
+      #
       # : (LambdaNode node) -> void
       def visit_lambda_node: (LambdaNode node) -> void
 
       # Dispatch enter and leave events for LocalVariableAndWriteNode nodes.
-      # --
+      #
       # : (LocalVariableAndWriteNode node) -> void
       def visit_local_variable_and_write_node: (LocalVariableAndWriteNode node) -> void
 
       # Dispatch enter and leave events for LocalVariableOperatorWriteNode nodes.
-      # --
+      #
       # : (LocalVariableOperatorWriteNode node) -> void
       def visit_local_variable_operator_write_node: (LocalVariableOperatorWriteNode node) -> void
 
       # Dispatch enter and leave events for LocalVariableOrWriteNode nodes.
-      # --
+      #
       # : (LocalVariableOrWriteNode node) -> void
       def visit_local_variable_or_write_node: (LocalVariableOrWriteNode node) -> void
 
       # Dispatch enter and leave events for LocalVariableReadNode nodes.
-      # --
+      #
       # : (LocalVariableReadNode node) -> void
       def visit_local_variable_read_node: (LocalVariableReadNode node) -> void
 
       # Dispatch enter and leave events for LocalVariableTargetNode nodes.
-      # --
+      #
       # : (LocalVariableTargetNode node) -> void
       def visit_local_variable_target_node: (LocalVariableTargetNode node) -> void
 
       # Dispatch enter and leave events for LocalVariableWriteNode nodes.
-      # --
+      #
       # : (LocalVariableWriteNode node) -> void
       def visit_local_variable_write_node: (LocalVariableWriteNode node) -> void
 
       # Dispatch enter and leave events for MatchLastLineNode nodes.
-      # --
+      #
       # : (MatchLastLineNode node) -> void
       def visit_match_last_line_node: (MatchLastLineNode node) -> void
 
       # Dispatch enter and leave events for MatchPredicateNode nodes.
-      # --
+      #
       # : (MatchPredicateNode node) -> void
       def visit_match_predicate_node: (MatchPredicateNode node) -> void
 
       # Dispatch enter and leave events for MatchRequiredNode nodes.
-      # --
+      #
       # : (MatchRequiredNode node) -> void
       def visit_match_required_node: (MatchRequiredNode node) -> void
 
       # Dispatch enter and leave events for MatchWriteNode nodes.
-      # --
+      #
       # : (MatchWriteNode node) -> void
       def visit_match_write_node: (MatchWriteNode node) -> void
 
       # Dispatch enter and leave events for ModuleNode nodes.
-      # --
+      #
       # : (ModuleNode node) -> void
       def visit_module_node: (ModuleNode node) -> void
 
       # Dispatch enter and leave events for MultiTargetNode nodes.
-      # --
+      #
       # : (MultiTargetNode node) -> void
       def visit_multi_target_node: (MultiTargetNode node) -> void
 
       # Dispatch enter and leave events for MultiWriteNode nodes.
-      # --
+      #
       # : (MultiWriteNode node) -> void
       def visit_multi_write_node: (MultiWriteNode node) -> void
 
       # Dispatch enter and leave events for NextNode nodes.
-      # --
+      #
       # : (NextNode node) -> void
       def visit_next_node: (NextNode node) -> void
 
       # Dispatch enter and leave events for NilNode nodes.
-      # --
+      #
       # : (NilNode node) -> void
       def visit_nil_node: (NilNode node) -> void
 
       # Dispatch enter and leave events for NoBlockParameterNode nodes.
-      # --
+      #
       # : (NoBlockParameterNode node) -> void
       def visit_no_block_parameter_node: (NoBlockParameterNode node) -> void
 
       # Dispatch enter and leave events for NoKeywordsParameterNode nodes.
-      # --
+      #
       # : (NoKeywordsParameterNode node) -> void
       def visit_no_keywords_parameter_node: (NoKeywordsParameterNode node) -> void
 
       # Dispatch enter and leave events for NumberedParametersNode nodes.
-      # --
+      #
       # : (NumberedParametersNode node) -> void
       def visit_numbered_parameters_node: (NumberedParametersNode node) -> void
 
       # Dispatch enter and leave events for NumberedReferenceReadNode nodes.
-      # --
+      #
       # : (NumberedReferenceReadNode node) -> void
       def visit_numbered_reference_read_node: (NumberedReferenceReadNode node) -> void
 
       # Dispatch enter and leave events for OptionalKeywordParameterNode nodes.
-      # --
+      #
       # : (OptionalKeywordParameterNode node) -> void
       def visit_optional_keyword_parameter_node: (OptionalKeywordParameterNode node) -> void
 
       # Dispatch enter and leave events for OptionalParameterNode nodes.
-      # --
+      #
       # : (OptionalParameterNode node) -> void
       def visit_optional_parameter_node: (OptionalParameterNode node) -> void
 
       # Dispatch enter and leave events for OrNode nodes.
-      # --
+      #
       # : (OrNode node) -> void
       def visit_or_node: (OrNode node) -> void
 
       # Dispatch enter and leave events for ParametersNode nodes.
-      # --
+      #
       # : (ParametersNode node) -> void
       def visit_parameters_node: (ParametersNode node) -> void
 
       # Dispatch enter and leave events for ParenthesesNode nodes.
-      # --
+      #
       # : (ParenthesesNode node) -> void
       def visit_parentheses_node: (ParenthesesNode node) -> void
 
       # Dispatch enter and leave events for PinnedExpressionNode nodes.
-      # --
+      #
       # : (PinnedExpressionNode node) -> void
       def visit_pinned_expression_node: (PinnedExpressionNode node) -> void
 
       # Dispatch enter and leave events for PinnedVariableNode nodes.
-      # --
+      #
       # : (PinnedVariableNode node) -> void
       def visit_pinned_variable_node: (PinnedVariableNode node) -> void
 
       # Dispatch enter and leave events for PostExecutionNode nodes.
-      # --
+      #
       # : (PostExecutionNode node) -> void
       def visit_post_execution_node: (PostExecutionNode node) -> void
 
       # Dispatch enter and leave events for PreExecutionNode nodes.
-      # --
+      #
       # : (PreExecutionNode node) -> void
       def visit_pre_execution_node: (PreExecutionNode node) -> void
 
       # Dispatch enter and leave events for ProgramNode nodes.
-      # --
+      #
       # : (ProgramNode node) -> void
       def visit_program_node: (ProgramNode node) -> void
 
       # Dispatch enter and leave events for RangeNode nodes.
-      # --
+      #
       # : (RangeNode node) -> void
       def visit_range_node: (RangeNode node) -> void
 
       # Dispatch enter and leave events for RationalNode nodes.
-      # --
+      #
       # : (RationalNode node) -> void
       def visit_rational_node: (RationalNode node) -> void
 
       # Dispatch enter and leave events for RedoNode nodes.
-      # --
+      #
       # : (RedoNode node) -> void
       def visit_redo_node: (RedoNode node) -> void
 
       # Dispatch enter and leave events for RegularExpressionNode nodes.
-      # --
+      #
       # : (RegularExpressionNode node) -> void
       def visit_regular_expression_node: (RegularExpressionNode node) -> void
 
       # Dispatch enter and leave events for RequiredKeywordParameterNode nodes.
-      # --
+      #
       # : (RequiredKeywordParameterNode node) -> void
       def visit_required_keyword_parameter_node: (RequiredKeywordParameterNode node) -> void
 
       # Dispatch enter and leave events for RequiredParameterNode nodes.
-      # --
+      #
       # : (RequiredParameterNode node) -> void
       def visit_required_parameter_node: (RequiredParameterNode node) -> void
 
       # Dispatch enter and leave events for RescueModifierNode nodes.
-      # --
+      #
       # : (RescueModifierNode node) -> void
       def visit_rescue_modifier_node: (RescueModifierNode node) -> void
 
       # Dispatch enter and leave events for RescueNode nodes.
-      # --
+      #
       # : (RescueNode node) -> void
       def visit_rescue_node: (RescueNode node) -> void
 
       # Dispatch enter and leave events for RestParameterNode nodes.
-      # --
+      #
       # : (RestParameterNode node) -> void
       def visit_rest_parameter_node: (RestParameterNode node) -> void
 
       # Dispatch enter and leave events for RetryNode nodes.
-      # --
+      #
       # : (RetryNode node) -> void
       def visit_retry_node: (RetryNode node) -> void
 
       # Dispatch enter and leave events for ReturnNode nodes.
-      # --
+      #
       # : (ReturnNode node) -> void
       def visit_return_node: (ReturnNode node) -> void
 
       # Dispatch enter and leave events for SelfNode nodes.
-      # --
+      #
       # : (SelfNode node) -> void
       def visit_self_node: (SelfNode node) -> void
 
       # Dispatch enter and leave events for ShareableConstantNode nodes.
-      # --
+      #
       # : (ShareableConstantNode node) -> void
       def visit_shareable_constant_node: (ShareableConstantNode node) -> void
 
       # Dispatch enter and leave events for SingletonClassNode nodes.
-      # --
+      #
       # : (SingletonClassNode node) -> void
       def visit_singleton_class_node: (SingletonClassNode node) -> void
 
       # Dispatch enter and leave events for SourceEncodingNode nodes.
-      # --
+      #
       # : (SourceEncodingNode node) -> void
       def visit_source_encoding_node: (SourceEncodingNode node) -> void
 
       # Dispatch enter and leave events for SourceFileNode nodes.
-      # --
+      #
       # : (SourceFileNode node) -> void
       def visit_source_file_node: (SourceFileNode node) -> void
 
       # Dispatch enter and leave events for SourceLineNode nodes.
-      # --
+      #
       # : (SourceLineNode node) -> void
       def visit_source_line_node: (SourceLineNode node) -> void
 
       # Dispatch enter and leave events for SplatNode nodes.
-      # --
+      #
       # : (SplatNode node) -> void
       def visit_splat_node: (SplatNode node) -> void
 
       # Dispatch enter and leave events for StatementsNode nodes.
-      # --
+      #
       # : (StatementsNode node) -> void
       def visit_statements_node: (StatementsNode node) -> void
 
       # Dispatch enter and leave events for StringNode nodes.
-      # --
+      #
       # : (StringNode node) -> void
       def visit_string_node: (StringNode node) -> void
 
       # Dispatch enter and leave events for SuperNode nodes.
-      # --
+      #
       # : (SuperNode node) -> void
       def visit_super_node: (SuperNode node) -> void
 
       # Dispatch enter and leave events for SymbolNode nodes.
-      # --
+      #
       # : (SymbolNode node) -> void
       def visit_symbol_node: (SymbolNode node) -> void
 
       # Dispatch enter and leave events for TrueNode nodes.
-      # --
+      #
       # : (TrueNode node) -> void
       def visit_true_node: (TrueNode node) -> void
 
       # Dispatch enter and leave events for UndefNode nodes.
-      # --
+      #
       # : (UndefNode node) -> void
       def visit_undef_node: (UndefNode node) -> void
 
       # Dispatch enter and leave events for UnlessNode nodes.
-      # --
+      #
       # : (UnlessNode node) -> void
       def visit_unless_node: (UnlessNode node) -> void
 
       # Dispatch enter and leave events for UntilNode nodes.
-      # --
+      #
       # : (UntilNode node) -> void
       def visit_until_node: (UntilNode node) -> void
 
       # Dispatch enter and leave events for WhenNode nodes.
-      # --
+      #
       # : (WhenNode node) -> void
       def visit_when_node: (WhenNode node) -> void
 
       # Dispatch enter and leave events for WhileNode nodes.
-      # --
+      #
       # : (WhileNode node) -> void
       def visit_while_node: (WhileNode node) -> void
 
       # Dispatch enter and leave events for XStringNode nodes.
-      # --
+      #
       # : (XStringNode node) -> void
       def visit_x_string_node: (XStringNode node) -> void
 
       # Dispatch enter and leave events for YieldNode nodes.
-      # --
+      #
       # : (YieldNode node) -> void
       def visit_yield_node: (YieldNode node) -> void
     end

--- a/sig/generated/prism/dot_visitor.rbs
+++ b/sig/generated/prism/dot_visitor.rbs
@@ -65,12 +65,12 @@ module Prism
     attr_reader digraph: Digraph
 
     # Initialize a new dot visitor.
-    # --
+    #
     # : () -> void
     def initialize: () -> void
 
     # Convert this visitor into a graphviz dot graph string.
-    # --
+    #
     # : () -> String
     def to_dot: () -> String
 
@@ -533,102 +533,102 @@ module Prism
     private
 
     # Generate a unique node ID for a node throughout the digraph.
-    # --
+    #
     # : (node) -> String
     def node_id: (node) -> String
 
     # Inspect a location to display the start and end line and columns in bytes.
-    # --
+    #
     # : (Location) -> String
     def location_inspect: (Location) -> String
 
     # Inspect a node that has arguments_node_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (ArgumentsNode node) -> String
     def arguments_node_flags_inspect: (ArgumentsNode node) -> String
 
     # Inspect a node that has array_node_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (ArrayNode node) -> String
     def array_node_flags_inspect: (ArrayNode node) -> String
 
     # Inspect a node that has call_node_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (CallAndWriteNode | CallNode | CallOperatorWriteNode | CallOrWriteNode | CallTargetNode | IndexAndWriteNode | IndexOperatorWriteNode | IndexOrWriteNode | IndexTargetNode node) -> String
     def call_node_flags_inspect: (CallAndWriteNode | CallNode | CallOperatorWriteNode | CallOrWriteNode | CallTargetNode | IndexAndWriteNode | IndexOperatorWriteNode | IndexOrWriteNode | IndexTargetNode node) -> String
 
     # Inspect a node that has encoding_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (XStringNode node) -> String
     def encoding_flags_inspect: (XStringNode node) -> String
 
     # Inspect a node that has integer_base_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (IntegerNode | RationalNode node) -> String
     def integer_base_flags_inspect: (IntegerNode | RationalNode node) -> String
 
     # Inspect a node that has interpolated_string_node_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (InterpolatedStringNode node) -> String
     def interpolated_string_node_flags_inspect: (InterpolatedStringNode node) -> String
 
     # Inspect a node that has keyword_hash_node_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (KeywordHashNode node) -> String
     def keyword_hash_node_flags_inspect: (KeywordHashNode node) -> String
 
     # Inspect a node that has loop_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (UntilNode | WhileNode node) -> String
     def loop_flags_inspect: (UntilNode | WhileNode node) -> String
 
     # Inspect a node that has parameter_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (BlockLocalVariableNode | BlockParameterNode | KeywordRestParameterNode | OptionalKeywordParameterNode | OptionalParameterNode | RequiredKeywordParameterNode | RequiredParameterNode | RestParameterNode node) -> String
     def parameter_flags_inspect: (BlockLocalVariableNode | BlockParameterNode | KeywordRestParameterNode | OptionalKeywordParameterNode | OptionalParameterNode | RequiredKeywordParameterNode | RequiredParameterNode | RestParameterNode node) -> String
 
     # Inspect a node that has parentheses_node_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (ParenthesesNode node) -> String
     def parentheses_node_flags_inspect: (ParenthesesNode node) -> String
 
     # Inspect a node that has range_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (FlipFlopNode | RangeNode node) -> String
     def range_flags_inspect: (FlipFlopNode | RangeNode node) -> String
 
     # Inspect a node that has regular_expression_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (InterpolatedMatchLastLineNode | InterpolatedRegularExpressionNode | MatchLastLineNode | RegularExpressionNode node) -> String
     def regular_expression_flags_inspect: (InterpolatedMatchLastLineNode | InterpolatedRegularExpressionNode | MatchLastLineNode | RegularExpressionNode node) -> String
 
     # Inspect a node that has shareable_constant_node_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (ShareableConstantNode node) -> String
     def shareable_constant_node_flags_inspect: (ShareableConstantNode node) -> String
 
     # Inspect a node that has string_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (SourceFileNode | StringNode node) -> String
     def string_flags_inspect: (SourceFileNode | StringNode node) -> String
 
     # Inspect a node that has symbol_flags flags to display the flags as a
     # comma-separated list.
-    # --
+    #
     # : (SymbolNode node) -> String
     def symbol_flags_inspect: (SymbolNode node) -> String
   end

--- a/sig/generated/prism/dsl.rbs
+++ b/sig/generated/prism/dsl.rbs
@@ -54,847 +54,847 @@ module Prism
   # This is mostly helpful in the context of generating trees programmatically.
   module DSL
     # Create a new Source object.
-    # --
+    #
     # : (String string) -> Source
     def source: (String string) -> Source
 
     # Create a new Location object.
-    # --
+    #
     # : (?source: Source, ?start_offset: Integer, ?length: Integer) -> Location
     def location: (?source: Source, ?start_offset: Integer, ?length: Integer) -> Location
 
     # Create a new AliasGlobalVariableNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?new_name: (GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode), ?old_name: (GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode), ?keyword_loc: Location) -> AliasGlobalVariableNode
     def alias_global_variable_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?new_name: GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode, ?old_name: GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode, ?keyword_loc: Location) -> AliasGlobalVariableNode
 
     # Create a new AliasMethodNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?new_name: (SymbolNode | InterpolatedSymbolNode), ?old_name: (SymbolNode | InterpolatedSymbolNode), ?keyword_loc: Location) -> AliasMethodNode
     def alias_method_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?new_name: SymbolNode | InterpolatedSymbolNode, ?old_name: SymbolNode | InterpolatedSymbolNode, ?keyword_loc: Location) -> AliasMethodNode
 
     # Create a new AlternationPatternNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> AlternationPatternNode
     def alternation_pattern_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> AlternationPatternNode
 
     # Create a new AndNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> AndNode
     def and_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> AndNode
 
     # Create a new ArgumentsNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: Array[Prism::node]) -> ArgumentsNode
     def arguments_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: Array[Prism::node]) -> ArgumentsNode
 
     # Create a new ArrayNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?elements: Array[Prism::node], ?opening_loc: Location?, ?closing_loc: Location?) -> ArrayNode
     def array_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?elements: Array[Prism::node], ?opening_loc: Location?, ?closing_loc: Location?) -> ArrayNode
 
     # Create a new ArrayPatternNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?requireds: Array[Prism::node], ?rest: (ImplicitRestNode | SplatNode)?, ?posts: Array[Prism::node], ?opening_loc: Location?, ?closing_loc: Location?) -> ArrayPatternNode
     def array_pattern_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?requireds: Array[Prism::node], ?rest: (ImplicitRestNode | SplatNode)?, ?posts: Array[Prism::node], ?opening_loc: Location?, ?closing_loc: Location?) -> ArrayPatternNode
 
     # Create a new AssocNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?key: Prism::node, ?value: Prism::node, ?operator_loc: Location?) -> AssocNode
     def assoc_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?key: Prism::node, ?value: Prism::node, ?operator_loc: Location?) -> AssocNode
 
     # Create a new AssocSplatNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node?, ?operator_loc: Location) -> AssocSplatNode
     def assoc_splat_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node?, ?operator_loc: Location) -> AssocSplatNode
 
     # Create a new BackReferenceReadNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> BackReferenceReadNode
     def back_reference_read_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> BackReferenceReadNode
 
     # Create a new BeginNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?begin_keyword_loc: Location?, ?statements: StatementsNode?, ?rescue_clause: RescueNode?, ?else_clause: ElseNode?, ?ensure_clause: EnsureNode?, ?end_keyword_loc: Location?) -> BeginNode
     def begin_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?begin_keyword_loc: Location?, ?statements: StatementsNode?, ?rescue_clause: RescueNode?, ?else_clause: ElseNode?, ?ensure_clause: EnsureNode?, ?end_keyword_loc: Location?) -> BeginNode
 
     # Create a new BlockArgumentNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node?, ?operator_loc: Location) -> BlockArgumentNode
     def block_argument_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node?, ?operator_loc: Location) -> BlockArgumentNode
 
     # Create a new BlockLocalVariableNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> BlockLocalVariableNode
     def block_local_variable_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> BlockLocalVariableNode
 
     # Create a new BlockNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?parameters: (BlockParametersNode | NumberedParametersNode | ItParametersNode)?, ?body: (StatementsNode | BeginNode)?, ?opening_loc: Location, ?closing_loc: Location) -> BlockNode
     def block_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?parameters: (BlockParametersNode | NumberedParametersNode | ItParametersNode)?, ?body: (StatementsNode | BeginNode)?, ?opening_loc: Location, ?closing_loc: Location) -> BlockNode
 
     # Create a new BlockParameterNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> BlockParameterNode
     def block_parameter_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> BlockParameterNode
 
     # Create a new BlockParametersNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?parameters: ParametersNode?, ?locals: Array[BlockLocalVariableNode], ?opening_loc: Location?, ?closing_loc: Location?) -> BlockParametersNode
     def block_parameters_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?parameters: ParametersNode?, ?locals: Array[BlockLocalVariableNode], ?opening_loc: Location?, ?closing_loc: Location?) -> BlockParametersNode
 
     # Create a new BreakNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: ArgumentsNode?, ?keyword_loc: Location) -> BreakNode
     def break_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: ArgumentsNode?, ?keyword_loc: Location) -> BreakNode
 
     # Create a new CallAndWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?operator_loc: Location, ?value: Prism::node) -> CallAndWriteNode
     def call_and_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?operator_loc: Location, ?value: Prism::node) -> CallAndWriteNode
 
     # Create a new CallNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?name: Symbol, ?message_loc: Location?, ?opening_loc: Location?, ?arguments: ArgumentsNode?, ?closing_loc: Location?, ?equal_loc: Location?, ?block: (BlockNode | BlockArgumentNode)?) -> CallNode
     def call_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?name: Symbol, ?message_loc: Location?, ?opening_loc: Location?, ?arguments: ArgumentsNode?, ?closing_loc: Location?, ?equal_loc: Location?, ?block: (BlockNode | BlockArgumentNode)?) -> CallNode
 
     # Create a new CallOperatorWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?binary_operator: Symbol, ?binary_operator_loc: Location, ?value: Prism::node) -> CallOperatorWriteNode
     def call_operator_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?binary_operator: Symbol, ?binary_operator_loc: Location, ?value: Prism::node) -> CallOperatorWriteNode
 
     # Create a new CallOrWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?operator_loc: Location, ?value: Prism::node) -> CallOrWriteNode
     def call_or_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?operator_loc: Location, ?value: Prism::node) -> CallOrWriteNode
 
     # Create a new CallTargetNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node, ?call_operator_loc: Location, ?name: Symbol, ?message_loc: Location) -> CallTargetNode
     def call_target_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node, ?call_operator_loc: Location, ?name: Symbol, ?message_loc: Location) -> CallTargetNode
 
     # Create a new CapturePatternNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?target: LocalVariableTargetNode, ?operator_loc: Location) -> CapturePatternNode
     def capture_pattern_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?target: LocalVariableTargetNode, ?operator_loc: Location) -> CapturePatternNode
 
     # Create a new CaseMatchNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?predicate: Prism::node?, ?conditions: Array[InNode], ?else_clause: ElseNode?, ?case_keyword_loc: Location, ?end_keyword_loc: Location) -> CaseMatchNode
     def case_match_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?predicate: Prism::node?, ?conditions: Array[InNode], ?else_clause: ElseNode?, ?case_keyword_loc: Location, ?end_keyword_loc: Location) -> CaseMatchNode
 
     # Create a new CaseNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?predicate: Prism::node?, ?conditions: Array[WhenNode], ?else_clause: ElseNode?, ?case_keyword_loc: Location, ?end_keyword_loc: Location) -> CaseNode
     def case_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?predicate: Prism::node?, ?conditions: Array[WhenNode], ?else_clause: ElseNode?, ?case_keyword_loc: Location, ?end_keyword_loc: Location) -> CaseNode
 
     # Create a new ClassNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?class_keyword_loc: Location, ?constant_path: (ConstantReadNode | ConstantPathNode), ?inheritance_operator_loc: Location?, ?superclass: Prism::node?, ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location, ?name: Symbol) -> ClassNode
     def class_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?class_keyword_loc: Location, ?constant_path: ConstantReadNode | ConstantPathNode, ?inheritance_operator_loc: Location?, ?superclass: Prism::node?, ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location, ?name: Symbol) -> ClassNode
 
     # Create a new ClassVariableAndWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ClassVariableAndWriteNode
     def class_variable_and_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ClassVariableAndWriteNode
 
     # Create a new ClassVariableOperatorWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ClassVariableOperatorWriteNode
     def class_variable_operator_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ClassVariableOperatorWriteNode
 
     # Create a new ClassVariableOrWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ClassVariableOrWriteNode
     def class_variable_or_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ClassVariableOrWriteNode
 
     # Create a new ClassVariableReadNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ClassVariableReadNode
     def class_variable_read_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ClassVariableReadNode
 
     # Create a new ClassVariableTargetNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ClassVariableTargetNode
     def class_variable_target_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ClassVariableTargetNode
 
     # Create a new ClassVariableWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> ClassVariableWriteNode
     def class_variable_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> ClassVariableWriteNode
 
     # Create a new ConstantAndWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ConstantAndWriteNode
     def constant_and_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ConstantAndWriteNode
 
     # Create a new ConstantOperatorWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ConstantOperatorWriteNode
     def constant_operator_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ConstantOperatorWriteNode
 
     # Create a new ConstantOrWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ConstantOrWriteNode
     def constant_or_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ConstantOrWriteNode
 
     # Create a new ConstantPathAndWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathAndWriteNode
     def constant_path_and_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathAndWriteNode
 
     # Create a new ConstantPathNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?parent: Prism::node?, ?name: Symbol?, ?delimiter_loc: Location, ?name_loc: Location) -> ConstantPathNode
     def constant_path_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?parent: Prism::node?, ?name: Symbol?, ?delimiter_loc: Location, ?name_loc: Location) -> ConstantPathNode
 
     # Create a new ConstantPathOperatorWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ConstantPathOperatorWriteNode
     def constant_path_operator_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ConstantPathOperatorWriteNode
 
     # Create a new ConstantPathOrWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathOrWriteNode
     def constant_path_or_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathOrWriteNode
 
     # Create a new ConstantPathTargetNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?parent: Prism::node?, ?name: Symbol?, ?delimiter_loc: Location, ?name_loc: Location) -> ConstantPathTargetNode
     def constant_path_target_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?parent: Prism::node?, ?name: Symbol?, ?delimiter_loc: Location, ?name_loc: Location) -> ConstantPathTargetNode
 
     # Create a new ConstantPathWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathWriteNode
     def constant_path_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathWriteNode
 
     # Create a new ConstantReadNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ConstantReadNode
     def constant_read_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ConstantReadNode
 
     # Create a new ConstantTargetNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ConstantTargetNode
     def constant_target_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ConstantTargetNode
 
     # Create a new ConstantWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> ConstantWriteNode
     def constant_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> ConstantWriteNode
 
     # Create a new DefNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?receiver: Prism::node?, ?parameters: ParametersNode?, ?body: (StatementsNode | BeginNode)?, ?locals: Array[Symbol], ?def_keyword_loc: Location, ?operator_loc: Location?, ?lparen_loc: Location?, ?rparen_loc: Location?, ?equal_loc: Location?, ?end_keyword_loc: Location?) -> DefNode
     def def_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?receiver: Prism::node?, ?parameters: ParametersNode?, ?body: (StatementsNode | BeginNode)?, ?locals: Array[Symbol], ?def_keyword_loc: Location, ?operator_loc: Location?, ?lparen_loc: Location?, ?rparen_loc: Location?, ?equal_loc: Location?, ?end_keyword_loc: Location?) -> DefNode
 
     # Create a new DefinedNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?lparen_loc: Location?, ?value: Prism::node, ?rparen_loc: Location?, ?keyword_loc: Location) -> DefinedNode
     def defined_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?lparen_loc: Location?, ?value: Prism::node, ?rparen_loc: Location?, ?keyword_loc: Location) -> DefinedNode
 
     # Create a new ElseNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?else_keyword_loc: Location, ?statements: StatementsNode?, ?end_keyword_loc: Location?) -> ElseNode
     def else_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?else_keyword_loc: Location, ?statements: StatementsNode?, ?end_keyword_loc: Location?) -> ElseNode
 
     # Create a new EmbeddedStatementsNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?statements: StatementsNode?, ?closing_loc: Location) -> EmbeddedStatementsNode
     def embedded_statements_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?statements: StatementsNode?, ?closing_loc: Location) -> EmbeddedStatementsNode
 
     # Create a new EmbeddedVariableNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?variable: (InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode)) -> EmbeddedVariableNode
     def embedded_variable_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?variable: InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode) -> EmbeddedVariableNode
 
     # Create a new EnsureNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?ensure_keyword_loc: Location, ?statements: StatementsNode?, ?end_keyword_loc: Location) -> EnsureNode
     def ensure_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?ensure_keyword_loc: Location, ?statements: StatementsNode?, ?end_keyword_loc: Location) -> EnsureNode
 
     # Create a new ErrorRecoveryNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?unexpected: Prism::node?) -> ErrorRecoveryNode
     def error_recovery_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?unexpected: Prism::node?) -> ErrorRecoveryNode
 
     # Create a new FalseNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> FalseNode
     def false_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> FalseNode
 
     # Create a new FindPatternNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?left: SplatNode, ?requireds: Array[Prism::node], ?right: SplatNode, ?opening_loc: Location?, ?closing_loc: Location?) -> FindPatternNode
     def find_pattern_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?left: SplatNode, ?requireds: Array[Prism::node], ?right: SplatNode, ?opening_loc: Location?, ?closing_loc: Location?) -> FindPatternNode
 
     # Create a new FlipFlopNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node?, ?right: Prism::node?, ?operator_loc: Location) -> FlipFlopNode
     def flip_flop_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node?, ?right: Prism::node?, ?operator_loc: Location) -> FlipFlopNode
 
     # Create a new FloatNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Float) -> FloatNode
     def float_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Float) -> FloatNode
 
     # Create a new ForNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?index: (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode), ?collection: Prism::node, ?statements: StatementsNode?, ?for_keyword_loc: Location, ?in_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location) -> ForNode
     def for_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?index: LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode, ?collection: Prism::node, ?statements: StatementsNode?, ?for_keyword_loc: Location, ?in_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location) -> ForNode
 
     # Create a new ForwardingArgumentsNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> ForwardingArgumentsNode
     def forwarding_arguments_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> ForwardingArgumentsNode
 
     # Create a new ForwardingParameterNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> ForwardingParameterNode
     def forwarding_parameter_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> ForwardingParameterNode
 
     # Create a new ForwardingSuperNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?block: BlockNode?) -> ForwardingSuperNode
     def forwarding_super_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?block: BlockNode?) -> ForwardingSuperNode
 
     # Create a new GlobalVariableAndWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> GlobalVariableAndWriteNode
     def global_variable_and_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> GlobalVariableAndWriteNode
 
     # Create a new GlobalVariableOperatorWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> GlobalVariableOperatorWriteNode
     def global_variable_operator_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> GlobalVariableOperatorWriteNode
 
     # Create a new GlobalVariableOrWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> GlobalVariableOrWriteNode
     def global_variable_or_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> GlobalVariableOrWriteNode
 
     # Create a new GlobalVariableReadNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> GlobalVariableReadNode
     def global_variable_read_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> GlobalVariableReadNode
 
     # Create a new GlobalVariableTargetNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> GlobalVariableTargetNode
     def global_variable_target_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> GlobalVariableTargetNode
 
     # Create a new GlobalVariableWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> GlobalVariableWriteNode
     def global_variable_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> GlobalVariableWriteNode
 
     # Create a new HashNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?elements: Array[AssocNode | AssocSplatNode], ?closing_loc: Location) -> HashNode
     def hash_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?elements: Array[AssocNode | AssocSplatNode], ?closing_loc: Location) -> HashNode
 
     # Create a new HashPatternNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?elements: Array[AssocNode], ?rest: (AssocSplatNode | NoKeywordsParameterNode)?, ?opening_loc: Location?, ?closing_loc: Location?) -> HashPatternNode
     def hash_pattern_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?elements: Array[AssocNode], ?rest: (AssocSplatNode | NoKeywordsParameterNode)?, ?opening_loc: Location?, ?closing_loc: Location?) -> HashPatternNode
 
     # Create a new IfNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?if_keyword_loc: Location?, ?predicate: Prism::node, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?subsequent: (ElseNode | IfNode)?, ?end_keyword_loc: Location?) -> IfNode
     def if_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?if_keyword_loc: Location?, ?predicate: Prism::node, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?subsequent: (ElseNode | IfNode)?, ?end_keyword_loc: Location?) -> IfNode
 
     # Create a new ImaginaryNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?numeric: (FloatNode | IntegerNode | RationalNode)) -> ImaginaryNode
     def imaginary_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?numeric: FloatNode | IntegerNode | RationalNode) -> ImaginaryNode
 
     # Create a new ImplicitNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: (LocalVariableReadNode | CallNode | ConstantReadNode | LocalVariableTargetNode)) -> ImplicitNode
     def implicit_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: LocalVariableReadNode | CallNode | ConstantReadNode | LocalVariableTargetNode) -> ImplicitNode
 
     # Create a new ImplicitRestNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> ImplicitRestNode
     def implicit_rest_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> ImplicitRestNode
 
     # Create a new InNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?pattern: Prism::node, ?statements: StatementsNode?, ?in_keyword_loc: Location, ?then_keyword_loc: Location?) -> InNode
     def in_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?pattern: Prism::node, ?statements: StatementsNode?, ?in_keyword_loc: Location, ?then_keyword_loc: Location?) -> InNode
 
     # Create a new IndexAndWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?operator_loc: Location, ?value: Prism::node) -> IndexAndWriteNode
     def index_and_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?operator_loc: Location, ?value: Prism::node) -> IndexAndWriteNode
 
     # Create a new IndexOperatorWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?binary_operator: Symbol, ?binary_operator_loc: Location, ?value: Prism::node) -> IndexOperatorWriteNode
     def index_operator_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?binary_operator: Symbol, ?binary_operator_loc: Location, ?value: Prism::node) -> IndexOperatorWriteNode
 
     # Create a new IndexOrWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?operator_loc: Location, ?value: Prism::node) -> IndexOrWriteNode
     def index_or_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?operator_loc: Location, ?value: Prism::node) -> IndexOrWriteNode
 
     # Create a new IndexTargetNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?) -> IndexTargetNode
     def index_target_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?) -> IndexTargetNode
 
     # Create a new InstanceVariableAndWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> InstanceVariableAndWriteNode
     def instance_variable_and_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> InstanceVariableAndWriteNode
 
     # Create a new InstanceVariableOperatorWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> InstanceVariableOperatorWriteNode
     def instance_variable_operator_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> InstanceVariableOperatorWriteNode
 
     # Create a new InstanceVariableOrWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> InstanceVariableOrWriteNode
     def instance_variable_or_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> InstanceVariableOrWriteNode
 
     # Create a new InstanceVariableReadNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> InstanceVariableReadNode
     def instance_variable_read_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> InstanceVariableReadNode
 
     # Create a new InstanceVariableTargetNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> InstanceVariableTargetNode
     def instance_variable_target_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> InstanceVariableTargetNode
 
     # Create a new InstanceVariableWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> InstanceVariableWriteNode
     def instance_variable_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> InstanceVariableWriteNode
 
     # Create a new IntegerNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Integer) -> IntegerNode
     def integer_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Integer) -> IntegerNode
 
     # Create a new InterpolatedMatchLastLineNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedMatchLastLineNode
     def interpolated_match_last_line_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedMatchLastLineNode
 
     # Create a new InterpolatedRegularExpressionNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedRegularExpressionNode
     def interpolated_regular_expression_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedRegularExpressionNode
 
     # Create a new InterpolatedStringNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode | InterpolatedStringNode], ?closing_loc: Location?) -> InterpolatedStringNode
     def interpolated_string_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode | InterpolatedStringNode], ?closing_loc: Location?) -> InterpolatedStringNode
 
     # Create a new InterpolatedSymbolNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location?) -> InterpolatedSymbolNode
     def interpolated_symbol_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location?) -> InterpolatedSymbolNode
 
     # Create a new InterpolatedXStringNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedXStringNode
     def interpolated_x_string_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedXStringNode
 
     # Create a new ItLocalVariableReadNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> ItLocalVariableReadNode
     def it_local_variable_read_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> ItLocalVariableReadNode
 
     # Create a new ItParametersNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> ItParametersNode
     def it_parameters_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> ItParametersNode
 
     # Create a new KeywordHashNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?elements: Array[AssocNode | AssocSplatNode]) -> KeywordHashNode
     def keyword_hash_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?elements: Array[AssocNode | AssocSplatNode]) -> KeywordHashNode
 
     # Create a new KeywordRestParameterNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> KeywordRestParameterNode
     def keyword_rest_parameter_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> KeywordRestParameterNode
 
     # Create a new LambdaNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?operator_loc: Location, ?opening_loc: Location, ?closing_loc: Location, ?parameters: (BlockParametersNode | NumberedParametersNode | ItParametersNode)?, ?body: (StatementsNode | BeginNode)?) -> LambdaNode
     def lambda_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?operator_loc: Location, ?opening_loc: Location, ?closing_loc: Location, ?parameters: (BlockParametersNode | NumberedParametersNode | ItParametersNode)?, ?body: (StatementsNode | BeginNode)?) -> LambdaNode
 
     # Create a new LocalVariableAndWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?depth: Integer) -> LocalVariableAndWriteNode
     def local_variable_and_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?depth: Integer) -> LocalVariableAndWriteNode
 
     # Create a new LocalVariableOperatorWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?binary_operator: Symbol, ?depth: Integer) -> LocalVariableOperatorWriteNode
     def local_variable_operator_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?binary_operator: Symbol, ?depth: Integer) -> LocalVariableOperatorWriteNode
 
     # Create a new LocalVariableOrWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?depth: Integer) -> LocalVariableOrWriteNode
     def local_variable_or_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?depth: Integer) -> LocalVariableOrWriteNode
 
     # Create a new LocalVariableReadNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer) -> LocalVariableReadNode
     def local_variable_read_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer) -> LocalVariableReadNode
 
     # Create a new LocalVariableTargetNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer) -> LocalVariableTargetNode
     def local_variable_target_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer) -> LocalVariableTargetNode
 
     # Create a new LocalVariableWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> LocalVariableWriteNode
     def local_variable_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> LocalVariableWriteNode
 
     # Create a new MatchLastLineNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> MatchLastLineNode
     def match_last_line_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> MatchLastLineNode
 
     # Create a new MatchPredicateNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?pattern: Prism::node, ?keyword_loc: Location) -> MatchPredicateNode
     def match_predicate_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?pattern: Prism::node, ?keyword_loc: Location) -> MatchPredicateNode
 
     # Create a new MatchRequiredNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?pattern: Prism::node, ?operator_loc: Location) -> MatchRequiredNode
     def match_required_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?pattern: Prism::node, ?operator_loc: Location) -> MatchRequiredNode
 
     # Create a new MatchWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?call: CallNode, ?targets: Array[LocalVariableTargetNode]) -> MatchWriteNode
     def match_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?call: CallNode, ?targets: Array[LocalVariableTargetNode]) -> MatchWriteNode
 
     # Create a new ModuleNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?module_keyword_loc: Location, ?constant_path: (ConstantReadNode | ConstantPathNode), ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location, ?name: Symbol) -> ModuleNode
     def module_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?module_keyword_loc: Location, ?constant_path: ConstantReadNode | ConstantPathNode, ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location, ?name: Symbol) -> ModuleNode
 
     # Create a new MultiTargetNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?lefts: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode], ?rest: (ImplicitRestNode | SplatNode)?, ?rights: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode], ?lparen_loc: Location?, ?rparen_loc: Location?) -> MultiTargetNode
     def multi_target_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?lefts: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode], ?rest: (ImplicitRestNode | SplatNode)?, ?rights: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode], ?lparen_loc: Location?, ?rparen_loc: Location?) -> MultiTargetNode
 
     # Create a new MultiWriteNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?lefts: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode], ?rest: (ImplicitRestNode | SplatNode)?, ?rights: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode], ?lparen_loc: Location?, ?rparen_loc: Location?, ?operator_loc: Location, ?value: Prism::node) -> MultiWriteNode
     def multi_write_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?lefts: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode], ?rest: (ImplicitRestNode | SplatNode)?, ?rights: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode], ?lparen_loc: Location?, ?rparen_loc: Location?, ?operator_loc: Location, ?value: Prism::node) -> MultiWriteNode
 
     # Create a new NextNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: ArgumentsNode?, ?keyword_loc: Location) -> NextNode
     def next_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: ArgumentsNode?, ?keyword_loc: Location) -> NextNode
 
     # Create a new NilNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> NilNode
     def nil_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> NilNode
 
     # Create a new NoBlockParameterNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?keyword_loc: Location) -> NoBlockParameterNode
     def no_block_parameter_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?keyword_loc: Location) -> NoBlockParameterNode
 
     # Create a new NoKeywordsParameterNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?keyword_loc: Location) -> NoKeywordsParameterNode
     def no_keywords_parameter_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?keyword_loc: Location) -> NoKeywordsParameterNode
 
     # Create a new NumberedParametersNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?maximum: Integer) -> NumberedParametersNode
     def numbered_parameters_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?maximum: Integer) -> NumberedParametersNode
 
     # Create a new NumberedReferenceReadNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?number: Integer) -> NumberedReferenceReadNode
     def numbered_reference_read_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?number: Integer) -> NumberedReferenceReadNode
 
     # Create a new OptionalKeywordParameterNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node) -> OptionalKeywordParameterNode
     def optional_keyword_parameter_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node) -> OptionalKeywordParameterNode
 
     # Create a new OptionalParameterNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> OptionalParameterNode
     def optional_parameter_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> OptionalParameterNode
 
     # Create a new OrNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> OrNode
     def or_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> OrNode
 
     # Create a new ParametersNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?requireds: Array[RequiredParameterNode | MultiTargetNode], ?optionals: Array[OptionalParameterNode], ?rest: (RestParameterNode | ImplicitRestNode)?, ?posts: Array[RequiredParameterNode | MultiTargetNode], ?keywords: Array[RequiredKeywordParameterNode | OptionalKeywordParameterNode], ?keyword_rest: (KeywordRestParameterNode | ForwardingParameterNode | NoKeywordsParameterNode)?, ?block: (BlockParameterNode | NoBlockParameterNode)?) -> ParametersNode
     def parameters_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?requireds: Array[RequiredParameterNode | MultiTargetNode], ?optionals: Array[OptionalParameterNode], ?rest: (RestParameterNode | ImplicitRestNode)?, ?posts: Array[RequiredParameterNode | MultiTargetNode], ?keywords: Array[RequiredKeywordParameterNode | OptionalKeywordParameterNode], ?keyword_rest: (KeywordRestParameterNode | ForwardingParameterNode | NoKeywordsParameterNode)?, ?block: (BlockParameterNode | NoBlockParameterNode)?) -> ParametersNode
 
     # Create a new ParenthesesNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?body: Prism::node?, ?opening_loc: Location, ?closing_loc: Location) -> ParenthesesNode
     def parentheses_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?body: Prism::node?, ?opening_loc: Location, ?closing_loc: Location) -> ParenthesesNode
 
     # Create a new PinnedExpressionNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node, ?operator_loc: Location, ?lparen_loc: Location, ?rparen_loc: Location) -> PinnedExpressionNode
     def pinned_expression_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node, ?operator_loc: Location, ?lparen_loc: Location, ?rparen_loc: Location) -> PinnedExpressionNode
 
     # Create a new PinnedVariableNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?variable: (LocalVariableReadNode | InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode | ItLocalVariableReadNode), ?operator_loc: Location) -> PinnedVariableNode
     def pinned_variable_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?variable: LocalVariableReadNode | InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode | ItLocalVariableReadNode, ?operator_loc: Location) -> PinnedVariableNode
 
     # Create a new PostExecutionNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?statements: StatementsNode?, ?keyword_loc: Location, ?opening_loc: Location, ?closing_loc: Location) -> PostExecutionNode
     def post_execution_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?statements: StatementsNode?, ?keyword_loc: Location, ?opening_loc: Location, ?closing_loc: Location) -> PostExecutionNode
 
     # Create a new PreExecutionNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?statements: StatementsNode?, ?keyword_loc: Location, ?opening_loc: Location, ?closing_loc: Location) -> PreExecutionNode
     def pre_execution_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?statements: StatementsNode?, ?keyword_loc: Location, ?opening_loc: Location, ?closing_loc: Location) -> PreExecutionNode
 
     # Create a new ProgramNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?statements: StatementsNode) -> ProgramNode
     def program_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?statements: StatementsNode) -> ProgramNode
 
     # Create a new RangeNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node?, ?right: Prism::node?, ?operator_loc: Location) -> RangeNode
     def range_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node?, ?right: Prism::node?, ?operator_loc: Location) -> RangeNode
 
     # Create a new RationalNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?numerator: Integer, ?denominator: Integer) -> RationalNode
     def rational_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?numerator: Integer, ?denominator: Integer) -> RationalNode
 
     # Create a new RedoNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> RedoNode
     def redo_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> RedoNode
 
     # Create a new RegularExpressionNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> RegularExpressionNode
     def regular_expression_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> RegularExpressionNode
 
     # Create a new RequiredKeywordParameterNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location) -> RequiredKeywordParameterNode
     def required_keyword_parameter_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location) -> RequiredKeywordParameterNode
 
     # Create a new RequiredParameterNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> RequiredParameterNode
     def required_parameter_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> RequiredParameterNode
 
     # Create a new RescueModifierNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node, ?keyword_loc: Location, ?rescue_expression: Prism::node) -> RescueModifierNode
     def rescue_modifier_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node, ?keyword_loc: Location, ?rescue_expression: Prism::node) -> RescueModifierNode
 
     # Create a new RescueNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?exceptions: Array[Prism::node], ?operator_loc: Location?, ?reference: (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode)?, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?subsequent: RescueNode?) -> RescueNode
     def rescue_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?exceptions: Array[Prism::node], ?operator_loc: Location?, ?reference: (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode)?, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?subsequent: RescueNode?) -> RescueNode
 
     # Create a new RestParameterNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> RestParameterNode
     def rest_parameter_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> RestParameterNode
 
     # Create a new RetryNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> RetryNode
     def retry_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> RetryNode
 
     # Create a new ReturnNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?arguments: ArgumentsNode?) -> ReturnNode
     def return_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?arguments: ArgumentsNode?) -> ReturnNode
 
     # Create a new SelfNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> SelfNode
     def self_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> SelfNode
 
     # Create a new ShareableConstantNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?write: (ConstantWriteNode | ConstantAndWriteNode | ConstantOrWriteNode | ConstantOperatorWriteNode | ConstantPathWriteNode | ConstantPathAndWriteNode | ConstantPathOrWriteNode | ConstantPathOperatorWriteNode)) -> ShareableConstantNode
     def shareable_constant_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?write: ConstantWriteNode | ConstantAndWriteNode | ConstantOrWriteNode | ConstantOperatorWriteNode | ConstantPathWriteNode | ConstantPathAndWriteNode | ConstantPathOrWriteNode | ConstantPathOperatorWriteNode) -> ShareableConstantNode
 
     # Create a new SingletonClassNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?class_keyword_loc: Location, ?operator_loc: Location, ?expression: Prism::node, ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location) -> SingletonClassNode
     def singleton_class_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?class_keyword_loc: Location, ?operator_loc: Location, ?expression: Prism::node, ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location) -> SingletonClassNode
 
     # Create a new SourceEncodingNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> SourceEncodingNode
     def source_encoding_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> SourceEncodingNode
 
     # Create a new SourceFileNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?filepath: String) -> SourceFileNode
     def source_file_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?filepath: String) -> SourceFileNode
 
     # Create a new SourceLineNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> SourceLineNode
     def source_line_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> SourceLineNode
 
     # Create a new SplatNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?expression: Prism::node?) -> SplatNode
     def splat_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?expression: Prism::node?) -> SplatNode
 
     # Create a new StatementsNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?body: Array[Prism::node]) -> StatementsNode
     def statements_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?body: Array[Prism::node]) -> StatementsNode
 
     # Create a new StringNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?content_loc: Location, ?closing_loc: Location?, ?unescaped: String) -> StringNode
     def string_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?content_loc: Location, ?closing_loc: Location?, ?unescaped: String) -> StringNode
 
     # Create a new SuperNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?lparen_loc: Location?, ?arguments: ArgumentsNode?, ?rparen_loc: Location?, ?block: (BlockNode | BlockArgumentNode)?) -> SuperNode
     def super_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?lparen_loc: Location?, ?arguments: ArgumentsNode?, ?rparen_loc: Location?, ?block: (BlockNode | BlockArgumentNode)?) -> SuperNode
 
     # Create a new SymbolNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?value_loc: Location?, ?closing_loc: Location?, ?unescaped: String) -> SymbolNode
     def symbol_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?value_loc: Location?, ?closing_loc: Location?, ?unescaped: String) -> SymbolNode
 
     # Create a new TrueNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> TrueNode
     def true_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer) -> TrueNode
 
     # Create a new UndefNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?names: Array[SymbolNode | InterpolatedSymbolNode], ?keyword_loc: Location) -> UndefNode
     def undef_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?names: Array[SymbolNode | InterpolatedSymbolNode], ?keyword_loc: Location) -> UndefNode
 
     # Create a new UnlessNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?unless_keyword_loc: Location, ?predicate: Prism::node, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?else_clause: ElseNode?, ?end_keyword_loc: Location?) -> UnlessNode
     def unless_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?unless_keyword_loc: Location, ?predicate: Prism::node, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?else_clause: ElseNode?, ?end_keyword_loc: Location?) -> UnlessNode
 
     # Create a new UntilNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?until_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location?, ?predicate: Prism::node, ?statements: StatementsNode?) -> UntilNode
     def until_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?until_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location?, ?predicate: Prism::node, ?statements: StatementsNode?) -> UntilNode
 
     # Create a new WhenNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?when_keyword_loc: Location, ?conditions: Array[Prism::node], ?then_keyword_loc: Location?, ?statements: StatementsNode?) -> WhenNode
     def when_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?when_keyword_loc: Location, ?conditions: Array[Prism::node], ?then_keyword_loc: Location?, ?statements: StatementsNode?) -> WhenNode
 
     # Create a new WhileNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?while_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location?, ?predicate: Prism::node, ?statements: StatementsNode?) -> WhileNode
     def while_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?while_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location?, ?predicate: Prism::node, ?statements: StatementsNode?) -> WhileNode
 
     # Create a new XStringNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> XStringNode
     def x_string_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> XStringNode
 
     # Create a new YieldNode node.
-    # --
+    #
     # : (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?lparen_loc: Location?, ?arguments: ArgumentsNode?, ?rparen_loc: Location?) -> YieldNode
     def yield_node: (?source: Source, ?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?lparen_loc: Location?, ?arguments: ArgumentsNode?, ?rparen_loc: Location?) -> YieldNode
 
     # Retrieve the value of one of the ArgumentsNodeFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def arguments_node_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the ArrayNodeFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def array_node_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the CallNodeFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def call_node_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the EncodingFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def encoding_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the IntegerBaseFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def integer_base_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the InterpolatedStringNodeFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def interpolated_string_node_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the KeywordHashNodeFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def keyword_hash_node_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the LoopFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def loop_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the ParameterFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def parameter_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the ParenthesesNodeFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def parentheses_node_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the RangeFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def range_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the RegularExpressionFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def regular_expression_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the ShareableConstantNodeFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def shareable_constant_node_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the StringFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def string_flag: (Symbol name) -> Integer
 
     # Retrieve the value of one of the SymbolFlags flags.
-    # --
+    #
     # : (Symbol name) -> Integer
     def symbol_flag: (Symbol name) -> Integer
 
@@ -902,26 +902,26 @@ module Prism
 
     # The default source object that gets attached to nodes and locations if no
     # source is specified.
-    # --
+    #
     # : () -> Source
     def default_source: () -> Source
 
     # The default location object that gets attached to nodes if no location is
     # specified, which uses the given source.
-    # --
+    #
     # : () -> Location
     def default_location: () -> Location
 
     # The default node that gets attached to nodes if no node is specified for a
     # required node field.
-    # --
+    #
     # : (Source source, Location location) -> node
     def default_node: (Source source, Location location) -> node
 
     private
 
     # Build the newline byte offset array for the given source string.
-    # --
+    #
     # : (String source) -> Array[Integer]
     def build_offsets: (String source) -> Array[Integer]
   end

--- a/sig/generated/prism/inspect_visitor.rbs
+++ b/sig/generated/prism/inspect_visitor.rbs
@@ -29,12 +29,12 @@ module Prism
     def initialize: (?String indent) -> void
 
     # Compose an inspect string for the given node.
-    # --
+    #
     # : (node node) -> String
     def self.compose: (node node) -> String
 
     # Compose the final string.
-    # --
+    #
     # : () -> String
     def compose: () -> String
 
@@ -497,12 +497,12 @@ module Prism
     private
 
     # Compose a header for the given node.
-    # --
+    #
     # : (String name, node node) -> String
     def inspect_node: (String name, node node) -> String
 
     # Compose a string representing the given inner location field.
-    # --
+    #
     # : (Location? location) -> String
     def inspect_location: (Location? location) -> String
   end

--- a/sig/generated/prism/lex_compat.rbs
+++ b/sig/generated/prism/lex_compat.rbs
@@ -43,12 +43,12 @@ module Prism
       attr_reader value: Array[lex_compat_token]
 
       # Create a new lex compat result object with the given values.
-      # --
+      #
       # : (Array[lex_compat_token] value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
       def initialize: (Array[lex_compat_token] value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
 
       # Implement the hash pattern matching interface for Result.
-      # --
+      #
       # : (Array[Symbol]? keys) -> Hash[Symbol, untyped]
       def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     end
@@ -139,7 +139,7 @@ module Prism
 
       # Here we will split between the two types of heredocs and return the
       # object that will store their tokens.
-      # --
+      #
       # : (lex_compat_token opening) -> (PlainHeredoc | DashHeredoc | DedentingHeredoc)
       def self.build: (lex_compat_token opening) -> (PlainHeredoc | DashHeredoc | DedentingHeredoc)
     end

--- a/sig/generated/prism/node.rbs
+++ b/sig/generated/prism/node.rbs
@@ -29,116 +29,116 @@ module Prism
     @location: Location | Integer
 
     # Save this node using a saved source so that it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save: (_Repository repository) -> Relocation::Entry
 
     # A Location instance that represents the location of this node in the
     # source.
-    # --
+    #
     # : () -> Location
     def location: () -> Location
 
     # Save the location using a saved source so that it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_location: (_Repository repository) -> Relocation::Entry
 
     # Delegates to [`start_line`](rdoc-ref:Location#start_line) of the associated location object.
-    # --
+    #
     # : () -> Integer
     def start_line: () -> Integer
 
     # Delegates to [`end_line`](rdoc-ref:Location#end_line) of the associated location object.
-    # --
+    #
     # : () -> Integer
     def end_line: () -> Integer
 
     # Delegates to [`start_offset`](rdoc-ref:Location#start_offset) of the associated location object.
-    # --
+    #
     # : () -> Integer
     def start_offset: () -> Integer
 
     # Delegates to [`end_offset`](rdoc-ref:Location#end_offset) of the associated location object.
-    # --
+    #
     # : () -> Integer
     def end_offset: () -> Integer
 
     # Delegates to [`start_character_offset`](rdoc-ref:Location#start_character_offset)
     # of the associated location object.
-    # --
+    #
     # : () -> Integer
     def start_character_offset: () -> Integer
 
     # Delegates to [`end_character_offset`](rdoc-ref:Location#end_character_offset)
     # of the associated location object.
-    # --
+    #
     # : () -> Integer
     def end_character_offset: () -> Integer
 
     # Delegates to [`cached_start_code_units_offset`](rdoc-ref:Location#cached_start_code_units_offset)
     # of the associated location object.
-    # --
+    #
     # : (_CodeUnitsCache cache) -> Integer
     def cached_start_code_units_offset: (_CodeUnitsCache cache) -> Integer
 
     # Delegates to [`cached_end_code_units_offset`](rdoc-ref:Location#cached_end_code_units_offset)
     # of the associated location object.
-    # --
+    #
     # : (_CodeUnitsCache cache) -> Integer
     def cached_end_code_units_offset: (_CodeUnitsCache cache) -> Integer
 
     # Delegates to [`start_column`](rdoc-ref:Location#start_column) of the associated location object.
-    # --
+    #
     # : () -> Integer
     def start_column: () -> Integer
 
     # Delegates to [`end_column`](rdoc-ref:Location#end_column) of the associated location object.
-    # --
+    #
     # : () -> Integer
     def end_column: () -> Integer
 
     # Delegates to [`start_character_column`](rdoc-ref:Location#start_character_column)
     # of the associated location object.
-    # --
+    #
     # : () -> Integer
     def start_character_column: () -> Integer
 
     # Delegates to [`end_character_column`](rdoc-ref:Location#end_character_column)
     # of the associated location object.
-    # --
+    #
     # : () -> Integer
     def end_character_column: () -> Integer
 
     # Delegates to [`cached_start_code_units_column`](rdoc-ref:Location#cached_start_code_units_column)
     # of the associated location object.
-    # --
+    #
     # : (_CodeUnitsCache cache) -> Integer
     def cached_start_code_units_column: (_CodeUnitsCache cache) -> Integer
 
     # Delegates to [`cached_end_code_units_column`](rdoc-ref:Location#cached_end_code_units_column)
     # of the associated location object.
-    # --
+    #
     # : (_CodeUnitsCache cache) -> Integer
     def cached_end_code_units_column: (_CodeUnitsCache cache) -> Integer
 
     # Delegates to [`leading_comments`](rdoc-ref:Location#leading_comments) of the associated location object.
-    # --
+    #
     # : () -> Array[Comment]
     def leading_comments: () -> Array[Comment]
 
     # Delegates to [`trailing_comments`](rdoc-ref:Location#trailing_comments) of the associated location object.
-    # --
+    #
     # : () -> Array[Comment]
     def trailing_comments: () -> Array[Comment]
 
     # Delegates to [`comments`](rdoc-ref:Location#comments) of the associated location object.
-    # --
+    #
     # : () -> Array[Comment]
     def comments: () -> Array[Comment]
 
     # Returns all of the lines of the source code associated with this node.
-    # --
+    #
     # : () -> Array[String]
     def source_lines: () -> Array[String]
 
@@ -147,14 +147,14 @@ module Prism
     alias script_lines source_lines
 
     # Slice the location of the node from the source.
-    # --
+    #
     # : () -> String
     def slice: () -> String
 
     # Slice the location of the node from the source, starting at the beginning
     # of the line that the location starts on, ending at the end of the line
     # that the location ends on.
-    # --
+    #
     # : () -> String
     def slice_lines: () -> String
 
@@ -164,23 +164,23 @@ module Prism
     attr_reader flags: Integer
 
     # Returns true if the node has the newline flag set.
-    # --
+    #
     # : () -> bool
     def newline?: () -> bool
 
     # Returns true if the node has the static literal flag set.
-    # --
+    #
     # : () -> bool
     def static_literal?: () -> bool
 
     # Similar to inspect, but respects the current level of indentation given by
     # the pretty print object.
-    # --
+    #
     # : (PP q) -> void
     def pretty_print: (PP q) -> void
 
     # Convert this node into a graphviz dot graph string.
-    # --
+    #
     # : () -> String
     def to_dot: () -> String
 
@@ -190,7 +190,7 @@ module Prism
     #
     # Important to note is that the column given to this method should be in
     # bytes, as opposed to characters or code units.
-    # --
+    #
     # : (Integer line, Integer column) -> Array[node]
     def tunnel: (Integer line, Integer column) -> Array[node]
 
@@ -199,7 +199,7 @@ module Prism
     # particular condition.
     #
     #     node.breadth_first_search { |node| node.node_id == node_id }
-    # --
+    #
     # : () { (node) -> bool } -> node?
     def breadth_first_search: () { (node) -> bool } -> node?
 
@@ -210,7 +210,7 @@ module Prism
     # particular condition.
     #
     #     node.breadth_first_search_all { |node| node.is_a?(Prism::CallNode) }
-    # --
+    #
     # : () { (node) -> bool } -> Array[node]
     def breadth_first_search_all: () { (node) -> bool } -> Array[node]
 
@@ -219,18 +219,18 @@ module Prism
     # Returns a list of the fields that exist for this node class. Fields
     # describe the structure of the node. This kind of reflection is useful for
     # things like recursively visiting each node _and_ field in the tree.
-    # --
+    #
     # : () -> Array[Reflection::Field]
     def self.fields: () -> Array[Reflection::Field]
 
     # Accepts a visitor and calls back into the specialized visit function.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # Returns an array of child nodes, including `nil`s in the place of optional
     # nodes that were not present.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
@@ -239,7 +239,7 @@ module Prism
     # With a block given, yields each child node. Without a block, returns
     # an enumerator that contains each child node. Excludes any `nil`s in
     # the place of optional nodes that were not present.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
@@ -247,18 +247,18 @@ module Prism
 
     # Returns an array of child nodes, excluding any `nil`s in the place of
     # optional nodes that were not present.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # Returns an array of child nodes and locations that could potentially have
     # comments attached to them.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
     # Returns a string representation of the node.
-    # --
+    #
     # : () -> String
     def inspect: () -> String
 
@@ -274,7 +274,7 @@ module Prism
     # it uses a single integer comparison, but also because if you're on CRuby
     # you can take advantage of the fact that case statements with all symbol
     # keys will use a jump table.
-    # --
+    #
     # : () -> Symbol
     def type: () -> Symbol
 
@@ -282,7 +282,7 @@ module Prism
     # splitting on the type of the node without having to do a long === chain.
     # Note that like #type, it will still be slower than using == for a single
     # class, but should be faster in a case statement or an array comparison.
-    # --
+    #
     # : () -> Symbol
     def self.type: () -> Symbol
   end
@@ -299,34 +299,34 @@ module Prism
     @new_name: GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode
 
     # Initialize a new AliasGlobalVariableNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, (GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode) new_name, (GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode) old_name, Location keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode new_name, GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode old_name, Location keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -334,7 +334,7 @@ module Prism
     #   copy(**fields) -> AliasGlobalVariableNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?new_name: (GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode), ?old_name: (GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode), ?keyword_loc: Location) -> AliasGlobalVariableNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?new_name: GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode, ?old_name: GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode, ?keyword_loc: Location) -> AliasGlobalVariableNode
 
@@ -344,12 +344,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :alias_global_variable_node
     def type: () -> :alias_global_variable_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :alias_global_variable_node
     def self.type: () -> :alias_global_variable_node
 
@@ -363,7 +363,7 @@ module Prism
     #
     #     alias $foo $bar
     #           ^^^^
-    # --
+    #
     # : () -> (GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode)
     def new_name: () -> (GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode)
 
@@ -374,7 +374,7 @@ module Prism
     #
     #     alias $foo $bar
     #                ^^^^
-    # --
+    #
     # : () -> (GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode)
     def old_name: () -> (GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode)
 
@@ -386,14 +386,14 @@ module Prism
     #
     #     alias $foo $bar
     #     ^^^^^
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -401,7 +401,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -421,34 +421,34 @@ module Prism
     @new_name: SymbolNode | InterpolatedSymbolNode
 
     # Initialize a new AliasMethodNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, (SymbolNode | InterpolatedSymbolNode) new_name, (SymbolNode | InterpolatedSymbolNode) old_name, Location keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, SymbolNode | InterpolatedSymbolNode new_name, SymbolNode | InterpolatedSymbolNode old_name, Location keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -456,7 +456,7 @@ module Prism
     #   copy(**fields) -> AliasMethodNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?new_name: (SymbolNode | InterpolatedSymbolNode), ?old_name: (SymbolNode | InterpolatedSymbolNode), ?keyword_loc: Location) -> AliasMethodNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?new_name: SymbolNode | InterpolatedSymbolNode, ?old_name: SymbolNode | InterpolatedSymbolNode, ?keyword_loc: Location) -> AliasMethodNode
 
@@ -466,12 +466,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :alias_method_node
     def type: () -> :alias_method_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :alias_method_node
     def self.type: () -> :alias_method_node
 
@@ -491,7 +491,7 @@ module Prism
     #
     #     alias :"#{foo}" :"#{bar}"
     #           ^^^^^^^^^
-    # --
+    #
     # : () -> (SymbolNode | InterpolatedSymbolNode)
     def new_name: () -> (SymbolNode | InterpolatedSymbolNode)
 
@@ -508,7 +508,7 @@ module Prism
     #
     #     alias :"#{foo}" :"#{bar}"
     #                     ^^^^^^^^^
-    # --
+    #
     # : () -> (SymbolNode | InterpolatedSymbolNode)
     def old_name: () -> (SymbolNode | InterpolatedSymbolNode)
 
@@ -520,14 +520,14 @@ module Prism
     #
     #     alias foo bar
     #     ^^^^^
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -535,7 +535,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -555,34 +555,34 @@ module Prism
     @left: Prism::node
 
     # Initialize a new AlternationPatternNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node left, Prism::node right, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node left, Prism::node right, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -590,7 +590,7 @@ module Prism
     #   copy(**fields) -> AlternationPatternNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> AlternationPatternNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> AlternationPatternNode
 
@@ -600,12 +600,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :alternation_pattern_node
     def type: () -> :alternation_pattern_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :alternation_pattern_node
     def self.type: () -> :alternation_pattern_node
 
@@ -619,7 +619,7 @@ module Prism
     #
     #     foo => bar | baz
     #            ^^^
-    # --
+    #
     # : () -> Prism::node
     def left: () -> Prism::node
 
@@ -630,7 +630,7 @@ module Prism
     #
     #     foo => bar | baz
     #                  ^^^
-    # --
+    #
     # : () -> Prism::node
     def right: () -> Prism::node
 
@@ -642,14 +642,14 @@ module Prism
     #
     #     foo => bar | baz
     #                ^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -657,7 +657,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -677,34 +677,34 @@ module Prism
     @left: Prism::node
 
     # Initialize a new AndNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node left, Prism::node right, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node left, Prism::node right, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -712,7 +712,7 @@ module Prism
     #   copy(**fields) -> AndNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> AndNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> AndNode
 
@@ -722,12 +722,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :and_node
     def type: () -> :and_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :and_node
     def self.type: () -> :and_node
 
@@ -744,7 +744,7 @@ module Prism
     #
     #     1 && 2
     #     ^
-    # --
+    #
     # : () -> Prism::node
     def left: () -> Prism::node
 
@@ -758,7 +758,7 @@ module Prism
     #
     #     1 and 2
     #           ^
-    # --
+    #
     # : () -> Prism::node
     def right: () -> Prism::node
 
@@ -770,14 +770,14 @@ module Prism
     #
     #     left and right
     #          ^^^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -785,7 +785,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -801,34 +801,34 @@ module Prism
     @arguments: Array[Prism::node]
 
     # Initialize a new ArgumentsNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[Prism::node] arguments) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[Prism::node] arguments) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -836,7 +836,7 @@ module Prism
     #   copy(**fields) -> ArgumentsNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: Array[Prism::node]) -> ArgumentsNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: Array[Prism::node]) -> ArgumentsNode
 
@@ -846,12 +846,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :arguments_node
     def type: () -> :arguments_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :arguments_node
     def self.type: () -> :arguments_node
 
@@ -860,31 +860,31 @@ module Prism
 
     # :category: Flags
     # if the arguments contain forwarding
-    # --
+    #
     # : () -> bool
     def contains_forwarding?: () -> bool
 
     # :category: Flags
     # if the arguments contain keywords
-    # --
+    #
     # : () -> bool
     def contains_keywords?: () -> bool
 
     # :category: Flags
     # if the arguments contain a keyword splat
-    # --
+    #
     # : () -> bool
     def contains_keyword_splat?: () -> bool
 
     # :category: Flags
     # if the arguments contain a splat
-    # --
+    #
     # : () -> bool
     def contains_splat?: () -> bool
 
     # :category: Flags
     # if the arguments contain multiple splats
-    # --
+    #
     # : () -> bool
     def contains_multiple_splats?: () -> bool
 
@@ -895,7 +895,7 @@ module Prism
     #
     #     foo(bar, baz)
     #         ^^^^^^^^
-    # --
+    #
     # : () -> Array[Prism::node]
     def arguments: () -> Array[Prism::node]
 
@@ -915,34 +915,34 @@ module Prism
     @elements: Array[Prism::node]
 
     # Initialize a new ArrayNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[Prism::node] elements, Location? opening_loc, Location? closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[Prism::node] elements, Location? opening_loc, Location? closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -950,7 +950,7 @@ module Prism
     #   copy(**fields) -> ArrayNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?elements: Array[Prism::node], ?opening_loc: Location?, ?closing_loc: Location?) -> ArrayNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?elements: Array[Prism::node], ?opening_loc: Location?, ?closing_loc: Location?) -> ArrayNode
 
@@ -960,12 +960,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :array_node
     def type: () -> :array_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :array_node
     def self.type: () -> :array_node
 
@@ -974,7 +974,7 @@ module Prism
 
     # :category: Flags
     # if array contains splat nodes
-    # --
+    #
     # : () -> bool
     def contains_splat?: () -> bool
 
@@ -982,7 +982,7 @@ module Prism
     #   elements -> Array[Node]
     #
     # Represent the list of zero or more [non-void expressions](https://github.com/ruby/prism/blob/main/docs/parsing_rules.md#non-void-expression) within the array.
-    # --
+    #
     # : () -> Array[Prism::node]
     def elements: () -> Array[Prism::node]
 
@@ -996,14 +996,14 @@ module Prism
     #     %w[foo bar baz]         # "%w["
     #     %I(apple orange banana) # "%I("
     #     foo = 1, 2, 3           # nil
-    # --
+    #
     # : () -> Location?
     def opening_loc: () -> Location?
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_opening_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -1017,14 +1017,14 @@ module Prism
     #     %w[foo bar baz]         # "]"
     #     %I(apple orange banana) # ")"
     #     foo = 1, 2, 3           # nil
-    # --
+    #
     # : () -> Location?
     def closing_loc: () -> Location?
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_closing_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -1032,7 +1032,7 @@ module Prism
     #   opening -> String | nil
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String?
     def opening: () -> String?
 
@@ -1040,7 +1040,7 @@ module Prism
     #   closing -> String | nil
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String?
     def closing: () -> String?
 
@@ -1078,34 +1078,34 @@ module Prism
     @constant: (ConstantPathNode | ConstantReadNode)?
 
     # Initialize a new ArrayPatternNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, (ConstantPathNode | ConstantReadNode)? constant, Array[Prism::node] requireds, (ImplicitRestNode | SplatNode)? rest, Array[Prism::node] posts, Location? opening_loc, Location? closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, (ConstantPathNode | ConstantReadNode)? constant, Array[Prism::node] requireds, (ImplicitRestNode | SplatNode)? rest, Array[Prism::node] posts, Location? opening_loc, Location? closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -1113,7 +1113,7 @@ module Prism
     #   copy(**fields) -> ArrayPatternNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?requireds: Array[Prism::node], ?rest: (ImplicitRestNode | SplatNode)?, ?posts: Array[Prism::node], ?opening_loc: Location?, ?closing_loc: Location?) -> ArrayPatternNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?requireds: Array[Prism::node], ?rest: (ImplicitRestNode | SplatNode)?, ?posts: Array[Prism::node], ?opening_loc: Location?, ?closing_loc: Location?) -> ArrayPatternNode
 
@@ -1123,12 +1123,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :array_pattern_node
     def type: () -> :array_pattern_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :array_pattern_node
     def self.type: () -> :array_pattern_node
 
@@ -1148,7 +1148,7 @@ module Prism
     #
     #     foo in Bar::Baz[1, 2, 3]
     #            ^^^^^^^^
-    # --
+    #
     # : () -> (ConstantPathNode | ConstantReadNode)?
     def constant: () -> (ConstantPathNode | ConstantReadNode)?
 
@@ -1159,7 +1159,7 @@ module Prism
     #
     #     foo in [1, 2]
     #             ^  ^
-    # --
+    #
     # : () -> Array[Prism::node]
     def requireds: () -> Array[Prism::node]
 
@@ -1170,7 +1170,7 @@ module Prism
     #
     #     foo in *bar
     #            ^^^^
-    # --
+    #
     # : () -> (ImplicitRestNode | SplatNode)?
     def rest: () -> (ImplicitRestNode | SplatNode)?
 
@@ -1181,7 +1181,7 @@ module Prism
     #
     #     foo in *bar, baz
     #                  ^^^
-    # --
+    #
     # : () -> Array[Prism::node]
     def posts: () -> Array[Prism::node]
 
@@ -1193,14 +1193,14 @@ module Prism
     #
     #     foo in [1, 2]
     #            ^
-    # --
+    #
     # : () -> Location?
     def opening_loc: () -> Location?
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_opening_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -1212,14 +1212,14 @@ module Prism
     #
     #     foo in [1, 2]
     #                 ^
-    # --
+    #
     # : () -> Location?
     def closing_loc: () -> Location?
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_closing_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -1227,7 +1227,7 @@ module Prism
     #   opening -> String | nil
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String?
     def opening: () -> String?
 
@@ -1235,7 +1235,7 @@ module Prism
     #   closing -> String | nil
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String?
     def closing: () -> String?
 
@@ -1255,34 +1255,34 @@ module Prism
     @key: Prism::node
 
     # Initialize a new AssocNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node key, Prism::node value, Location? operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node key, Prism::node value, Location? operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -1290,7 +1290,7 @@ module Prism
     #   copy(**fields) -> AssocNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?key: Prism::node, ?value: Prism::node, ?operator_loc: Location?) -> AssocNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?key: Prism::node, ?value: Prism::node, ?operator_loc: Location?) -> AssocNode
 
@@ -1300,12 +1300,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :assoc_node
     def type: () -> :assoc_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :assoc_node
     def self.type: () -> :assoc_node
 
@@ -1325,7 +1325,7 @@ module Prism
     #
     #     { def a; end => 1 }
     #       ^^^^^^^^^^
-    # --
+    #
     # : () -> Prism::node
     def key: () -> Prism::node
 
@@ -1339,7 +1339,7 @@ module Prism
     #
     #     { x: 1 }
     #          ^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -1351,14 +1351,14 @@ module Prism
     #
     #     { foo => bar }
     #           ^^
-    # --
+    #
     # : () -> Location?
     def operator_loc: () -> Location?
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_operator_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -1366,7 +1366,7 @@ module Prism
     #   operator -> String | nil
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String?
     def operator: () -> String?
 
@@ -1384,34 +1384,34 @@ module Prism
     @value: Prism::node?
 
     # Initialize a new AssocSplatNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? value, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? value, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -1419,7 +1419,7 @@ module Prism
     #   copy(**fields) -> AssocSplatNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node?, ?operator_loc: Location) -> AssocSplatNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node?, ?operator_loc: Location) -> AssocSplatNode
 
@@ -1429,12 +1429,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :assoc_splat_node
     def type: () -> :assoc_splat_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :assoc_splat_node
     def self.type: () -> :assoc_splat_node
 
@@ -1448,7 +1448,7 @@ module Prism
     #
     #     { **foo }
     #         ^^^
-    # --
+    #
     # : () -> Prism::node?
     def value: () -> Prism::node?
 
@@ -1460,14 +1460,14 @@ module Prism
     #
     #     { **x }
     #       ^^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -1475,7 +1475,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -1491,34 +1491,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new BackReferenceReadNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -1526,7 +1526,7 @@ module Prism
     #   copy(**fields) -> BackReferenceReadNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> BackReferenceReadNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> BackReferenceReadNode
 
@@ -1536,12 +1536,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :back_reference_read_node
     def type: () -> :back_reference_read_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :back_reference_read_node
     def self.type: () -> :back_reference_read_node
 
@@ -1556,7 +1556,7 @@ module Prism
     #     $& # name `:$&`
     #
     #     $+ # name `:$+`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -1584,34 +1584,34 @@ module Prism
     @begin_keyword_loc: Location?
 
     # Initialize a new BeginNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location? begin_keyword_loc, StatementsNode? statements, RescueNode? rescue_clause, ElseNode? else_clause, EnsureNode? ensure_clause, Location? end_keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location? begin_keyword_loc, StatementsNode? statements, RescueNode? rescue_clause, ElseNode? else_clause, EnsureNode? ensure_clause, Location? end_keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -1619,7 +1619,7 @@ module Prism
     #   copy(**fields) -> BeginNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?begin_keyword_loc: Location?, ?statements: StatementsNode?, ?rescue_clause: RescueNode?, ?else_clause: ElseNode?, ?ensure_clause: EnsureNode?, ?end_keyword_loc: Location?) -> BeginNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?begin_keyword_loc: Location?, ?statements: StatementsNode?, ?rescue_clause: RescueNode?, ?else_clause: ElseNode?, ?ensure_clause: EnsureNode?, ?end_keyword_loc: Location?) -> BeginNode
 
@@ -1629,12 +1629,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :begin_node
     def type: () -> :begin_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :begin_node
     def self.type: () -> :begin_node
 
@@ -1649,14 +1649,14 @@ module Prism
     #
     #     begin x end
     #     ^^^^^
-    # --
+    #
     # : () -> Location?
     def begin_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the begin_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_begin_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -1667,7 +1667,7 @@ module Prism
     #
     #     begin x end
     #           ^
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -1678,7 +1678,7 @@ module Prism
     #
     #     begin x; rescue y; end
     #              ^^^^^^^^
-    # --
+    #
     # : () -> RescueNode?
     def rescue_clause: () -> RescueNode?
 
@@ -1689,7 +1689,7 @@ module Prism
     #
     #     begin x; rescue y; else z; end
     #                        ^^^^^^^^^^^
-    # --
+    #
     # : () -> ElseNode?
     def else_clause: () -> ElseNode?
 
@@ -1700,7 +1700,7 @@ module Prism
     #
     #     begin x; ensure y; end
     #              ^^^^^^^^
-    # --
+    #
     # : () -> EnsureNode?
     def ensure_clause: () -> EnsureNode?
 
@@ -1712,14 +1712,14 @@ module Prism
     #
     #     begin x end
     #             ^^^
-    # --
+    #
     # : () -> Location?
     def end_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -1727,7 +1727,7 @@ module Prism
     #   begin_keyword -> String | nil
     #
     # Slice the location of begin_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def begin_keyword: () -> String?
 
@@ -1735,7 +1735,7 @@ module Prism
     #   end_keyword -> String | nil
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def end_keyword: () -> String?
 
@@ -1753,34 +1753,34 @@ module Prism
     @expression: Prism::node?
 
     # Initialize a new BlockArgumentNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? expression, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? expression, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -1788,7 +1788,7 @@ module Prism
     #   copy(**fields) -> BlockArgumentNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node?, ?operator_loc: Location) -> BlockArgumentNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node?, ?operator_loc: Location) -> BlockArgumentNode
 
@@ -1798,12 +1798,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :block_argument_node
     def type: () -> :block_argument_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :block_argument_node
     def self.type: () -> :block_argument_node
 
@@ -1817,7 +1817,7 @@ module Prism
     #
     #     foo(&args)
     #          ^^^^
-    # --
+    #
     # : () -> Prism::node?
     def expression: () -> Prism::node?
 
@@ -1829,14 +1829,14 @@ module Prism
     #
     #     foo(&args)
     #         ^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -1844,7 +1844,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -1860,34 +1860,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new BlockLocalVariableNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -1895,7 +1895,7 @@ module Prism
     #   copy(**fields) -> BlockLocalVariableNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> BlockLocalVariableNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> BlockLocalVariableNode
 
@@ -1905,12 +1905,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :block_local_variable_node
     def type: () -> :block_local_variable_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :block_local_variable_node
     def self.type: () -> :block_local_variable_node
 
@@ -1919,7 +1919,7 @@ module Prism
 
     # :category: Flags
     # a parameter name that has been repeated in the method signature
-    # --
+    #
     # : () -> bool
     def repeated_parameter?: () -> bool
 
@@ -1930,7 +1930,7 @@ module Prism
     #
     #     a { |; b| } # name `:b`
     #            ^
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -1954,34 +1954,34 @@ module Prism
     @locals: Array[Symbol]
 
     # Initialize a new BlockNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, (BlockParametersNode | NumberedParametersNode | ItParametersNode)? parameters, (StatementsNode | BeginNode)? body, Location opening_loc, Location closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, (BlockParametersNode | NumberedParametersNode | ItParametersNode)? parameters, (StatementsNode | BeginNode)? body, Location opening_loc, Location closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -1989,7 +1989,7 @@ module Prism
     #   copy(**fields) -> BlockNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?parameters: (BlockParametersNode | NumberedParametersNode | ItParametersNode)?, ?body: (StatementsNode | BeginNode)?, ?opening_loc: Location, ?closing_loc: Location) -> BlockNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?parameters: (BlockParametersNode | NumberedParametersNode | ItParametersNode)?, ?body: (StatementsNode | BeginNode)?, ?opening_loc: Location, ?closing_loc: Location) -> BlockNode
 
@@ -1999,12 +1999,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :block_node
     def type: () -> :block_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :block_node
     def self.type: () -> :block_node
 
@@ -2018,7 +2018,7 @@ module Prism
     #
     #     [1, 2, 3].each { |i| puts x } # locals: [:i]
     #                       ^
-    # --
+    #
     # : () -> Array[Symbol]
     def locals: () -> Array[Symbol]
 
@@ -2033,7 +2033,7 @@ module Prism
     #                    ^^^^^^^^^^^
     #     [1, 2, 3].each { puts it }
     #                    ^^^^^^^^^^^
-    # --
+    #
     # : () -> (BlockParametersNode | NumberedParametersNode | ItParametersNode)?
     def parameters: () -> (BlockParametersNode | NumberedParametersNode | ItParametersNode)?
 
@@ -2044,7 +2044,7 @@ module Prism
     #
     #     [1, 2, 3].each { |i| puts x }
     #                          ^^^^^^
-    # --
+    #
     # : () -> (StatementsNode | BeginNode)?
     def body: () -> (StatementsNode | BeginNode)?
 
@@ -2056,14 +2056,14 @@ module Prism
     #
     #     [1, 2, 3].each { |i| puts x }
     #                    ^
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -2075,14 +2075,14 @@ module Prism
     #
     #     [1, 2, 3].each { |i| puts x }
     #                                 ^
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -2090,7 +2090,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -2098,7 +2098,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -2119,34 +2119,34 @@ module Prism
     @name: Symbol?
 
     # Initialize a new BlockParameterNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol? name, Location? name_loc, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol? name, Location? name_loc, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -2154,7 +2154,7 @@ module Prism
     #   copy(**fields) -> BlockParameterNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> BlockParameterNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> BlockParameterNode
 
@@ -2164,12 +2164,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :block_parameter_node
     def type: () -> :block_parameter_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :block_parameter_node
     def self.type: () -> :block_parameter_node
 
@@ -2178,7 +2178,7 @@ module Prism
 
     # :category: Flags
     # a parameter name that has been repeated in the method signature
-    # --
+    #
     # : () -> bool
     def repeated_parameter?: () -> bool
 
@@ -2190,7 +2190,7 @@ module Prism
     #     def a(&b) # name `:b`
     #            ^
     #     end
-    # --
+    #
     # : () -> Symbol?
     def name: () -> Symbol?
 
@@ -2202,14 +2202,14 @@ module Prism
     #
     #     def a(&b)
     #            ^
-    # --
+    #
     # : () -> Location?
     def name_loc: () -> Location?
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_name_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -2222,14 +2222,14 @@ module Prism
     #     def a(&b)
     #           ^
     #     end
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -2237,7 +2237,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -2263,34 +2263,34 @@ module Prism
     @parameters: ParametersNode?
 
     # Initialize a new BlockParametersNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ParametersNode? parameters, Array[BlockLocalVariableNode] locals, Location? opening_loc, Location? closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, ParametersNode? parameters, Array[BlockLocalVariableNode] locals, Location? opening_loc, Location? closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -2298,7 +2298,7 @@ module Prism
     #   copy(**fields) -> BlockParametersNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?parameters: ParametersNode?, ?locals: Array[BlockLocalVariableNode], ?opening_loc: Location?, ?closing_loc: Location?) -> BlockParametersNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?parameters: ParametersNode?, ?locals: Array[BlockLocalVariableNode], ?opening_loc: Location?, ?closing_loc: Location?) -> BlockParametersNode
 
@@ -2308,12 +2308,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :block_parameters_node
     def type: () -> :block_parameters_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :block_parameters_node
     def self.type: () -> :block_parameters_node
 
@@ -2331,7 +2331,7 @@ module Prism
     #     foo do |a, b = 1; local|
     #             ^^^^^^^^
     #     end
-    # --
+    #
     # : () -> ParametersNode?
     def parameters: () -> ParametersNode?
 
@@ -2346,7 +2346,7 @@ module Prism
     #     foo do |a, b = 1; local|
     #                       ^^^^^
     #     end
-    # --
+    #
     # : () -> Array[BlockLocalVariableNode]
     def locals: () -> Array[BlockLocalVariableNode]
 
@@ -2362,14 +2362,14 @@ module Prism
     #     foo do |a, b = 1; local|
     #            ^
     #     end
-    # --
+    #
     # : () -> Location?
     def opening_loc: () -> Location?
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_opening_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -2385,14 +2385,14 @@ module Prism
     #     foo do |a, b = 1; local|
     #                            ^
     #     end
-    # --
+    #
     # : () -> Location?
     def closing_loc: () -> Location?
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_closing_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -2400,7 +2400,7 @@ module Prism
     #   opening -> String | nil
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String?
     def opening: () -> String?
 
@@ -2408,7 +2408,7 @@ module Prism
     #   closing -> String | nil
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String?
     def closing: () -> String?
 
@@ -2426,34 +2426,34 @@ module Prism
     @arguments: ArgumentsNode?
 
     # Initialize a new BreakNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ArgumentsNode? arguments, Location keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, ArgumentsNode? arguments, Location keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -2461,7 +2461,7 @@ module Prism
     #   copy(**fields) -> BreakNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: ArgumentsNode?, ?keyword_loc: Location) -> BreakNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: ArgumentsNode?, ?keyword_loc: Location) -> BreakNode
 
@@ -2471,12 +2471,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :break_node
     def type: () -> :break_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :break_node
     def self.type: () -> :break_node
 
@@ -2490,7 +2490,7 @@ module Prism
     #
     #     break foo
     #           ^^^
-    # --
+    #
     # : () -> ArgumentsNode?
     def arguments: () -> ArgumentsNode?
 
@@ -2502,14 +2502,14 @@ module Prism
     #
     #     break foo
     #     ^^^^^
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -2517,7 +2517,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -2545,34 +2545,34 @@ module Prism
     @receiver: Prism::node?
 
     # Initialize a new CallAndWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location? message_loc, Symbol read_name, Symbol write_name, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location? message_loc, Symbol read_name, Symbol write_name, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -2580,7 +2580,7 @@ module Prism
     #   copy(**fields) -> CallAndWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?operator_loc: Location, ?value: Prism::node) -> CallAndWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?operator_loc: Location, ?value: Prism::node) -> CallAndWriteNode
 
@@ -2590,12 +2590,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :call_and_write_node
     def type: () -> :call_and_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :call_and_write_node
     def self.type: () -> :call_and_write_node
 
@@ -2604,25 +2604,25 @@ module Prism
 
     # :category: Flags
     # &. operator
-    # --
+    #
     # : () -> bool
     def safe_navigation?: () -> bool
 
     # :category: Flags
     # a call that could have been a local variable
-    # --
+    #
     # : () -> bool
     def variable_call?: () -> bool
 
     # :category: Flags
     # a call that is an attribute write, so the value being written should be returned
-    # --
+    #
     # : () -> bool
     def attribute_write?: () -> bool
 
     # :category: Flags
     # a call that ignores method visibility
-    # --
+    #
     # : () -> bool
     def ignore_visibility?: () -> bool
 
@@ -2633,7 +2633,7 @@ module Prism
     #
     #     foo.bar &&= value
     #     ^^^
-    # --
+    #
     # : () -> Prism::node?
     def receiver: () -> Prism::node?
 
@@ -2645,14 +2645,14 @@ module Prism
     #
     #     foo.bar &&= value
     #        ^
-    # --
+    #
     # : () -> Location?
     def call_operator_loc: () -> Location?
 
     # :category: Repository
     # Save the call_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_call_operator_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -2664,14 +2664,14 @@ module Prism
     #
     #     foo.bar &&= value
     #         ^^^
-    # --
+    #
     # : () -> Location?
     def message_loc: () -> Location?
 
     # :category: Repository
     # Save the message_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_message_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -2682,7 +2682,7 @@ module Prism
     #
     #     foo.bar &&= value # read_name `:bar`
     #         ^^^
-    # --
+    #
     # : () -> Symbol
     def read_name: () -> Symbol
 
@@ -2693,7 +2693,7 @@ module Prism
     #
     #     foo.bar &&= value # write_name `:bar=`
     #         ^^^
-    # --
+    #
     # : () -> Symbol
     def write_name: () -> Symbol
 
@@ -2705,14 +2705,14 @@ module Prism
     #
     #     foo.bar &&= value
     #             ^^^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -2723,7 +2723,7 @@ module Prism
     #
     #     foo.bar &&= value
     #                 ^^^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -2731,7 +2731,7 @@ module Prism
     #   call_operator -> String | nil
     #
     # Slice the location of call_operator_loc from the source.
-    # --
+    #
     # : () -> String?
     def call_operator: () -> String?
 
@@ -2739,7 +2739,7 @@ module Prism
     #   message -> String | nil
     #
     # Slice the location of message_loc from the source.
-    # --
+    #
     # : () -> String?
     def message: () -> String?
 
@@ -2747,7 +2747,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -2794,34 +2794,34 @@ module Prism
     @receiver: Prism::node?
 
     # Initialize a new CallNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Symbol name, Location? message_loc, Location? opening_loc, ArgumentsNode? arguments, Location? closing_loc, Location? equal_loc, (BlockNode | BlockArgumentNode)? block) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Symbol name, Location? message_loc, Location? opening_loc, ArgumentsNode? arguments, Location? closing_loc, Location? equal_loc, (BlockNode | BlockArgumentNode)? block) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -2829,7 +2829,7 @@ module Prism
     #   copy(**fields) -> CallNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?name: Symbol, ?message_loc: Location?, ?opening_loc: Location?, ?arguments: ArgumentsNode?, ?closing_loc: Location?, ?equal_loc: Location?, ?block: (BlockNode | BlockArgumentNode)?) -> CallNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?name: Symbol, ?message_loc: Location?, ?opening_loc: Location?, ?arguments: ArgumentsNode?, ?closing_loc: Location?, ?equal_loc: Location?, ?block: (BlockNode | BlockArgumentNode)?) -> CallNode
 
@@ -2839,12 +2839,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :call_node
     def type: () -> :call_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :call_node
     def self.type: () -> :call_node
 
@@ -2853,25 +2853,25 @@ module Prism
 
     # :category: Flags
     # &. operator
-    # --
+    #
     # : () -> bool
     def safe_navigation?: () -> bool
 
     # :category: Flags
     # a call that could have been a local variable
-    # --
+    #
     # : () -> bool
     def variable_call?: () -> bool
 
     # :category: Flags
     # a call that is an attribute write, so the value being written should be returned
-    # --
+    #
     # : () -> bool
     def attribute_write?: () -> bool
 
     # :category: Flags
     # a call that ignores method visibility
-    # --
+    #
     # : () -> bool
     def ignore_visibility?: () -> bool
 
@@ -2888,7 +2888,7 @@ module Prism
     #
     #     foo + bar
     #     ^^^
-    # --
+    #
     # : () -> Prism::node?
     def receiver: () -> Prism::node?
 
@@ -2903,14 +2903,14 @@ module Prism
     #
     #     foo&.bar
     #        ^^
-    # --
+    #
     # : () -> Location?
     def call_operator_loc: () -> Location?
 
     # :category: Repository
     # Save the call_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_call_operator_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -2921,7 +2921,7 @@ module Prism
     #
     #     foo.bar # name `:foo`
     #     ^^^
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -2933,14 +2933,14 @@ module Prism
     #
     #     foo.bar
     #         ^^^
-    # --
+    #
     # : () -> Location?
     def message_loc: () -> Location?
 
     # :category: Repository
     # Save the message_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_message_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -2952,14 +2952,14 @@ module Prism
     #
     #     foo(bar)
     #        ^
-    # --
+    #
     # : () -> Location?
     def opening_loc: () -> Location?
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_opening_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -2970,7 +2970,7 @@ module Prism
     #
     #     foo(bar)
     #         ^^^
-    # --
+    #
     # : () -> ArgumentsNode?
     def arguments: () -> ArgumentsNode?
 
@@ -2982,14 +2982,14 @@ module Prism
     #
     #     foo(bar)
     #            ^
-    # --
+    #
     # : () -> Location?
     def closing_loc: () -> Location?
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_closing_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -3004,14 +3004,14 @@ module Prism
     #
     #     foo[bar] = value
     #              ^
-    # --
+    #
     # : () -> Location?
     def equal_loc: () -> Location?
 
     # :category: Repository
     # Save the equal_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_equal_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -3022,7 +3022,7 @@ module Prism
     #
     #     foo { |a| a }
     #         ^^^^^^^^^
-    # --
+    #
     # : () -> (BlockNode | BlockArgumentNode)?
     def block: () -> (BlockNode | BlockArgumentNode)?
 
@@ -3030,7 +3030,7 @@ module Prism
     #   call_operator -> String | nil
     #
     # Slice the location of call_operator_loc from the source.
-    # --
+    #
     # : () -> String?
     def call_operator: () -> String?
 
@@ -3038,7 +3038,7 @@ module Prism
     #   message -> String | nil
     #
     # Slice the location of message_loc from the source.
-    # --
+    #
     # : () -> String?
     def message: () -> String?
 
@@ -3046,7 +3046,7 @@ module Prism
     #   opening -> String | nil
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String?
     def opening: () -> String?
 
@@ -3054,7 +3054,7 @@ module Prism
     #   closing -> String | nil
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String?
     def closing: () -> String?
 
@@ -3062,7 +3062,7 @@ module Prism
     #   equal -> String | nil
     #
     # Slice the location of equal_loc from the source.
-    # --
+    #
     # : () -> String?
     def equal: () -> String?
 
@@ -3092,34 +3092,34 @@ module Prism
     @receiver: Prism::node?
 
     # Initialize a new CallOperatorWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location? message_loc, Symbol read_name, Symbol write_name, Symbol binary_operator, Location binary_operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location? message_loc, Symbol read_name, Symbol write_name, Symbol binary_operator, Location binary_operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -3127,7 +3127,7 @@ module Prism
     #   copy(**fields) -> CallOperatorWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?binary_operator: Symbol, ?binary_operator_loc: Location, ?value: Prism::node) -> CallOperatorWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?binary_operator: Symbol, ?binary_operator_loc: Location, ?value: Prism::node) -> CallOperatorWriteNode
 
@@ -3137,12 +3137,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :call_operator_write_node
     def type: () -> :call_operator_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :call_operator_write_node
     def self.type: () -> :call_operator_write_node
 
@@ -3151,25 +3151,25 @@ module Prism
 
     # :category: Flags
     # &. operator
-    # --
+    #
     # : () -> bool
     def safe_navigation?: () -> bool
 
     # :category: Flags
     # a call that could have been a local variable
-    # --
+    #
     # : () -> bool
     def variable_call?: () -> bool
 
     # :category: Flags
     # a call that is an attribute write, so the value being written should be returned
-    # --
+    #
     # : () -> bool
     def attribute_write?: () -> bool
 
     # :category: Flags
     # a call that ignores method visibility
-    # --
+    #
     # : () -> bool
     def ignore_visibility?: () -> bool
 
@@ -3180,7 +3180,7 @@ module Prism
     #
     #     foo.bar += value
     #     ^^^
-    # --
+    #
     # : () -> Prism::node?
     def receiver: () -> Prism::node?
 
@@ -3192,14 +3192,14 @@ module Prism
     #
     #     foo.bar += value
     #        ^
-    # --
+    #
     # : () -> Location?
     def call_operator_loc: () -> Location?
 
     # :category: Repository
     # Save the call_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_call_operator_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -3211,14 +3211,14 @@ module Prism
     #
     #     foo.bar += value
     #         ^^^
-    # --
+    #
     # : () -> Location?
     def message_loc: () -> Location?
 
     # :category: Repository
     # Save the message_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_message_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -3229,7 +3229,7 @@ module Prism
     #
     #     foo.bar += value # read_name `:bar`
     #         ^^^
-    # --
+    #
     # : () -> Symbol
     def read_name: () -> Symbol
 
@@ -3240,7 +3240,7 @@ module Prism
     #
     #     foo.bar += value # write_name `:bar=`
     #         ^^^
-    # --
+    #
     # : () -> Symbol
     def write_name: () -> Symbol
 
@@ -3251,7 +3251,7 @@ module Prism
     #
     #     foo.bar += value # binary_operator `:+`
     #             ^
-    # --
+    #
     # : () -> Symbol
     def binary_operator: () -> Symbol
 
@@ -3263,14 +3263,14 @@ module Prism
     #
     #     foo.bar += value
     #             ^^
-    # --
+    #
     # : () -> Location
     def binary_operator_loc: () -> Location
 
     # :category: Repository
     # Save the binary_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_binary_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -3281,7 +3281,7 @@ module Prism
     #
     #     foo.bar += value
     #                ^^^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -3289,7 +3289,7 @@ module Prism
     #   call_operator -> String | nil
     #
     # Slice the location of call_operator_loc from the source.
-    # --
+    #
     # : () -> String?
     def call_operator: () -> String?
 
@@ -3297,7 +3297,7 @@ module Prism
     #   message -> String | nil
     #
     # Slice the location of message_loc from the source.
-    # --
+    #
     # : () -> String?
     def message: () -> String?
 
@@ -3325,34 +3325,34 @@ module Prism
     @receiver: Prism::node?
 
     # Initialize a new CallOrWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location? message_loc, Symbol read_name, Symbol write_name, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location? message_loc, Symbol read_name, Symbol write_name, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -3360,7 +3360,7 @@ module Prism
     #   copy(**fields) -> CallOrWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?operator_loc: Location, ?value: Prism::node) -> CallOrWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?message_loc: Location?, ?read_name: Symbol, ?write_name: Symbol, ?operator_loc: Location, ?value: Prism::node) -> CallOrWriteNode
 
@@ -3370,12 +3370,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :call_or_write_node
     def type: () -> :call_or_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :call_or_write_node
     def self.type: () -> :call_or_write_node
 
@@ -3384,25 +3384,25 @@ module Prism
 
     # :category: Flags
     # &. operator
-    # --
+    #
     # : () -> bool
     def safe_navigation?: () -> bool
 
     # :category: Flags
     # a call that could have been a local variable
-    # --
+    #
     # : () -> bool
     def variable_call?: () -> bool
 
     # :category: Flags
     # a call that is an attribute write, so the value being written should be returned
-    # --
+    #
     # : () -> bool
     def attribute_write?: () -> bool
 
     # :category: Flags
     # a call that ignores method visibility
-    # --
+    #
     # : () -> bool
     def ignore_visibility?: () -> bool
 
@@ -3413,7 +3413,7 @@ module Prism
     #
     #     foo.bar ||= value
     #     ^^^
-    # --
+    #
     # : () -> Prism::node?
     def receiver: () -> Prism::node?
 
@@ -3425,14 +3425,14 @@ module Prism
     #
     #     foo.bar ||= value
     #        ^
-    # --
+    #
     # : () -> Location?
     def call_operator_loc: () -> Location?
 
     # :category: Repository
     # Save the call_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_call_operator_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -3444,14 +3444,14 @@ module Prism
     #
     #     foo.bar ||= value
     #         ^^^
-    # --
+    #
     # : () -> Location?
     def message_loc: () -> Location?
 
     # :category: Repository
     # Save the message_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_message_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -3462,7 +3462,7 @@ module Prism
     #
     #     foo.bar ||= value # read_name `:bar`
     #         ^^^
-    # --
+    #
     # : () -> Symbol
     def read_name: () -> Symbol
 
@@ -3473,7 +3473,7 @@ module Prism
     #
     #     foo.bar ||= value # write_name `:bar=`
     #         ^^^
-    # --
+    #
     # : () -> Symbol
     def write_name: () -> Symbol
 
@@ -3485,14 +3485,14 @@ module Prism
     #
     #     foo.bar ||= value
     #             ^^^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -3503,7 +3503,7 @@ module Prism
     #
     #     foo.bar ||= value
     #                 ^^^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -3511,7 +3511,7 @@ module Prism
     #   call_operator -> String | nil
     #
     # Slice the location of call_operator_loc from the source.
-    # --
+    #
     # : () -> String?
     def call_operator: () -> String?
 
@@ -3519,7 +3519,7 @@ module Prism
     #   message -> String | nil
     #
     # Slice the location of message_loc from the source.
-    # --
+    #
     # : () -> String?
     def message: () -> String?
 
@@ -3527,7 +3527,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -3557,34 +3557,34 @@ module Prism
     @receiver: Prism::node
 
     # Initialize a new CallTargetNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node receiver, Location call_operator_loc, Symbol name, Location message_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node receiver, Location call_operator_loc, Symbol name, Location message_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -3592,7 +3592,7 @@ module Prism
     #   copy(**fields) -> CallTargetNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node, ?call_operator_loc: Location, ?name: Symbol, ?message_loc: Location) -> CallTargetNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node, ?call_operator_loc: Location, ?name: Symbol, ?message_loc: Location) -> CallTargetNode
 
@@ -3602,12 +3602,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :call_target_node
     def type: () -> :call_target_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :call_target_node
     def self.type: () -> :call_target_node
 
@@ -3616,25 +3616,25 @@ module Prism
 
     # :category: Flags
     # &. operator
-    # --
+    #
     # : () -> bool
     def safe_navigation?: () -> bool
 
     # :category: Flags
     # a call that could have been a local variable
-    # --
+    #
     # : () -> bool
     def variable_call?: () -> bool
 
     # :category: Flags
     # a call that is an attribute write, so the value being written should be returned
-    # --
+    #
     # : () -> bool
     def attribute_write?: () -> bool
 
     # :category: Flags
     # a call that ignores method visibility
-    # --
+    #
     # : () -> bool
     def ignore_visibility?: () -> bool
 
@@ -3645,7 +3645,7 @@ module Prism
     #
     #     foo.bar = 1
     #     ^^^
-    # --
+    #
     # : () -> Prism::node
     def receiver: () -> Prism::node
 
@@ -3657,14 +3657,14 @@ module Prism
     #
     #     foo.bar = 1
     #        ^
-    # --
+    #
     # : () -> Location
     def call_operator_loc: () -> Location
 
     # :category: Repository
     # Save the call_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_call_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -3675,7 +3675,7 @@ module Prism
     #
     #     foo.bar = 1 # name `:foo`
     #     ^^^
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -3687,14 +3687,14 @@ module Prism
     #
     #     foo.bar = 1
     #         ^^^
-    # --
+    #
     # : () -> Location
     def message_loc: () -> Location
 
     # :category: Repository
     # Save the message_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_message_loc: (_Repository repository) -> Relocation::Entry
 
@@ -3702,7 +3702,7 @@ module Prism
     #   call_operator -> String
     #
     # Slice the location of call_operator_loc from the source.
-    # --
+    #
     # : () -> String
     def call_operator: () -> String
 
@@ -3710,7 +3710,7 @@ module Prism
     #   message -> String
     #
     # Slice the location of message_loc from the source.
-    # --
+    #
     # : () -> String
     def message: () -> String
 
@@ -3730,34 +3730,34 @@ module Prism
     @value: Prism::node
 
     # Initialize a new CapturePatternNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node value, LocalVariableTargetNode target, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node value, LocalVariableTargetNode target, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -3765,7 +3765,7 @@ module Prism
     #   copy(**fields) -> CapturePatternNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?target: LocalVariableTargetNode, ?operator_loc: Location) -> CapturePatternNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?target: LocalVariableTargetNode, ?operator_loc: Location) -> CapturePatternNode
 
@@ -3775,12 +3775,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :capture_pattern_node
     def type: () -> :capture_pattern_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :capture_pattern_node
     def self.type: () -> :capture_pattern_node
 
@@ -3794,7 +3794,7 @@ module Prism
     #
     #     foo => bar
     #            ^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -3805,7 +3805,7 @@ module Prism
     #
     #     foo => bar
     #     ^^^
-    # --
+    #
     # : () -> LocalVariableTargetNode
     def target: () -> LocalVariableTargetNode
 
@@ -3817,14 +3817,14 @@ module Prism
     #
     #     foo => bar
     #         ^^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -3832,7 +3832,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -3858,34 +3858,34 @@ module Prism
     @predicate: Prism::node?
 
     # Initialize a new CaseMatchNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? predicate, Array[InNode] conditions, ElseNode? else_clause, Location case_keyword_loc, Location end_keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? predicate, Array[InNode] conditions, ElseNode? else_clause, Location case_keyword_loc, Location end_keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -3893,7 +3893,7 @@ module Prism
     #   copy(**fields) -> CaseMatchNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?predicate: Prism::node?, ?conditions: Array[InNode], ?else_clause: ElseNode?, ?case_keyword_loc: Location, ?end_keyword_loc: Location) -> CaseMatchNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?predicate: Prism::node?, ?conditions: Array[InNode], ?else_clause: ElseNode?, ?case_keyword_loc: Location, ?end_keyword_loc: Location) -> CaseMatchNode
 
@@ -3903,12 +3903,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :case_match_node
     def type: () -> :case_match_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :case_match_node
     def self.type: () -> :case_match_node
 
@@ -3922,7 +3922,7 @@ module Prism
     #
     #     case true; in false; end
     #          ^^^^
-    # --
+    #
     # : () -> Prism::node?
     def predicate: () -> Prism::node?
 
@@ -3933,7 +3933,7 @@ module Prism
     #
     #     case true; in false; end
     #                ^^^^^^^^
-    # --
+    #
     # : () -> Array[InNode]
     def conditions: () -> Array[InNode]
 
@@ -3944,7 +3944,7 @@ module Prism
     #
     #     case true; in false; else; end
     #                          ^^^^^^^^^
-    # --
+    #
     # : () -> ElseNode?
     def else_clause: () -> ElseNode?
 
@@ -3956,14 +3956,14 @@ module Prism
     #
     #     case true; in false; end
     #     ^^^^
-    # --
+    #
     # : () -> Location
     def case_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the case_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_case_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -3975,14 +3975,14 @@ module Prism
     #
     #     case true; in false; end
     #                          ^^^
-    # --
+    #
     # : () -> Location
     def end_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -3990,7 +3990,7 @@ module Prism
     #   case_keyword -> String
     #
     # Slice the location of case_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def case_keyword: () -> String
 
@@ -3998,7 +3998,7 @@ module Prism
     #   end_keyword -> String
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def end_keyword: () -> String
 
@@ -4024,34 +4024,34 @@ module Prism
     @predicate: Prism::node?
 
     # Initialize a new CaseNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? predicate, Array[WhenNode] conditions, ElseNode? else_clause, Location case_keyword_loc, Location end_keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? predicate, Array[WhenNode] conditions, ElseNode? else_clause, Location case_keyword_loc, Location end_keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -4059,7 +4059,7 @@ module Prism
     #   copy(**fields) -> CaseNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?predicate: Prism::node?, ?conditions: Array[WhenNode], ?else_clause: ElseNode?, ?case_keyword_loc: Location, ?end_keyword_loc: Location) -> CaseNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?predicate: Prism::node?, ?conditions: Array[WhenNode], ?else_clause: ElseNode?, ?case_keyword_loc: Location, ?end_keyword_loc: Location) -> CaseNode
 
@@ -4069,12 +4069,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :case_node
     def type: () -> :case_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :case_node
     def self.type: () -> :case_node
 
@@ -4088,7 +4088,7 @@ module Prism
     #
     #     case true; when false; end
     #          ^^^^
-    # --
+    #
     # : () -> Prism::node?
     def predicate: () -> Prism::node?
 
@@ -4099,7 +4099,7 @@ module Prism
     #
     #     case true; when false; end
     #                ^^^^^^^^^^
-    # --
+    #
     # : () -> Array[WhenNode]
     def conditions: () -> Array[WhenNode]
 
@@ -4110,7 +4110,7 @@ module Prism
     #
     #     case true; when false; else; end
     #                            ^^^^^^^^^
-    # --
+    #
     # : () -> ElseNode?
     def else_clause: () -> ElseNode?
 
@@ -4122,14 +4122,14 @@ module Prism
     #
     #     case true; when false; end
     #     ^^^^
-    # --
+    #
     # : () -> Location
     def case_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the case_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_case_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -4141,14 +4141,14 @@ module Prism
     #
     #     case true; when false; end
     #                            ^^^
-    # --
+    #
     # : () -> Location
     def end_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -4156,7 +4156,7 @@ module Prism
     #   case_keyword -> String
     #
     # Slice the location of case_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def case_keyword: () -> String
 
@@ -4164,7 +4164,7 @@ module Prism
     #   end_keyword -> String
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def end_keyword: () -> String
 
@@ -4194,34 +4194,34 @@ module Prism
     @locals: Array[Symbol]
 
     # Initialize a new ClassNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, Location class_keyword_loc, (ConstantReadNode | ConstantPathNode) constant_path, Location? inheritance_operator_loc, Prism::node? superclass, (StatementsNode | BeginNode)? body, Location end_keyword_loc, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, Location class_keyword_loc, ConstantReadNode | ConstantPathNode constant_path, Location? inheritance_operator_loc, Prism::node? superclass, (StatementsNode | BeginNode)? body, Location end_keyword_loc, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -4229,7 +4229,7 @@ module Prism
     #   copy(**fields) -> ClassNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?class_keyword_loc: Location, ?constant_path: (ConstantReadNode | ConstantPathNode), ?inheritance_operator_loc: Location?, ?superclass: Prism::node?, ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location, ?name: Symbol) -> ClassNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?class_keyword_loc: Location, ?constant_path: ConstantReadNode | ConstantPathNode, ?inheritance_operator_loc: Location?, ?superclass: Prism::node?, ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location, ?name: Symbol) -> ClassNode
 
@@ -4239,12 +4239,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :class_node
     def type: () -> :class_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :class_node
     def self.type: () -> :class_node
 
@@ -4255,7 +4255,7 @@ module Prism
     #   locals -> Array[Symbol]
     #
     # Returns the `locals` attribute.
-    # --
+    #
     # : () -> Array[Symbol]
     def locals: () -> Array[Symbol]
 
@@ -4267,14 +4267,14 @@ module Prism
     #
     #     class Foo end
     #     ^^^^^
-    # --
+    #
     # : () -> Location
     def class_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the class_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_class_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -4282,7 +4282,7 @@ module Prism
     #   constant_path -> ConstantReadNode | ConstantPathNode
     #
     # Returns the `constant_path` attribute.
-    # --
+    #
     # : () -> (ConstantReadNode | ConstantPathNode)
     def constant_path: () -> (ConstantReadNode | ConstantPathNode)
 
@@ -4294,14 +4294,14 @@ module Prism
     #
     #     class Foo < Bar
     #               ^
-    # --
+    #
     # : () -> Location?
     def inheritance_operator_loc: () -> Location?
 
     # :category: Repository
     # Save the inheritance_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_inheritance_operator_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -4312,7 +4312,7 @@ module Prism
     #
     #     class Foo < Bar
     #                 ^^^
-    # --
+    #
     # : () -> Prism::node?
     def superclass: () -> Prism::node?
 
@@ -4323,7 +4323,7 @@ module Prism
     #
     #     class Foo; bar; end
     #                ^^^
-    # --
+    #
     # : () -> (StatementsNode | BeginNode)?
     def body: () -> (StatementsNode | BeginNode)?
 
@@ -4335,14 +4335,14 @@ module Prism
     #
     #     class Foo end
     #               ^^^
-    # --
+    #
     # : () -> Location
     def end_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -4352,7 +4352,7 @@ module Prism
     # The name of the class.
     #
     #     class Foo end # name `:Foo`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -4360,7 +4360,7 @@ module Prism
     #   class_keyword -> String
     #
     # Slice the location of class_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def class_keyword: () -> String
 
@@ -4368,7 +4368,7 @@ module Prism
     #   inheritance_operator -> String | nil
     #
     # Slice the location of inheritance_operator_loc from the source.
-    # --
+    #
     # : () -> String?
     def inheritance_operator: () -> String?
 
@@ -4376,7 +4376,7 @@ module Prism
     #   end_keyword -> String
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def end_keyword: () -> String
 
@@ -4398,34 +4398,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ClassVariableAndWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -4433,7 +4433,7 @@ module Prism
     #   copy(**fields) -> ClassVariableAndWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ClassVariableAndWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ClassVariableAndWriteNode
 
@@ -4443,12 +4443,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :class_variable_and_write_node
     def type: () -> :class_variable_and_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :class_variable_and_write_node
     def self.type: () -> :class_variable_and_write_node
 
@@ -4462,7 +4462,7 @@ module Prism
     #
     #     @@target &&= value # name `:@@target`
     #     ^^^^^^^^
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -4474,14 +4474,14 @@ module Prism
     #
     #     @@target &&= value
     #     ^^^^^^^^
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -4493,14 +4493,14 @@ module Prism
     #
     #     @@target &&= value
     #              ^^^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -4511,7 +4511,7 @@ module Prism
     #
     #     @@target &&= value
     #                  ^^^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -4519,7 +4519,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -4543,34 +4543,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ClassVariableOperatorWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location binary_operator_loc, Prism::node value, Symbol binary_operator) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location binary_operator_loc, Prism::node value, Symbol binary_operator) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -4578,7 +4578,7 @@ module Prism
     #   copy(**fields) -> ClassVariableOperatorWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ClassVariableOperatorWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ClassVariableOperatorWriteNode
 
@@ -4588,12 +4588,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :class_variable_operator_write_node
     def type: () -> :class_variable_operator_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :class_variable_operator_write_node
     def self.type: () -> :class_variable_operator_write_node
 
@@ -4604,7 +4604,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -4613,14 +4613,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -4629,14 +4629,14 @@ module Prism
     #   binary_operator_loc -> Location
     #
     # Returns the Location represented by `binary_operator_loc`.
-    # --
+    #
     # : () -> Location
     def binary_operator_loc: () -> Location
 
     # :category: Repository
     # Save the binary_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_binary_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -4644,7 +4644,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -4652,7 +4652,7 @@ module Prism
     #   binary_operator -> Symbol
     #
     # Returns the `binary_operator` attribute.
-    # --
+    #
     # : () -> Symbol
     def binary_operator: () -> Symbol
 
@@ -4674,34 +4674,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ClassVariableOrWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -4709,7 +4709,7 @@ module Prism
     #   copy(**fields) -> ClassVariableOrWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ClassVariableOrWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ClassVariableOrWriteNode
 
@@ -4719,12 +4719,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :class_variable_or_write_node
     def type: () -> :class_variable_or_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :class_variable_or_write_node
     def self.type: () -> :class_variable_or_write_node
 
@@ -4735,7 +4735,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -4744,14 +4744,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -4760,14 +4760,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -4775,7 +4775,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -4783,7 +4783,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -4799,34 +4799,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ClassVariableReadNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -4834,7 +4834,7 @@ module Prism
     #   copy(**fields) -> ClassVariableReadNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ClassVariableReadNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ClassVariableReadNode
 
@@ -4844,12 +4844,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :class_variable_read_node
     def type: () -> :class_variable_read_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :class_variable_read_node
     def self.type: () -> :class_variable_read_node
 
@@ -4864,7 +4864,7 @@ module Prism
     #     @@abc   # name `:@@abc`
     #
     #     @@_test # name `:@@_test`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -4880,34 +4880,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ClassVariableTargetNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -4915,7 +4915,7 @@ module Prism
     #   copy(**fields) -> ClassVariableTargetNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ClassVariableTargetNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ClassVariableTargetNode
 
@@ -4925,12 +4925,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :class_variable_target_node
     def type: () -> :class_variable_target_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :class_variable_target_node
     def self.type: () -> :class_variable_target_node
 
@@ -4941,7 +4941,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -4963,34 +4963,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ClassVariableWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node value, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node value, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -4998,7 +4998,7 @@ module Prism
     #   copy(**fields) -> ClassVariableWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> ClassVariableWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> ClassVariableWriteNode
 
@@ -5008,12 +5008,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :class_variable_write_node
     def type: () -> :class_variable_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :class_variable_write_node
     def self.type: () -> :class_variable_write_node
 
@@ -5028,7 +5028,7 @@ module Prism
     #     @@abc = 123     # name `@@abc`
     #
     #     @@_test = :test # name `@@_test`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -5040,14 +5040,14 @@ module Prism
     #
     #     @@foo = :bar
     #     ^^^^^
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5061,7 +5061,7 @@ module Prism
     #
     #     @@_xyz = 123
     #              ^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -5073,14 +5073,14 @@ module Prism
     #
     #     @@foo = :bar
     #           ^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5088,7 +5088,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -5110,34 +5110,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ConstantAndWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -5145,7 +5145,7 @@ module Prism
     #   copy(**fields) -> ConstantAndWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ConstantAndWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ConstantAndWriteNode
 
@@ -5155,12 +5155,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_and_write_node
     def type: () -> :constant_and_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_and_write_node
     def self.type: () -> :constant_and_write_node
 
@@ -5171,7 +5171,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -5180,14 +5180,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5196,14 +5196,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5211,7 +5211,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -5219,7 +5219,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -5243,34 +5243,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ConstantOperatorWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location binary_operator_loc, Prism::node value, Symbol binary_operator) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location binary_operator_loc, Prism::node value, Symbol binary_operator) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -5278,7 +5278,7 @@ module Prism
     #   copy(**fields) -> ConstantOperatorWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ConstantOperatorWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ConstantOperatorWriteNode
 
@@ -5288,12 +5288,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_operator_write_node
     def type: () -> :constant_operator_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_operator_write_node
     def self.type: () -> :constant_operator_write_node
 
@@ -5304,7 +5304,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -5313,14 +5313,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5329,14 +5329,14 @@ module Prism
     #   binary_operator_loc -> Location
     #
     # Returns the Location represented by `binary_operator_loc`.
-    # --
+    #
     # : () -> Location
     def binary_operator_loc: () -> Location
 
     # :category: Repository
     # Save the binary_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_binary_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5344,7 +5344,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -5352,7 +5352,7 @@ module Prism
     #   binary_operator -> Symbol
     #
     # Returns the `binary_operator` attribute.
-    # --
+    #
     # : () -> Symbol
     def binary_operator: () -> Symbol
 
@@ -5374,34 +5374,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ConstantOrWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -5409,7 +5409,7 @@ module Prism
     #   copy(**fields) -> ConstantOrWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ConstantOrWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> ConstantOrWriteNode
 
@@ -5419,12 +5419,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_or_write_node
     def type: () -> :constant_or_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_or_write_node
     def self.type: () -> :constant_or_write_node
 
@@ -5435,7 +5435,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -5444,14 +5444,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5460,14 +5460,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5475,7 +5475,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -5483,7 +5483,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -5503,34 +5503,34 @@ module Prism
     @target: ConstantPathNode
 
     # Initialize a new ConstantPathAndWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ConstantPathNode target, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, ConstantPathNode target, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -5538,7 +5538,7 @@ module Prism
     #   copy(**fields) -> ConstantPathAndWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathAndWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathAndWriteNode
 
@@ -5548,12 +5548,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_path_and_write_node
     def type: () -> :constant_path_and_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_path_and_write_node
     def self.type: () -> :constant_path_and_write_node
 
@@ -5564,7 +5564,7 @@ module Prism
     #   target -> ConstantPathNode
     #
     # Returns the `target` attribute.
-    # --
+    #
     # : () -> ConstantPathNode
     def target: () -> ConstantPathNode
 
@@ -5573,14 +5573,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5588,7 +5588,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -5596,7 +5596,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -5618,34 +5618,34 @@ module Prism
     @parent: Prism::node?
 
     # Initialize a new ConstantPathNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? parent, Symbol? name, Location delimiter_loc, Location name_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? parent, Symbol? name, Location delimiter_loc, Location name_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -5653,7 +5653,7 @@ module Prism
     #   copy(**fields) -> ConstantPathNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?parent: Prism::node?, ?name: Symbol?, ?delimiter_loc: Location, ?name_loc: Location) -> ConstantPathNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?parent: Prism::node?, ?name: Symbol?, ?delimiter_loc: Location, ?name_loc: Location) -> ConstantPathNode
 
@@ -5663,12 +5663,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_path_node
     def type: () -> :constant_path_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_path_node
     def self.type: () -> :constant_path_node
 
@@ -5688,7 +5688,7 @@ module Prism
     #
     #     a.b::C
     #     ^^^
-    # --
+    #
     # : () -> Prism::node?
     def parent: () -> Prism::node?
 
@@ -5696,7 +5696,7 @@ module Prism
     #   name -> Symbol | nil
     #
     # The name of the constant being accessed. This could be `nil` in the event of a syntax error.
-    # --
+    #
     # : () -> Symbol?
     def name: () -> Symbol?
 
@@ -5711,14 +5711,14 @@ module Prism
     #
     #     One::Two
     #        ^^
-    # --
+    #
     # : () -> Location
     def delimiter_loc: () -> Location
 
     # :category: Repository
     # Save the delimiter_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_delimiter_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5733,14 +5733,14 @@ module Prism
     #
     #     One::Two
     #          ^^^
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5748,7 +5748,7 @@ module Prism
     #   delimiter -> String
     #
     # Slice the location of delimiter_loc from the source.
-    # --
+    #
     # : () -> String
     def delimiter: () -> String
 
@@ -5770,34 +5770,34 @@ module Prism
     @target: ConstantPathNode
 
     # Initialize a new ConstantPathOperatorWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ConstantPathNode target, Location binary_operator_loc, Prism::node value, Symbol binary_operator) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, ConstantPathNode target, Location binary_operator_loc, Prism::node value, Symbol binary_operator) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -5805,7 +5805,7 @@ module Prism
     #   copy(**fields) -> ConstantPathOperatorWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ConstantPathOperatorWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> ConstantPathOperatorWriteNode
 
@@ -5815,12 +5815,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_path_operator_write_node
     def type: () -> :constant_path_operator_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_path_operator_write_node
     def self.type: () -> :constant_path_operator_write_node
 
@@ -5831,7 +5831,7 @@ module Prism
     #   target -> ConstantPathNode
     #
     # Returns the `target` attribute.
-    # --
+    #
     # : () -> ConstantPathNode
     def target: () -> ConstantPathNode
 
@@ -5840,14 +5840,14 @@ module Prism
     #   binary_operator_loc -> Location
     #
     # Returns the Location represented by `binary_operator_loc`.
-    # --
+    #
     # : () -> Location
     def binary_operator_loc: () -> Location
 
     # :category: Repository
     # Save the binary_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_binary_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5855,7 +5855,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -5863,7 +5863,7 @@ module Prism
     #   binary_operator -> Symbol
     #
     # Returns the `binary_operator` attribute.
-    # --
+    #
     # : () -> Symbol
     def binary_operator: () -> Symbol
 
@@ -5883,34 +5883,34 @@ module Prism
     @target: ConstantPathNode
 
     # Initialize a new ConstantPathOrWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ConstantPathNode target, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, ConstantPathNode target, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -5918,7 +5918,7 @@ module Prism
     #   copy(**fields) -> ConstantPathOrWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathOrWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathOrWriteNode
 
@@ -5928,12 +5928,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_path_or_write_node
     def type: () -> :constant_path_or_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_path_or_write_node
     def self.type: () -> :constant_path_or_write_node
 
@@ -5944,7 +5944,7 @@ module Prism
     #   target -> ConstantPathNode
     #
     # Returns the `target` attribute.
-    # --
+    #
     # : () -> ConstantPathNode
     def target: () -> ConstantPathNode
 
@@ -5953,14 +5953,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -5968,7 +5968,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -5976,7 +5976,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -5998,34 +5998,34 @@ module Prism
     @parent: Prism::node?
 
     # Initialize a new ConstantPathTargetNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? parent, Symbol? name, Location delimiter_loc, Location name_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? parent, Symbol? name, Location delimiter_loc, Location name_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -6033,7 +6033,7 @@ module Prism
     #   copy(**fields) -> ConstantPathTargetNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?parent: Prism::node?, ?name: Symbol?, ?delimiter_loc: Location, ?name_loc: Location) -> ConstantPathTargetNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?parent: Prism::node?, ?name: Symbol?, ?delimiter_loc: Location, ?name_loc: Location) -> ConstantPathTargetNode
 
@@ -6043,12 +6043,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_path_target_node
     def type: () -> :constant_path_target_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_path_target_node
     def self.type: () -> :constant_path_target_node
 
@@ -6059,7 +6059,7 @@ module Prism
     #   parent -> Node | nil
     #
     # Returns the `parent` attribute.
-    # --
+    #
     # : () -> Prism::node?
     def parent: () -> Prism::node?
 
@@ -6067,7 +6067,7 @@ module Prism
     #   name -> Symbol | nil
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol?
     def name: () -> Symbol?
 
@@ -6076,14 +6076,14 @@ module Prism
     #   delimiter_loc -> Location
     #
     # Returns the Location represented by `delimiter_loc`.
-    # --
+    #
     # : () -> Location
     def delimiter_loc: () -> Location
 
     # :category: Repository
     # Save the delimiter_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_delimiter_loc: (_Repository repository) -> Relocation::Entry
 
@@ -6092,14 +6092,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -6107,7 +6107,7 @@ module Prism
     #   delimiter -> String
     #
     # Slice the location of delimiter_loc from the source.
-    # --
+    #
     # : () -> String
     def delimiter: () -> String
 
@@ -6133,34 +6133,34 @@ module Prism
     @target: ConstantPathNode
 
     # Initialize a new ConstantPathWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ConstantPathNode target, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, ConstantPathNode target, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -6168,7 +6168,7 @@ module Prism
     #   copy(**fields) -> ConstantPathWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?target: ConstantPathNode, ?operator_loc: Location, ?value: Prism::node) -> ConstantPathWriteNode
 
@@ -6178,12 +6178,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_path_write_node
     def type: () -> :constant_path_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_path_write_node
     def self.type: () -> :constant_path_write_node
 
@@ -6200,7 +6200,7 @@ module Prism
     #
     #     ::Foo = :abc
     #     ^^^^^
-    # --
+    #
     # : () -> ConstantPathNode
     def target: () -> ConstantPathNode
 
@@ -6212,14 +6212,14 @@ module Prism
     #
     #     ::ABC = 123
     #           ^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -6230,7 +6230,7 @@ module Prism
     #
     #     FOO::BAR = :abc
     #                ^^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -6238,7 +6238,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -6254,34 +6254,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ConstantReadNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -6289,7 +6289,7 @@ module Prism
     #   copy(**fields) -> ConstantReadNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ConstantReadNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ConstantReadNode
 
@@ -6299,12 +6299,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_read_node
     def type: () -> :constant_read_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_read_node
     def self.type: () -> :constant_read_node
 
@@ -6319,7 +6319,7 @@ module Prism
     #     X              # name `:X`
     #
     #     SOME_CONSTANT  # name `:SOME_CONSTANT`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -6335,34 +6335,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ConstantTargetNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -6370,7 +6370,7 @@ module Prism
     #   copy(**fields) -> ConstantTargetNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ConstantTargetNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> ConstantTargetNode
 
@@ -6380,12 +6380,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_target_node
     def type: () -> :constant_target_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_target_node
     def self.type: () -> :constant_target_node
 
@@ -6396,7 +6396,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -6418,34 +6418,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new ConstantWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node value, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node value, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -6453,7 +6453,7 @@ module Prism
     #   copy(**fields) -> ConstantWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> ConstantWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> ConstantWriteNode
 
@@ -6463,12 +6463,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :constant_write_node
     def type: () -> :constant_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :constant_write_node
     def self.type: () -> :constant_write_node
 
@@ -6483,7 +6483,7 @@ module Prism
     #     Foo = :bar # name `:Foo`
     #
     #     XYZ = 1    # name `:XYZ`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -6495,14 +6495,14 @@ module Prism
     #
     #     FOO = 1
     #     ^^^
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -6516,7 +6516,7 @@ module Prism
     #
     #     MyClass = Class.new
     #               ^^^^^^^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -6528,14 +6528,14 @@ module Prism
     #
     #     FOO = :bar
     #         ^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -6543,7 +6543,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -6582,34 +6582,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new DefNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node? receiver, ParametersNode? parameters, (StatementsNode | BeginNode)? body, Array[Symbol] locals, Location def_keyword_loc, Location? operator_loc, Location? lparen_loc, Location? rparen_loc, Location? equal_loc, Location? end_keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node? receiver, ParametersNode? parameters, (StatementsNode | BeginNode)? body, Array[Symbol] locals, Location def_keyword_loc, Location? operator_loc, Location? lparen_loc, Location? rparen_loc, Location? equal_loc, Location? end_keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -6617,7 +6617,7 @@ module Prism
     #   copy(**fields) -> DefNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?receiver: Prism::node?, ?parameters: ParametersNode?, ?body: (StatementsNode | BeginNode)?, ?locals: Array[Symbol], ?def_keyword_loc: Location, ?operator_loc: Location?, ?lparen_loc: Location?, ?rparen_loc: Location?, ?equal_loc: Location?, ?end_keyword_loc: Location?) -> DefNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?receiver: Prism::node?, ?parameters: ParametersNode?, ?body: (StatementsNode | BeginNode)?, ?locals: Array[Symbol], ?def_keyword_loc: Location, ?operator_loc: Location?, ?lparen_loc: Location?, ?rparen_loc: Location?, ?equal_loc: Location?, ?end_keyword_loc: Location?) -> DefNode
 
@@ -6627,12 +6627,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :def_node
     def type: () -> :def_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :def_node
     def self.type: () -> :def_node
 
@@ -6643,7 +6643,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -6652,14 +6652,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -6667,7 +6667,7 @@ module Prism
     #   receiver -> Node | nil
     #
     # Returns the `receiver` attribute.
-    # --
+    #
     # : () -> Prism::node?
     def receiver: () -> Prism::node?
 
@@ -6675,7 +6675,7 @@ module Prism
     #   parameters -> ParametersNode | nil
     #
     # Returns the `parameters` attribute.
-    # --
+    #
     # : () -> ParametersNode?
     def parameters: () -> ParametersNode?
 
@@ -6683,7 +6683,7 @@ module Prism
     #   body -> StatementsNode | BeginNode | nil
     #
     # Returns the `body` attribute.
-    # --
+    #
     # : () -> (StatementsNode | BeginNode)?
     def body: () -> (StatementsNode | BeginNode)?
 
@@ -6691,7 +6691,7 @@ module Prism
     #   locals -> Array[Symbol]
     #
     # Returns the `locals` attribute.
-    # --
+    #
     # : () -> Array[Symbol]
     def locals: () -> Array[Symbol]
 
@@ -6700,14 +6700,14 @@ module Prism
     #   def_keyword_loc -> Location
     #
     # Returns the Location represented by `def_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def def_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the def_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_def_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -6716,14 +6716,14 @@ module Prism
     #   operator_loc -> Location | nil
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location?
     def operator_loc: () -> Location?
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_operator_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -6732,14 +6732,14 @@ module Prism
     #   lparen_loc -> Location | nil
     #
     # Returns the Location represented by `lparen_loc`.
-    # --
+    #
     # : () -> Location?
     def lparen_loc: () -> Location?
 
     # :category: Repository
     # Save the lparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_lparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -6748,14 +6748,14 @@ module Prism
     #   rparen_loc -> Location | nil
     #
     # Returns the Location represented by `rparen_loc`.
-    # --
+    #
     # : () -> Location?
     def rparen_loc: () -> Location?
 
     # :category: Repository
     # Save the rparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_rparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -6764,14 +6764,14 @@ module Prism
     #   equal_loc -> Location | nil
     #
     # Returns the Location represented by `equal_loc`.
-    # --
+    #
     # : () -> Location?
     def equal_loc: () -> Location?
 
     # :category: Repository
     # Save the equal_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_equal_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -6780,14 +6780,14 @@ module Prism
     #   end_keyword_loc -> Location | nil
     #
     # Returns the Location represented by `end_keyword_loc`.
-    # --
+    #
     # : () -> Location?
     def end_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -6795,7 +6795,7 @@ module Prism
     #   def_keyword -> String
     #
     # Slice the location of def_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def def_keyword: () -> String
 
@@ -6803,7 +6803,7 @@ module Prism
     #   operator -> String | nil
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String?
     def operator: () -> String?
 
@@ -6811,7 +6811,7 @@ module Prism
     #   lparen -> String | nil
     #
     # Slice the location of lparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def lparen: () -> String?
 
@@ -6819,7 +6819,7 @@ module Prism
     #   rparen -> String | nil
     #
     # Slice the location of rparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def rparen: () -> String?
 
@@ -6827,7 +6827,7 @@ module Prism
     #   equal -> String | nil
     #
     # Slice the location of equal_loc from the source.
-    # --
+    #
     # : () -> String?
     def equal: () -> String?
 
@@ -6835,7 +6835,7 @@ module Prism
     #   end_keyword -> String | nil
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def end_keyword: () -> String?
 
@@ -6857,34 +6857,34 @@ module Prism
     @lparen_loc: Location?
 
     # Initialize a new DefinedNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location? lparen_loc, Prism::node value, Location? rparen_loc, Location keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location? lparen_loc, Prism::node value, Location? rparen_loc, Location keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -6892,7 +6892,7 @@ module Prism
     #   copy(**fields) -> DefinedNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?lparen_loc: Location?, ?value: Prism::node, ?rparen_loc: Location?, ?keyword_loc: Location) -> DefinedNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?lparen_loc: Location?, ?value: Prism::node, ?rparen_loc: Location?, ?keyword_loc: Location) -> DefinedNode
 
@@ -6902,12 +6902,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :defined_node
     def type: () -> :defined_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :defined_node
     def self.type: () -> :defined_node
 
@@ -6919,14 +6919,14 @@ module Prism
     #   lparen_loc -> Location | nil
     #
     # Returns the Location represented by `lparen_loc`.
-    # --
+    #
     # : () -> Location?
     def lparen_loc: () -> Location?
 
     # :category: Repository
     # Save the lparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_lparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -6934,7 +6934,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -6943,14 +6943,14 @@ module Prism
     #   rparen_loc -> Location | nil
     #
     # Returns the Location represented by `rparen_loc`.
-    # --
+    #
     # : () -> Location?
     def rparen_loc: () -> Location?
 
     # :category: Repository
     # Save the rparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_rparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -6959,14 +6959,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -6974,7 +6974,7 @@ module Prism
     #   lparen -> String | nil
     #
     # Slice the location of lparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def lparen: () -> String?
 
@@ -6982,7 +6982,7 @@ module Prism
     #   rparen -> String | nil
     #
     # Slice the location of rparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def rparen: () -> String?
 
@@ -6990,7 +6990,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -7010,34 +7010,34 @@ module Prism
     @else_keyword_loc: Location
 
     # Initialize a new ElseNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location else_keyword_loc, StatementsNode? statements, Location? end_keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location else_keyword_loc, StatementsNode? statements, Location? end_keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -7045,7 +7045,7 @@ module Prism
     #   copy(**fields) -> ElseNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?else_keyword_loc: Location, ?statements: StatementsNode?, ?end_keyword_loc: Location?) -> ElseNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?else_keyword_loc: Location, ?statements: StatementsNode?, ?end_keyword_loc: Location?) -> ElseNode
 
@@ -7055,12 +7055,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :else_node
     def type: () -> :else_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :else_node
     def self.type: () -> :else_node
 
@@ -7072,14 +7072,14 @@ module Prism
     #   else_keyword_loc -> Location
     #
     # Returns the Location represented by `else_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def else_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the else_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_else_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -7087,7 +7087,7 @@ module Prism
     #   statements -> StatementsNode | nil
     #
     # Returns the `statements` attribute.
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -7096,14 +7096,14 @@ module Prism
     #   end_keyword_loc -> Location | nil
     #
     # Returns the Location represented by `end_keyword_loc`.
-    # --
+    #
     # : () -> Location?
     def end_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -7111,7 +7111,7 @@ module Prism
     #   else_keyword -> String
     #
     # Slice the location of else_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def else_keyword: () -> String
 
@@ -7119,7 +7119,7 @@ module Prism
     #   end_keyword -> String | nil
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def end_keyword: () -> String?
 
@@ -7139,34 +7139,34 @@ module Prism
     @opening_loc: Location
 
     # Initialize a new EmbeddedStatementsNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, StatementsNode? statements, Location closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, StatementsNode? statements, Location closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -7174,7 +7174,7 @@ module Prism
     #   copy(**fields) -> EmbeddedStatementsNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?statements: StatementsNode?, ?closing_loc: Location) -> EmbeddedStatementsNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?statements: StatementsNode?, ?closing_loc: Location) -> EmbeddedStatementsNode
 
@@ -7184,12 +7184,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :embedded_statements_node
     def type: () -> :embedded_statements_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :embedded_statements_node
     def self.type: () -> :embedded_statements_node
 
@@ -7201,14 +7201,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -7216,7 +7216,7 @@ module Prism
     #   statements -> StatementsNode | nil
     #
     # Returns the `statements` attribute.
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -7225,14 +7225,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -7240,7 +7240,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -7248,7 +7248,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -7266,34 +7266,34 @@ module Prism
     @operator_loc: Location
 
     # Initialize a new EmbeddedVariableNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location operator_loc, (InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode) variable) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location operator_loc, InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode variable) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -7301,7 +7301,7 @@ module Prism
     #   copy(**fields) -> EmbeddedVariableNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?variable: (InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode)) -> EmbeddedVariableNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?variable: InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode) -> EmbeddedVariableNode
 
@@ -7311,12 +7311,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :embedded_variable_node
     def type: () -> :embedded_variable_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :embedded_variable_node
     def self.type: () -> :embedded_variable_node
 
@@ -7328,14 +7328,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -7343,7 +7343,7 @@ module Prism
     #   variable -> InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode
     #
     # Returns the `variable` attribute.
-    # --
+    #
     # : () -> (InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode)
     def variable: () -> (InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode)
 
@@ -7351,7 +7351,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -7375,34 +7375,34 @@ module Prism
     @ensure_keyword_loc: Location
 
     # Initialize a new EnsureNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location ensure_keyword_loc, StatementsNode? statements, Location end_keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location ensure_keyword_loc, StatementsNode? statements, Location end_keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -7410,7 +7410,7 @@ module Prism
     #   copy(**fields) -> EnsureNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?ensure_keyword_loc: Location, ?statements: StatementsNode?, ?end_keyword_loc: Location) -> EnsureNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?ensure_keyword_loc: Location, ?statements: StatementsNode?, ?end_keyword_loc: Location) -> EnsureNode
 
@@ -7420,12 +7420,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :ensure_node
     def type: () -> :ensure_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :ensure_node
     def self.type: () -> :ensure_node
 
@@ -7437,14 +7437,14 @@ module Prism
     #   ensure_keyword_loc -> Location
     #
     # Returns the Location represented by `ensure_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def ensure_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the ensure_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_ensure_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -7452,7 +7452,7 @@ module Prism
     #   statements -> StatementsNode | nil
     #
     # Returns the `statements` attribute.
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -7461,14 +7461,14 @@ module Prism
     #   end_keyword_loc -> Location
     #
     # Returns the Location represented by `end_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def end_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -7476,7 +7476,7 @@ module Prism
     #   ensure_keyword -> String
     #
     # Slice the location of ensure_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def ensure_keyword: () -> String
 
@@ -7484,7 +7484,7 @@ module Prism
     #   end_keyword -> String
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def end_keyword: () -> String
 
@@ -7497,34 +7497,34 @@ module Prism
     @unexpected: Prism::node?
 
     # Initialize a new ErrorRecoveryNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? unexpected) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? unexpected) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -7532,7 +7532,7 @@ module Prism
     #   copy(**fields) -> ErrorRecoveryNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?unexpected: Prism::node?) -> ErrorRecoveryNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?unexpected: Prism::node?) -> ErrorRecoveryNode
 
@@ -7542,12 +7542,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :error_recovery_node
     def type: () -> :error_recovery_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :error_recovery_node
     def self.type: () -> :error_recovery_node
 
@@ -7558,7 +7558,7 @@ module Prism
     #   unexpected -> Node | nil
     #
     # The unexpected node that was found in the tree, if there was one.
-    # --
+    #
     # : () -> Prism::node?
     def unexpected: () -> Prism::node?
 
@@ -7572,34 +7572,34 @@ module Prism
   #     ^^^^^
   class FalseNode < Node
     # Initialize a new FalseNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -7607,7 +7607,7 @@ module Prism
     #   copy(**fields) -> FalseNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> FalseNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> FalseNode
 
@@ -7617,12 +7617,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :false_node
     def type: () -> :false_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :false_node
     def self.type: () -> :false_node
 
@@ -7660,34 +7660,34 @@ module Prism
     @constant: (ConstantPathNode | ConstantReadNode)?
 
     # Initialize a new FindPatternNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, (ConstantPathNode | ConstantReadNode)? constant, SplatNode left, Array[Prism::node] requireds, SplatNode right, Location? opening_loc, Location? closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, (ConstantPathNode | ConstantReadNode)? constant, SplatNode left, Array[Prism::node] requireds, SplatNode right, Location? opening_loc, Location? closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -7695,7 +7695,7 @@ module Prism
     #   copy(**fields) -> FindPatternNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?left: SplatNode, ?requireds: Array[Prism::node], ?right: SplatNode, ?opening_loc: Location?, ?closing_loc: Location?) -> FindPatternNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?left: SplatNode, ?requireds: Array[Prism::node], ?right: SplatNode, ?opening_loc: Location?, ?closing_loc: Location?) -> FindPatternNode
 
@@ -7705,12 +7705,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :find_pattern_node
     def type: () -> :find_pattern_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :find_pattern_node
     def self.type: () -> :find_pattern_node
 
@@ -7724,7 +7724,7 @@ module Prism
     #
     #     foo in Foo(*bar, baz, *qux)
     #            ^^^
-    # --
+    #
     # : () -> (ConstantPathNode | ConstantReadNode)?
     def constant: () -> (ConstantPathNode | ConstantReadNode)?
 
@@ -7738,7 +7738,7 @@ module Prism
     #
     #     foo in Foo(*bar, baz, *qux)
     #                ^^^^
-    # --
+    #
     # : () -> SplatNode
     def left: () -> SplatNode
 
@@ -7752,7 +7752,7 @@ module Prism
     #
     #     foo in Foo(*bar, baz, 1, *qux)
     #                      ^^^^^^
-    # --
+    #
     # : () -> Array[Prism::node]
     def requireds: () -> Array[Prism::node]
 
@@ -7766,7 +7766,7 @@ module Prism
     #
     #     foo in Foo(*bar, baz, *qux)
     #                           ^^^^
-    # --
+    #
     # : () -> SplatNode
     def right: () -> SplatNode
 
@@ -7781,14 +7781,14 @@ module Prism
     #
     #     foo in Foo(*bar, baz, *qux)
     #               ^
-    # --
+    #
     # : () -> Location?
     def opening_loc: () -> Location?
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_opening_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -7803,14 +7803,14 @@ module Prism
     #
     #     foo in Foo(*bar, baz, *qux)
     #                               ^
-    # --
+    #
     # : () -> Location?
     def closing_loc: () -> Location?
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_closing_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -7818,7 +7818,7 @@ module Prism
     #   opening -> String | nil
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String?
     def opening: () -> String?
 
@@ -7826,7 +7826,7 @@ module Prism
     #   closing -> String | nil
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String?
     def closing: () -> String?
 
@@ -7846,34 +7846,34 @@ module Prism
     @left: Prism::node?
 
     # Initialize a new FlipFlopNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? left, Prism::node? right, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? left, Prism::node? right, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -7881,7 +7881,7 @@ module Prism
     #   copy(**fields) -> FlipFlopNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node?, ?right: Prism::node?, ?operator_loc: Location) -> FlipFlopNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node?, ?right: Prism::node?, ?operator_loc: Location) -> FlipFlopNode
 
@@ -7891,12 +7891,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :flip_flop_node
     def type: () -> :flip_flop_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :flip_flop_node
     def self.type: () -> :flip_flop_node
 
@@ -7905,7 +7905,7 @@ module Prism
 
     # :category: Flags
     # ... operator
-    # --
+    #
     # : () -> bool
     def exclude_end?: () -> bool
 
@@ -7913,7 +7913,7 @@ module Prism
     #   left -> Node | nil
     #
     # Returns the `left` attribute.
-    # --
+    #
     # : () -> Prism::node?
     def left: () -> Prism::node?
 
@@ -7921,7 +7921,7 @@ module Prism
     #   right -> Node | nil
     #
     # Returns the `right` attribute.
-    # --
+    #
     # : () -> Prism::node?
     def right: () -> Prism::node?
 
@@ -7930,14 +7930,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -7945,7 +7945,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -7961,34 +7961,34 @@ module Prism
     @value: Float
 
     # Initialize a new FloatNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Float value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Float value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -7996,7 +7996,7 @@ module Prism
     #   copy(**fields) -> FloatNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Float) -> FloatNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Float) -> FloatNode
 
@@ -8006,12 +8006,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :float_node
     def type: () -> :float_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :float_node
     def self.type: () -> :float_node
 
@@ -8022,7 +8022,7 @@ module Prism
     #   value -> Float
     #
     # The value of the floating point number as a Float.
-    # --
+    #
     # : () -> Float
     def value: () -> Float
 
@@ -8050,34 +8050,34 @@ module Prism
     @index: LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode
 
     # Initialize a new ForNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode) index, Prism::node collection, StatementsNode? statements, Location for_keyword_loc, Location in_keyword_loc, Location? do_keyword_loc, Location end_keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode index, Prism::node collection, StatementsNode? statements, Location for_keyword_loc, Location in_keyword_loc, Location? do_keyword_loc, Location end_keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -8085,7 +8085,7 @@ module Prism
     #   copy(**fields) -> ForNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?index: (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode), ?collection: Prism::node, ?statements: StatementsNode?, ?for_keyword_loc: Location, ?in_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location) -> ForNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?index: LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode, ?collection: Prism::node, ?statements: StatementsNode?, ?for_keyword_loc: Location, ?in_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location) -> ForNode
 
@@ -8095,12 +8095,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :for_node
     def type: () -> :for_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :for_node
     def self.type: () -> :for_node
 
@@ -8114,7 +8114,7 @@ module Prism
     #
     #     for i in a end
     #         ^
-    # --
+    #
     # : () -> (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode)
     def index: () -> (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode)
 
@@ -8125,7 +8125,7 @@ module Prism
     #
     #     for i in a end
     #              ^
-    # --
+    #
     # : () -> Prism::node
     def collection: () -> Prism::node
 
@@ -8138,7 +8138,7 @@ module Prism
     #       foo(i)
     #       ^^^^^^
     #     end
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -8150,14 +8150,14 @@ module Prism
     #
     #     for i in a end
     #     ^^^
-    # --
+    #
     # : () -> Location
     def for_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the for_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_for_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -8169,14 +8169,14 @@ module Prism
     #
     #     for i in a end
     #           ^^
-    # --
+    #
     # : () -> Location
     def in_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the in_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_in_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -8188,14 +8188,14 @@ module Prism
     #
     #     for i in a do end
     #                ^^
-    # --
+    #
     # : () -> Location?
     def do_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the do_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_do_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -8207,14 +8207,14 @@ module Prism
     #
     #     for i in a end
     #                ^^^
-    # --
+    #
     # : () -> Location
     def end_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -8222,7 +8222,7 @@ module Prism
     #   for_keyword -> String
     #
     # Slice the location of for_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def for_keyword: () -> String
 
@@ -8230,7 +8230,7 @@ module Prism
     #   in_keyword -> String
     #
     # Slice the location of in_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def in_keyword: () -> String
 
@@ -8238,7 +8238,7 @@ module Prism
     #   do_keyword -> String | nil
     #
     # Slice the location of do_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def do_keyword: () -> String?
 
@@ -8246,7 +8246,7 @@ module Prism
     #   end_keyword -> String
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def end_keyword: () -> String
 
@@ -8262,34 +8262,34 @@ module Prism
   #     end
   class ForwardingArgumentsNode < Node
     # Initialize a new ForwardingArgumentsNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -8297,7 +8297,7 @@ module Prism
     #   copy(**fields) -> ForwardingArgumentsNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> ForwardingArgumentsNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> ForwardingArgumentsNode
 
@@ -8307,12 +8307,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :forwarding_arguments_node
     def type: () -> :forwarding_arguments_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :forwarding_arguments_node
     def self.type: () -> :forwarding_arguments_node
 
@@ -8330,34 +8330,34 @@ module Prism
   #     end
   class ForwardingParameterNode < Node
     # Initialize a new ForwardingParameterNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -8365,7 +8365,7 @@ module Prism
     #   copy(**fields) -> ForwardingParameterNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> ForwardingParameterNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> ForwardingParameterNode
 
@@ -8375,12 +8375,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :forwarding_parameter_node
     def type: () -> :forwarding_parameter_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :forwarding_parameter_node
     def self.type: () -> :forwarding_parameter_node
 
@@ -8406,34 +8406,34 @@ module Prism
     @keyword_loc: Location
 
     # Initialize a new ForwardingSuperNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, BlockNode? block) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, BlockNode? block) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -8441,7 +8441,7 @@ module Prism
     #   copy(**fields) -> ForwardingSuperNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?block: BlockNode?) -> ForwardingSuperNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?block: BlockNode?) -> ForwardingSuperNode
 
@@ -8451,12 +8451,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :forwarding_super_node
     def type: () -> :forwarding_super_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :forwarding_super_node
     def self.type: () -> :forwarding_super_node
 
@@ -8472,14 +8472,14 @@ module Prism
     #
     # super { 123 }
     # ^^^^^
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -8487,7 +8487,7 @@ module Prism
     #   block -> BlockNode | nil
     #
     # All other arguments are forwarded as normal, except the original block is replaced with the new block.
-    # --
+    #
     # : () -> BlockNode?
     def block: () -> BlockNode?
 
@@ -8495,7 +8495,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -8517,34 +8517,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new GlobalVariableAndWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -8552,7 +8552,7 @@ module Prism
     #   copy(**fields) -> GlobalVariableAndWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> GlobalVariableAndWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> GlobalVariableAndWriteNode
 
@@ -8562,12 +8562,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :global_variable_and_write_node
     def type: () -> :global_variable_and_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :global_variable_and_write_node
     def self.type: () -> :global_variable_and_write_node
 
@@ -8578,7 +8578,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -8587,14 +8587,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -8603,14 +8603,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -8618,7 +8618,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -8626,7 +8626,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -8650,34 +8650,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new GlobalVariableOperatorWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location binary_operator_loc, Prism::node value, Symbol binary_operator) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location binary_operator_loc, Prism::node value, Symbol binary_operator) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -8685,7 +8685,7 @@ module Prism
     #   copy(**fields) -> GlobalVariableOperatorWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> GlobalVariableOperatorWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> GlobalVariableOperatorWriteNode
 
@@ -8695,12 +8695,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :global_variable_operator_write_node
     def type: () -> :global_variable_operator_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :global_variable_operator_write_node
     def self.type: () -> :global_variable_operator_write_node
 
@@ -8711,7 +8711,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -8720,14 +8720,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -8736,14 +8736,14 @@ module Prism
     #   binary_operator_loc -> Location
     #
     # Returns the Location represented by `binary_operator_loc`.
-    # --
+    #
     # : () -> Location
     def binary_operator_loc: () -> Location
 
     # :category: Repository
     # Save the binary_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_binary_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -8751,7 +8751,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -8759,7 +8759,7 @@ module Prism
     #   binary_operator -> Symbol
     #
     # Returns the `binary_operator` attribute.
-    # --
+    #
     # : () -> Symbol
     def binary_operator: () -> Symbol
 
@@ -8781,34 +8781,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new GlobalVariableOrWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -8816,7 +8816,7 @@ module Prism
     #   copy(**fields) -> GlobalVariableOrWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> GlobalVariableOrWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> GlobalVariableOrWriteNode
 
@@ -8826,12 +8826,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :global_variable_or_write_node
     def type: () -> :global_variable_or_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :global_variable_or_write_node
     def self.type: () -> :global_variable_or_write_node
 
@@ -8842,7 +8842,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -8851,14 +8851,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -8867,14 +8867,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -8882,7 +8882,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -8890,7 +8890,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -8906,34 +8906,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new GlobalVariableReadNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -8941,7 +8941,7 @@ module Prism
     #   copy(**fields) -> GlobalVariableReadNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> GlobalVariableReadNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> GlobalVariableReadNode
 
@@ -8951,12 +8951,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :global_variable_read_node
     def type: () -> :global_variable_read_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :global_variable_read_node
     def self.type: () -> :global_variable_read_node
 
@@ -8971,7 +8971,7 @@ module Prism
     #     $foo   # name `:$foo`
     #
     #     $_Test # name `:$_Test`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -8987,34 +8987,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new GlobalVariableTargetNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -9022,7 +9022,7 @@ module Prism
     #   copy(**fields) -> GlobalVariableTargetNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> GlobalVariableTargetNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> GlobalVariableTargetNode
 
@@ -9032,12 +9032,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :global_variable_target_node
     def type: () -> :global_variable_target_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :global_variable_target_node
     def self.type: () -> :global_variable_target_node
 
@@ -9048,7 +9048,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -9070,34 +9070,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new GlobalVariableWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node value, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node value, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -9105,7 +9105,7 @@ module Prism
     #   copy(**fields) -> GlobalVariableWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> GlobalVariableWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> GlobalVariableWriteNode
 
@@ -9115,12 +9115,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :global_variable_write_node
     def type: () -> :global_variable_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :global_variable_write_node
     def self.type: () -> :global_variable_write_node
 
@@ -9135,7 +9135,7 @@ module Prism
     #     $foo = :bar  # name `:$foo`
     #
     #     $_Test = 123 # name `:$_Test`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -9147,14 +9147,14 @@ module Prism
     #
     #     $foo = :bar
     #     ^^^^
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -9168,7 +9168,7 @@ module Prism
     #
     #     $-xyz = 123
     #             ^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -9180,14 +9180,14 @@ module Prism
     #
     #     $foo = :bar
     #          ^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -9195,7 +9195,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -9215,34 +9215,34 @@ module Prism
     @opening_loc: Location
 
     # Initialize a new HashNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Array[AssocNode | AssocSplatNode] elements, Location closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Array[AssocNode | AssocSplatNode] elements, Location closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -9250,7 +9250,7 @@ module Prism
     #   copy(**fields) -> HashNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?elements: Array[AssocNode | AssocSplatNode], ?closing_loc: Location) -> HashNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?elements: Array[AssocNode | AssocSplatNode], ?closing_loc: Location) -> HashNode
 
@@ -9260,12 +9260,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :hash_node
     def type: () -> :hash_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :hash_node
     def self.type: () -> :hash_node
 
@@ -9280,14 +9280,14 @@ module Prism
     #
     #     { a => b }
     #     ^
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -9301,7 +9301,7 @@ module Prism
     #
     #     { **foo }
     #       ^^^^^
-    # --
+    #
     # : () -> Array[AssocNode | AssocSplatNode]
     def elements: () -> Array[AssocNode | AssocSplatNode]
 
@@ -9313,14 +9313,14 @@ module Prism
     #
     #     { a => b }
     #              ^
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -9328,7 +9328,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -9336,7 +9336,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -9369,34 +9369,34 @@ module Prism
     @constant: (ConstantPathNode | ConstantReadNode)?
 
     # Initialize a new HashPatternNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, (ConstantPathNode | ConstantReadNode)? constant, Array[AssocNode] elements, (AssocSplatNode | NoKeywordsParameterNode)? rest, Location? opening_loc, Location? closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, (ConstantPathNode | ConstantReadNode)? constant, Array[AssocNode] elements, (AssocSplatNode | NoKeywordsParameterNode)? rest, Location? opening_loc, Location? closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -9404,7 +9404,7 @@ module Prism
     #   copy(**fields) -> HashPatternNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?elements: Array[AssocNode], ?rest: (AssocSplatNode | NoKeywordsParameterNode)?, ?opening_loc: Location?, ?closing_loc: Location?) -> HashPatternNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?constant: (ConstantPathNode | ConstantReadNode)?, ?elements: Array[AssocNode], ?rest: (AssocSplatNode | NoKeywordsParameterNode)?, ?opening_loc: Location?, ?closing_loc: Location?) -> HashPatternNode
 
@@ -9414,12 +9414,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :hash_pattern_node
     def type: () -> :hash_pattern_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :hash_pattern_node
     def self.type: () -> :hash_pattern_node
 
@@ -9436,7 +9436,7 @@ module Prism
     #
     #     foo => Bar::Baz[a: 1, b: 2]
     #          ^^^^^^^^
-    # --
+    #
     # : () -> (ConstantPathNode | ConstantReadNode)?
     def constant: () -> (ConstantPathNode | ConstantReadNode)?
 
@@ -9447,7 +9447,7 @@ module Prism
     #
     #     foo => { a: 1, b:, ** }
     #              ^^^^^^^^
-    # --
+    #
     # : () -> Array[AssocNode]
     def elements: () -> Array[AssocNode]
 
@@ -9464,7 +9464,7 @@ module Prism
     #
     #     foo => { a: 1, b:, **nil }
     #                        ^^^^^
-    # --
+    #
     # : () -> (AssocSplatNode | NoKeywordsParameterNode)?
     def rest: () -> (AssocSplatNode | NoKeywordsParameterNode)?
 
@@ -9479,14 +9479,14 @@ module Prism
     #
     #     foo => Bar[a: 1]
     #               ^
-    # --
+    #
     # : () -> Location?
     def opening_loc: () -> Location?
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_opening_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -9501,14 +9501,14 @@ module Prism
     #
     #     foo => Bar[a: 1]
     #                    ^
-    # --
+    #
     # : () -> Location?
     def closing_loc: () -> Location?
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_closing_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -9516,7 +9516,7 @@ module Prism
     #   opening -> String | nil
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String?
     def opening: () -> String?
 
@@ -9524,7 +9524,7 @@ module Prism
     #   closing -> String | nil
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String?
     def closing: () -> String?
 
@@ -9556,34 +9556,34 @@ module Prism
     @if_keyword_loc: Location?
 
     # Initialize a new IfNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location? if_keyword_loc, Prism::node predicate, Location? then_keyword_loc, StatementsNode? statements, (ElseNode | IfNode)? subsequent, Location? end_keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location? if_keyword_loc, Prism::node predicate, Location? then_keyword_loc, StatementsNode? statements, (ElseNode | IfNode)? subsequent, Location? end_keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -9591,7 +9591,7 @@ module Prism
     #   copy(**fields) -> IfNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?if_keyword_loc: Location?, ?predicate: Prism::node, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?subsequent: (ElseNode | IfNode)?, ?end_keyword_loc: Location?) -> IfNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?if_keyword_loc: Location?, ?predicate: Prism::node, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?subsequent: (ElseNode | IfNode)?, ?end_keyword_loc: Location?) -> IfNode
 
@@ -9601,12 +9601,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :if_node
     def type: () -> :if_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :if_node
     def self.type: () -> :if_node
 
@@ -9623,14 +9623,14 @@ module Prism
     #         ^^
     #
     # The `if_keyword_loc` field will be `nil` when the `IfNode` represents a ternary expression.
-    # --
+    #
     # : () -> Location?
     def if_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the if_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_if_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -9649,7 +9649,7 @@ module Prism
     #
     #     foo ? bar : baz
     #     ^^^
-    # --
+    #
     # : () -> Prism::node
     def predicate: () -> Prism::node
 
@@ -9664,14 +9664,14 @@ module Prism
     #
     #     a ? b : c
     #       ^
-    # --
+    #
     # : () -> Location?
     def then_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the then_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_then_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -9686,7 +9686,7 @@ module Prism
     #       baz
     #       ^^^
     #     end
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -9706,7 +9706,7 @@ module Prism
     #
     #     if foo then bar else baz end
     #                     ^^^^^^^^^^^^
-    # --
+    #
     # : () -> (ElseNode | IfNode)?
     def subsequent: () -> (ElseNode | IfNode)?
 
@@ -9720,14 +9720,14 @@ module Prism
     #       bar
     #     end
     #     ^^^
-    # --
+    #
     # : () -> Location?
     def end_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -9735,7 +9735,7 @@ module Prism
     #   if_keyword -> String | nil
     #
     # Slice the location of if_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def if_keyword: () -> String?
 
@@ -9743,7 +9743,7 @@ module Prism
     #   then_keyword -> String | nil
     #
     # Slice the location of then_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def then_keyword: () -> String?
 
@@ -9751,7 +9751,7 @@ module Prism
     #   end_keyword -> String | nil
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def end_keyword: () -> String?
 
@@ -9767,34 +9767,34 @@ module Prism
     @numeric: FloatNode | IntegerNode | RationalNode
 
     # Initialize a new ImaginaryNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, (FloatNode | IntegerNode | RationalNode) numeric) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, FloatNode | IntegerNode | RationalNode numeric) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -9802,7 +9802,7 @@ module Prism
     #   copy(**fields) -> ImaginaryNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?numeric: (FloatNode | IntegerNode | RationalNode)) -> ImaginaryNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?numeric: FloatNode | IntegerNode | RationalNode) -> ImaginaryNode
 
@@ -9812,12 +9812,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :imaginary_node
     def type: () -> :imaginary_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :imaginary_node
     def self.type: () -> :imaginary_node
 
@@ -9828,7 +9828,7 @@ module Prism
     #   numeric -> FloatNode | IntegerNode | RationalNode
     #
     # Returns the `numeric` attribute.
-    # --
+    #
     # : () -> (FloatNode | IntegerNode | RationalNode)
     def numeric: () -> (FloatNode | IntegerNode | RationalNode)
 
@@ -9850,34 +9850,34 @@ module Prism
     @value: LocalVariableReadNode | CallNode | ConstantReadNode | LocalVariableTargetNode
 
     # Initialize a new ImplicitNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, (LocalVariableReadNode | CallNode | ConstantReadNode | LocalVariableTargetNode) value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, LocalVariableReadNode | CallNode | ConstantReadNode | LocalVariableTargetNode value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -9885,7 +9885,7 @@ module Prism
     #   copy(**fields) -> ImplicitNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: (LocalVariableReadNode | CallNode | ConstantReadNode | LocalVariableTargetNode)) -> ImplicitNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: LocalVariableReadNode | CallNode | ConstantReadNode | LocalVariableTargetNode) -> ImplicitNode
 
@@ -9895,12 +9895,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :implicit_node
     def type: () -> :implicit_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :implicit_node
     def self.type: () -> :implicit_node
 
@@ -9911,7 +9911,7 @@ module Prism
     #   value -> LocalVariableReadNode | CallNode | ConstantReadNode | LocalVariableTargetNode
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> (LocalVariableReadNode | CallNode | ConstantReadNode | LocalVariableTargetNode)
     def value: () -> (LocalVariableReadNode | CallNode | ConstantReadNode | LocalVariableTargetNode)
 
@@ -9934,34 +9934,34 @@ module Prism
   #        ^
   class ImplicitRestNode < Node
     # Initialize a new ImplicitRestNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -9969,7 +9969,7 @@ module Prism
     #   copy(**fields) -> ImplicitRestNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> ImplicitRestNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> ImplicitRestNode
 
@@ -9979,12 +9979,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :implicit_rest_node
     def type: () -> :implicit_rest_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :implicit_rest_node
     def self.type: () -> :implicit_rest_node
 
@@ -10009,34 +10009,34 @@ module Prism
     @pattern: Prism::node
 
     # Initialize a new InNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node pattern, StatementsNode? statements, Location in_keyword_loc, Location? then_keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node pattern, StatementsNode? statements, Location in_keyword_loc, Location? then_keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -10044,7 +10044,7 @@ module Prism
     #   copy(**fields) -> InNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?pattern: Prism::node, ?statements: StatementsNode?, ?in_keyword_loc: Location, ?then_keyword_loc: Location?) -> InNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?pattern: Prism::node, ?statements: StatementsNode?, ?in_keyword_loc: Location, ?then_keyword_loc: Location?) -> InNode
 
@@ -10054,12 +10054,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :in_node
     def type: () -> :in_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :in_node
     def self.type: () -> :in_node
 
@@ -10070,7 +10070,7 @@ module Prism
     #   pattern -> Node
     #
     # Returns the `pattern` attribute.
-    # --
+    #
     # : () -> Prism::node
     def pattern: () -> Prism::node
 
@@ -10078,7 +10078,7 @@ module Prism
     #   statements -> StatementsNode | nil
     #
     # Returns the `statements` attribute.
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -10087,14 +10087,14 @@ module Prism
     #   in_keyword_loc -> Location
     #
     # Returns the Location represented by `in_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def in_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the in_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_in_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10103,14 +10103,14 @@ module Prism
     #   then_keyword_loc -> Location | nil
     #
     # Returns the Location represented by `then_keyword_loc`.
-    # --
+    #
     # : () -> Location?
     def then_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the then_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_then_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -10118,7 +10118,7 @@ module Prism
     #   in_keyword -> String
     #
     # Slice the location of in_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def in_keyword: () -> String
 
@@ -10126,7 +10126,7 @@ module Prism
     #   then_keyword -> String | nil
     #
     # Slice the location of then_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def then_keyword: () -> String?
 
@@ -10156,34 +10156,34 @@ module Prism
     @receiver: Prism::node?
 
     # Initialize a new IndexAndWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location opening_loc, ArgumentsNode? arguments, Location closing_loc, BlockArgumentNode? block, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location opening_loc, ArgumentsNode? arguments, Location closing_loc, BlockArgumentNode? block, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -10191,7 +10191,7 @@ module Prism
     #   copy(**fields) -> IndexAndWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?operator_loc: Location, ?value: Prism::node) -> IndexAndWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?operator_loc: Location, ?value: Prism::node) -> IndexAndWriteNode
 
@@ -10201,12 +10201,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :index_and_write_node
     def type: () -> :index_and_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :index_and_write_node
     def self.type: () -> :index_and_write_node
 
@@ -10215,25 +10215,25 @@ module Prism
 
     # :category: Flags
     # &. operator
-    # --
+    #
     # : () -> bool
     def safe_navigation?: () -> bool
 
     # :category: Flags
     # a call that could have been a local variable
-    # --
+    #
     # : () -> bool
     def variable_call?: () -> bool
 
     # :category: Flags
     # a call that is an attribute write, so the value being written should be returned
-    # --
+    #
     # : () -> bool
     def attribute_write?: () -> bool
 
     # :category: Flags
     # a call that ignores method visibility
-    # --
+    #
     # : () -> bool
     def ignore_visibility?: () -> bool
 
@@ -10241,7 +10241,7 @@ module Prism
     #   receiver -> Node | nil
     #
     # Returns the `receiver` attribute.
-    # --
+    #
     # : () -> Prism::node?
     def receiver: () -> Prism::node?
 
@@ -10250,14 +10250,14 @@ module Prism
     #   call_operator_loc -> Location | nil
     #
     # Returns the Location represented by `call_operator_loc`.
-    # --
+    #
     # : () -> Location?
     def call_operator_loc: () -> Location?
 
     # :category: Repository
     # Save the call_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_call_operator_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -10266,14 +10266,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10281,7 +10281,7 @@ module Prism
     #   arguments -> ArgumentsNode | nil
     #
     # Returns the `arguments` attribute.
-    # --
+    #
     # : () -> ArgumentsNode?
     def arguments: () -> ArgumentsNode?
 
@@ -10290,14 +10290,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10305,7 +10305,7 @@ module Prism
     #   block -> BlockArgumentNode | nil
     #
     # Returns the `block` attribute.
-    # --
+    #
     # : () -> BlockArgumentNode?
     def block: () -> BlockArgumentNode?
 
@@ -10314,14 +10314,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10329,7 +10329,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -10337,7 +10337,7 @@ module Prism
     #   call_operator -> String | nil
     #
     # Slice the location of call_operator_loc from the source.
-    # --
+    #
     # : () -> String?
     def call_operator: () -> String?
 
@@ -10345,7 +10345,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -10353,7 +10353,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -10361,7 +10361,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -10393,34 +10393,34 @@ module Prism
     @receiver: Prism::node?
 
     # Initialize a new IndexOperatorWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location opening_loc, ArgumentsNode? arguments, Location closing_loc, BlockArgumentNode? block, Symbol binary_operator, Location binary_operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location opening_loc, ArgumentsNode? arguments, Location closing_loc, BlockArgumentNode? block, Symbol binary_operator, Location binary_operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -10428,7 +10428,7 @@ module Prism
     #   copy(**fields) -> IndexOperatorWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?binary_operator: Symbol, ?binary_operator_loc: Location, ?value: Prism::node) -> IndexOperatorWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?binary_operator: Symbol, ?binary_operator_loc: Location, ?value: Prism::node) -> IndexOperatorWriteNode
 
@@ -10438,12 +10438,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :index_operator_write_node
     def type: () -> :index_operator_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :index_operator_write_node
     def self.type: () -> :index_operator_write_node
 
@@ -10452,25 +10452,25 @@ module Prism
 
     # :category: Flags
     # &. operator
-    # --
+    #
     # : () -> bool
     def safe_navigation?: () -> bool
 
     # :category: Flags
     # a call that could have been a local variable
-    # --
+    #
     # : () -> bool
     def variable_call?: () -> bool
 
     # :category: Flags
     # a call that is an attribute write, so the value being written should be returned
-    # --
+    #
     # : () -> bool
     def attribute_write?: () -> bool
 
     # :category: Flags
     # a call that ignores method visibility
-    # --
+    #
     # : () -> bool
     def ignore_visibility?: () -> bool
 
@@ -10478,7 +10478,7 @@ module Prism
     #   receiver -> Node | nil
     #
     # Returns the `receiver` attribute.
-    # --
+    #
     # : () -> Prism::node?
     def receiver: () -> Prism::node?
 
@@ -10487,14 +10487,14 @@ module Prism
     #   call_operator_loc -> Location | nil
     #
     # Returns the Location represented by `call_operator_loc`.
-    # --
+    #
     # : () -> Location?
     def call_operator_loc: () -> Location?
 
     # :category: Repository
     # Save the call_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_call_operator_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -10503,14 +10503,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10518,7 +10518,7 @@ module Prism
     #   arguments -> ArgumentsNode | nil
     #
     # Returns the `arguments` attribute.
-    # --
+    #
     # : () -> ArgumentsNode?
     def arguments: () -> ArgumentsNode?
 
@@ -10527,14 +10527,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10542,7 +10542,7 @@ module Prism
     #   block -> BlockArgumentNode | nil
     #
     # Returns the `block` attribute.
-    # --
+    #
     # : () -> BlockArgumentNode?
     def block: () -> BlockArgumentNode?
 
@@ -10550,7 +10550,7 @@ module Prism
     #   binary_operator -> Symbol
     #
     # Returns the `binary_operator` attribute.
-    # --
+    #
     # : () -> Symbol
     def binary_operator: () -> Symbol
 
@@ -10559,14 +10559,14 @@ module Prism
     #   binary_operator_loc -> Location
     #
     # Returns the Location represented by `binary_operator_loc`.
-    # --
+    #
     # : () -> Location
     def binary_operator_loc: () -> Location
 
     # :category: Repository
     # Save the binary_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_binary_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10574,7 +10574,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -10582,7 +10582,7 @@ module Prism
     #   call_operator -> String | nil
     #
     # Slice the location of call_operator_loc from the source.
-    # --
+    #
     # : () -> String?
     def call_operator: () -> String?
 
@@ -10590,7 +10590,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -10598,7 +10598,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -10628,34 +10628,34 @@ module Prism
     @receiver: Prism::node?
 
     # Initialize a new IndexOrWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location opening_loc, ArgumentsNode? arguments, Location closing_loc, BlockArgumentNode? block, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? receiver, Location? call_operator_loc, Location opening_loc, ArgumentsNode? arguments, Location closing_loc, BlockArgumentNode? block, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -10663,7 +10663,7 @@ module Prism
     #   copy(**fields) -> IndexOrWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?operator_loc: Location, ?value: Prism::node) -> IndexOrWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node?, ?call_operator_loc: Location?, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?, ?operator_loc: Location, ?value: Prism::node) -> IndexOrWriteNode
 
@@ -10673,12 +10673,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :index_or_write_node
     def type: () -> :index_or_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :index_or_write_node
     def self.type: () -> :index_or_write_node
 
@@ -10687,25 +10687,25 @@ module Prism
 
     # :category: Flags
     # &. operator
-    # --
+    #
     # : () -> bool
     def safe_navigation?: () -> bool
 
     # :category: Flags
     # a call that could have been a local variable
-    # --
+    #
     # : () -> bool
     def variable_call?: () -> bool
 
     # :category: Flags
     # a call that is an attribute write, so the value being written should be returned
-    # --
+    #
     # : () -> bool
     def attribute_write?: () -> bool
 
     # :category: Flags
     # a call that ignores method visibility
-    # --
+    #
     # : () -> bool
     def ignore_visibility?: () -> bool
 
@@ -10713,7 +10713,7 @@ module Prism
     #   receiver -> Node | nil
     #
     # Returns the `receiver` attribute.
-    # --
+    #
     # : () -> Prism::node?
     def receiver: () -> Prism::node?
 
@@ -10722,14 +10722,14 @@ module Prism
     #   call_operator_loc -> Location | nil
     #
     # Returns the Location represented by `call_operator_loc`.
-    # --
+    #
     # : () -> Location?
     def call_operator_loc: () -> Location?
 
     # :category: Repository
     # Save the call_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_call_operator_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -10738,14 +10738,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10753,7 +10753,7 @@ module Prism
     #   arguments -> ArgumentsNode | nil
     #
     # Returns the `arguments` attribute.
-    # --
+    #
     # : () -> ArgumentsNode?
     def arguments: () -> ArgumentsNode?
 
@@ -10762,14 +10762,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10777,7 +10777,7 @@ module Prism
     #   block -> BlockArgumentNode | nil
     #
     # Returns the `block` attribute.
-    # --
+    #
     # : () -> BlockArgumentNode?
     def block: () -> BlockArgumentNode?
 
@@ -10786,14 +10786,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10801,7 +10801,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -10809,7 +10809,7 @@ module Prism
     #   call_operator -> String | nil
     #
     # Slice the location of call_operator_loc from the source.
-    # --
+    #
     # : () -> String?
     def call_operator: () -> String?
 
@@ -10817,7 +10817,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -10825,7 +10825,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -10833,7 +10833,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -10865,34 +10865,34 @@ module Prism
     @receiver: Prism::node
 
     # Initialize a new IndexTargetNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node receiver, Location opening_loc, ArgumentsNode? arguments, Location closing_loc, BlockArgumentNode? block) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node receiver, Location opening_loc, ArgumentsNode? arguments, Location closing_loc, BlockArgumentNode? block) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -10900,7 +10900,7 @@ module Prism
     #   copy(**fields) -> IndexTargetNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?) -> IndexTargetNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?receiver: Prism::node, ?opening_loc: Location, ?arguments: ArgumentsNode?, ?closing_loc: Location, ?block: BlockArgumentNode?) -> IndexTargetNode
 
@@ -10910,12 +10910,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :index_target_node
     def type: () -> :index_target_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :index_target_node
     def self.type: () -> :index_target_node
 
@@ -10924,25 +10924,25 @@ module Prism
 
     # :category: Flags
     # &. operator
-    # --
+    #
     # : () -> bool
     def safe_navigation?: () -> bool
 
     # :category: Flags
     # a call that could have been a local variable
-    # --
+    #
     # : () -> bool
     def variable_call?: () -> bool
 
     # :category: Flags
     # a call that is an attribute write, so the value being written should be returned
-    # --
+    #
     # : () -> bool
     def attribute_write?: () -> bool
 
     # :category: Flags
     # a call that ignores method visibility
-    # --
+    #
     # : () -> bool
     def ignore_visibility?: () -> bool
 
@@ -10950,7 +10950,7 @@ module Prism
     #   receiver -> Node
     #
     # Returns the `receiver` attribute.
-    # --
+    #
     # : () -> Prism::node
     def receiver: () -> Prism::node
 
@@ -10959,14 +10959,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10974,7 +10974,7 @@ module Prism
     #   arguments -> ArgumentsNode | nil
     #
     # Returns the `arguments` attribute.
-    # --
+    #
     # : () -> ArgumentsNode?
     def arguments: () -> ArgumentsNode?
 
@@ -10983,14 +10983,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -10998,7 +10998,7 @@ module Prism
     #   block -> BlockArgumentNode | nil
     #
     # Returns the `block` attribute.
-    # --
+    #
     # : () -> BlockArgumentNode?
     def block: () -> BlockArgumentNode?
 
@@ -11006,7 +11006,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -11014,7 +11014,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -11036,34 +11036,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new InstanceVariableAndWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -11071,7 +11071,7 @@ module Prism
     #   copy(**fields) -> InstanceVariableAndWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> InstanceVariableAndWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> InstanceVariableAndWriteNode
 
@@ -11081,12 +11081,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :instance_variable_and_write_node
     def type: () -> :instance_variable_and_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :instance_variable_and_write_node
     def self.type: () -> :instance_variable_and_write_node
 
@@ -11097,7 +11097,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -11106,14 +11106,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -11122,14 +11122,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -11137,7 +11137,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -11145,7 +11145,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -11169,34 +11169,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new InstanceVariableOperatorWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location binary_operator_loc, Prism::node value, Symbol binary_operator) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location binary_operator_loc, Prism::node value, Symbol binary_operator) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -11204,7 +11204,7 @@ module Prism
     #   copy(**fields) -> InstanceVariableOperatorWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> InstanceVariableOperatorWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?binary_operator: Symbol) -> InstanceVariableOperatorWriteNode
 
@@ -11214,12 +11214,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :instance_variable_operator_write_node
     def type: () -> :instance_variable_operator_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :instance_variable_operator_write_node
     def self.type: () -> :instance_variable_operator_write_node
 
@@ -11230,7 +11230,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -11239,14 +11239,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -11255,14 +11255,14 @@ module Prism
     #   binary_operator_loc -> Location
     #
     # Returns the Location represented by `binary_operator_loc`.
-    # --
+    #
     # : () -> Location
     def binary_operator_loc: () -> Location
 
     # :category: Repository
     # Save the binary_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_binary_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -11270,7 +11270,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -11278,7 +11278,7 @@ module Prism
     #   binary_operator -> Symbol
     #
     # Returns the `binary_operator` attribute.
-    # --
+    #
     # : () -> Symbol
     def binary_operator: () -> Symbol
 
@@ -11300,34 +11300,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new InstanceVariableOrWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -11335,7 +11335,7 @@ module Prism
     #   copy(**fields) -> InstanceVariableOrWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> InstanceVariableOrWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> InstanceVariableOrWriteNode
 
@@ -11345,12 +11345,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :instance_variable_or_write_node
     def type: () -> :instance_variable_or_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :instance_variable_or_write_node
     def self.type: () -> :instance_variable_or_write_node
 
@@ -11361,7 +11361,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -11370,14 +11370,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -11386,14 +11386,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -11401,7 +11401,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -11409,7 +11409,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -11425,34 +11425,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new InstanceVariableReadNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -11460,7 +11460,7 @@ module Prism
     #   copy(**fields) -> InstanceVariableReadNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> InstanceVariableReadNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> InstanceVariableReadNode
 
@@ -11470,12 +11470,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :instance_variable_read_node
     def type: () -> :instance_variable_read_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :instance_variable_read_node
     def self.type: () -> :instance_variable_read_node
 
@@ -11490,7 +11490,7 @@ module Prism
     #     @x     # name `:@x`
     #
     #     @_test # name `:@_test`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -11506,34 +11506,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new InstanceVariableTargetNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -11541,7 +11541,7 @@ module Prism
     #   copy(**fields) -> InstanceVariableTargetNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> InstanceVariableTargetNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> InstanceVariableTargetNode
 
@@ -11551,12 +11551,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :instance_variable_target_node
     def type: () -> :instance_variable_target_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :instance_variable_target_node
     def self.type: () -> :instance_variable_target_node
 
@@ -11567,7 +11567,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -11589,34 +11589,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new InstanceVariableWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node value, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node value, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -11624,7 +11624,7 @@ module Prism
     #   copy(**fields) -> InstanceVariableWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> InstanceVariableWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> InstanceVariableWriteNode
 
@@ -11634,12 +11634,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :instance_variable_write_node
     def type: () -> :instance_variable_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :instance_variable_write_node
     def self.type: () -> :instance_variable_write_node
 
@@ -11654,7 +11654,7 @@ module Prism
     #     @x = :y       # name `:@x`
     #
     #     @_foo = "bar" # name `@_foo`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -11666,14 +11666,14 @@ module Prism
     #
     #     @_x = 1
     #     ^^^
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -11687,7 +11687,7 @@ module Prism
     #
     #     @_x = 1234
     #           ^^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -11699,14 +11699,14 @@ module Prism
     #
     #     @x = y
     #        ^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -11714,7 +11714,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -11730,34 +11730,34 @@ module Prism
     @value: Integer
 
     # Initialize a new IntegerNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Integer value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Integer value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -11765,7 +11765,7 @@ module Prism
     #   copy(**fields) -> IntegerNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Integer) -> IntegerNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Integer) -> IntegerNode
 
@@ -11775,12 +11775,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :integer_node
     def type: () -> :integer_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :integer_node
     def self.type: () -> :integer_node
 
@@ -11789,25 +11789,25 @@ module Prism
 
     # :category: Flags
     # 0b prefix
-    # --
+    #
     # : () -> bool
     def binary?: () -> bool
 
     # :category: Flags
     # 0d or no prefix
-    # --
+    #
     # : () -> bool
     def decimal?: () -> bool
 
     # :category: Flags
     # 0o or 0 prefix
-    # --
+    #
     # : () -> bool
     def octal?: () -> bool
 
     # :category: Flags
     # 0x prefix
-    # --
+    #
     # : () -> bool
     def hexadecimal?: () -> bool
 
@@ -11815,7 +11815,7 @@ module Prism
     #   value -> Integer
     #
     # The value of the integer literal as a number.
-    # --
+    #
     # : () -> Integer
     def value: () -> Integer
 
@@ -11835,34 +11835,34 @@ module Prism
     @opening_loc: Location
 
     # Initialize a new InterpolatedMatchLastLineNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode] parts, Location closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode] parts, Location closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -11870,7 +11870,7 @@ module Prism
     #   copy(**fields) -> InterpolatedMatchLastLineNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedMatchLastLineNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedMatchLastLineNode
 
@@ -11880,12 +11880,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :interpolated_match_last_line_node
     def type: () -> :interpolated_match_last_line_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :interpolated_match_last_line_node
     def self.type: () -> :interpolated_match_last_line_node
 
@@ -11894,67 +11894,67 @@ module Prism
 
     # :category: Flags
     # i - ignores the case of characters when matching
-    # --
+    #
     # : () -> bool
     def ignore_case?: () -> bool
 
     # :category: Flags
     # x - ignores whitespace and allows comments in regular expressions
-    # --
+    #
     # : () -> bool
     def extended?: () -> bool
 
     # :category: Flags
     # m - allows $ to match the end of lines within strings
-    # --
+    #
     # : () -> bool
     def multi_line?: () -> bool
 
     # :category: Flags
     # o - only interpolates values into the regular expression once
-    # --
+    #
     # : () -> bool
     def once?: () -> bool
 
     # :category: Flags
     # e - forces the EUC-JP encoding
-    # --
+    #
     # : () -> bool
     def euc_jp?: () -> bool
 
     # :category: Flags
     # n - forces the ASCII-8BIT encoding
-    # --
+    #
     # : () -> bool
     def ascii_8bit?: () -> bool
 
     # :category: Flags
     # s - forces the Windows-31J encoding
-    # --
+    #
     # : () -> bool
     def windows_31j?: () -> bool
 
     # :category: Flags
     # u - forces the UTF-8 encoding
-    # --
+    #
     # : () -> bool
     def utf_8?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to UTF-8
-    # --
+    #
     # : () -> bool
     def forced_utf8_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to binary
-    # --
+    #
     # : () -> bool
     def forced_binary_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to US-ASCII
-    # --
+    #
     # : () -> bool
     def forced_us_ascii_encoding?: () -> bool
 
@@ -11963,14 +11963,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -11978,7 +11978,7 @@ module Prism
     #   parts -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
     #
     # Returns the `parts` attribute.
-    # --
+    #
     # : () -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
     def parts: () -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
 
@@ -11987,14 +11987,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -12002,7 +12002,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -12010,7 +12010,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -12030,34 +12030,34 @@ module Prism
     @opening_loc: Location
 
     # Initialize a new InterpolatedRegularExpressionNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode] parts, Location closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode] parts, Location closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -12065,7 +12065,7 @@ module Prism
     #   copy(**fields) -> InterpolatedRegularExpressionNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedRegularExpressionNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedRegularExpressionNode
 
@@ -12075,12 +12075,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :interpolated_regular_expression_node
     def type: () -> :interpolated_regular_expression_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :interpolated_regular_expression_node
     def self.type: () -> :interpolated_regular_expression_node
 
@@ -12089,67 +12089,67 @@ module Prism
 
     # :category: Flags
     # i - ignores the case of characters when matching
-    # --
+    #
     # : () -> bool
     def ignore_case?: () -> bool
 
     # :category: Flags
     # x - ignores whitespace and allows comments in regular expressions
-    # --
+    #
     # : () -> bool
     def extended?: () -> bool
 
     # :category: Flags
     # m - allows $ to match the end of lines within strings
-    # --
+    #
     # : () -> bool
     def multi_line?: () -> bool
 
     # :category: Flags
     # o - only interpolates values into the regular expression once
-    # --
+    #
     # : () -> bool
     def once?: () -> bool
 
     # :category: Flags
     # e - forces the EUC-JP encoding
-    # --
+    #
     # : () -> bool
     def euc_jp?: () -> bool
 
     # :category: Flags
     # n - forces the ASCII-8BIT encoding
-    # --
+    #
     # : () -> bool
     def ascii_8bit?: () -> bool
 
     # :category: Flags
     # s - forces the Windows-31J encoding
-    # --
+    #
     # : () -> bool
     def windows_31j?: () -> bool
 
     # :category: Flags
     # u - forces the UTF-8 encoding
-    # --
+    #
     # : () -> bool
     def utf_8?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to UTF-8
-    # --
+    #
     # : () -> bool
     def forced_utf8_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to binary
-    # --
+    #
     # : () -> bool
     def forced_binary_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to US-ASCII
-    # --
+    #
     # : () -> bool
     def forced_us_ascii_encoding?: () -> bool
 
@@ -12158,14 +12158,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -12173,7 +12173,7 @@ module Prism
     #   parts -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
     #
     # Returns the `parts` attribute.
-    # --
+    #
     # : () -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
     def parts: () -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
 
@@ -12182,14 +12182,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -12197,7 +12197,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -12205,7 +12205,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -12225,34 +12225,34 @@ module Prism
     @opening_loc: Location?
 
     # Initialize a new InterpolatedStringNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location? opening_loc, Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode | InterpolatedStringNode] parts, Location? closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location? opening_loc, Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode | InterpolatedStringNode] parts, Location? closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -12260,7 +12260,7 @@ module Prism
     #   copy(**fields) -> InterpolatedStringNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode | InterpolatedStringNode], ?closing_loc: Location?) -> InterpolatedStringNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode | InterpolatedStringNode], ?closing_loc: Location?) -> InterpolatedStringNode
 
@@ -12270,12 +12270,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :interpolated_string_node
     def type: () -> :interpolated_string_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :interpolated_string_node
     def self.type: () -> :interpolated_string_node
 
@@ -12284,13 +12284,13 @@ module Prism
 
     # :category: Flags
     # frozen by virtue of a `frozen_string_literal: true` comment or `--enable-frozen-string-literal`; only for adjacent string literals like `'a' 'b'`
-    # --
+    #
     # : () -> bool
     def frozen?: () -> bool
 
     # :category: Flags
     # mutable by virtue of a `frozen_string_literal: false` comment or `--disable-frozen-string-literal`; only for adjacent string literals like `'a' 'b'`
-    # --
+    #
     # : () -> bool
     def mutable?: () -> bool
 
@@ -12299,14 +12299,14 @@ module Prism
     #   opening_loc -> Location | nil
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location?
     def opening_loc: () -> Location?
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_opening_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -12314,7 +12314,7 @@ module Prism
     #   parts -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode | InterpolatedStringNode]
     #
     # Returns the `parts` attribute.
-    # --
+    #
     # : () -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode | InterpolatedStringNode]
     def parts: () -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode | InterpolatedStringNode]
 
@@ -12323,14 +12323,14 @@ module Prism
     #   closing_loc -> Location | nil
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location?
     def closing_loc: () -> Location?
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_closing_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -12338,7 +12338,7 @@ module Prism
     #   opening -> String | nil
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String?
     def opening: () -> String?
 
@@ -12346,7 +12346,7 @@ module Prism
     #   closing -> String | nil
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String?
     def closing: () -> String?
 
@@ -12366,34 +12366,34 @@ module Prism
     @opening_loc: Location?
 
     # Initialize a new InterpolatedSymbolNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location? opening_loc, Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode] parts, Location? closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location? opening_loc, Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode] parts, Location? closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -12401,7 +12401,7 @@ module Prism
     #   copy(**fields) -> InterpolatedSymbolNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location?) -> InterpolatedSymbolNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location?) -> InterpolatedSymbolNode
 
@@ -12411,12 +12411,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :interpolated_symbol_node
     def type: () -> :interpolated_symbol_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :interpolated_symbol_node
     def self.type: () -> :interpolated_symbol_node
 
@@ -12428,14 +12428,14 @@ module Prism
     #   opening_loc -> Location | nil
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location?
     def opening_loc: () -> Location?
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_opening_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -12443,7 +12443,7 @@ module Prism
     #   parts -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
     #
     # Returns the `parts` attribute.
-    # --
+    #
     # : () -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
     def parts: () -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
 
@@ -12452,14 +12452,14 @@ module Prism
     #   closing_loc -> Location | nil
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location?
     def closing_loc: () -> Location?
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_closing_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -12467,7 +12467,7 @@ module Prism
     #   opening -> String | nil
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String?
     def opening: () -> String?
 
@@ -12475,7 +12475,7 @@ module Prism
     #   closing -> String | nil
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String?
     def closing: () -> String?
 
@@ -12495,34 +12495,34 @@ module Prism
     @opening_loc: Location
 
     # Initialize a new InterpolatedXStringNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode] parts, Location closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode] parts, Location closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -12530,7 +12530,7 @@ module Prism
     #   copy(**fields) -> InterpolatedXStringNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedXStringNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?parts: Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode], ?closing_loc: Location) -> InterpolatedXStringNode
 
@@ -12540,12 +12540,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :interpolated_x_string_node
     def type: () -> :interpolated_x_string_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :interpolated_x_string_node
     def self.type: () -> :interpolated_x_string_node
 
@@ -12557,14 +12557,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -12572,7 +12572,7 @@ module Prism
     #   parts -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
     #
     # Returns the `parts` attribute.
-    # --
+    #
     # : () -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
     def parts: () -> Array[StringNode | EmbeddedStatementsNode | EmbeddedVariableNode]
 
@@ -12581,14 +12581,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -12596,7 +12596,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -12604,7 +12604,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -12618,34 +12618,34 @@ module Prism
   #          ^^
   class ItLocalVariableReadNode < Node
     # Initialize a new ItLocalVariableReadNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -12653,7 +12653,7 @@ module Prism
     #   copy(**fields) -> ItLocalVariableReadNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> ItLocalVariableReadNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> ItLocalVariableReadNode
 
@@ -12663,12 +12663,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :it_local_variable_read_node
     def type: () -> :it_local_variable_read_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :it_local_variable_read_node
     def self.type: () -> :it_local_variable_read_node
 
@@ -12685,34 +12685,34 @@ module Prism
   #     ^^^^^^^^^^^^^^
   class ItParametersNode < Node
     # Initialize a new ItParametersNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -12720,7 +12720,7 @@ module Prism
     #   copy(**fields) -> ItParametersNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> ItParametersNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> ItParametersNode
 
@@ -12730,12 +12730,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :it_parameters_node
     def type: () -> :it_parameters_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :it_parameters_node
     def self.type: () -> :it_parameters_node
 
@@ -12754,34 +12754,34 @@ module Prism
     @elements: Array[AssocNode | AssocSplatNode]
 
     # Initialize a new KeywordHashNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[AssocNode | AssocSplatNode] elements) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[AssocNode | AssocSplatNode] elements) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -12789,7 +12789,7 @@ module Prism
     #   copy(**fields) -> KeywordHashNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?elements: Array[AssocNode | AssocSplatNode]) -> KeywordHashNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?elements: Array[AssocNode | AssocSplatNode]) -> KeywordHashNode
 
@@ -12799,12 +12799,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :keyword_hash_node
     def type: () -> :keyword_hash_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :keyword_hash_node
     def self.type: () -> :keyword_hash_node
 
@@ -12813,7 +12813,7 @@ module Prism
 
     # :category: Flags
     # a keyword hash which only has `AssocNode` elements all with symbol keys, which means the elements can be treated as keyword arguments
-    # --
+    #
     # : () -> bool
     def symbol_keys?: () -> bool
 
@@ -12821,7 +12821,7 @@ module Prism
     #   elements -> Array[AssocNode | AssocSplatNode]
     #
     # Returns the `elements` attribute.
-    # --
+    #
     # : () -> Array[AssocNode | AssocSplatNode]
     def elements: () -> Array[AssocNode | AssocSplatNode]
 
@@ -12842,34 +12842,34 @@ module Prism
     @name: Symbol?
 
     # Initialize a new KeywordRestParameterNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol? name, Location? name_loc, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol? name, Location? name_loc, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -12877,7 +12877,7 @@ module Prism
     #   copy(**fields) -> KeywordRestParameterNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> KeywordRestParameterNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> KeywordRestParameterNode
 
@@ -12887,12 +12887,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :keyword_rest_parameter_node
     def type: () -> :keyword_rest_parameter_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :keyword_rest_parameter_node
     def self.type: () -> :keyword_rest_parameter_node
 
@@ -12901,7 +12901,7 @@ module Prism
 
     # :category: Flags
     # a parameter name that has been repeated in the method signature
-    # --
+    #
     # : () -> bool
     def repeated_parameter?: () -> bool
 
@@ -12909,7 +12909,7 @@ module Prism
     #   name -> Symbol | nil
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol?
     def name: () -> Symbol?
 
@@ -12918,14 +12918,14 @@ module Prism
     #   name_loc -> Location | nil
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location?
     def name_loc: () -> Location?
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_name_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -12934,14 +12934,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -12949,7 +12949,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -12975,34 +12975,34 @@ module Prism
     @locals: Array[Symbol]
 
     # Initialize a new LambdaNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, Location operator_loc, Location opening_loc, Location closing_loc, (BlockParametersNode | NumberedParametersNode | ItParametersNode)? parameters, (StatementsNode | BeginNode)? body) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, Location operator_loc, Location opening_loc, Location closing_loc, (BlockParametersNode | NumberedParametersNode | ItParametersNode)? parameters, (StatementsNode | BeginNode)? body) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -13010,7 +13010,7 @@ module Prism
     #   copy(**fields) -> LambdaNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?operator_loc: Location, ?opening_loc: Location, ?closing_loc: Location, ?parameters: (BlockParametersNode | NumberedParametersNode | ItParametersNode)?, ?body: (StatementsNode | BeginNode)?) -> LambdaNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?operator_loc: Location, ?opening_loc: Location, ?closing_loc: Location, ?parameters: (BlockParametersNode | NumberedParametersNode | ItParametersNode)?, ?body: (StatementsNode | BeginNode)?) -> LambdaNode
 
@@ -13020,12 +13020,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :lambda_node
     def type: () -> :lambda_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :lambda_node
     def self.type: () -> :lambda_node
 
@@ -13036,7 +13036,7 @@ module Prism
     #   locals -> Array[Symbol]
     #
     # Returns the `locals` attribute.
-    # --
+    #
     # : () -> Array[Symbol]
     def locals: () -> Array[Symbol]
 
@@ -13045,14 +13045,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -13061,14 +13061,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -13077,14 +13077,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -13092,7 +13092,7 @@ module Prism
     #   parameters -> BlockParametersNode | NumberedParametersNode | ItParametersNode | nil
     #
     # Returns the `parameters` attribute.
-    # --
+    #
     # : () -> (BlockParametersNode | NumberedParametersNode | ItParametersNode)?
     def parameters: () -> (BlockParametersNode | NumberedParametersNode | ItParametersNode)?
 
@@ -13100,7 +13100,7 @@ module Prism
     #   body -> StatementsNode | BeginNode | nil
     #
     # Returns the `body` attribute.
-    # --
+    #
     # : () -> (StatementsNode | BeginNode)?
     def body: () -> (StatementsNode | BeginNode)?
 
@@ -13108,7 +13108,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -13116,7 +13116,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -13124,7 +13124,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -13148,34 +13148,34 @@ module Prism
     @name_loc: Location
 
     # Initialize a new LocalVariableAndWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location name_loc, Location operator_loc, Prism::node value, Symbol name, Integer depth) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location name_loc, Location operator_loc, Prism::node value, Symbol name, Integer depth) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -13183,7 +13183,7 @@ module Prism
     #   copy(**fields) -> LocalVariableAndWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?depth: Integer) -> LocalVariableAndWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?depth: Integer) -> LocalVariableAndWriteNode
 
@@ -13193,12 +13193,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :local_variable_and_write_node
     def type: () -> :local_variable_and_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :local_variable_and_write_node
     def self.type: () -> :local_variable_and_write_node
 
@@ -13210,14 +13210,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -13226,14 +13226,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -13241,7 +13241,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -13249,7 +13249,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -13257,7 +13257,7 @@ module Prism
     #   depth -> Integer
     #
     # Returns the `depth` attribute.
-    # --
+    #
     # : () -> Integer
     def depth: () -> Integer
 
@@ -13265,7 +13265,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -13291,34 +13291,34 @@ module Prism
     @name_loc: Location
 
     # Initialize a new LocalVariableOperatorWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location name_loc, Location binary_operator_loc, Prism::node value, Symbol name, Symbol binary_operator, Integer depth) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location name_loc, Location binary_operator_loc, Prism::node value, Symbol name, Symbol binary_operator, Integer depth) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -13326,7 +13326,7 @@ module Prism
     #   copy(**fields) -> LocalVariableOperatorWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?binary_operator: Symbol, ?depth: Integer) -> LocalVariableOperatorWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?binary_operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?binary_operator: Symbol, ?depth: Integer) -> LocalVariableOperatorWriteNode
 
@@ -13336,12 +13336,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :local_variable_operator_write_node
     def type: () -> :local_variable_operator_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :local_variable_operator_write_node
     def self.type: () -> :local_variable_operator_write_node
 
@@ -13353,14 +13353,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -13369,14 +13369,14 @@ module Prism
     #   binary_operator_loc -> Location
     #
     # Returns the Location represented by `binary_operator_loc`.
-    # --
+    #
     # : () -> Location
     def binary_operator_loc: () -> Location
 
     # :category: Repository
     # Save the binary_operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_binary_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -13384,7 +13384,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -13392,7 +13392,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -13400,7 +13400,7 @@ module Prism
     #   binary_operator -> Symbol
     #
     # Returns the `binary_operator` attribute.
-    # --
+    #
     # : () -> Symbol
     def binary_operator: () -> Symbol
 
@@ -13408,7 +13408,7 @@ module Prism
     #   depth -> Integer
     #
     # Returns the `depth` attribute.
-    # --
+    #
     # : () -> Integer
     def depth: () -> Integer
 
@@ -13432,34 +13432,34 @@ module Prism
     @name_loc: Location
 
     # Initialize a new LocalVariableOrWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location name_loc, Location operator_loc, Prism::node value, Symbol name, Integer depth) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location name_loc, Location operator_loc, Prism::node value, Symbol name, Integer depth) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -13467,7 +13467,7 @@ module Prism
     #   copy(**fields) -> LocalVariableOrWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?depth: Integer) -> LocalVariableOrWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node, ?name: Symbol, ?depth: Integer) -> LocalVariableOrWriteNode
 
@@ -13477,12 +13477,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :local_variable_or_write_node
     def type: () -> :local_variable_or_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :local_variable_or_write_node
     def self.type: () -> :local_variable_or_write_node
 
@@ -13494,14 +13494,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -13510,14 +13510,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -13525,7 +13525,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -13533,7 +13533,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -13541,7 +13541,7 @@ module Prism
     #   depth -> Integer
     #
     # Returns the `depth` attribute.
-    # --
+    #
     # : () -> Integer
     def depth: () -> Integer
 
@@ -13549,7 +13549,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -13567,34 +13567,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new LocalVariableReadNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Integer depth) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Integer depth) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -13602,7 +13602,7 @@ module Prism
     #   copy(**fields) -> LocalVariableReadNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer) -> LocalVariableReadNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer) -> LocalVariableReadNode
 
@@ -13612,12 +13612,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :local_variable_read_node
     def type: () -> :local_variable_read_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :local_variable_read_node
     def self.type: () -> :local_variable_read_node
 
@@ -13636,7 +13636,7 @@ module Prism
     # Note that this can also be an underscore followed by a number for the default block parameters.
     #
     #     _1     # name `:_1`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -13650,7 +13650,7 @@ module Prism
     #     bar = 2; tap { bar } # depth 1
     #
     # The specific rules for calculating the depth may differ from individual Ruby implementations, as they are not specified by the language. For more information, see [the Prism documentation](https://github.com/ruby/prism/blob/main/docs/local_variable_depth.md).
-    # --
+    #
     # : () -> Integer
     def depth: () -> Integer
 
@@ -13671,34 +13671,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new LocalVariableTargetNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Integer depth) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Integer depth) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -13706,7 +13706,7 @@ module Prism
     #   copy(**fields) -> LocalVariableTargetNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer) -> LocalVariableTargetNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer) -> LocalVariableTargetNode
 
@@ -13716,12 +13716,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :local_variable_target_node
     def type: () -> :local_variable_target_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :local_variable_target_node
     def self.type: () -> :local_variable_target_node
 
@@ -13732,7 +13732,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -13740,7 +13740,7 @@ module Prism
     #   depth -> Integer
     #
     # Returns the `depth` attribute.
-    # --
+    #
     # : () -> Integer
     def depth: () -> Integer
 
@@ -13764,34 +13764,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new LocalVariableWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Integer depth, Location name_loc, Prism::node value, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Integer depth, Location name_loc, Prism::node value, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -13799,7 +13799,7 @@ module Prism
     #   copy(**fields) -> LocalVariableWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> LocalVariableWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?depth: Integer, ?name_loc: Location, ?value: Prism::node, ?operator_loc: Location) -> LocalVariableWriteNode
 
@@ -13809,12 +13809,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :local_variable_write_node
     def type: () -> :local_variable_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :local_variable_write_node
     def self.type: () -> :local_variable_write_node
 
@@ -13829,7 +13829,7 @@ module Prism
     #     foo = :bar # name `:foo`
     #
     #     abc = 123  # name `:abc`
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -13843,7 +13843,7 @@ module Prism
     #     tap { foo = 1 } # depth 1
     #
     # The specific rules for calculating the depth may differ from individual Ruby implementations, as they are not specified by the language. For more information, see [the Prism documentation](https://github.com/ruby/prism/blob/main/docs/local_variable_depth.md).
-    # --
+    #
     # : () -> Integer
     def depth: () -> Integer
 
@@ -13855,14 +13855,14 @@ module Prism
     #
     #     foo = :bar
     #     ^^^
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -13880,7 +13880,7 @@ module Prism
     # Note that since the name of a local variable is known before the value is parsed, it is valid for a local variable to appear within the value of its own write.
     #
     #     foo = foo
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -13892,14 +13892,14 @@ module Prism
     #
     #     x = :y
     #       ^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -13907,7 +13907,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -13929,34 +13929,34 @@ module Prism
     @opening_loc: Location
 
     # Initialize a new MatchLastLineNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Location content_loc, Location closing_loc, String unescaped) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Location content_loc, Location closing_loc, String unescaped) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -13964,7 +13964,7 @@ module Prism
     #   copy(**fields) -> MatchLastLineNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> MatchLastLineNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> MatchLastLineNode
 
@@ -13974,12 +13974,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :match_last_line_node
     def type: () -> :match_last_line_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :match_last_line_node
     def self.type: () -> :match_last_line_node
 
@@ -13988,67 +13988,67 @@ module Prism
 
     # :category: Flags
     # i - ignores the case of characters when matching
-    # --
+    #
     # : () -> bool
     def ignore_case?: () -> bool
 
     # :category: Flags
     # x - ignores whitespace and allows comments in regular expressions
-    # --
+    #
     # : () -> bool
     def extended?: () -> bool
 
     # :category: Flags
     # m - allows $ to match the end of lines within strings
-    # --
+    #
     # : () -> bool
     def multi_line?: () -> bool
 
     # :category: Flags
     # o - only interpolates values into the regular expression once
-    # --
+    #
     # : () -> bool
     def once?: () -> bool
 
     # :category: Flags
     # e - forces the EUC-JP encoding
-    # --
+    #
     # : () -> bool
     def euc_jp?: () -> bool
 
     # :category: Flags
     # n - forces the ASCII-8BIT encoding
-    # --
+    #
     # : () -> bool
     def ascii_8bit?: () -> bool
 
     # :category: Flags
     # s - forces the Windows-31J encoding
-    # --
+    #
     # : () -> bool
     def windows_31j?: () -> bool
 
     # :category: Flags
     # u - forces the UTF-8 encoding
-    # --
+    #
     # : () -> bool
     def utf_8?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to UTF-8
-    # --
+    #
     # : () -> bool
     def forced_utf8_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to binary
-    # --
+    #
     # : () -> bool
     def forced_binary_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to US-ASCII
-    # --
+    #
     # : () -> bool
     def forced_us_ascii_encoding?: () -> bool
 
@@ -14057,14 +14057,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -14073,14 +14073,14 @@ module Prism
     #   content_loc -> Location
     #
     # Returns the Location represented by `content_loc`.
-    # --
+    #
     # : () -> Location
     def content_loc: () -> Location
 
     # :category: Repository
     # Save the content_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_content_loc: (_Repository repository) -> Relocation::Entry
 
@@ -14089,14 +14089,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -14104,7 +14104,7 @@ module Prism
     #   unescaped -> String
     #
     # Returns the `unescaped` attribute.
-    # --
+    #
     # : () -> String
     def unescaped: () -> String
 
@@ -14112,7 +14112,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -14120,7 +14120,7 @@ module Prism
     #   content -> String
     #
     # Slice the location of content_loc from the source.
-    # --
+    #
     # : () -> String
     def content: () -> String
 
@@ -14128,7 +14128,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -14148,34 +14148,34 @@ module Prism
     @value: Prism::node
 
     # Initialize a new MatchPredicateNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node value, Prism::node pattern, Location keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node value, Prism::node pattern, Location keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -14183,7 +14183,7 @@ module Prism
     #   copy(**fields) -> MatchPredicateNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?pattern: Prism::node, ?keyword_loc: Location) -> MatchPredicateNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?pattern: Prism::node, ?keyword_loc: Location) -> MatchPredicateNode
 
@@ -14193,12 +14193,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :match_predicate_node
     def type: () -> :match_predicate_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :match_predicate_node
     def self.type: () -> :match_predicate_node
 
@@ -14209,7 +14209,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -14217,7 +14217,7 @@ module Prism
     #   pattern -> Node
     #
     # Returns the `pattern` attribute.
-    # --
+    #
     # : () -> Prism::node
     def pattern: () -> Prism::node
 
@@ -14226,14 +14226,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -14241,7 +14241,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -14261,34 +14261,34 @@ module Prism
     @value: Prism::node
 
     # Initialize a new MatchRequiredNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node value, Prism::node pattern, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node value, Prism::node pattern, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -14296,7 +14296,7 @@ module Prism
     #   copy(**fields) -> MatchRequiredNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?pattern: Prism::node, ?operator_loc: Location) -> MatchRequiredNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?value: Prism::node, ?pattern: Prism::node, ?operator_loc: Location) -> MatchRequiredNode
 
@@ -14306,12 +14306,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :match_required_node
     def type: () -> :match_required_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :match_required_node
     def self.type: () -> :match_required_node
 
@@ -14325,7 +14325,7 @@ module Prism
     #
     #     foo => bar
     #     ^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -14375,7 +14375,7 @@ module Prism
     # Anything else will result in the regular node for that expression, for example a `ConstantReadNode`.
     #
     #     foo => CONST
-    # --
+    #
     # : () -> Prism::node
     def pattern: () -> Prism::node
 
@@ -14387,14 +14387,14 @@ module Prism
     #
     #     foo => bar
     #         ^^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -14402,7 +14402,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -14420,34 +14420,34 @@ module Prism
     @call: CallNode
 
     # Initialize a new MatchWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, CallNode call, Array[LocalVariableTargetNode] targets) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, CallNode call, Array[LocalVariableTargetNode] targets) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -14455,7 +14455,7 @@ module Prism
     #   copy(**fields) -> MatchWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?call: CallNode, ?targets: Array[LocalVariableTargetNode]) -> MatchWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?call: CallNode, ?targets: Array[LocalVariableTargetNode]) -> MatchWriteNode
 
@@ -14465,12 +14465,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :match_write_node
     def type: () -> :match_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :match_write_node
     def self.type: () -> :match_write_node
 
@@ -14481,7 +14481,7 @@ module Prism
     #   call -> CallNode
     #
     # Returns the `call` attribute.
-    # --
+    #
     # : () -> CallNode
     def call: () -> CallNode
 
@@ -14489,7 +14489,7 @@ module Prism
     #   targets -> Array[LocalVariableTargetNode]
     #
     # Returns the `targets` attribute.
-    # --
+    #
     # : () -> Array[LocalVariableTargetNode]
     def targets: () -> Array[LocalVariableTargetNode]
 
@@ -14515,34 +14515,34 @@ module Prism
     @locals: Array[Symbol]
 
     # Initialize a new ModuleNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, Location module_keyword_loc, (ConstantReadNode | ConstantPathNode) constant_path, (StatementsNode | BeginNode)? body, Location end_keyword_loc, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, Location module_keyword_loc, ConstantReadNode | ConstantPathNode constant_path, (StatementsNode | BeginNode)? body, Location end_keyword_loc, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -14550,7 +14550,7 @@ module Prism
     #   copy(**fields) -> ModuleNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?module_keyword_loc: Location, ?constant_path: (ConstantReadNode | ConstantPathNode), ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location, ?name: Symbol) -> ModuleNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?module_keyword_loc: Location, ?constant_path: ConstantReadNode | ConstantPathNode, ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location, ?name: Symbol) -> ModuleNode
 
@@ -14560,12 +14560,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :module_node
     def type: () -> :module_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :module_node
     def self.type: () -> :module_node
 
@@ -14576,7 +14576,7 @@ module Prism
     #   locals -> Array[Symbol]
     #
     # Returns the `locals` attribute.
-    # --
+    #
     # : () -> Array[Symbol]
     def locals: () -> Array[Symbol]
 
@@ -14585,14 +14585,14 @@ module Prism
     #   module_keyword_loc -> Location
     #
     # Returns the Location represented by `module_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def module_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the module_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_module_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -14600,7 +14600,7 @@ module Prism
     #   constant_path -> ConstantReadNode | ConstantPathNode
     #
     # Returns the `constant_path` attribute.
-    # --
+    #
     # : () -> (ConstantReadNode | ConstantPathNode)
     def constant_path: () -> (ConstantReadNode | ConstantPathNode)
 
@@ -14608,7 +14608,7 @@ module Prism
     #   body -> StatementsNode | BeginNode | nil
     #
     # Returns the `body` attribute.
-    # --
+    #
     # : () -> (StatementsNode | BeginNode)?
     def body: () -> (StatementsNode | BeginNode)?
 
@@ -14617,14 +14617,14 @@ module Prism
     #   end_keyword_loc -> Location
     #
     # Returns the Location represented by `end_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def end_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -14632,7 +14632,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -14640,7 +14640,7 @@ module Prism
     #   module_keyword -> String
     #
     # Slice the location of module_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def module_keyword: () -> String
 
@@ -14648,7 +14648,7 @@ module Prism
     #   end_keyword -> String
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def end_keyword: () -> String
 
@@ -14677,34 +14677,34 @@ module Prism
     @lefts: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode]
 
     # Initialize a new MultiTargetNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode] lefts, (ImplicitRestNode | SplatNode)? rest, Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode] rights, Location? lparen_loc, Location? rparen_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode] lefts, (ImplicitRestNode | SplatNode)? rest, Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode] rights, Location? lparen_loc, Location? rparen_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -14712,7 +14712,7 @@ module Prism
     #   copy(**fields) -> MultiTargetNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?lefts: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode], ?rest: (ImplicitRestNode | SplatNode)?, ?rights: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode], ?lparen_loc: Location?, ?rparen_loc: Location?) -> MultiTargetNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?lefts: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode], ?rest: (ImplicitRestNode | SplatNode)?, ?rights: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode], ?lparen_loc: Location?, ?rparen_loc: Location?) -> MultiTargetNode
 
@@ -14722,12 +14722,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :multi_target_node
     def type: () -> :multi_target_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :multi_target_node
     def self.type: () -> :multi_target_node
 
@@ -14746,7 +14746,7 @@ module Prism
     #
     #     a, (b, c) = 1, 2, 3, 4, 5
     #         ^^^^
-    # --
+    #
     # : () -> Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode]
     def lefts: () -> Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode]
 
@@ -14767,7 +14767,7 @@ module Prism
     #
     #     a, (b,) = 1, 2, 3, 4
     #          ^
-    # --
+    #
     # : () -> (ImplicitRestNode | SplatNode)?
     def rest: () -> (ImplicitRestNode | SplatNode)?
 
@@ -14778,7 +14778,7 @@ module Prism
     #
     #     a, (*, b, c) = 1, 2, 3, 4, 5
     #            ^^^^
-    # --
+    #
     # : () -> Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode]
     def rights: () -> Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode | RequiredParameterNode]
 
@@ -14790,14 +14790,14 @@ module Prism
     #
     #     a, (b, c) = 1, 2, 3
     #        ^
-    # --
+    #
     # : () -> Location?
     def lparen_loc: () -> Location?
 
     # :category: Repository
     # Save the lparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_lparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -14809,14 +14809,14 @@ module Prism
     #
     #     a, (b, c) = 1, 2, 3
     #             ^
-    # --
+    #
     # : () -> Location?
     def rparen_loc: () -> Location?
 
     # :category: Repository
     # Save the rparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_rparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -14824,7 +14824,7 @@ module Prism
     #   lparen -> String | nil
     #
     # Slice the location of lparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def lparen: () -> String?
 
@@ -14832,7 +14832,7 @@ module Prism
     #   rparen -> String | nil
     #
     # Slice the location of rparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def rparen: () -> String?
 
@@ -14860,34 +14860,34 @@ module Prism
     @lefts: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode]
 
     # Initialize a new MultiWriteNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode] lefts, (ImplicitRestNode | SplatNode)? rest, Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode] rights, Location? lparen_loc, Location? rparen_loc, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode] lefts, (ImplicitRestNode | SplatNode)? rest, Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode] rights, Location? lparen_loc, Location? rparen_loc, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -14895,7 +14895,7 @@ module Prism
     #   copy(**fields) -> MultiWriteNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?lefts: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode], ?rest: (ImplicitRestNode | SplatNode)?, ?rights: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode], ?lparen_loc: Location?, ?rparen_loc: Location?, ?operator_loc: Location, ?value: Prism::node) -> MultiWriteNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?lefts: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode], ?rest: (ImplicitRestNode | SplatNode)?, ?rights: Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode], ?lparen_loc: Location?, ?rparen_loc: Location?, ?operator_loc: Location, ?value: Prism::node) -> MultiWriteNode
 
@@ -14905,12 +14905,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :multi_write_node
     def type: () -> :multi_write_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :multi_write_node
     def self.type: () -> :multi_write_node
 
@@ -14929,7 +14929,7 @@ module Prism
     #
     #     a, b, c = 1, 2, 3, 4, 5
     #     ^^^^^^^
-    # --
+    #
     # : () -> Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode]
     def lefts: () -> Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode]
 
@@ -14950,7 +14950,7 @@ module Prism
     #
     #     a, b, = 1, 2, 3, 4
     #         ^
-    # --
+    #
     # : () -> (ImplicitRestNode | SplatNode)?
     def rest: () -> (ImplicitRestNode | SplatNode)?
 
@@ -14961,7 +14961,7 @@ module Prism
     #
     #     a, *, b, c = 1, 2, 3, 4, 5
     #           ^^^^
-    # --
+    #
     # : () -> Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode]
     def rights: () -> Array[LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | MultiTargetNode]
 
@@ -14973,14 +14973,14 @@ module Prism
     #
     #     (a, b, c) = 1, 2, 3
     #     ^
-    # --
+    #
     # : () -> Location?
     def lparen_loc: () -> Location?
 
     # :category: Repository
     # Save the lparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_lparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -14992,14 +14992,14 @@ module Prism
     #
     #     (a, b, c) = 1, 2, 3
     #             ^
-    # --
+    #
     # : () -> Location?
     def rparen_loc: () -> Location?
 
     # :category: Repository
     # Save the rparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_rparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -15011,14 +15011,14 @@ module Prism
     #
     #     a, b, c = 1, 2, 3
     #             ^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -15029,7 +15029,7 @@ module Prism
     #
     #     a, b, c = 1, 2, 3
     #               ^^^^^^^
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -15037,7 +15037,7 @@ module Prism
     #   lparen -> String | nil
     #
     # Slice the location of lparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def lparen: () -> String?
 
@@ -15045,7 +15045,7 @@ module Prism
     #   rparen -> String | nil
     #
     # Slice the location of rparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def rparen: () -> String?
 
@@ -15053,7 +15053,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -15071,34 +15071,34 @@ module Prism
     @arguments: ArgumentsNode?
 
     # Initialize a new NextNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ArgumentsNode? arguments, Location keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, ArgumentsNode? arguments, Location keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -15106,7 +15106,7 @@ module Prism
     #   copy(**fields) -> NextNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: ArgumentsNode?, ?keyword_loc: Location) -> NextNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?arguments: ArgumentsNode?, ?keyword_loc: Location) -> NextNode
 
@@ -15116,12 +15116,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :next_node
     def type: () -> :next_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :next_node
     def self.type: () -> :next_node
 
@@ -15132,7 +15132,7 @@ module Prism
     #   arguments -> ArgumentsNode | nil
     #
     # Returns the `arguments` attribute.
-    # --
+    #
     # : () -> ArgumentsNode?
     def arguments: () -> ArgumentsNode?
 
@@ -15141,14 +15141,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -15156,7 +15156,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -15170,34 +15170,34 @@ module Prism
   #     ^^^
   class NilNode < Node
     # Initialize a new NilNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -15205,7 +15205,7 @@ module Prism
     #   copy(**fields) -> NilNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> NilNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> NilNode
 
@@ -15215,12 +15215,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :nil_node
     def type: () -> :nil_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :nil_node
     def self.type: () -> :nil_node
 
@@ -15242,34 +15242,34 @@ module Prism
     @operator_loc: Location
 
     # Initialize a new NoBlockParameterNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location operator_loc, Location keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location operator_loc, Location keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -15277,7 +15277,7 @@ module Prism
     #   copy(**fields) -> NoBlockParameterNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?keyword_loc: Location) -> NoBlockParameterNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?keyword_loc: Location) -> NoBlockParameterNode
 
@@ -15287,12 +15287,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :no_block_parameter_node
     def type: () -> :no_block_parameter_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :no_block_parameter_node
     def self.type: () -> :no_block_parameter_node
 
@@ -15304,14 +15304,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -15320,14 +15320,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -15335,7 +15335,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -15343,7 +15343,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -15362,34 +15362,34 @@ module Prism
     @operator_loc: Location
 
     # Initialize a new NoKeywordsParameterNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location operator_loc, Location keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location operator_loc, Location keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -15397,7 +15397,7 @@ module Prism
     #   copy(**fields) -> NoKeywordsParameterNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?keyword_loc: Location) -> NoKeywordsParameterNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?keyword_loc: Location) -> NoKeywordsParameterNode
 
@@ -15407,12 +15407,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :no_keywords_parameter_node
     def type: () -> :no_keywords_parameter_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :no_keywords_parameter_node
     def self.type: () -> :no_keywords_parameter_node
 
@@ -15424,14 +15424,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -15440,14 +15440,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -15455,7 +15455,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -15463,7 +15463,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -15479,34 +15479,34 @@ module Prism
     @maximum: Integer
 
     # Initialize a new NumberedParametersNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Integer maximum) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Integer maximum) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -15514,7 +15514,7 @@ module Prism
     #   copy(**fields) -> NumberedParametersNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?maximum: Integer) -> NumberedParametersNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?maximum: Integer) -> NumberedParametersNode
 
@@ -15524,12 +15524,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :numbered_parameters_node
     def type: () -> :numbered_parameters_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :numbered_parameters_node
     def self.type: () -> :numbered_parameters_node
 
@@ -15540,7 +15540,7 @@ module Prism
     #   maximum -> Integer
     #
     # Returns the `maximum` attribute.
-    # --
+    #
     # : () -> Integer
     def maximum: () -> Integer
 
@@ -15556,34 +15556,34 @@ module Prism
     @number: Integer
 
     # Initialize a new NumberedReferenceReadNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Integer number) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Integer number) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -15591,7 +15591,7 @@ module Prism
     #   copy(**fields) -> NumberedReferenceReadNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?number: Integer) -> NumberedReferenceReadNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?number: Integer) -> NumberedReferenceReadNode
 
@@ -15601,12 +15601,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :numbered_reference_read_node
     def type: () -> :numbered_reference_read_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :numbered_reference_read_node
     def self.type: () -> :numbered_reference_read_node
 
@@ -15623,7 +15623,7 @@ module Prism
     #     $5432       # number `5432`
     #
     #     $4294967296 # number `0`
-    # --
+    #
     # : () -> Integer
     def number: () -> Integer
 
@@ -15644,34 +15644,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new OptionalKeywordParameterNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -15679,7 +15679,7 @@ module Prism
     #   copy(**fields) -> OptionalKeywordParameterNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node) -> OptionalKeywordParameterNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?value: Prism::node) -> OptionalKeywordParameterNode
 
@@ -15689,12 +15689,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :optional_keyword_parameter_node
     def type: () -> :optional_keyword_parameter_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :optional_keyword_parameter_node
     def self.type: () -> :optional_keyword_parameter_node
 
@@ -15703,7 +15703,7 @@ module Prism
 
     # :category: Flags
     # a parameter name that has been repeated in the method signature
-    # --
+    #
     # : () -> bool
     def repeated_parameter?: () -> bool
 
@@ -15711,7 +15711,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -15720,14 +15720,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -15735,7 +15735,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -15758,34 +15758,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new OptionalParameterNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc, Location operator_loc, Prism::node value) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -15793,7 +15793,7 @@ module Prism
     #   copy(**fields) -> OptionalParameterNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> OptionalParameterNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location, ?operator_loc: Location, ?value: Prism::node) -> OptionalParameterNode
 
@@ -15803,12 +15803,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :optional_parameter_node
     def type: () -> :optional_parameter_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :optional_parameter_node
     def self.type: () -> :optional_parameter_node
 
@@ -15817,7 +15817,7 @@ module Prism
 
     # :category: Flags
     # a parameter name that has been repeated in the method signature
-    # --
+    #
     # : () -> bool
     def repeated_parameter?: () -> bool
 
@@ -15825,7 +15825,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -15834,14 +15834,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -15850,14 +15850,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -15865,7 +15865,7 @@ module Prism
     #   value -> Node
     #
     # Returns the `value` attribute.
-    # --
+    #
     # : () -> Prism::node
     def value: () -> Prism::node
 
@@ -15873,7 +15873,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -15893,34 +15893,34 @@ module Prism
     @left: Prism::node
 
     # Initialize a new OrNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node left, Prism::node right, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node left, Prism::node right, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -15928,7 +15928,7 @@ module Prism
     #   copy(**fields) -> OrNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> OrNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node, ?right: Prism::node, ?operator_loc: Location) -> OrNode
 
@@ -15938,12 +15938,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :or_node
     def type: () -> :or_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :or_node
     def self.type: () -> :or_node
 
@@ -15960,7 +15960,7 @@ module Prism
     #
     #     1 || 2
     #     ^
-    # --
+    #
     # : () -> Prism::node
     def left: () -> Prism::node
 
@@ -15974,7 +15974,7 @@ module Prism
     #
     #     1 or 2
     #          ^
-    # --
+    #
     # : () -> Prism::node
     def right: () -> Prism::node
 
@@ -15986,14 +15986,14 @@ module Prism
     #
     #     left or right
     #          ^^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16001,7 +16001,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -16030,34 +16030,34 @@ module Prism
     @requireds: Array[RequiredParameterNode | MultiTargetNode]
 
     # Initialize a new ParametersNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[RequiredParameterNode | MultiTargetNode] requireds, Array[OptionalParameterNode] optionals, (RestParameterNode | ImplicitRestNode)? rest, Array[RequiredParameterNode | MultiTargetNode] posts, Array[RequiredKeywordParameterNode | OptionalKeywordParameterNode] keywords, (KeywordRestParameterNode | ForwardingParameterNode | NoKeywordsParameterNode)? keyword_rest, (BlockParameterNode | NoBlockParameterNode)? block) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[RequiredParameterNode | MultiTargetNode] requireds, Array[OptionalParameterNode] optionals, (RestParameterNode | ImplicitRestNode)? rest, Array[RequiredParameterNode | MultiTargetNode] posts, Array[RequiredKeywordParameterNode | OptionalKeywordParameterNode] keywords, (KeywordRestParameterNode | ForwardingParameterNode | NoKeywordsParameterNode)? keyword_rest, (BlockParameterNode | NoBlockParameterNode)? block) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -16065,7 +16065,7 @@ module Prism
     #   copy(**fields) -> ParametersNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?requireds: Array[RequiredParameterNode | MultiTargetNode], ?optionals: Array[OptionalParameterNode], ?rest: (RestParameterNode | ImplicitRestNode)?, ?posts: Array[RequiredParameterNode | MultiTargetNode], ?keywords: Array[RequiredKeywordParameterNode | OptionalKeywordParameterNode], ?keyword_rest: (KeywordRestParameterNode | ForwardingParameterNode | NoKeywordsParameterNode)?, ?block: (BlockParameterNode | NoBlockParameterNode)?) -> ParametersNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?requireds: Array[RequiredParameterNode | MultiTargetNode], ?optionals: Array[OptionalParameterNode], ?rest: (RestParameterNode | ImplicitRestNode)?, ?posts: Array[RequiredParameterNode | MultiTargetNode], ?keywords: Array[RequiredKeywordParameterNode | OptionalKeywordParameterNode], ?keyword_rest: (KeywordRestParameterNode | ForwardingParameterNode | NoKeywordsParameterNode)?, ?block: (BlockParameterNode | NoBlockParameterNode)?) -> ParametersNode
 
@@ -16075,12 +16075,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :parameters_node
     def type: () -> :parameters_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :parameters_node
     def self.type: () -> :parameters_node
 
@@ -16091,7 +16091,7 @@ module Prism
     #   requireds -> Array[RequiredParameterNode | MultiTargetNode]
     #
     # Returns the `requireds` attribute.
-    # --
+    #
     # : () -> Array[RequiredParameterNode | MultiTargetNode]
     def requireds: () -> Array[RequiredParameterNode | MultiTargetNode]
 
@@ -16099,7 +16099,7 @@ module Prism
     #   optionals -> Array[OptionalParameterNode]
     #
     # Returns the `optionals` attribute.
-    # --
+    #
     # : () -> Array[OptionalParameterNode]
     def optionals: () -> Array[OptionalParameterNode]
 
@@ -16107,7 +16107,7 @@ module Prism
     #   rest -> RestParameterNode | ImplicitRestNode | nil
     #
     # Returns the `rest` attribute.
-    # --
+    #
     # : () -> (RestParameterNode | ImplicitRestNode)?
     def rest: () -> (RestParameterNode | ImplicitRestNode)?
 
@@ -16115,7 +16115,7 @@ module Prism
     #   posts -> Array[RequiredParameterNode | MultiTargetNode]
     #
     # Returns the `posts` attribute.
-    # --
+    #
     # : () -> Array[RequiredParameterNode | MultiTargetNode]
     def posts: () -> Array[RequiredParameterNode | MultiTargetNode]
 
@@ -16123,7 +16123,7 @@ module Prism
     #   keywords -> Array[RequiredKeywordParameterNode | OptionalKeywordParameterNode]
     #
     # Returns the `keywords` attribute.
-    # --
+    #
     # : () -> Array[RequiredKeywordParameterNode | OptionalKeywordParameterNode]
     def keywords: () -> Array[RequiredKeywordParameterNode | OptionalKeywordParameterNode]
 
@@ -16131,7 +16131,7 @@ module Prism
     #   keyword_rest -> KeywordRestParameterNode | ForwardingParameterNode | NoKeywordsParameterNode | nil
     #
     # Returns the `keyword_rest` attribute.
-    # --
+    #
     # : () -> (KeywordRestParameterNode | ForwardingParameterNode | NoKeywordsParameterNode)?
     def keyword_rest: () -> (KeywordRestParameterNode | ForwardingParameterNode | NoKeywordsParameterNode)?
 
@@ -16139,7 +16139,7 @@ module Prism
     #   block -> BlockParameterNode | NoBlockParameterNode | nil
     #
     # Returns the `block` attribute.
-    # --
+    #
     # : () -> (BlockParameterNode | NoBlockParameterNode)?
     def block: () -> (BlockParameterNode | NoBlockParameterNode)?
 
@@ -16159,34 +16159,34 @@ module Prism
     @body: Prism::node?
 
     # Initialize a new ParenthesesNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? body, Location opening_loc, Location closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? body, Location opening_loc, Location closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -16194,7 +16194,7 @@ module Prism
     #   copy(**fields) -> ParenthesesNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?body: Prism::node?, ?opening_loc: Location, ?closing_loc: Location) -> ParenthesesNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?body: Prism::node?, ?opening_loc: Location, ?closing_loc: Location) -> ParenthesesNode
 
@@ -16204,12 +16204,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :parentheses_node
     def type: () -> :parentheses_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :parentheses_node
     def self.type: () -> :parentheses_node
 
@@ -16218,7 +16218,7 @@ module Prism
 
     # :category: Flags
     # parentheses that contain multiple potentially void statements
-    # --
+    #
     # : () -> bool
     def multiple_statements?: () -> bool
 
@@ -16226,7 +16226,7 @@ module Prism
     #   body -> Node | nil
     #
     # Returns the `body` attribute.
-    # --
+    #
     # : () -> Prism::node?
     def body: () -> Prism::node?
 
@@ -16235,14 +16235,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16251,14 +16251,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16266,7 +16266,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -16274,7 +16274,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -16296,34 +16296,34 @@ module Prism
     @expression: Prism::node
 
     # Initialize a new PinnedExpressionNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node expression, Location operator_loc, Location lparen_loc, Location rparen_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node expression, Location operator_loc, Location lparen_loc, Location rparen_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -16331,7 +16331,7 @@ module Prism
     #   copy(**fields) -> PinnedExpressionNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node, ?operator_loc: Location, ?lparen_loc: Location, ?rparen_loc: Location) -> PinnedExpressionNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node, ?operator_loc: Location, ?lparen_loc: Location, ?rparen_loc: Location) -> PinnedExpressionNode
 
@@ -16341,12 +16341,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :pinned_expression_node
     def type: () -> :pinned_expression_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :pinned_expression_node
     def self.type: () -> :pinned_expression_node
 
@@ -16360,7 +16360,7 @@ module Prism
     #
     #     foo in ^(bar)
     #              ^^^
-    # --
+    #
     # : () -> Prism::node
     def expression: () -> Prism::node
 
@@ -16372,14 +16372,14 @@ module Prism
     #
     #     foo in ^(bar)
     #            ^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16391,14 +16391,14 @@ module Prism
     #
     #     foo in ^(bar)
     #             ^
-    # --
+    #
     # : () -> Location
     def lparen_loc: () -> Location
 
     # :category: Repository
     # Save the lparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_lparen_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16410,14 +16410,14 @@ module Prism
     #
     #     foo in ^(bar)
     #                 ^
-    # --
+    #
     # : () -> Location
     def rparen_loc: () -> Location
 
     # :category: Repository
     # Save the rparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_rparen_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16425,7 +16425,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -16433,7 +16433,7 @@ module Prism
     #   lparen -> String
     #
     # Slice the location of lparen_loc from the source.
-    # --
+    #
     # : () -> String
     def lparen: () -> String
 
@@ -16441,7 +16441,7 @@ module Prism
     #   rparen -> String
     #
     # Slice the location of rparen_loc from the source.
-    # --
+    #
     # : () -> String
     def rparen: () -> String
 
@@ -16459,34 +16459,34 @@ module Prism
     @variable: LocalVariableReadNode | InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode | ItLocalVariableReadNode
 
     # Initialize a new PinnedVariableNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, (LocalVariableReadNode | InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode | ItLocalVariableReadNode) variable, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, LocalVariableReadNode | InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode | ItLocalVariableReadNode variable, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -16494,7 +16494,7 @@ module Prism
     #   copy(**fields) -> PinnedVariableNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?variable: (LocalVariableReadNode | InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode | ItLocalVariableReadNode), ?operator_loc: Location) -> PinnedVariableNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?variable: LocalVariableReadNode | InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode | ItLocalVariableReadNode, ?operator_loc: Location) -> PinnedVariableNode
 
@@ -16504,12 +16504,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :pinned_variable_node
     def type: () -> :pinned_variable_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :pinned_variable_node
     def self.type: () -> :pinned_variable_node
 
@@ -16523,7 +16523,7 @@ module Prism
     #
     #     foo in ^bar
     #             ^^^
-    # --
+    #
     # : () -> (LocalVariableReadNode | InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode | ItLocalVariableReadNode)
     def variable: () -> (LocalVariableReadNode | InstanceVariableReadNode | ClassVariableReadNode | GlobalVariableReadNode | BackReferenceReadNode | NumberedReferenceReadNode | ItLocalVariableReadNode)
 
@@ -16535,14 +16535,14 @@ module Prism
     #
     #     foo in ^bar
     #            ^
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16550,7 +16550,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -16572,34 +16572,34 @@ module Prism
     @statements: StatementsNode?
 
     # Initialize a new PostExecutionNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, StatementsNode? statements, Location keyword_loc, Location opening_loc, Location closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, StatementsNode? statements, Location keyword_loc, Location opening_loc, Location closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -16607,7 +16607,7 @@ module Prism
     #   copy(**fields) -> PostExecutionNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?statements: StatementsNode?, ?keyword_loc: Location, ?opening_loc: Location, ?closing_loc: Location) -> PostExecutionNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?statements: StatementsNode?, ?keyword_loc: Location, ?opening_loc: Location, ?closing_loc: Location) -> PostExecutionNode
 
@@ -16617,12 +16617,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :post_execution_node
     def type: () -> :post_execution_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :post_execution_node
     def self.type: () -> :post_execution_node
 
@@ -16633,7 +16633,7 @@ module Prism
     #   statements -> StatementsNode | nil
     #
     # Returns the `statements` attribute.
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -16642,14 +16642,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16658,14 +16658,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16674,14 +16674,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16689,7 +16689,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -16697,7 +16697,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -16705,7 +16705,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -16727,34 +16727,34 @@ module Prism
     @statements: StatementsNode?
 
     # Initialize a new PreExecutionNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, StatementsNode? statements, Location keyword_loc, Location opening_loc, Location closing_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, StatementsNode? statements, Location keyword_loc, Location opening_loc, Location closing_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -16762,7 +16762,7 @@ module Prism
     #   copy(**fields) -> PreExecutionNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?statements: StatementsNode?, ?keyword_loc: Location, ?opening_loc: Location, ?closing_loc: Location) -> PreExecutionNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?statements: StatementsNode?, ?keyword_loc: Location, ?opening_loc: Location, ?closing_loc: Location) -> PreExecutionNode
 
@@ -16772,12 +16772,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :pre_execution_node
     def type: () -> :pre_execution_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :pre_execution_node
     def self.type: () -> :pre_execution_node
 
@@ -16788,7 +16788,7 @@ module Prism
     #   statements -> StatementsNode | nil
     #
     # Returns the `statements` attribute.
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -16797,14 +16797,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16813,14 +16813,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16829,14 +16829,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -16844,7 +16844,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -16852,7 +16852,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -16860,7 +16860,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -16875,34 +16875,34 @@ module Prism
     @locals: Array[Symbol]
 
     # Initialize a new ProgramNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, StatementsNode statements) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, StatementsNode statements) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -16910,7 +16910,7 @@ module Prism
     #   copy(**fields) -> ProgramNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?statements: StatementsNode) -> ProgramNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?statements: StatementsNode) -> ProgramNode
 
@@ -16920,12 +16920,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :program_node
     def type: () -> :program_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :program_node
     def self.type: () -> :program_node
 
@@ -16936,7 +16936,7 @@ module Prism
     #   locals -> Array[Symbol]
     #
     # Returns the `locals` attribute.
-    # --
+    #
     # : () -> Array[Symbol]
     def locals: () -> Array[Symbol]
 
@@ -16944,7 +16944,7 @@ module Prism
     #   statements -> StatementsNode
     #
     # Returns the `statements` attribute.
-    # --
+    #
     # : () -> StatementsNode
     def statements: () -> StatementsNode
 
@@ -16967,34 +16967,34 @@ module Prism
     @left: Prism::node?
 
     # Initialize a new RangeNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node? left, Prism::node? right, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node? left, Prism::node? right, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -17002,7 +17002,7 @@ module Prism
     #   copy(**fields) -> RangeNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node?, ?right: Prism::node?, ?operator_loc: Location) -> RangeNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?left: Prism::node?, ?right: Prism::node?, ?operator_loc: Location) -> RangeNode
 
@@ -17012,12 +17012,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :range_node
     def type: () -> :range_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :range_node
     def self.type: () -> :range_node
 
@@ -17026,7 +17026,7 @@ module Prism
 
     # :category: Flags
     # ... operator
-    # --
+    #
     # : () -> bool
     def exclude_end?: () -> bool
 
@@ -17040,7 +17040,7 @@ module Prism
     #
     #     hello...goodbye
     #     ^^^^^
-    # --
+    #
     # : () -> Prism::node?
     def left: () -> Prism::node?
 
@@ -17055,7 +17055,7 @@ module Prism
     #     1...foo
     #         ^^^
     # If neither right-hand or left-hand side was included, this will be an ErrorRecoveryNode.
-    # --
+    #
     # : () -> Prism::node?
     def right: () -> Prism::node?
 
@@ -17064,14 +17064,14 @@ module Prism
     #   operator_loc -> Location
     #
     # The Location of the `..` or `...` operator.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -17079,7 +17079,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -17097,34 +17097,34 @@ module Prism
     @numerator: Integer
 
     # Initialize a new RationalNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Integer numerator, Integer denominator) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Integer numerator, Integer denominator) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -17132,7 +17132,7 @@ module Prism
     #   copy(**fields) -> RationalNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?numerator: Integer, ?denominator: Integer) -> RationalNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?numerator: Integer, ?denominator: Integer) -> RationalNode
 
@@ -17142,12 +17142,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :rational_node
     def type: () -> :rational_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :rational_node
     def self.type: () -> :rational_node
 
@@ -17156,25 +17156,25 @@ module Prism
 
     # :category: Flags
     # 0b prefix
-    # --
+    #
     # : () -> bool
     def binary?: () -> bool
 
     # :category: Flags
     # 0d or no prefix
-    # --
+    #
     # : () -> bool
     def decimal?: () -> bool
 
     # :category: Flags
     # 0o or 0 prefix
-    # --
+    #
     # : () -> bool
     def octal?: () -> bool
 
     # :category: Flags
     # 0x prefix
-    # --
+    #
     # : () -> bool
     def hexadecimal?: () -> bool
 
@@ -17184,7 +17184,7 @@ module Prism
     # The numerator of the rational number.
     #
     #     1.5r # numerator 3
-    # --
+    #
     # : () -> Integer
     def numerator: () -> Integer
 
@@ -17194,7 +17194,7 @@ module Prism
     # The denominator of the rational number.
     #
     #     1.5r # denominator 2
-    # --
+    #
     # : () -> Integer
     def denominator: () -> Integer
 
@@ -17208,34 +17208,34 @@ module Prism
   #     ^^^^
   class RedoNode < Node
     # Initialize a new RedoNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -17243,7 +17243,7 @@ module Prism
     #   copy(**fields) -> RedoNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> RedoNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> RedoNode
 
@@ -17253,12 +17253,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :redo_node
     def type: () -> :redo_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :redo_node
     def self.type: () -> :redo_node
 
@@ -17283,34 +17283,34 @@ module Prism
     @opening_loc: Location
 
     # Initialize a new RegularExpressionNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Location content_loc, Location closing_loc, String unescaped) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Location content_loc, Location closing_loc, String unescaped) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -17318,7 +17318,7 @@ module Prism
     #   copy(**fields) -> RegularExpressionNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> RegularExpressionNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> RegularExpressionNode
 
@@ -17328,12 +17328,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :regular_expression_node
     def type: () -> :regular_expression_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :regular_expression_node
     def self.type: () -> :regular_expression_node
 
@@ -17342,67 +17342,67 @@ module Prism
 
     # :category: Flags
     # i - ignores the case of characters when matching
-    # --
+    #
     # : () -> bool
     def ignore_case?: () -> bool
 
     # :category: Flags
     # x - ignores whitespace and allows comments in regular expressions
-    # --
+    #
     # : () -> bool
     def extended?: () -> bool
 
     # :category: Flags
     # m - allows $ to match the end of lines within strings
-    # --
+    #
     # : () -> bool
     def multi_line?: () -> bool
 
     # :category: Flags
     # o - only interpolates values into the regular expression once
-    # --
+    #
     # : () -> bool
     def once?: () -> bool
 
     # :category: Flags
     # e - forces the EUC-JP encoding
-    # --
+    #
     # : () -> bool
     def euc_jp?: () -> bool
 
     # :category: Flags
     # n - forces the ASCII-8BIT encoding
-    # --
+    #
     # : () -> bool
     def ascii_8bit?: () -> bool
 
     # :category: Flags
     # s - forces the Windows-31J encoding
-    # --
+    #
     # : () -> bool
     def windows_31j?: () -> bool
 
     # :category: Flags
     # u - forces the UTF-8 encoding
-    # --
+    #
     # : () -> bool
     def utf_8?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to UTF-8
-    # --
+    #
     # : () -> bool
     def forced_utf8_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to binary
-    # --
+    #
     # : () -> bool
     def forced_binary_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to US-ASCII
-    # --
+    #
     # : () -> bool
     def forced_us_ascii_encoding?: () -> bool
 
@@ -17411,14 +17411,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -17427,14 +17427,14 @@ module Prism
     #   content_loc -> Location
     #
     # Returns the Location represented by `content_loc`.
-    # --
+    #
     # : () -> Location
     def content_loc: () -> Location
 
     # :category: Repository
     # Save the content_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_content_loc: (_Repository repository) -> Relocation::Entry
 
@@ -17443,14 +17443,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -17458,7 +17458,7 @@ module Prism
     #   unescaped -> String
     #
     # Returns the `unescaped` attribute.
-    # --
+    #
     # : () -> String
     def unescaped: () -> String
 
@@ -17466,7 +17466,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -17474,7 +17474,7 @@ module Prism
     #   content -> String
     #
     # Slice the location of content_loc from the source.
-    # --
+    #
     # : () -> String
     def content: () -> String
 
@@ -17482,7 +17482,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -17501,34 +17501,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new RequiredKeywordParameterNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name, Location name_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -17536,7 +17536,7 @@ module Prism
     #   copy(**fields) -> RequiredKeywordParameterNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location) -> RequiredKeywordParameterNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol, ?name_loc: Location) -> RequiredKeywordParameterNode
 
@@ -17546,12 +17546,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :required_keyword_parameter_node
     def type: () -> :required_keyword_parameter_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :required_keyword_parameter_node
     def self.type: () -> :required_keyword_parameter_node
 
@@ -17560,7 +17560,7 @@ module Prism
 
     # :category: Flags
     # a parameter name that has been repeated in the method signature
-    # --
+    #
     # : () -> bool
     def repeated_parameter?: () -> bool
 
@@ -17568,7 +17568,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -17577,14 +17577,14 @@ module Prism
     #   name_loc -> Location
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location
     def name_loc: () -> Location
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_name_loc: (_Repository repository) -> Relocation::Entry
 
@@ -17601,34 +17601,34 @@ module Prism
     @name: Symbol
 
     # Initialize a new RequiredParameterNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol name) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -17636,7 +17636,7 @@ module Prism
     #   copy(**fields) -> RequiredParameterNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> RequiredParameterNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol) -> RequiredParameterNode
 
@@ -17646,12 +17646,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :required_parameter_node
     def type: () -> :required_parameter_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :required_parameter_node
     def self.type: () -> :required_parameter_node
 
@@ -17660,7 +17660,7 @@ module Prism
 
     # :category: Flags
     # a parameter name that has been repeated in the method signature
-    # --
+    #
     # : () -> bool
     def repeated_parameter?: () -> bool
 
@@ -17668,7 +17668,7 @@ module Prism
     #   name -> Symbol
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol
     def name: () -> Symbol
 
@@ -17688,34 +17688,34 @@ module Prism
     @expression: Prism::node
 
     # Initialize a new RescueModifierNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Prism::node expression, Location keyword_loc, Prism::node rescue_expression) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Prism::node expression, Location keyword_loc, Prism::node rescue_expression) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -17723,7 +17723,7 @@ module Prism
     #   copy(**fields) -> RescueModifierNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node, ?keyword_loc: Location, ?rescue_expression: Prism::node) -> RescueModifierNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?expression: Prism::node, ?keyword_loc: Location, ?rescue_expression: Prism::node) -> RescueModifierNode
 
@@ -17733,12 +17733,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :rescue_modifier_node
     def type: () -> :rescue_modifier_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :rescue_modifier_node
     def self.type: () -> :rescue_modifier_node
 
@@ -17749,7 +17749,7 @@ module Prism
     #   expression -> Node
     #
     # Returns the `expression` attribute.
-    # --
+    #
     # : () -> Prism::node
     def expression: () -> Prism::node
 
@@ -17758,14 +17758,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -17773,7 +17773,7 @@ module Prism
     #   rescue_expression -> Node
     #
     # Returns the `rescue_expression` attribute.
-    # --
+    #
     # : () -> Prism::node
     def rescue_expression: () -> Prism::node
 
@@ -17781,7 +17781,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -17814,34 +17814,34 @@ module Prism
     @keyword_loc: Location
 
     # Initialize a new RescueNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, Array[Prism::node] exceptions, Location? operator_loc, (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode)? reference, Location? then_keyword_loc, StatementsNode? statements, RescueNode? subsequent) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, Array[Prism::node] exceptions, Location? operator_loc, (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode)? reference, Location? then_keyword_loc, StatementsNode? statements, RescueNode? subsequent) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -17849,7 +17849,7 @@ module Prism
     #   copy(**fields) -> RescueNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?exceptions: Array[Prism::node], ?operator_loc: Location?, ?reference: (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode)?, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?subsequent: RescueNode?) -> RescueNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?exceptions: Array[Prism::node], ?operator_loc: Location?, ?reference: (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode)?, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?subsequent: RescueNode?) -> RescueNode
 
@@ -17859,12 +17859,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :rescue_node
     def type: () -> :rescue_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :rescue_node
     def self.type: () -> :rescue_node
 
@@ -17876,14 +17876,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -17891,7 +17891,7 @@ module Prism
     #   exceptions -> Array[Node]
     #
     # Returns the `exceptions` attribute.
-    # --
+    #
     # : () -> Array[Prism::node]
     def exceptions: () -> Array[Prism::node]
 
@@ -17900,14 +17900,14 @@ module Prism
     #   operator_loc -> Location | nil
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location?
     def operator_loc: () -> Location?
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_operator_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -17915,7 +17915,7 @@ module Prism
     #   reference -> LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode | nil
     #
     # Returns the `reference` attribute.
-    # --
+    #
     # : () -> (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode)?
     def reference: () -> (LocalVariableTargetNode | InstanceVariableTargetNode | ClassVariableTargetNode | GlobalVariableTargetNode | ConstantTargetNode | ConstantPathTargetNode | CallTargetNode | IndexTargetNode)?
 
@@ -17924,14 +17924,14 @@ module Prism
     #   then_keyword_loc -> Location | nil
     #
     # Returns the Location represented by `then_keyword_loc`.
-    # --
+    #
     # : () -> Location?
     def then_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the then_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_then_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -17939,7 +17939,7 @@ module Prism
     #   statements -> StatementsNode | nil
     #
     # Returns the `statements` attribute.
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -17947,7 +17947,7 @@ module Prism
     #   subsequent -> RescueNode | nil
     #
     # Returns the `subsequent` attribute.
-    # --
+    #
     # : () -> RescueNode?
     def subsequent: () -> RescueNode?
 
@@ -17955,7 +17955,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -17963,7 +17963,7 @@ module Prism
     #   operator -> String | nil
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String?
     def operator: () -> String?
 
@@ -17971,7 +17971,7 @@ module Prism
     #   then_keyword -> String | nil
     #
     # Slice the location of then_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def then_keyword: () -> String?
 
@@ -17992,34 +17992,34 @@ module Prism
     @name: Symbol?
 
     # Initialize a new RestParameterNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Symbol? name, Location? name_loc, Location operator_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Symbol? name, Location? name_loc, Location operator_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -18027,7 +18027,7 @@ module Prism
     #   copy(**fields) -> RestParameterNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> RestParameterNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?name: Symbol?, ?name_loc: Location?, ?operator_loc: Location) -> RestParameterNode
 
@@ -18037,12 +18037,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :rest_parameter_node
     def type: () -> :rest_parameter_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :rest_parameter_node
     def self.type: () -> :rest_parameter_node
 
@@ -18051,7 +18051,7 @@ module Prism
 
     # :category: Flags
     # a parameter name that has been repeated in the method signature
-    # --
+    #
     # : () -> bool
     def repeated_parameter?: () -> bool
 
@@ -18059,7 +18059,7 @@ module Prism
     #   name -> Symbol | nil
     #
     # Returns the `name` attribute.
-    # --
+    #
     # : () -> Symbol?
     def name: () -> Symbol?
 
@@ -18068,14 +18068,14 @@ module Prism
     #   name_loc -> Location | nil
     #
     # Returns the Location represented by `name_loc`.
-    # --
+    #
     # : () -> Location?
     def name_loc: () -> Location?
 
     # :category: Repository
     # Save the name_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_name_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -18084,14 +18084,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -18099,7 +18099,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -18113,34 +18113,34 @@ module Prism
   #     ^^^^^
   class RetryNode < Node
     # Initialize a new RetryNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -18148,7 +18148,7 @@ module Prism
     #   copy(**fields) -> RetryNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> RetryNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> RetryNode
 
@@ -18158,12 +18158,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :retry_node
     def type: () -> :retry_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :retry_node
     def self.type: () -> :retry_node
 
@@ -18184,34 +18184,34 @@ module Prism
     @keyword_loc: Location
 
     # Initialize a new ReturnNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, ArgumentsNode? arguments) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, ArgumentsNode? arguments) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -18219,7 +18219,7 @@ module Prism
     #   copy(**fields) -> ReturnNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?arguments: ArgumentsNode?) -> ReturnNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?arguments: ArgumentsNode?) -> ReturnNode
 
@@ -18229,12 +18229,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :return_node
     def type: () -> :return_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :return_node
     def self.type: () -> :return_node
 
@@ -18246,14 +18246,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -18261,7 +18261,7 @@ module Prism
     #   arguments -> ArgumentsNode | nil
     #
     # Returns the `arguments` attribute.
-    # --
+    #
     # : () -> ArgumentsNode?
     def arguments: () -> ArgumentsNode?
 
@@ -18269,7 +18269,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -18283,34 +18283,34 @@ module Prism
   #     ^^^^
   class SelfNode < Node
     # Initialize a new SelfNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -18318,7 +18318,7 @@ module Prism
     #   copy(**fields) -> SelfNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> SelfNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> SelfNode
 
@@ -18328,12 +18328,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :self_node
     def type: () -> :self_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :self_node
     def self.type: () -> :self_node
 
@@ -18353,34 +18353,34 @@ module Prism
     @write: ConstantWriteNode | ConstantAndWriteNode | ConstantOrWriteNode | ConstantOperatorWriteNode | ConstantPathWriteNode | ConstantPathAndWriteNode | ConstantPathOrWriteNode | ConstantPathOperatorWriteNode
 
     # Initialize a new ShareableConstantNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, (ConstantWriteNode | ConstantAndWriteNode | ConstantOrWriteNode | ConstantOperatorWriteNode | ConstantPathWriteNode | ConstantPathAndWriteNode | ConstantPathOrWriteNode | ConstantPathOperatorWriteNode) write) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, ConstantWriteNode | ConstantAndWriteNode | ConstantOrWriteNode | ConstantOperatorWriteNode | ConstantPathWriteNode | ConstantPathAndWriteNode | ConstantPathOrWriteNode | ConstantPathOperatorWriteNode write) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -18388,7 +18388,7 @@ module Prism
     #   copy(**fields) -> ShareableConstantNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?write: (ConstantWriteNode | ConstantAndWriteNode | ConstantOrWriteNode | ConstantOperatorWriteNode | ConstantPathWriteNode | ConstantPathAndWriteNode | ConstantPathOrWriteNode | ConstantPathOperatorWriteNode)) -> ShareableConstantNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?write: ConstantWriteNode | ConstantAndWriteNode | ConstantOrWriteNode | ConstantOperatorWriteNode | ConstantPathWriteNode | ConstantPathAndWriteNode | ConstantPathOrWriteNode | ConstantPathOperatorWriteNode) -> ShareableConstantNode
 
@@ -18398,12 +18398,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :shareable_constant_node
     def type: () -> :shareable_constant_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :shareable_constant_node
     def self.type: () -> :shareable_constant_node
 
@@ -18412,19 +18412,19 @@ module Prism
 
     # :category: Flags
     # constant writes that should be modified with shareable constant value literal
-    # --
+    #
     # : () -> bool
     def literal?: () -> bool
 
     # :category: Flags
     # constant writes that should be modified with shareable constant value experimental everything
-    # --
+    #
     # : () -> bool
     def experimental_everything?: () -> bool
 
     # :category: Flags
     # constant writes that should be modified with shareable constant value experimental copy
-    # --
+    #
     # : () -> bool
     def experimental_copy?: () -> bool
 
@@ -18432,7 +18432,7 @@ module Prism
     #   write -> ConstantWriteNode | ConstantAndWriteNode | ConstantOrWriteNode | ConstantOperatorWriteNode | ConstantPathWriteNode | ConstantPathAndWriteNode | ConstantPathOrWriteNode | ConstantPathOperatorWriteNode
     #
     # The constant write that should be modified with the shareability state.
-    # --
+    #
     # : () -> (ConstantWriteNode | ConstantAndWriteNode | ConstantOrWriteNode | ConstantOperatorWriteNode | ConstantPathWriteNode | ConstantPathAndWriteNode | ConstantPathOrWriteNode | ConstantPathOperatorWriteNode)
     def write: () -> (ConstantWriteNode | ConstantAndWriteNode | ConstantOrWriteNode | ConstantOperatorWriteNode | ConstantPathWriteNode | ConstantPathAndWriteNode | ConstantPathOrWriteNode | ConstantPathOperatorWriteNode)
 
@@ -18458,34 +18458,34 @@ module Prism
     @locals: Array[Symbol]
 
     # Initialize a new SingletonClassNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, Location class_keyword_loc, Location operator_loc, Prism::node expression, (StatementsNode | BeginNode)? body, Location end_keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[Symbol] locals, Location class_keyword_loc, Location operator_loc, Prism::node expression, (StatementsNode | BeginNode)? body, Location end_keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -18493,7 +18493,7 @@ module Prism
     #   copy(**fields) -> SingletonClassNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?class_keyword_loc: Location, ?operator_loc: Location, ?expression: Prism::node, ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location) -> SingletonClassNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?locals: Array[Symbol], ?class_keyword_loc: Location, ?operator_loc: Location, ?expression: Prism::node, ?body: (StatementsNode | BeginNode)?, ?end_keyword_loc: Location) -> SingletonClassNode
 
@@ -18503,12 +18503,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :singleton_class_node
     def type: () -> :singleton_class_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :singleton_class_node
     def self.type: () -> :singleton_class_node
 
@@ -18519,7 +18519,7 @@ module Prism
     #   locals -> Array[Symbol]
     #
     # Returns the `locals` attribute.
-    # --
+    #
     # : () -> Array[Symbol]
     def locals: () -> Array[Symbol]
 
@@ -18528,14 +18528,14 @@ module Prism
     #   class_keyword_loc -> Location
     #
     # Returns the Location represented by `class_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def class_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the class_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_class_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -18544,14 +18544,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -18559,7 +18559,7 @@ module Prism
     #   expression -> Node
     #
     # Returns the `expression` attribute.
-    # --
+    #
     # : () -> Prism::node
     def expression: () -> Prism::node
 
@@ -18567,7 +18567,7 @@ module Prism
     #   body -> StatementsNode | BeginNode | nil
     #
     # Returns the `body` attribute.
-    # --
+    #
     # : () -> (StatementsNode | BeginNode)?
     def body: () -> (StatementsNode | BeginNode)?
 
@@ -18576,14 +18576,14 @@ module Prism
     #   end_keyword_loc -> Location
     #
     # Returns the Location represented by `end_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def end_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -18591,7 +18591,7 @@ module Prism
     #   class_keyword -> String
     #
     # Slice the location of class_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def class_keyword: () -> String
 
@@ -18599,7 +18599,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -18607,7 +18607,7 @@ module Prism
     #   end_keyword -> String
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def end_keyword: () -> String
 
@@ -18621,34 +18621,34 @@ module Prism
   #     ^^^^^^^^^^^^
   class SourceEncodingNode < Node
     # Initialize a new SourceEncodingNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -18656,7 +18656,7 @@ module Prism
     #   copy(**fields) -> SourceEncodingNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> SourceEncodingNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> SourceEncodingNode
 
@@ -18666,12 +18666,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :source_encoding_node
     def type: () -> :source_encoding_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :source_encoding_node
     def self.type: () -> :source_encoding_node
 
@@ -18690,34 +18690,34 @@ module Prism
     @filepath: String
 
     # Initialize a new SourceFileNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, String filepath) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, String filepath) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -18725,7 +18725,7 @@ module Prism
     #   copy(**fields) -> SourceFileNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?filepath: String) -> SourceFileNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?filepath: String) -> SourceFileNode
 
@@ -18735,12 +18735,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :source_file_node
     def type: () -> :source_file_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :source_file_node
     def self.type: () -> :source_file_node
 
@@ -18749,25 +18749,25 @@ module Prism
 
     # :category: Flags
     # internal bytes forced the encoding to UTF-8
-    # --
+    #
     # : () -> bool
     def forced_utf8_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to binary
-    # --
+    #
     # : () -> bool
     def forced_binary_encoding?: () -> bool
 
     # :category: Flags
     # frozen by virtue of a `frozen_string_literal: true` comment or `--enable-frozen-string-literal`
-    # --
+    #
     # : () -> bool
     def frozen?: () -> bool
 
     # :category: Flags
     # mutable by virtue of a `frozen_string_literal: false` comment or `--disable-frozen-string-literal`
-    # --
+    #
     # : () -> bool
     def mutable?: () -> bool
 
@@ -18775,7 +18775,7 @@ module Prism
     #   filepath -> String
     #
     # Represents the file path being parsed. This corresponds directly to the `filepath` option given to the various `Prism.parse*` APIs.
-    # --
+    #
     # : () -> String
     def filepath: () -> String
 
@@ -18789,34 +18789,34 @@ module Prism
   #     ^^^^^^^^
   class SourceLineNode < Node
     # Initialize a new SourceLineNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -18824,7 +18824,7 @@ module Prism
     #   copy(**fields) -> SourceLineNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> SourceLineNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> SourceLineNode
 
@@ -18834,12 +18834,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :source_line_node
     def type: () -> :source_line_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :source_line_node
     def self.type: () -> :source_line_node
 
@@ -18860,34 +18860,34 @@ module Prism
     @operator_loc: Location
 
     # Initialize a new SplatNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location operator_loc, Prism::node? expression) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location operator_loc, Prism::node? expression) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -18895,7 +18895,7 @@ module Prism
     #   copy(**fields) -> SplatNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?expression: Prism::node?) -> SplatNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?operator_loc: Location, ?expression: Prism::node?) -> SplatNode
 
@@ -18905,12 +18905,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :splat_node
     def type: () -> :splat_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :splat_node
     def self.type: () -> :splat_node
 
@@ -18922,14 +18922,14 @@ module Prism
     #   operator_loc -> Location
     #
     # Returns the Location represented by `operator_loc`.
-    # --
+    #
     # : () -> Location
     def operator_loc: () -> Location
 
     # :category: Repository
     # Save the operator_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_operator_loc: (_Repository repository) -> Relocation::Entry
 
@@ -18937,7 +18937,7 @@ module Prism
     #   expression -> Node | nil
     #
     # Returns the `expression` attribute.
-    # --
+    #
     # : () -> Prism::node?
     def expression: () -> Prism::node?
 
@@ -18945,7 +18945,7 @@ module Prism
     #   operator -> String
     #
     # Slice the location of operator_loc from the source.
-    # --
+    #
     # : () -> String
     def operator: () -> String
 
@@ -18961,34 +18961,34 @@ module Prism
     @body: Array[Prism::node]
 
     # Initialize a new StatementsNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[Prism::node] body) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[Prism::node] body) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -18996,7 +18996,7 @@ module Prism
     #   copy(**fields) -> StatementsNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?body: Array[Prism::node]) -> StatementsNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?body: Array[Prism::node]) -> StatementsNode
 
@@ -19006,12 +19006,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :statements_node
     def type: () -> :statements_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :statements_node
     def self.type: () -> :statements_node
 
@@ -19022,7 +19022,7 @@ module Prism
     #   body -> Array[Node]
     #
     # Returns the `body` attribute.
-    # --
+    #
     # : () -> Array[Prism::node]
     def body: () -> Array[Prism::node]
 
@@ -19050,34 +19050,34 @@ module Prism
     @opening_loc: Location?
 
     # Initialize a new StringNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location? opening_loc, Location content_loc, Location? closing_loc, String unescaped) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location? opening_loc, Location content_loc, Location? closing_loc, String unescaped) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -19085,7 +19085,7 @@ module Prism
     #   copy(**fields) -> StringNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?content_loc: Location, ?closing_loc: Location?, ?unescaped: String) -> StringNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?content_loc: Location, ?closing_loc: Location?, ?unescaped: String) -> StringNode
 
@@ -19095,12 +19095,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :string_node
     def type: () -> :string_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :string_node
     def self.type: () -> :string_node
 
@@ -19109,25 +19109,25 @@ module Prism
 
     # :category: Flags
     # internal bytes forced the encoding to UTF-8
-    # --
+    #
     # : () -> bool
     def forced_utf8_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to binary
-    # --
+    #
     # : () -> bool
     def forced_binary_encoding?: () -> bool
 
     # :category: Flags
     # frozen by virtue of a `frozen_string_literal: true` comment or `--enable-frozen-string-literal`
-    # --
+    #
     # : () -> bool
     def frozen?: () -> bool
 
     # :category: Flags
     # mutable by virtue of a `frozen_string_literal: false` comment or `--disable-frozen-string-literal`
-    # --
+    #
     # : () -> bool
     def mutable?: () -> bool
 
@@ -19136,14 +19136,14 @@ module Prism
     #   opening_loc -> Location | nil
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location?
     def opening_loc: () -> Location?
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_opening_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -19152,14 +19152,14 @@ module Prism
     #   content_loc -> Location
     #
     # Returns the Location represented by `content_loc`.
-    # --
+    #
     # : () -> Location
     def content_loc: () -> Location
 
     # :category: Repository
     # Save the content_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_content_loc: (_Repository repository) -> Relocation::Entry
 
@@ -19168,14 +19168,14 @@ module Prism
     #   closing_loc -> Location | nil
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location?
     def closing_loc: () -> Location?
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_closing_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -19183,7 +19183,7 @@ module Prism
     #   unescaped -> String
     #
     # Returns the `unescaped` attribute.
-    # --
+    #
     # : () -> String
     def unescaped: () -> String
 
@@ -19191,7 +19191,7 @@ module Prism
     #   opening -> String | nil
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String?
     def opening: () -> String?
 
@@ -19199,7 +19199,7 @@ module Prism
     #   content -> String
     #
     # Slice the location of content_loc from the source.
-    # --
+    #
     # : () -> String
     def content: () -> String
 
@@ -19207,7 +19207,7 @@ module Prism
     #   closing -> String | nil
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String?
     def closing: () -> String?
 
@@ -19236,34 +19236,34 @@ module Prism
     @keyword_loc: Location
 
     # Initialize a new SuperNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, Location? lparen_loc, ArgumentsNode? arguments, Location? rparen_loc, (BlockNode | BlockArgumentNode)? block) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, Location? lparen_loc, ArgumentsNode? arguments, Location? rparen_loc, (BlockNode | BlockArgumentNode)? block) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -19271,7 +19271,7 @@ module Prism
     #   copy(**fields) -> SuperNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?lparen_loc: Location?, ?arguments: ArgumentsNode?, ?rparen_loc: Location?, ?block: (BlockNode | BlockArgumentNode)?) -> SuperNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?lparen_loc: Location?, ?arguments: ArgumentsNode?, ?rparen_loc: Location?, ?block: (BlockNode | BlockArgumentNode)?) -> SuperNode
 
@@ -19281,12 +19281,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :super_node
     def type: () -> :super_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :super_node
     def self.type: () -> :super_node
 
@@ -19298,14 +19298,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -19314,14 +19314,14 @@ module Prism
     #   lparen_loc -> Location | nil
     #
     # Returns the Location represented by `lparen_loc`.
-    # --
+    #
     # : () -> Location?
     def lparen_loc: () -> Location?
 
     # :category: Repository
     # Save the lparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_lparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -19329,7 +19329,7 @@ module Prism
     #   arguments -> ArgumentsNode | nil
     #
     # Can be only `nil` when there are empty parentheses, like `super()`.
-    # --
+    #
     # : () -> ArgumentsNode?
     def arguments: () -> ArgumentsNode?
 
@@ -19338,14 +19338,14 @@ module Prism
     #   rparen_loc -> Location | nil
     #
     # Returns the Location represented by `rparen_loc`.
-    # --
+    #
     # : () -> Location?
     def rparen_loc: () -> Location?
 
     # :category: Repository
     # Save the rparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_rparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -19353,7 +19353,7 @@ module Prism
     #   block -> BlockNode | BlockArgumentNode | nil
     #
     # Returns the `block` attribute.
-    # --
+    #
     # : () -> (BlockNode | BlockArgumentNode)?
     def block: () -> (BlockNode | BlockArgumentNode)?
 
@@ -19361,7 +19361,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -19369,7 +19369,7 @@ module Prism
     #   lparen -> String | nil
     #
     # Slice the location of lparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def lparen: () -> String?
 
@@ -19377,7 +19377,7 @@ module Prism
     #   rparen -> String | nil
     #
     # Slice the location of rparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def rparen: () -> String?
 
@@ -19402,34 +19402,34 @@ module Prism
     @opening_loc: Location?
 
     # Initialize a new SymbolNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location? opening_loc, Location? value_loc, Location? closing_loc, String unescaped) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location? opening_loc, Location? value_loc, Location? closing_loc, String unescaped) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -19437,7 +19437,7 @@ module Prism
     #   copy(**fields) -> SymbolNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?value_loc: Location?, ?closing_loc: Location?, ?unescaped: String) -> SymbolNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location?, ?value_loc: Location?, ?closing_loc: Location?, ?unescaped: String) -> SymbolNode
 
@@ -19447,12 +19447,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :symbol_node
     def type: () -> :symbol_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :symbol_node
     def self.type: () -> :symbol_node
 
@@ -19461,19 +19461,19 @@ module Prism
 
     # :category: Flags
     # internal bytes forced the encoding to UTF-8
-    # --
+    #
     # : () -> bool
     def forced_utf8_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to binary
-    # --
+    #
     # : () -> bool
     def forced_binary_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to US-ASCII
-    # --
+    #
     # : () -> bool
     def forced_us_ascii_encoding?: () -> bool
 
@@ -19482,14 +19482,14 @@ module Prism
     #   opening_loc -> Location | nil
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location?
     def opening_loc: () -> Location?
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_opening_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -19498,14 +19498,14 @@ module Prism
     #   value_loc -> Location | nil
     #
     # Returns the Location represented by `value_loc`.
-    # --
+    #
     # : () -> Location?
     def value_loc: () -> Location?
 
     # :category: Repository
     # Save the value_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_value_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -19514,14 +19514,14 @@ module Prism
     #   closing_loc -> Location | nil
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location?
     def closing_loc: () -> Location?
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_closing_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -19529,7 +19529,7 @@ module Prism
     #   unescaped -> String
     #
     # Returns the `unescaped` attribute.
-    # --
+    #
     # : () -> String
     def unescaped: () -> String
 
@@ -19537,7 +19537,7 @@ module Prism
     #   opening -> String | nil
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String?
     def opening: () -> String?
 
@@ -19545,7 +19545,7 @@ module Prism
     #   value -> String | nil
     #
     # Slice the location of value_loc from the source.
-    # --
+    #
     # : () -> String?
     def value: () -> String?
 
@@ -19553,7 +19553,7 @@ module Prism
     #   closing -> String | nil
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String?
     def closing: () -> String?
 
@@ -19567,34 +19567,34 @@ module Prism
   #     ^^^^
   class TrueNode < Node
     # Initialize a new TrueNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, ) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -19602,7 +19602,7 @@ module Prism
     #   copy(**fields) -> TrueNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ) -> TrueNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer) -> TrueNode
 
@@ -19612,12 +19612,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :true_node
     def type: () -> :true_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :true_node
     def self.type: () -> :true_node
 
@@ -19638,34 +19638,34 @@ module Prism
     @names: Array[SymbolNode | InterpolatedSymbolNode]
 
     # Initialize a new UndefNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Array[SymbolNode | InterpolatedSymbolNode] names, Location keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Array[SymbolNode | InterpolatedSymbolNode] names, Location keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -19673,7 +19673,7 @@ module Prism
     #   copy(**fields) -> UndefNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?names: Array[SymbolNode | InterpolatedSymbolNode], ?keyword_loc: Location) -> UndefNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?names: Array[SymbolNode | InterpolatedSymbolNode], ?keyword_loc: Location) -> UndefNode
 
@@ -19683,12 +19683,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :undef_node
     def type: () -> :undef_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :undef_node
     def self.type: () -> :undef_node
 
@@ -19699,7 +19699,7 @@ module Prism
     #   names -> Array[SymbolNode | InterpolatedSymbolNode]
     #
     # Returns the `names` attribute.
-    # --
+    #
     # : () -> Array[SymbolNode | InterpolatedSymbolNode]
     def names: () -> Array[SymbolNode | InterpolatedSymbolNode]
 
@@ -19708,14 +19708,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -19723,7 +19723,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -19752,34 +19752,34 @@ module Prism
     @unless_keyword_loc: Location
 
     # Initialize a new UnlessNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location unless_keyword_loc, Prism::node predicate, Location? then_keyword_loc, StatementsNode? statements, ElseNode? else_clause, Location? end_keyword_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location unless_keyword_loc, Prism::node predicate, Location? then_keyword_loc, StatementsNode? statements, ElseNode? else_clause, Location? end_keyword_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -19787,7 +19787,7 @@ module Prism
     #   copy(**fields) -> UnlessNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?unless_keyword_loc: Location, ?predicate: Prism::node, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?else_clause: ElseNode?, ?end_keyword_loc: Location?) -> UnlessNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?unless_keyword_loc: Location, ?predicate: Prism::node, ?then_keyword_loc: Location?, ?statements: StatementsNode?, ?else_clause: ElseNode?, ?end_keyword_loc: Location?) -> UnlessNode
 
@@ -19797,12 +19797,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :unless_node
     def type: () -> :unless_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :unless_node
     def self.type: () -> :unless_node
 
@@ -19820,14 +19820,14 @@ module Prism
     #
     #     bar unless cond
     #         ^^^^^^
-    # --
+    #
     # : () -> Location
     def unless_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the unless_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_unless_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -19841,7 +19841,7 @@ module Prism
     #
     #     bar unless cond
     #                ^^^^
-    # --
+    #
     # : () -> Prism::node
     def predicate: () -> Prism::node
 
@@ -19853,14 +19853,14 @@ module Prism
     #
     #     unless cond then bar end
     #                 ^^^^
-    # --
+    #
     # : () -> Location?
     def then_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the then_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_then_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -19872,7 +19872,7 @@ module Prism
     #
     #     unless cond then bar end
     #                      ^^^
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -19883,7 +19883,7 @@ module Prism
     #
     #     unless cond then bar else baz end
     #                          ^^^^^^^^^^^^
-    # --
+    #
     # : () -> ElseNode?
     def else_clause: () -> ElseNode?
 
@@ -19895,14 +19895,14 @@ module Prism
     #
     #     unless cond then bar end
     #                          ^^^
-    # --
+    #
     # : () -> Location?
     def end_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -19910,7 +19910,7 @@ module Prism
     #   unless_keyword -> String
     #
     # Slice the location of unless_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def unless_keyword: () -> String
 
@@ -19918,7 +19918,7 @@ module Prism
     #   then_keyword -> String | nil
     #
     # Slice the location of then_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def then_keyword: () -> String?
 
@@ -19926,7 +19926,7 @@ module Prism
     #   end_keyword -> String | nil
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def end_keyword: () -> String?
 
@@ -19953,34 +19953,34 @@ module Prism
     @until_keyword_loc: Location
 
     # Initialize a new UntilNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location until_keyword_loc, Location? do_keyword_loc, Location? end_keyword_loc, Prism::node predicate, StatementsNode? statements) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location until_keyword_loc, Location? do_keyword_loc, Location? end_keyword_loc, Prism::node predicate, StatementsNode? statements) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -19988,7 +19988,7 @@ module Prism
     #   copy(**fields) -> UntilNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?until_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location?, ?predicate: Prism::node, ?statements: StatementsNode?) -> UntilNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?until_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location?, ?predicate: Prism::node, ?statements: StatementsNode?) -> UntilNode
 
@@ -19998,12 +19998,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :until_node
     def type: () -> :until_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :until_node
     def self.type: () -> :until_node
 
@@ -20012,7 +20012,7 @@ module Prism
 
     # :category: Flags
     # a loop after a begin statement, so the body is executed first before the condition
-    # --
+    #
     # : () -> bool
     def begin_modifier?: () -> bool
 
@@ -20021,14 +20021,14 @@ module Prism
     #   until_keyword_loc -> Location
     #
     # Returns the Location represented by `until_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def until_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the until_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_until_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -20037,14 +20037,14 @@ module Prism
     #   do_keyword_loc -> Location | nil
     #
     # Returns the Location represented by `do_keyword_loc`.
-    # --
+    #
     # : () -> Location?
     def do_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the do_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_do_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -20053,14 +20053,14 @@ module Prism
     #   end_keyword_loc -> Location | nil
     #
     # Returns the Location represented by `end_keyword_loc`.
-    # --
+    #
     # : () -> Location?
     def end_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -20068,7 +20068,7 @@ module Prism
     #   predicate -> Node
     #
     # Returns the `predicate` attribute.
-    # --
+    #
     # : () -> Prism::node
     def predicate: () -> Prism::node
 
@@ -20076,7 +20076,7 @@ module Prism
     #   statements -> StatementsNode | nil
     #
     # Returns the `statements` attribute.
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -20084,7 +20084,7 @@ module Prism
     #   until_keyword -> String
     #
     # Slice the location of until_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def until_keyword: () -> String
 
@@ -20092,7 +20092,7 @@ module Prism
     #   do_keyword -> String | nil
     #
     # Slice the location of do_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def do_keyword: () -> String?
 
@@ -20100,7 +20100,7 @@ module Prism
     #   end_keyword -> String | nil
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def end_keyword: () -> String?
 
@@ -20124,34 +20124,34 @@ module Prism
     @when_keyword_loc: Location
 
     # Initialize a new WhenNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location when_keyword_loc, Array[Prism::node] conditions, Location? then_keyword_loc, StatementsNode? statements) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location when_keyword_loc, Array[Prism::node] conditions, Location? then_keyword_loc, StatementsNode? statements) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -20159,7 +20159,7 @@ module Prism
     #   copy(**fields) -> WhenNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?when_keyword_loc: Location, ?conditions: Array[Prism::node], ?then_keyword_loc: Location?, ?statements: StatementsNode?) -> WhenNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?when_keyword_loc: Location, ?conditions: Array[Prism::node], ?then_keyword_loc: Location?, ?statements: StatementsNode?) -> WhenNode
 
@@ -20169,12 +20169,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :when_node
     def type: () -> :when_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :when_node
     def self.type: () -> :when_node
 
@@ -20186,14 +20186,14 @@ module Prism
     #   when_keyword_loc -> Location
     #
     # Returns the Location represented by `when_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def when_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the when_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_when_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -20201,7 +20201,7 @@ module Prism
     #   conditions -> Array[Node]
     #
     # Returns the `conditions` attribute.
-    # --
+    #
     # : () -> Array[Prism::node]
     def conditions: () -> Array[Prism::node]
 
@@ -20210,14 +20210,14 @@ module Prism
     #   then_keyword_loc -> Location | nil
     #
     # Returns the Location represented by `then_keyword_loc`.
-    # --
+    #
     # : () -> Location?
     def then_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the then_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_then_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -20225,7 +20225,7 @@ module Prism
     #   statements -> StatementsNode | nil
     #
     # Returns the `statements` attribute.
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -20233,7 +20233,7 @@ module Prism
     #   when_keyword -> String
     #
     # Slice the location of when_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def when_keyword: () -> String
 
@@ -20241,7 +20241,7 @@ module Prism
     #   then_keyword -> String | nil
     #
     # Slice the location of then_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def then_keyword: () -> String?
 
@@ -20268,34 +20268,34 @@ module Prism
     @while_keyword_loc: Location
 
     # Initialize a new WhileNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location while_keyword_loc, Location? do_keyword_loc, Location? end_keyword_loc, Prism::node predicate, StatementsNode? statements) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location while_keyword_loc, Location? do_keyword_loc, Location? end_keyword_loc, Prism::node predicate, StatementsNode? statements) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -20303,7 +20303,7 @@ module Prism
     #   copy(**fields) -> WhileNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?while_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location?, ?predicate: Prism::node, ?statements: StatementsNode?) -> WhileNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?while_keyword_loc: Location, ?do_keyword_loc: Location?, ?end_keyword_loc: Location?, ?predicate: Prism::node, ?statements: StatementsNode?) -> WhileNode
 
@@ -20313,12 +20313,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :while_node
     def type: () -> :while_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :while_node
     def self.type: () -> :while_node
 
@@ -20327,7 +20327,7 @@ module Prism
 
     # :category: Flags
     # a loop after a begin statement, so the body is executed first before the condition
-    # --
+    #
     # : () -> bool
     def begin_modifier?: () -> bool
 
@@ -20336,14 +20336,14 @@ module Prism
     #   while_keyword_loc -> Location
     #
     # Returns the Location represented by `while_keyword_loc`.
-    # --
+    #
     # : () -> Location
     def while_keyword_loc: () -> Location
 
     # :category: Repository
     # Save the while_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_while_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -20352,14 +20352,14 @@ module Prism
     #   do_keyword_loc -> Location | nil
     #
     # Returns the Location represented by `do_keyword_loc`.
-    # --
+    #
     # : () -> Location?
     def do_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the do_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_do_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -20368,14 +20368,14 @@ module Prism
     #   end_keyword_loc -> Location | nil
     #
     # Returns the Location represented by `end_keyword_loc`.
-    # --
+    #
     # : () -> Location?
     def end_keyword_loc: () -> Location?
 
     # :category: Repository
     # Save the end_keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_end_keyword_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -20383,7 +20383,7 @@ module Prism
     #   predicate -> Node
     #
     # Returns the `predicate` attribute.
-    # --
+    #
     # : () -> Prism::node
     def predicate: () -> Prism::node
 
@@ -20391,7 +20391,7 @@ module Prism
     #   statements -> StatementsNode | nil
     #
     # Returns the `statements` attribute.
-    # --
+    #
     # : () -> StatementsNode?
     def statements: () -> StatementsNode?
 
@@ -20399,7 +20399,7 @@ module Prism
     #   while_keyword -> String
     #
     # Slice the location of while_keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def while_keyword: () -> String
 
@@ -20407,7 +20407,7 @@ module Prism
     #   do_keyword -> String | nil
     #
     # Slice the location of do_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def do_keyword: () -> String?
 
@@ -20415,7 +20415,7 @@ module Prism
     #   end_keyword -> String | nil
     #
     # Slice the location of end_keyword_loc from the source.
-    # --
+    #
     # : () -> String?
     def end_keyword: () -> String?
 
@@ -20437,34 +20437,34 @@ module Prism
     @opening_loc: Location
 
     # Initialize a new XStringNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Location content_loc, Location closing_loc, String unescaped) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location opening_loc, Location content_loc, Location closing_loc, String unescaped) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -20472,7 +20472,7 @@ module Prism
     #   copy(**fields) -> XStringNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> XStringNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?opening_loc: Location, ?content_loc: Location, ?closing_loc: Location, ?unescaped: String) -> XStringNode
 
@@ -20482,12 +20482,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :x_string_node
     def type: () -> :x_string_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :x_string_node
     def self.type: () -> :x_string_node
 
@@ -20496,13 +20496,13 @@ module Prism
 
     # :category: Flags
     # internal bytes forced the encoding to UTF-8
-    # --
+    #
     # : () -> bool
     def forced_utf8_encoding?: () -> bool
 
     # :category: Flags
     # internal bytes forced the encoding to binary
-    # --
+    #
     # : () -> bool
     def forced_binary_encoding?: () -> bool
 
@@ -20511,14 +20511,14 @@ module Prism
     #   opening_loc -> Location
     #
     # Returns the Location represented by `opening_loc`.
-    # --
+    #
     # : () -> Location
     def opening_loc: () -> Location
 
     # :category: Repository
     # Save the opening_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_opening_loc: (_Repository repository) -> Relocation::Entry
 
@@ -20527,14 +20527,14 @@ module Prism
     #   content_loc -> Location
     #
     # Returns the Location represented by `content_loc`.
-    # --
+    #
     # : () -> Location
     def content_loc: () -> Location
 
     # :category: Repository
     # Save the content_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_content_loc: (_Repository repository) -> Relocation::Entry
 
@@ -20543,14 +20543,14 @@ module Prism
     #   closing_loc -> Location
     #
     # Returns the Location represented by `closing_loc`.
-    # --
+    #
     # : () -> Location
     def closing_loc: () -> Location
 
     # :category: Repository
     # Save the closing_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_closing_loc: (_Repository repository) -> Relocation::Entry
 
@@ -20558,7 +20558,7 @@ module Prism
     #   unescaped -> String
     #
     # Returns the `unescaped` attribute.
-    # --
+    #
     # : () -> String
     def unescaped: () -> String
 
@@ -20566,7 +20566,7 @@ module Prism
     #   opening -> String
     #
     # Slice the location of opening_loc from the source.
-    # --
+    #
     # : () -> String
     def opening: () -> String
 
@@ -20574,7 +20574,7 @@ module Prism
     #   content -> String
     #
     # Slice the location of content_loc from the source.
-    # --
+    #
     # : () -> String
     def content: () -> String
 
@@ -20582,7 +20582,7 @@ module Prism
     #   closing -> String
     #
     # Slice the location of closing_loc from the source.
-    # --
+    #
     # : () -> String
     def closing: () -> String
 
@@ -20604,34 +20604,34 @@ module Prism
     @keyword_loc: Location
 
     # Initialize a new YieldNode node.
-    # --
+    #
     # : (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, Location? lparen_loc, ArgumentsNode? arguments, Location? rparen_loc) -> void
     def initialize: (Source source, Integer node_id, Location location, Integer flags, Location keyword_loc, Location? lparen_loc, ArgumentsNode? arguments, Location? rparen_loc) -> void
 
     # See Node.accept.
-    # --
+    #
     # : (_Visitor visitor) -> untyped
     def accept: (_Visitor visitor) -> untyped
 
     # See Node.child_nodes.
-    # --
+    #
     # : () -> Array[node?]
     def child_nodes: () -> Array[node?]
 
     # See Node.each_child_node.
-    # --
+    #
     # : () -> Enumerator[node, void]
     # : () { (node) -> void } -> void
     def each_child_node: () -> Enumerator[node, void]
                        | () { (node) -> void } -> void
 
     # See Node.compact_child_nodes.
-    # --
+    #
     # : () -> Array[node]
     def compact_child_nodes: () -> Array[node]
 
     # See Node.comment_targets.
-    # --
+    #
     # : () -> Array[node | Location]
     def comment_targets: () -> Array[node | Location]
 
@@ -20639,7 +20639,7 @@ module Prism
     #   copy(**fields) -> YieldNode
     #
     # Creates a copy of self with the given fields, using self as the template.
-    # --
+    #
     # : (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?lparen_loc: Location?, ?arguments: ArgumentsNode?, ?rparen_loc: Location?) -> YieldNode
     def copy: (?node_id: Integer, ?location: Location, ?flags: Integer, ?keyword_loc: Location, ?lparen_loc: Location?, ?arguments: ArgumentsNode?, ?rparen_loc: Location?) -> YieldNode
 
@@ -20649,12 +20649,12 @@ module Prism
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # See `Node#type`.
-    # --
+    #
     # : () -> :yield_node
     def type: () -> :yield_node
 
     # See `Node.type`.
-    # --
+    #
     # : () -> :yield_node
     def self.type: () -> :yield_node
 
@@ -20666,14 +20666,14 @@ module Prism
     #   keyword_loc -> Location
     #
     # Returns the Location represented by `keyword_loc`.
-    # --
+    #
     # : () -> Location
     def keyword_loc: () -> Location
 
     # :category: Repository
     # Save the keyword_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry
     def save_keyword_loc: (_Repository repository) -> Relocation::Entry
 
@@ -20682,14 +20682,14 @@ module Prism
     #   lparen_loc -> Location | nil
     #
     # Returns the Location represented by `lparen_loc`.
-    # --
+    #
     # : () -> Location?
     def lparen_loc: () -> Location?
 
     # :category: Repository
     # Save the lparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_lparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -20697,7 +20697,7 @@ module Prism
     #   arguments -> ArgumentsNode | nil
     #
     # Returns the `arguments` attribute.
-    # --
+    #
     # : () -> ArgumentsNode?
     def arguments: () -> ArgumentsNode?
 
@@ -20706,14 +20706,14 @@ module Prism
     #   rparen_loc -> Location | nil
     #
     # Returns the Location represented by `rparen_loc`.
-    # --
+    #
     # : () -> Location?
     def rparen_loc: () -> Location?
 
     # :category: Repository
     # Save the rparen_loc location using the given saved source so that
     # it can be retrieved later.
-    # --
+    #
     # : (_Repository repository) -> Relocation::Entry?
     def save_rparen_loc: (_Repository repository) -> Relocation::Entry?
 
@@ -20721,7 +20721,7 @@ module Prism
     #   keyword -> String
     #
     # Slice the location of keyword_loc from the source.
-    # --
+    #
     # : () -> String
     def keyword: () -> String
 
@@ -20729,7 +20729,7 @@ module Prism
     #   lparen -> String | nil
     #
     # Slice the location of lparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def lparen: () -> String?
 
@@ -20737,7 +20737,7 @@ module Prism
     #   rparen -> String | nil
     #
     # Slice the location of rparen_loc from the source.
-    # --
+    #
     # : () -> String?
     def rparen: () -> String?
 

--- a/sig/generated/prism/node_ext.rbs
+++ b/sig/generated/prism/node_ext.rbs
@@ -13,7 +13,7 @@ module Prism
   module RegularExpressionOptions
     # Returns a numeric value that represents the flags that were used to create
     # the regular expression.
-    # --
+    #
     # : (Integer flags) -> Integer
     def self.options: (Integer flags) -> Integer
   end
@@ -21,7 +21,7 @@ module Prism
   class InterpolatedMatchLastLineNode < Node
     # Returns a numeric value that represents the flags that were used to create
     # the regular expression.
-    # --
+    #
     # : () -> Integer
     def options: () -> Integer
   end
@@ -29,7 +29,7 @@ module Prism
   class InterpolatedRegularExpressionNode < Node
     # Returns a numeric value that represents the flags that were used to create
     # the regular expression.
-    # --
+    #
     # : () -> Integer
     def options: () -> Integer
   end
@@ -37,7 +37,7 @@ module Prism
   class MatchLastLineNode < Node
     # Returns a numeric value that represents the flags that were used to create
     # the regular expression.
-    # --
+    #
     # : () -> Integer
     def options: () -> Integer
   end
@@ -45,68 +45,68 @@ module Prism
   class RegularExpressionNode < Node
     # Returns a numeric value that represents the flags that were used to create
     # the regular expression.
-    # --
+    #
     # : () -> Integer
     def options: () -> Integer
   end
 
   module HeredocQuery
     # Returns true if this node was represented as a heredoc in the source code.
-    # --
+    #
     # : (String? opening) -> bool?
     def self.heredoc?: (String? opening) -> bool?
   end
 
   class InterpolatedStringNode < Node
     # Returns true if this node was represented as a heredoc in the source code.
-    # --
+    #
     # : () -> bool?
     def heredoc?: () -> bool?
   end
 
   class InterpolatedXStringNode < Node
     # Returns true if this node was represented as a heredoc in the source code.
-    # --
+    #
     # : () -> bool?
     def heredoc?: () -> bool?
   end
 
   class StringNode < Node
     # Returns true if this node was represented as a heredoc in the source code.
-    # --
+    #
     # : () -> bool?
     def heredoc?: () -> bool?
 
     # Occasionally it's helpful to treat a string as if it were interpolated so
     # that there's a consistent interface for working with strings.
-    # --
+    #
     # : () -> InterpolatedStringNode
     def to_interpolated: () -> InterpolatedStringNode
   end
 
   class XStringNode < Node
     # Returns true if this node was represented as a heredoc in the source code.
-    # --
+    #
     # : () -> bool?
     def heredoc?: () -> bool?
 
     # Occasionally it's helpful to treat a string as if it were interpolated so
     # that there's a consistent interface for working with strings.
-    # --
+    #
     # : () -> InterpolatedXStringNode
     def to_interpolated: () -> InterpolatedXStringNode
   end
 
   class ImaginaryNode < Node
     # Returns the value of the node as a Ruby Complex.
-    # --
+    #
     # : () -> Complex
     def value: () -> Complex
   end
 
   class RationalNode < Node
     # Returns the value of the node as a Ruby Rational.
-    # --
+    #
     # : () -> Rational
     def value: () -> Rational
   end
@@ -114,12 +114,12 @@ module Prism
   class ConstantReadNode < Node
     # Returns the list of parts for the full name of this constant.
     # For example: [:Foo]
-    # --
+    #
     # : () -> Array[Symbol]
     def full_name_parts: () -> Array[Symbol]
 
     # Returns the full name of this constant. For example: "Foo"
-    # --
+    #
     # : () -> String
     def full_name: () -> String
   end
@@ -127,12 +127,12 @@ module Prism
   class ConstantWriteNode < Node
     # Returns the list of parts for the full name of this constant.
     # For example: [:Foo]
-    # --
+    #
     # : () -> Array[Symbol]
     def full_name_parts: () -> Array[Symbol]
 
     # Returns the full name of this constant. For example: "Foo"
-    # --
+    #
     # : () -> String
     def full_name: () -> String
   end
@@ -155,12 +155,12 @@ module Prism
 
     # Returns the list of parts for the full name of this constant path.
     # For example: [:Foo, :Bar]
-    # --
+    #
     # : () -> Array[Symbol]
     def full_name_parts: () -> Array[Symbol]
 
     # Returns the full name of this constant path. For example: "Foo::Bar"
-    # --
+    #
     # : () -> String
     def full_name: () -> String
   end
@@ -168,12 +168,12 @@ module Prism
   class ConstantPathTargetNode < Node
     # Returns the list of parts for the full name of this constant path.
     # For example: [:Foo, :Bar]
-    # --
+    #
     # : () -> Array[Symbol]
     def full_name_parts: () -> Array[Symbol]
 
     # Returns the full name of this constant path. For example: "Foo::Bar"
-    # --
+    #
     # : () -> String
     def full_name: () -> String
   end
@@ -181,19 +181,19 @@ module Prism
   class ConstantTargetNode < Node
     # Returns the list of parts for the full name of this constant.
     # For example: [:Foo]
-    # --
+    #
     # : () -> Array[Symbol]
     def full_name_parts: () -> Array[Symbol]
 
     # Returns the full name of this constant. For example: "Foo"
-    # --
+    #
     # : () -> String
     def full_name: () -> String
   end
 
   class ParametersNode < Node
     # Mirrors the Method#parameters method.
-    # --
+    #
     # : () -> Array[[Symbol, Symbol] | [Symbol]]
     def signature: () -> Array[[ Symbol, Symbol ] | [ Symbol ]]
   end
@@ -208,11 +208,12 @@ module Prism
     # can be any amount of space between the message and the = sign. However,
     # sometimes you want the location of the full message including the inner
     # space and the = sign. This method provides that.
-    # --
+    #
     # : () -> Location?
     def full_message_loc: () -> Location?
   end
 
+  # :stopdoc:
   class InNode < Node
     # : () -> String
     def in: () -> String

--- a/sig/generated/prism/node_find.rbs
+++ b/sig/generated/prism/node_find.rbs
@@ -10,7 +10,7 @@ module Prism
   # pay for its definition.
   module NodeFind
     # Find the node for the given callable or backtrace location.
-    # --
+    #
     # : (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
     def self.find: (Method | UnboundMethod | Proc | Thread::Backtrace::Location callable) -> Node?
 
@@ -19,7 +19,7 @@ module Prism
       private
 
       # Parse the given file path, returning a ParseResult or nil.
-      # --
+      #
       # : (String? file) -> ParseResult?
       def parse_file: (String? file) -> ParseResult?
     end
@@ -28,7 +28,7 @@ module Prism
     # from the instruction sequence.
     class RubyVMCallableFind < Find
       # Find the node for the given callable using the ISeq node_id.
-      # --
+      #
       # : (Method | UnboundMethod | Proc callable) -> Node?
       def find: (Method | UnboundMethod | Proc callable) -> Node?
     end
@@ -37,7 +37,7 @@ module Prism
     # from the backtrace location.
     class RubyVMBacktraceLocationFind < Find
       # Find the node for the given backtrace location using node_id.
-      # --
+      #
       # : (Thread::Backtrace::Location location) -> Node?
       def find: (Thread::Backtrace::Location location) -> Node?
     end
@@ -46,7 +46,7 @@ module Prism
     # matching. Used on non-CRuby implementations.
     class LineMethodFind < Find
       # Find the node for the given method by matching on name and line.
-      # --
+      #
       # : (Method | UnboundMethod callable) -> Node?
       def find: (Method | UnboundMethod callable) -> Node?
     end
@@ -55,7 +55,7 @@ module Prism
     # on non-CRuby implementations.
     class LineLambdaFind < Find
       # Find the node for the given lambda by matching on line.
-      # --
+      #
       # : (Proc callable) -> Node?
       def find: (Proc callable) -> Node?
     end
@@ -64,7 +64,7 @@ module Prism
     # matching. Used on non-CRuby implementations.
     class LineProcFind < Find
       # Find the node for the given proc by matching on line.
-      # --
+      #
       # : (Proc callable) -> Node?
       def find: (Proc callable) -> Node?
     end
@@ -73,7 +73,7 @@ module Prism
     # line matching. Used on non-CRuby implementations.
     class LineBacktraceLocationFind < Find
       # Find the node for the given backtrace location by matching on line.
-      # --
+      #
       # : (Thread::Backtrace::Location location) -> Node?
       def find: (Thread::Backtrace::Location location) -> Node?
     end

--- a/sig/generated/prism/parse_result.rbs
+++ b/sig/generated/prism/parse_result.rbs
@@ -24,7 +24,7 @@ module Prism
     # can be calculated by iterating through the source code and recording the
     # byte offset whenever a newline character is encountered.  The first
     # element is always 0 to mark the first line.
-    # --
+    #
     # : (String source, Integer start_line, Array[Integer] offsets) -> Source
     def self.for: (String source, Integer start_line, Array[Integer] offsets) -> Source
 
@@ -37,79 +37,79 @@ module Prism
     # The list of newline byte offsets in the source code. When initialized from
     # the C extension, this may be a packed binary string of uint32_t values
     # that is lazily unpacked on first access.
-    # --
+    #
     # : () -> Array[Integer]
     def offsets: () -> Array[Integer]
 
     # Create a new source object with the given source code. The offsets
     # parameter can be either an Array of Integer byte offsets or a packed
     # binary string of uint32_t values (from the C extension).
-    # --
+    #
     # : (String source, Integer start_line, Array[Integer] | String offsets) -> void
     def initialize: (String source, Integer start_line, Array[Integer] | String offsets) -> void
 
     # Replace the value of start_line with the given value.
-    # --
+    #
     # : (Integer start_line) -> void
     def replace_start_line: (Integer start_line) -> void
 
     # Replace the value of offsets with the given value.
-    # --
+    #
     # : (Array[Integer] offsets) -> void
     def replace_offsets: (Array[Integer] offsets) -> void
 
     # Returns the encoding of the source code, which is set by parameters to the
     # parser or by the encoding magic comment.
-    # --
+    #
     # : () -> Encoding
     def encoding: () -> Encoding
 
     # Returns the lines of the source code as an array of strings.
-    # --
+    #
     # : () -> Array[String]
     def lines: () -> Array[String]
 
     # Perform a byteslice on the source code using the given byte offset and
     # byte length.
-    # --
+    #
     # : (Integer byte_offset, Integer length) -> String
     def slice: (Integer byte_offset, Integer length) -> String
 
     # Converts the line number and column in bytes to a byte offset.
-    # --
+    #
     # : (Integer line, Integer column) -> Integer
     def byte_offset: (Integer line, Integer column) -> Integer
 
     # Binary search through the offsets to find the line number for the given
     # byte offset.
-    # --
+    #
     # : (Integer byte_offset) -> Integer
     def line: (Integer byte_offset) -> Integer
 
     # Return the byte offset of the start of the line corresponding to the given
     # byte offset.
-    # --
+    #
     # : (Integer byte_offset) -> Integer
     def line_start: (Integer byte_offset) -> Integer
 
     # Returns the byte offset of the end of the line corresponding to the given
     # byte offset.
-    # --
+    #
     # : (Integer byte_offset) -> Integer
     def line_end: (Integer byte_offset) -> Integer
 
     # Return the column in bytes for the given byte offset.
-    # --
+    #
     # : (Integer byte_offset) -> Integer
     def column: (Integer byte_offset) -> Integer
 
     # Return the character offset for the given byte offset.
-    # --
+    #
     # : (Integer byte_offset) -> Integer
     def character_offset: (Integer byte_offset) -> Integer
 
     # Return the column in characters for the given byte offset.
-    # --
+    #
     # : (Integer byte_offset) -> Integer
     def character_column: (Integer byte_offset) -> Integer
 
@@ -125,30 +125,30 @@ module Prism
     # possible that the given byte offset will not occur on a character
     # boundary. Second, it's possible that the source code will contain a
     # character that has no equivalent in the given encoding.
-    # --
+    #
     # : (Integer byte_offset, Encoding encoding) -> Integer
     def code_units_offset: (Integer byte_offset, Encoding encoding) -> Integer
 
     # Generate a cache that targets a specific encoding for calculating code
     # unit offsets.
-    # --
+    #
     # : (Encoding encoding) -> CodeUnitsCache
     def code_units_cache: (Encoding encoding) -> CodeUnitsCache
 
     # Returns the column in code units for the given encoding for the
     # given byte offset.
-    # --
+    #
     # : (Integer byte_offset, Encoding encoding) -> Integer
     def code_units_column: (Integer byte_offset, Encoding encoding) -> Integer
 
     # Freeze this object and the objects it contains.
-    # --
+    #
     # : () -> void
     def deep_freeze: () -> void
 
     # Binary search through the offsets to find the index for the given
     # byte offset.
-    # --
+    #
     # : (Integer byte_offset) -> Integer
     def find_line: (Integer byte_offset) -> Integer
   end
@@ -209,12 +209,12 @@ module Prism
     @offsets: Array[Integer]
 
     # Initialize a new cache with the given source and encoding.
-    # --
+    #
     # : (String source, Encoding encoding) -> void
     def initialize: (String source, Encoding encoding) -> void
 
     # Retrieve the code units offset from the given byte offset.
-    # --
+    #
     # : (Integer byte_offset) -> Integer
     def []: (Integer byte_offset) -> Integer
   end
@@ -229,12 +229,12 @@ module Prism
   # at that point we will treat everything as single-byte characters.
   class ASCIISource < Source
     # Return the character offset for the given byte offset.
-    # --
+    #
     # : (Integer byte_offset) -> Integer
     def character_offset: (Integer byte_offset) -> Integer
 
     # Return the column in characters for the given byte offset.
-    # --
+    #
     # : (Integer byte_offset) -> Integer
     def character_column: (Integer byte_offset) -> Integer
 
@@ -244,21 +244,21 @@ module Prism
     # This method is tested with UTF-8, UTF-16, and UTF-32. If there is the
     # concept of code units that differs from the number of characters in other
     # encodings, it is not captured here.
-    # --
+    #
     # : (Integer byte_offset, Encoding encoding) -> Integer
     def code_units_offset: (Integer byte_offset, Encoding encoding) -> Integer
 
     # Returns a cache that is the identity function in order to maintain the
     # same interface. We can do this because code units are always equivalent to
     # byte offsets for ASCII-only sources.
-    # --
+    #
     # : (Encoding encoding) -> _CodeUnitsCache
     def code_units_cache: (Encoding encoding) -> _CodeUnitsCache
 
     # Specialized version of `code_units_column` that does not depend on
     # `code_units_offset`, which is a more expensive operation. This is
     # essentially the same as `Prism::Source#column`.
-    # --
+    #
     # : (Integer byte_offset, Encoding encoding) -> Integer
     def code_units_column: (Integer byte_offset, Encoding encoding) -> Integer
   end
@@ -282,198 +282,198 @@ module Prism
 
     # Create a new location object with the given source, start byte offset, and
     # byte length.
-    # --
+    #
     # : (Source source, Integer start_offset, Integer length) -> void
     def initialize: (Source source, Integer start_offset, Integer length) -> void
 
     # These are the comments that are associated with this location that exist
     # before the start of this location.
-    # --
+    #
     # : () -> Array[Comment]
     def leading_comments: () -> Array[Comment]
 
     # Attach a comment to the leading comments of this location.
-    # --
+    #
     # : (Comment comment) -> void
     def leading_comment: (Comment comment) -> void
 
     # These are the comments that are associated with this location that exist
     # after the end of this location.
-    # --
+    #
     # : () -> Array[Comment]
     def trailing_comments: () -> Array[Comment]
 
     # Attach a comment to the trailing comments of this location.
-    # --
+    #
     # : (Comment comment) -> void
     def trailing_comment: (Comment comment) -> void
 
     # Returns all comments that are associated with this location (both leading
     # and trailing comments).
-    # --
+    #
     # : () -> Array[Comment]
     def comments: () -> Array[Comment]
 
     # Create a new location object with the given options.
-    # --
+    #
     # : (?source: Source, ?start_offset: Integer, ?length: Integer) -> Location
     def copy: (?source: Source, ?start_offset: Integer, ?length: Integer) -> Location
 
     # Returns a new location that is the result of chopping off the last byte.
-    # --
+    #
     # : () -> Location
     def chop: () -> Location
 
     # Returns a string representation of this location.
-    # --
+    #
     # : () -> String
     def inspect: () -> String
 
     # Returns all of the lines of the source code associated with this location.
-    # --
+    #
     # : () -> Array[String]
     def source_lines: () -> Array[String]
 
     # The source code that this location represents.
-    # --
+    #
     # : () -> String
     def slice: () -> String
 
     # The source code that this location represents starting from the beginning
     # of the line that this location starts on to the end of the line that this
     # location ends on.
-    # --
+    #
     # : () -> String
     def slice_lines: () -> String
 
     # The character offset from the beginning of the source where this location
     # starts.
-    # --
+    #
     # : () -> Integer
     def start_character_offset: () -> Integer
 
     # The offset from the start of the file in code units of the given encoding.
-    # --
+    #
     # : (Encoding encoding) -> Integer
     def start_code_units_offset: (Encoding encoding) -> Integer
 
     # The start offset from the start of the file in code units using the given
     # cache to fetch or calculate the value.
-    # --
+    #
     # : (_CodeUnitsCache cache) -> Integer
     def cached_start_code_units_offset: (_CodeUnitsCache cache) -> Integer
 
     # The byte offset from the beginning of the source where this location ends.
-    # --
+    #
     # : () -> Integer
     def end_offset: () -> Integer
 
     # The character offset from the beginning of the source where this location
     # ends.
-    # --
+    #
     # : () -> Integer
     def end_character_offset: () -> Integer
 
     # The offset from the start of the file in code units of the given encoding.
-    # --
+    #
     # : (Encoding encoding) -> Integer
     def end_code_units_offset: (Encoding encoding) -> Integer
 
     # The end offset from the start of the file in code units using the given
     # cache to fetch or calculate the value.
-    # --
+    #
     # : (_CodeUnitsCache cache) -> Integer
     def cached_end_code_units_offset: (_CodeUnitsCache cache) -> Integer
 
     # The line number where this location starts.
-    # --
+    #
     # : () -> Integer
     def start_line: () -> Integer
 
     # The content of the line where this location starts before this location.
-    # --
+    #
     # : () -> String
     def start_line_slice: () -> String
 
     # The line number where this location ends.
-    # --
+    #
     # : () -> Integer
     def end_line: () -> Integer
 
     # The column in bytes where this location starts from the start of
     # the line.
-    # --
+    #
     # : () -> Integer
     def start_column: () -> Integer
 
     # The column in characters where this location ends from the start of
     # the line.
-    # --
+    #
     # : () -> Integer
     def start_character_column: () -> Integer
 
     # The column in code units of the given encoding where this location
     # starts from the start of the line.
-    # --
+    #
     # : (?Encoding encoding) -> Integer
     def start_code_units_column: (?Encoding encoding) -> Integer
 
     # The start column in code units using the given cache to fetch or calculate
     # the value.
-    # --
+    #
     # : (_CodeUnitsCache cache) -> Integer
     def cached_start_code_units_column: (_CodeUnitsCache cache) -> Integer
 
     # The column in bytes where this location ends from the start of the
     # line.
-    # --
+    #
     # : () -> Integer
     def end_column: () -> Integer
 
     # The column in characters where this location ends from the start of
     # the line.
-    # --
+    #
     # : () -> Integer
     def end_character_column: () -> Integer
 
     # The column in code units of the given encoding where this location
     # ends from the start of the line.
-    # --
+    #
     # : (?Encoding encoding) -> Integer
     def end_code_units_column: (?Encoding encoding) -> Integer
 
     # The end column in code units using the given cache to fetch or calculate
     # the value.
-    # --
+    #
     # : (_CodeUnitsCache cache) -> Integer
     def cached_end_code_units_column: (_CodeUnitsCache cache) -> Integer
 
     # Implement the hash pattern matching interface for Location.
-    # --
+    #
     # : (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # Implement the pretty print interface for Location.
-    # --
+    #
     # : (PP q) -> void
     def pretty_print: (PP q) -> void
 
     # Returns true if the given other location is equal to this location.
-    # --
+    #
     # : (untyped other) -> bool
     def ==: (untyped other) -> bool
 
     # Returns a new location that stretches from this location to the given
     # other location. Raises an error if this location is not before the other
     # location or if they don't share the same source.
-    # --
+    #
     # : (Location other) -> Location
     def join: (Location other) -> Location
 
     # Join this location with the first occurrence of the string in the source
     # that occurs after this location on the same line, and return the new
     # location. This will raise an error if the string does not exist.
-    # --
+    #
     # : (String string) -> Location
     def adjoin: (String string) -> Location
   end
@@ -485,24 +485,24 @@ module Prism
     attr_reader location: Location
 
     # Create a new comment object with the given location.
-    # --
+    #
     # : (Location location) -> void
     def initialize: (Location location) -> void
 
     # Implement the hash pattern matching interface for Comment.
-    # --
+    #
     # : (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # Returns the content of the comment by slicing it from the source code.
-    # --
+    #
     # : () -> String
     def slice: () -> String
 
     # Returns true if this comment happens on the same line as other code and
     # false if the comment is by itself. This can only be true for inline
     # comments and should be false for block comments.
-    # --
+    #
     # : () -> bool
     def trailing?: () -> bool
   end
@@ -512,12 +512,12 @@ module Prism
   class InlineComment < Comment
     # Returns true if this comment happens on the same line as other code and
     # false if the comment is by itself.
-    # --
+    #
     # : () -> bool
     def trailing?: () -> bool
 
     # Returns a string representation of this comment.
-    # --
+    #
     # : () -> String
     def inspect: () -> String
   end
@@ -526,12 +526,12 @@ module Prism
   # and =end.
   class EmbDocComment < Comment
     # Returns false. This can only be true for inline comments.
-    # --
+    #
     # : () -> bool
     def trailing?: () -> bool
 
     # Returns a string representation of this comment.
-    # --
+    #
     # : () -> String
     def inspect: () -> String
   end
@@ -545,27 +545,27 @@ module Prism
     attr_reader value_loc: Location
 
     # Create a new magic comment object with the given key and value locations.
-    # --
+    #
     # : (Location key_loc, Location value_loc) -> void
     def initialize: (Location key_loc, Location value_loc) -> void
 
     # Returns the key of the magic comment by slicing it from the source code.
-    # --
+    #
     # : () -> String
     def key: () -> String
 
     # Returns the value of the magic comment by slicing it from the source code.
-    # --
+    #
     # : () -> String
     def value: () -> String
 
     # Implement the hash pattern matching interface for MagicComment.
-    # --
+    #
     # : (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # Returns a string representation of this magic comment.
-    # --
+    #
     # : () -> String
     def inspect: () -> String
   end
@@ -586,17 +586,17 @@ module Prism
     attr_reader level: Symbol
 
     # Create a new error object with the given message and location.
-    # --
+    #
     # : (Symbol type, String message, Location location, Symbol level) -> void
     def initialize: (Symbol type, String message, Location location, Symbol level) -> void
 
     # Implement the hash pattern matching interface for ParseError.
-    # --
+    #
     # : (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # Returns a string representation of this error.
-    # --
+    #
     # : () -> String
     def inspect: () -> String
   end
@@ -617,17 +617,17 @@ module Prism
     attr_reader level: Symbol
 
     # Create a new warning object with the given message and location.
-    # --
+    #
     # : (Symbol type, String message, Location location, Symbol level) -> void
     def initialize: (Symbol type, String message, Location location, Symbol level) -> void
 
     # Implement the hash pattern matching interface for ParseWarning.
-    # --
+    #
     # : (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # Returns a string representation of this warning.
-    # --
+    #
     # : () -> String
     def inspect: () -> String
   end
@@ -657,29 +657,29 @@ module Prism
     attr_reader source: Source
 
     # Create a new result object with the given values.
-    # --
+    #
     # : (Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
     def initialize: (Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
 
     # Implement the hash pattern matching interface for Result.
-    # --
+    #
     # : (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # Returns the encoding of the source code that was parsed.
-    # --
+    #
     # : () -> Encoding
     def encoding: () -> Encoding
 
     # Returns true if there were no errors during parsing and false if there
     # were.
-    # --
+    #
     # : () -> bool
     def success?: () -> bool
 
     # Returns true if there were errors during parsing and false if there were
     # not.
-    # --
+    #
     # : () -> bool
     def failure?: () -> bool
 
@@ -703,12 +703,11 @@ module Prism
     #     Prism.parse("tap do").continuable?     #=> true  (unclosed block)
     #     Prism.parse("end.tap do").continuable? #=> false (stray end)
     #
-    # --
     # : () -> bool
     def continuable?: () -> bool
 
     # Create a code units cache for the given encoding.
-    # --
+    #
     # : (Encoding encoding) -> _CodeUnitsCache
     def code_units_cache: (Encoding encoding) -> _CodeUnitsCache
   end
@@ -719,29 +718,29 @@ module Prism
     attr_reader value: ProgramNode
 
     # Create a new parse result object with the given values.
-    # --
+    #
     # : (ProgramNode value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
     def initialize: (ProgramNode value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
 
     # Implement the hash pattern matching interface for ParseResult.
-    # --
+    #
     # : (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # Attach the list of comments to their respective locations in the tree.
-    # --
+    #
     # : () -> void
     def attach_comments!: () -> void
 
     # Walk the tree and mark nodes that are on a new line, loosely emulating
     # the behavior of CRuby's `:line` tracepoint event.
-    # --
+    #
     # : () -> void
     def mark_newlines!: () -> void
 
     # Returns a string representation of the syntax tree with the errors
     # displayed inline.
-    # --
+    #
     # : () -> String
     def errors_format: () -> String
   end
@@ -752,12 +751,12 @@ module Prism
     attr_reader value: Array[Token]
 
     # Create a new lex result object with the given values.
-    # --
+    #
     # : (Array[Token] value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
     def initialize: (Array[Token] value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
 
     # Implement the hash pattern matching interface for LexResult.
-    # --
+    #
     # : (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
   end
@@ -769,12 +768,12 @@ module Prism
     attr_reader value: [ ProgramNode, Array[Token] ]
 
     # Create a new parse lex result object with the given values.
-    # --
+    #
     # : ([ProgramNode, Array[Token]] value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
     def initialize: ([ ProgramNode, Array[Token] ] value, Array[Comment] comments, Array[MagicComment] magic_comments, Location? data_loc, Array[ParseError] errors, Array[ParseWarning] warnings, bool continuable, Source source) -> void
 
     # Implement the hash pattern matching interface for ParseLexResult.
-    # --
+    #
     # : (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
   end
@@ -793,37 +792,37 @@ module Prism
     @location: Location | Integer
 
     # Create a new token object with the given type, value, and location.
-    # --
+    #
     # : (Source source, Symbol type, String value, Location | Integer location, Integer state) -> void
     def initialize: (Source source, Symbol type, String value, Location | Integer location, Integer state) -> void
 
     # Implement the hash pattern matching interface for Token.
-    # --
+    #
     # : (Array[Symbol]? keys) -> Hash[Symbol, untyped]
     def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, untyped]
 
     # A Location object representing the location of this token in the source.
-    # --
+    #
     # : () -> Location
     def location: () -> Location
 
     # Implement the pretty print interface for Token.
-    # --
+    #
     # : (PP q) -> void
     def pretty_print: (PP q) -> void
 
     # Returns true if the given other token is equal to this token.
-    # --
+    #
     # : (untyped other) -> bool
     def ==: (untyped other) -> bool
 
     # Returns a string representation of this token.
-    # --
+    #
     # : () -> String
     def inspect: () -> String
 
     # Freeze this object and the objects it contains.
-    # --
+    #
     # : () -> void
     def deep_freeze: () -> void
 
@@ -853,7 +852,7 @@ module Prism
     attr_reader forwarding: Array[Symbol]
 
     # Create a new scope object with the given locals and forwarding.
-    # --
+    #
     # : (Array[Symbol] locals, Array[Symbol] forwarding) -> void
     def initialize: (Array[Symbol] locals, Array[Symbol] forwarding) -> void
   end
@@ -861,7 +860,7 @@ module Prism
   # Create a new scope with the given locals and forwarding options that is
   # suitable for passing into one of the Prism.* methods that accepts the
   # `scopes` option.
-  # --
+  #
   # : (?locals: Array[Symbol], ?forwarding: Array[Symbol]) -> Scope
   def self.scope: (?locals: Array[Symbol], ?forwarding: Array[Symbol]) -> Scope
 end

--- a/sig/generated/prism/parse_result/comments.rbs
+++ b/sig/generated/prism/parse_result/comments.rbs
@@ -86,13 +86,13 @@ module Prism
 
       # Create a new Comments object that will attach comments to the given
       # parse result.
-      # --
+      #
       # : (ParseResult parse_result) -> void
       def initialize: (ParseResult parse_result) -> void
 
       # Attach the comments to their respective locations in the tree by
       # mutating the parse result.
-      # --
+      #
       # : () -> void
       def attach!: () -> void
 
@@ -100,7 +100,7 @@ module Prism
 
       # Responsible for finding the nearest targets to the given comment within
       # the context of the given encapsulating node.
-      # --
+      #
       # : (node node, Comment comment) -> [_CommentTarget?, _CommentTarget?, _CommentTarget?]
       def nearest_targets: (node node, Comment comment) -> [ _CommentTarget?, _CommentTarget?, _CommentTarget? ]
     end

--- a/sig/generated/prism/parse_result/errors.rbs
+++ b/sig/generated/prism/parse_result/errors.rbs
@@ -9,12 +9,12 @@ module Prism
       attr_reader parse_result: ParseResult
 
       # Initialize a new set of errors from the given parse result.
-      # --
+      #
       # : (ParseResult parse_result) -> void
       def initialize: (ParseResult parse_result) -> void
 
       # Formats the errors in a human-readable way and return them as a string.
-      # --
+      #
       # : () -> String
       def format: () -> String
     end

--- a/sig/generated/prism/parse_result/newlines.rbs
+++ b/sig/generated/prism/parse_result/newlines.rbs
@@ -26,32 +26,32 @@ module Prism
       @lines: Array[bool]
 
       # Create a new Newlines visitor with the given newline offsets.
-      # --
+      #
       # : (Integer lines) -> void
       def initialize: (Integer lines) -> void
 
       # Permit block nodes to mark newlines within themselves.
-      # --
+      #
       # : (BlockNode node) -> void
       def visit_block_node: (BlockNode node) -> void
 
       # Permit lambda nodes to mark newlines within themselves.
-      # --
+      #
       # : (LambdaNode node) -> void
       def visit_lambda_node: (LambdaNode node) -> void
 
       # Mark if nodes as newlines.
-      # --
+      #
       # : (IfNode node) -> void
       def visit_if_node: (IfNode node) -> void
 
       # Mark unless nodes as newlines.
-      # --
+      #
       # : (UnlessNode node) -> void
       def visit_unless_node: (UnlessNode node) -> void
 
       # Permit statements lists to mark newlines within themselves.
-      # --
+      #
       # : (StatementsNode node) -> void
       def visit_statements_node: (StatementsNode node) -> void
     end

--- a/sig/generated/prism/pattern.rbs
+++ b/sig/generated/prism/pattern.rbs
@@ -40,7 +40,7 @@ module Prism
     class CompilationError < StandardError
       # Create a new CompilationError with the given representation of the node
       # that caused the error.
-      # --
+      #
       # : (String repr) -> void
       def initialize: (String repr) -> void
     end
@@ -52,13 +52,13 @@ module Prism
 
     # Create a new pattern with the given query. The query should be a string
     # containing a Ruby pattern matching expression.
-    # --
+    #
     # : (String query) -> void
     def initialize: (String query) -> void
 
     # Compile the query into a callable object that can be used to match against
     # nodes.
-    # --
+    #
     # : () -> Proc
     def compile: () -> Proc
 
@@ -66,7 +66,7 @@ module Prism
     # pattern. If a block is given, it will be called with each node that
     # matches the pattern. If no block is given, an enumerator will be returned
     # that will yield each node that matches the pattern.
-    # --
+    #
     # : (node root) -> Enumerator[node, void]
     # : (node root) { (node) -> void } -> void
     def scan: (node root) -> Enumerator[node, void]
@@ -76,80 +76,80 @@ module Prism
 
     # Shortcut for combining two procs into one that returns true if both return
     # true.
-    # --
+    #
     # : (Proc left, Proc right) -> Proc
     def combine_and: (Proc left, Proc right) -> Proc
 
     # Shortcut for combining two procs into one that returns true if either
     # returns true.
-    # --
+    #
     # : (Proc left, Proc right) -> Proc
     def combine_or: (Proc left, Proc right) -> Proc
 
     # Raise an error because the given node is not supported. Note purposefully
     # not typing this method since it is a no return method that Steep does not
     # understand.
-    # --
+    #
     # : (node node) -> bot
     def compile_error: (node node) -> bot
 
     # in [foo, bar, baz]
-    # --
+    #
     # : (ArrayPatternNode node) -> Proc
     def compile_array_pattern_node: (ArrayPatternNode node) -> Proc
 
     # in foo | bar
-    # --
+    #
     # : (AlternationPatternNode node) -> Proc
     def compile_alternation_pattern_node: (AlternationPatternNode node) -> Proc
 
     # in Prism::ConstantReadNode
-    # --
+    #
     # : (ConstantPathNode node) -> Proc
     def compile_constant_path_node: (ConstantPathNode node) -> Proc
 
     # in ConstantReadNode
     # in String
-    # --
+    #
     # : (ConstantReadNode node) -> Proc
     def compile_constant_read_node: (ConstantReadNode node) -> Proc
 
     # Compile a name associated with a constant.
-    # --
+    #
     # : ((ConstantPathNode | ConstantReadNode) node, Symbol name) -> Proc
     def compile_constant_name: (ConstantPathNode | ConstantReadNode node, Symbol name) -> Proc
 
     # in InstanceVariableReadNode[name: Symbol]
     # in { name: Symbol }
-    # --
+    #
     # : (HashPatternNode node) -> Proc
     def compile_hash_pattern_node: (HashPatternNode node) -> Proc
 
     # in nil
-    # --
+    #
     # : (NilNode node) -> Proc
     def compile_nil_node: (NilNode node) -> Proc
 
     # in /foo/
-    # --
+    #
     # : (RegularExpressionNode node) -> Proc
     def compile_regular_expression_node: (RegularExpressionNode node) -> Proc
 
     # in ""
     # in "foo"
-    # --
+    #
     # : (StringNode node) -> Proc
     def compile_string_node: (StringNode node) -> Proc
 
     # in :+
     # in :foo
-    # --
+    #
     # : (SymbolNode node) -> Proc
     def compile_symbol_node: (SymbolNode node) -> Proc
 
     # Compile any kind of node. Dispatch out to the individual compilation
     # methods based on the type of node.
-    # --
+    #
     # : (node node) -> Proc
     def compile_node: (node node) -> Proc
   end

--- a/sig/generated/prism/reflection.rbs
+++ b/sig/generated/prism/reflection.rbs
@@ -12,7 +12,7 @@ module Prism
       attr_reader name: Symbol
 
       # Initializes the field with the given name.
-      # --
+      #
       # : (Symbol name) -> void
       def initialize: (Symbol name) -> void
     end
@@ -88,13 +88,13 @@ module Prism
       attr_reader flags: Array[Symbol]
 
       # Initializes the flags field with the given name and flags.
-      # --
+      #
       # : (Symbol name, Array[Symbol] flags) -> void
       def initialize: (Symbol name, Array[Symbol] flags) -> void
     end
 
     # Returns the fields for the given node.
-    # --
+    #
     # : (singleton(Node) node) -> Array[Field]
     def self.fields_for: (singleton(Node) node) -> Array[Field]
   end

--- a/sig/generated/prism/relocation.rbs
+++ b/sig/generated/prism/relocation.rbs
@@ -67,120 +67,120 @@ module Prism
       @repository: Repository?
 
       # Initialize a new entry with the given repository.
-      # --
+      #
       # : (Repository repository) -> void
       def initialize: (Repository repository) -> void
 
       # Fetch the filepath of the value.
-      # --
+      #
       # : () -> String
       def filepath: () -> String
 
       # Fetch the start line of the value.
-      # --
+      #
       # : () -> Integer
       def start_line: () -> Integer
 
       # Fetch the end line of the value.
-      # --
+      #
       # : () -> Integer
       def end_line: () -> Integer
 
       # Fetch the start byte offset of the value.
-      # --
+      #
       # : () -> Integer
       def start_offset: () -> Integer
 
       # Fetch the end byte offset of the value.
-      # --
+      #
       # : () -> Integer
       def end_offset: () -> Integer
 
       # Fetch the start character offset of the value.
-      # --
+      #
       # : () -> Integer
       def start_character_offset: () -> Integer
 
       # Fetch the end character offset of the value.
-      # --
+      #
       # : () -> Integer
       def end_character_offset: () -> Integer
 
       # Fetch the start code units offset of the value, for the encoding that
       # was configured on the repository.
-      # --
+      #
       # : () -> Integer
       def start_code_units_offset: () -> Integer
 
       # Fetch the end code units offset of the value, for the encoding that was
       # configured on the repository.
-      # --
+      #
       # : () -> Integer
       def end_code_units_offset: () -> Integer
 
       # Fetch the start byte column of the value.
-      # --
+      #
       # : () -> Integer
       def start_column: () -> Integer
 
       # Fetch the end byte column of the value.
-      # --
+      #
       # : () -> Integer
       def end_column: () -> Integer
 
       # Fetch the start character column of the value.
-      # --
+      #
       # : () -> Integer
       def start_character_column: () -> Integer
 
       # Fetch the end character column of the value.
-      # --
+      #
       # : () -> Integer
       def end_character_column: () -> Integer
 
       # Fetch the start code units column of the value, for the encoding that
       # was configured on the repository.
-      # --
+      #
       # : () -> Integer
       def start_code_units_column: () -> Integer
 
       # Fetch the end code units column of the value, for the encoding that was
       # configured on the repository.
-      # --
+      #
       # : () -> Integer
       def end_code_units_column: () -> Integer
 
       # Fetch the leading comments of the value.
-      # --
+      #
       # : () -> Array[CommentsField::Comment]
       def leading_comments: () -> Array[CommentsField::Comment]
 
       # Fetch the trailing comments of the value.
-      # --
+      #
       # : () -> Array[CommentsField::Comment]
       def trailing_comments: () -> Array[CommentsField::Comment]
 
       # Fetch the leading and trailing comments of the value.
-      # --
+      #
       # : () -> Array[CommentsField::Comment]
       def comments: () -> Array[CommentsField::Comment]
 
       # Reify the values on this entry with the given values. This is an
       # internal-only API that is called from the repository when it is time to
       # reify the values.
-      # --
+      #
       # : (entry_values values) -> void
       def reify!: (entry_values values) -> void
 
       private
 
       # Fetch a value from the entry, raising an error if it is missing.
-      # --
+      #
       # : (Symbol name) -> entry_value
       def fetch_value: (Symbol name) -> entry_value
 
       # Return the values from the repository, reifying them if necessary.
-      # --
+      #
       # : () -> entry_values
       def values: () -> entry_values
     end
@@ -191,17 +191,17 @@ module Prism
       attr_reader value: untyped
 
       # Initialize the source with the given value.
-      # --
+      #
       # : (untyped value) -> void
       def initialize: (untyped value) -> void
 
       # Reparse the value and return the parse result.
-      # --
+      #
       # : () -> ParseResult
       def result: () -> ParseResult
 
       # Create a code units cache for the given encoding.
-      # --
+      #
       # : (Encoding encoding) -> _CodeUnitsCache
       def code_units_cache: (Encoding encoding) -> _CodeUnitsCache
     end
@@ -209,7 +209,7 @@ module Prism
     # A source that is represented by a file path.
     class SourceFilepath < Source
       # Reparse the file and return the parse result.
-      # --
+      #
       # : () -> ParseResult
       def result: () -> ParseResult
     end
@@ -217,7 +217,7 @@ module Prism
     # A source that is represented by a string.
     class SourceString < Source
       # Reparse the string and return the parse result.
-      # --
+      #
       # : () -> ParseResult
       def result: () -> ParseResult
     end
@@ -228,12 +228,12 @@ module Prism
       attr_reader value: String
 
       # Initialize a new field with the given file path.
-      # --
+      #
       # : (String value) -> void
       def initialize: (String value) -> void
 
       # Fetch the file path.
-      # --
+      #
       # : (_Value _value) -> entry_values
       def fields: (_Value _value) -> entry_values
     end
@@ -241,7 +241,7 @@ module Prism
     # A field representing the start and end lines.
     class LinesField
       # Fetches the start and end line of a value.
-      # --
+      #
       # : (_Value value) -> entry_values
       def fields: (_Value value) -> entry_values
     end
@@ -249,7 +249,7 @@ module Prism
     # A field representing the start and end byte offsets.
     class OffsetsField
       # Fetches the start and end byte offset of a value.
-      # --
+      #
       # : (_Value value) -> entry_values
       def fields: (_Value value) -> entry_values
     end
@@ -257,7 +257,7 @@ module Prism
     # A field representing the start and end character offsets.
     class CharacterOffsetsField
       # Fetches the start and end character offset of a value.
-      # --
+      #
       # : (_Value value) -> entry_values
       def fields: (_Value value) -> entry_values
     end
@@ -274,20 +274,20 @@ module Prism
       @cache: _CodeUnitsCache?
 
       # Initialize a new field with the associated repository and encoding.
-      # --
+      #
       # : (Repository repository, Encoding encoding) -> void
       def initialize: (Repository repository, Encoding encoding) -> void
 
       # Fetches the start and end code units offset of a value for a particular
       # encoding.
-      # --
+      #
       # : (_Value value) -> entry_values
       def fields: (_Value value) -> entry_values
 
       private
 
       # Lazily create a code units cache for the associated encoding.
-      # --
+      #
       # : () -> _CodeUnitsCache
       def cache: () -> _CodeUnitsCache
     end
@@ -295,7 +295,7 @@ module Prism
     # A field representing the start and end byte columns.
     class ColumnsField
       # Fetches the start and end byte column of a value.
-      # --
+      #
       # : (_Value value) -> entry_values
       def fields: (_Value value) -> entry_values
     end
@@ -303,7 +303,7 @@ module Prism
     # A field representing the start and end character columns.
     class CharacterColumnsField
       # Fetches the start and end character column of a value.
-      # --
+      #
       # : (_Value value) -> entry_values
       def fields: (_Value value) -> entry_values
     end
@@ -321,20 +321,20 @@ module Prism
       @cache: _CodeUnitsCache?
 
       # Initialize a new field with the associated repository and encoding.
-      # --
+      #
       # : (Repository repository, Encoding encoding) -> void
       def initialize: (Repository repository, Encoding encoding) -> void
 
       # Fetches the start and end code units column of a value for a particular
       # encoding.
-      # --
+      #
       # : (_Value value) -> entry_values
       def fields: (_Value value) -> entry_values
 
       private
 
       # Lazily create a code units cache for the associated encoding.
-      # --
+      #
       # : () -> _CodeUnitsCache
       def cache: () -> _CodeUnitsCache
     end
@@ -355,7 +355,7 @@ module Prism
       private
 
       # Create comment objects from the given values.
-      # --
+      #
       # : (entry_value values) -> Array[Comment]
       def comments: (entry_value values) -> Array[Comment]
     end
@@ -363,7 +363,7 @@ module Prism
     # A field representing the leading comments.
     class LeadingCommentsField < CommentsField
       # Fetches the leading comments of a value.
-      # --
+      #
       # : (_Value value) -> entry_values
       def fields: (_Value value) -> entry_values
     end
@@ -371,7 +371,7 @@ module Prism
     # A field representing the trailing comments.
     class TrailingCommentsField < CommentsField
       # Fetches the trailing comments of a value.
-      # --
+      #
       # : (_Value value) -> entry_values
       def fields: (_Value value) -> entry_values
     end
@@ -395,88 +395,88 @@ module Prism
       attr_reader entries: Hash[Integer, Hash[Symbol, Entry]]
 
       # Initialize a new repository with the given source.
-      # --
+      #
       # : (Source source) -> void
       def initialize: (Source source) -> void
 
       # Create a code units cache for the given encoding from the source.
-      # --
+      #
       # : (Encoding encoding) -> _CodeUnitsCache
       def code_units_cache: (Encoding encoding) -> _CodeUnitsCache
 
       # Configure the filepath field for this repository and return self.
-      # --
+      #
       # : () -> self
       def filepath: () -> self
 
       # Configure the lines field for this repository and return self.
-      # --
+      #
       # : () -> self
       def lines: () -> self
 
       # Configure the offsets field for this repository and return self.
-      # --
+      #
       # : () -> self
       def offsets: () -> self
 
       # Configure the character offsets field for this repository and return
       # self.
-      # --
+      #
       # : () -> self
       def character_offsets: () -> self
 
       # Configure the code unit offsets field for this repository for a specific
       # encoding and return self.
-      # --
+      #
       # : (Encoding encoding) -> self
       def code_unit_offsets: (Encoding encoding) -> self
 
       # Configure the columns field for this repository and return self.
-      # --
+      #
       # : () -> self
       def columns: () -> self
 
       # Configure the character columns field for this repository and return
       # self.
-      # --
+      #
       # : () -> self
       def character_columns: () -> self
 
       # Configure the code unit columns field for this repository for a specific
       # encoding and return self.
-      # --
+      #
       # : (Encoding encoding) -> self
       def code_unit_columns: (Encoding encoding) -> self
 
       # Configure the leading comments field for this repository and return
       # self.
-      # --
+      #
       # : () -> self
       def leading_comments: () -> self
 
       # Configure the trailing comments field for this repository and return
       # self.
-      # --
+      #
       # : () -> self
       def trailing_comments: () -> self
 
       # Configure both the leading and trailing comment fields for this
       # repository and return self.
-      # --
+      #
       # : () -> self
       def comments: () -> self
 
       # This method is called from nodes and locations when they want to enter
       # themselves into the repository. It it internal-only and meant to be
       # called from the #save* APIs.
-      # --
+      #
       # : (Integer node_id, Symbol field_name) -> Entry
       def enter: (Integer node_id, Symbol field_name) -> Entry
 
       # This method is called from the entries in the repository when they need
       # to reify their values. It is internal-only and meant to be called from
       # the various value APIs.
-      # --
+      #
       # : () -> void
       def reify!: () -> void
 
@@ -484,18 +484,18 @@ module Prism
 
       # Append the given field to the repository and return the repository so
       # that these calls can be chained.
-      # --
+      #
       # : (Symbol name, _Field) -> self
       def field: (Symbol name, _Field) -> self
     end
 
     # Create a new repository for the given filepath.
-    # --
+    #
     # : (String value) -> Repository
     def self.filepath: (String value) -> Repository
 
     # Create a new repository for the given string.
-    # --
+    #
     # : (String value) -> Repository
     def self.string: (String value) -> Repository
   end

--- a/sig/generated/prism/serialize.rbs
+++ b/sig/generated/prism/serialize.rbs
@@ -19,7 +19,7 @@ module Prism
     #
     # The formatting of the source of this method is purposeful to illustrate
     # the structure of the serialized data.
-    # --
+    #
     # : (String input, String serialized, bool freeze) -> ParseResult
     def self.load_parse: (String input, String serialized, bool freeze) -> ParseResult
 
@@ -27,7 +27,7 @@ module Prism
     #
     # The formatting of the source of this method is purposeful to illustrate
     # the structure of the serialized data.
-    # --
+    #
     # : (String input, String serialized, bool freeze) -> LexResult
     def self.load_lex: (String input, String serialized, bool freeze) -> LexResult
 
@@ -36,7 +36,7 @@ module Prism
     #
     # The formatting of the source of this method is purposeful to illustrate
     # the structure of the serialized data.
-    # --
+    #
     # : (String input, String serialized, bool freeze) -> Array[Comment]
     def self.load_parse_comments: (String input, String serialized, bool freeze) -> Array[Comment]
 
@@ -45,7 +45,7 @@ module Prism
     #
     # The formatting of the source of this method is purposeful to illustrate
     # the structure of the serialized data.
-    # --
+    #
     # : (String input, String serialized, bool freeze) -> ParseLexResult
     def self.load_parse_lex: (String input, String serialized, bool freeze) -> ParseLexResult
 
@@ -119,7 +119,7 @@ module Prism
 
       # variable-length integer using https://en.wikipedia.org/wiki/LEB128
       # This is also what protobuf uses: https://protobuf.dev/programming-guides/encoding/#varints
-      # --
+      #
       # : () -> Integer
       def load_varuint: () -> Integer
 
@@ -150,14 +150,14 @@ module Prism
       # Load a location object from the serialized data. Note that we are lying
       # about the signature a bit here, because we sometimes load it as a packed
       # integer instead of an object.
-      # --
+      #
       # : (bool freeze) -> Location
       def load_location: (bool freeze) -> Location
 
       # Load an optional location object from the serialized data if it is
       # present. Note that we are lying about the signature a bit here, because
       # we sometimes load it as a packed integer instead of an object.
-      # --
+      #
       # : (bool freeze) -> Location?
       def load_optional_location: (bool freeze) -> Location?
 

--- a/sig/generated/prism/string_query.rbs
+++ b/sig/generated/prism/string_query.rbs
@@ -14,22 +14,22 @@ module Prism
     attr_reader string: String
 
     # Initialize a new query with the given string.
-    # --
+    #
     # : (String string) -> void
     def initialize: (String string) -> void
 
     # Whether or not this string is a valid local variable name.
-    # --
+    #
     # : () -> bool
     def local?: () -> bool
 
     # Whether or not this string is a valid constant name.
-    # --
+    #
     # : () -> bool
     def constant?: () -> bool
 
     # Whether or not this string is a valid method name.
-    # --
+    #
     # : () -> bool
     def method_name?: () -> bool
   end

--- a/sig/generated/prism/visitor.rbs
+++ b/sig/generated/prism/visitor.rbs
@@ -314,17 +314,17 @@ module Prism
   class BasicVisitor
     # Calls `accept` on the given node if it is not `nil`, which in turn should
     # call back into this visitor by calling the appropriate `visit_*` method.
-    # --
+    #
     # : (node? node) -> void
     def visit: (node? node) -> void
 
     # Visits each node in `nodes` by calling `accept` on each one.
-    # --
+    #
     # : (Array[node?] nodes) -> void
     def visit_all: (Array[node?] nodes) -> void
 
     # Visits the child nodes of `node` by calling `accept` on each one.
-    # --
+    #
     # : (node node) -> void
     def visit_child_nodes: (node node) -> void
   end
@@ -349,762 +349,762 @@ module Prism
   #     end
   class Visitor < BasicVisitor
     # Visit a AliasGlobalVariableNode node
-    # --
+    #
     # : (AliasGlobalVariableNode node) -> void
     def visit_alias_global_variable_node: (AliasGlobalVariableNode node) -> void
 
     # Visit a AliasMethodNode node
-    # --
+    #
     # : (AliasMethodNode node) -> void
     def visit_alias_method_node: (AliasMethodNode node) -> void
 
     # Visit a AlternationPatternNode node
-    # --
+    #
     # : (AlternationPatternNode node) -> void
     def visit_alternation_pattern_node: (AlternationPatternNode node) -> void
 
     # Visit a AndNode node
-    # --
+    #
     # : (AndNode node) -> void
     def visit_and_node: (AndNode node) -> void
 
     # Visit a ArgumentsNode node
-    # --
+    #
     # : (ArgumentsNode node) -> void
     def visit_arguments_node: (ArgumentsNode node) -> void
 
     # Visit a ArrayNode node
-    # --
+    #
     # : (ArrayNode node) -> void
     def visit_array_node: (ArrayNode node) -> void
 
     # Visit a ArrayPatternNode node
-    # --
+    #
     # : (ArrayPatternNode node) -> void
     def visit_array_pattern_node: (ArrayPatternNode node) -> void
 
     # Visit a AssocNode node
-    # --
+    #
     # : (AssocNode node) -> void
     def visit_assoc_node: (AssocNode node) -> void
 
     # Visit a AssocSplatNode node
-    # --
+    #
     # : (AssocSplatNode node) -> void
     def visit_assoc_splat_node: (AssocSplatNode node) -> void
 
     # Visit a BackReferenceReadNode node
-    # --
+    #
     # : (BackReferenceReadNode node) -> void
     def visit_back_reference_read_node: (BackReferenceReadNode node) -> void
 
     # Visit a BeginNode node
-    # --
+    #
     # : (BeginNode node) -> void
     def visit_begin_node: (BeginNode node) -> void
 
     # Visit a BlockArgumentNode node
-    # --
+    #
     # : (BlockArgumentNode node) -> void
     def visit_block_argument_node: (BlockArgumentNode node) -> void
 
     # Visit a BlockLocalVariableNode node
-    # --
+    #
     # : (BlockLocalVariableNode node) -> void
     def visit_block_local_variable_node: (BlockLocalVariableNode node) -> void
 
     # Visit a BlockNode node
-    # --
+    #
     # : (BlockNode node) -> void
     def visit_block_node: (BlockNode node) -> void
 
     # Visit a BlockParameterNode node
-    # --
+    #
     # : (BlockParameterNode node) -> void
     def visit_block_parameter_node: (BlockParameterNode node) -> void
 
     # Visit a BlockParametersNode node
-    # --
+    #
     # : (BlockParametersNode node) -> void
     def visit_block_parameters_node: (BlockParametersNode node) -> void
 
     # Visit a BreakNode node
-    # --
+    #
     # : (BreakNode node) -> void
     def visit_break_node: (BreakNode node) -> void
 
     # Visit a CallAndWriteNode node
-    # --
+    #
     # : (CallAndWriteNode node) -> void
     def visit_call_and_write_node: (CallAndWriteNode node) -> void
 
     # Visit a CallNode node
-    # --
+    #
     # : (CallNode node) -> void
     def visit_call_node: (CallNode node) -> void
 
     # Visit a CallOperatorWriteNode node
-    # --
+    #
     # : (CallOperatorWriteNode node) -> void
     def visit_call_operator_write_node: (CallOperatorWriteNode node) -> void
 
     # Visit a CallOrWriteNode node
-    # --
+    #
     # : (CallOrWriteNode node) -> void
     def visit_call_or_write_node: (CallOrWriteNode node) -> void
 
     # Visit a CallTargetNode node
-    # --
+    #
     # : (CallTargetNode node) -> void
     def visit_call_target_node: (CallTargetNode node) -> void
 
     # Visit a CapturePatternNode node
-    # --
+    #
     # : (CapturePatternNode node) -> void
     def visit_capture_pattern_node: (CapturePatternNode node) -> void
 
     # Visit a CaseMatchNode node
-    # --
+    #
     # : (CaseMatchNode node) -> void
     def visit_case_match_node: (CaseMatchNode node) -> void
 
     # Visit a CaseNode node
-    # --
+    #
     # : (CaseNode node) -> void
     def visit_case_node: (CaseNode node) -> void
 
     # Visit a ClassNode node
-    # --
+    #
     # : (ClassNode node) -> void
     def visit_class_node: (ClassNode node) -> void
 
     # Visit a ClassVariableAndWriteNode node
-    # --
+    #
     # : (ClassVariableAndWriteNode node) -> void
     def visit_class_variable_and_write_node: (ClassVariableAndWriteNode node) -> void
 
     # Visit a ClassVariableOperatorWriteNode node
-    # --
+    #
     # : (ClassVariableOperatorWriteNode node) -> void
     def visit_class_variable_operator_write_node: (ClassVariableOperatorWriteNode node) -> void
 
     # Visit a ClassVariableOrWriteNode node
-    # --
+    #
     # : (ClassVariableOrWriteNode node) -> void
     def visit_class_variable_or_write_node: (ClassVariableOrWriteNode node) -> void
 
     # Visit a ClassVariableReadNode node
-    # --
+    #
     # : (ClassVariableReadNode node) -> void
     def visit_class_variable_read_node: (ClassVariableReadNode node) -> void
 
     # Visit a ClassVariableTargetNode node
-    # --
+    #
     # : (ClassVariableTargetNode node) -> void
     def visit_class_variable_target_node: (ClassVariableTargetNode node) -> void
 
     # Visit a ClassVariableWriteNode node
-    # --
+    #
     # : (ClassVariableWriteNode node) -> void
     def visit_class_variable_write_node: (ClassVariableWriteNode node) -> void
 
     # Visit a ConstantAndWriteNode node
-    # --
+    #
     # : (ConstantAndWriteNode node) -> void
     def visit_constant_and_write_node: (ConstantAndWriteNode node) -> void
 
     # Visit a ConstantOperatorWriteNode node
-    # --
+    #
     # : (ConstantOperatorWriteNode node) -> void
     def visit_constant_operator_write_node: (ConstantOperatorWriteNode node) -> void
 
     # Visit a ConstantOrWriteNode node
-    # --
+    #
     # : (ConstantOrWriteNode node) -> void
     def visit_constant_or_write_node: (ConstantOrWriteNode node) -> void
 
     # Visit a ConstantPathAndWriteNode node
-    # --
+    #
     # : (ConstantPathAndWriteNode node) -> void
     def visit_constant_path_and_write_node: (ConstantPathAndWriteNode node) -> void
 
     # Visit a ConstantPathNode node
-    # --
+    #
     # : (ConstantPathNode node) -> void
     def visit_constant_path_node: (ConstantPathNode node) -> void
 
     # Visit a ConstantPathOperatorWriteNode node
-    # --
+    #
     # : (ConstantPathOperatorWriteNode node) -> void
     def visit_constant_path_operator_write_node: (ConstantPathOperatorWriteNode node) -> void
 
     # Visit a ConstantPathOrWriteNode node
-    # --
+    #
     # : (ConstantPathOrWriteNode node) -> void
     def visit_constant_path_or_write_node: (ConstantPathOrWriteNode node) -> void
 
     # Visit a ConstantPathTargetNode node
-    # --
+    #
     # : (ConstantPathTargetNode node) -> void
     def visit_constant_path_target_node: (ConstantPathTargetNode node) -> void
 
     # Visit a ConstantPathWriteNode node
-    # --
+    #
     # : (ConstantPathWriteNode node) -> void
     def visit_constant_path_write_node: (ConstantPathWriteNode node) -> void
 
     # Visit a ConstantReadNode node
-    # --
+    #
     # : (ConstantReadNode node) -> void
     def visit_constant_read_node: (ConstantReadNode node) -> void
 
     # Visit a ConstantTargetNode node
-    # --
+    #
     # : (ConstantTargetNode node) -> void
     def visit_constant_target_node: (ConstantTargetNode node) -> void
 
     # Visit a ConstantWriteNode node
-    # --
+    #
     # : (ConstantWriteNode node) -> void
     def visit_constant_write_node: (ConstantWriteNode node) -> void
 
     # Visit a DefNode node
-    # --
+    #
     # : (DefNode node) -> void
     def visit_def_node: (DefNode node) -> void
 
     # Visit a DefinedNode node
-    # --
+    #
     # : (DefinedNode node) -> void
     def visit_defined_node: (DefinedNode node) -> void
 
     # Visit a ElseNode node
-    # --
+    #
     # : (ElseNode node) -> void
     def visit_else_node: (ElseNode node) -> void
 
     # Visit a EmbeddedStatementsNode node
-    # --
+    #
     # : (EmbeddedStatementsNode node) -> void
     def visit_embedded_statements_node: (EmbeddedStatementsNode node) -> void
 
     # Visit a EmbeddedVariableNode node
-    # --
+    #
     # : (EmbeddedVariableNode node) -> void
     def visit_embedded_variable_node: (EmbeddedVariableNode node) -> void
 
     # Visit a EnsureNode node
-    # --
+    #
     # : (EnsureNode node) -> void
     def visit_ensure_node: (EnsureNode node) -> void
 
     # Visit a ErrorRecoveryNode node
-    # --
+    #
     # : (ErrorRecoveryNode node) -> void
     def visit_error_recovery_node: (ErrorRecoveryNode node) -> void
 
     # Visit a FalseNode node
-    # --
+    #
     # : (FalseNode node) -> void
     def visit_false_node: (FalseNode node) -> void
 
     # Visit a FindPatternNode node
-    # --
+    #
     # : (FindPatternNode node) -> void
     def visit_find_pattern_node: (FindPatternNode node) -> void
 
     # Visit a FlipFlopNode node
-    # --
+    #
     # : (FlipFlopNode node) -> void
     def visit_flip_flop_node: (FlipFlopNode node) -> void
 
     # Visit a FloatNode node
-    # --
+    #
     # : (FloatNode node) -> void
     def visit_float_node: (FloatNode node) -> void
 
     # Visit a ForNode node
-    # --
+    #
     # : (ForNode node) -> void
     def visit_for_node: (ForNode node) -> void
 
     # Visit a ForwardingArgumentsNode node
-    # --
+    #
     # : (ForwardingArgumentsNode node) -> void
     def visit_forwarding_arguments_node: (ForwardingArgumentsNode node) -> void
 
     # Visit a ForwardingParameterNode node
-    # --
+    #
     # : (ForwardingParameterNode node) -> void
     def visit_forwarding_parameter_node: (ForwardingParameterNode node) -> void
 
     # Visit a ForwardingSuperNode node
-    # --
+    #
     # : (ForwardingSuperNode node) -> void
     def visit_forwarding_super_node: (ForwardingSuperNode node) -> void
 
     # Visit a GlobalVariableAndWriteNode node
-    # --
+    #
     # : (GlobalVariableAndWriteNode node) -> void
     def visit_global_variable_and_write_node: (GlobalVariableAndWriteNode node) -> void
 
     # Visit a GlobalVariableOperatorWriteNode node
-    # --
+    #
     # : (GlobalVariableOperatorWriteNode node) -> void
     def visit_global_variable_operator_write_node: (GlobalVariableOperatorWriteNode node) -> void
 
     # Visit a GlobalVariableOrWriteNode node
-    # --
+    #
     # : (GlobalVariableOrWriteNode node) -> void
     def visit_global_variable_or_write_node: (GlobalVariableOrWriteNode node) -> void
 
     # Visit a GlobalVariableReadNode node
-    # --
+    #
     # : (GlobalVariableReadNode node) -> void
     def visit_global_variable_read_node: (GlobalVariableReadNode node) -> void
 
     # Visit a GlobalVariableTargetNode node
-    # --
+    #
     # : (GlobalVariableTargetNode node) -> void
     def visit_global_variable_target_node: (GlobalVariableTargetNode node) -> void
 
     # Visit a GlobalVariableWriteNode node
-    # --
+    #
     # : (GlobalVariableWriteNode node) -> void
     def visit_global_variable_write_node: (GlobalVariableWriteNode node) -> void
 
     # Visit a HashNode node
-    # --
+    #
     # : (HashNode node) -> void
     def visit_hash_node: (HashNode node) -> void
 
     # Visit a HashPatternNode node
-    # --
+    #
     # : (HashPatternNode node) -> void
     def visit_hash_pattern_node: (HashPatternNode node) -> void
 
     # Visit a IfNode node
-    # --
+    #
     # : (IfNode node) -> void
     def visit_if_node: (IfNode node) -> void
 
     # Visit a ImaginaryNode node
-    # --
+    #
     # : (ImaginaryNode node) -> void
     def visit_imaginary_node: (ImaginaryNode node) -> void
 
     # Visit a ImplicitNode node
-    # --
+    #
     # : (ImplicitNode node) -> void
     def visit_implicit_node: (ImplicitNode node) -> void
 
     # Visit a ImplicitRestNode node
-    # --
+    #
     # : (ImplicitRestNode node) -> void
     def visit_implicit_rest_node: (ImplicitRestNode node) -> void
 
     # Visit a InNode node
-    # --
+    #
     # : (InNode node) -> void
     def visit_in_node: (InNode node) -> void
 
     # Visit a IndexAndWriteNode node
-    # --
+    #
     # : (IndexAndWriteNode node) -> void
     def visit_index_and_write_node: (IndexAndWriteNode node) -> void
 
     # Visit a IndexOperatorWriteNode node
-    # --
+    #
     # : (IndexOperatorWriteNode node) -> void
     def visit_index_operator_write_node: (IndexOperatorWriteNode node) -> void
 
     # Visit a IndexOrWriteNode node
-    # --
+    #
     # : (IndexOrWriteNode node) -> void
     def visit_index_or_write_node: (IndexOrWriteNode node) -> void
 
     # Visit a IndexTargetNode node
-    # --
+    #
     # : (IndexTargetNode node) -> void
     def visit_index_target_node: (IndexTargetNode node) -> void
 
     # Visit a InstanceVariableAndWriteNode node
-    # --
+    #
     # : (InstanceVariableAndWriteNode node) -> void
     def visit_instance_variable_and_write_node: (InstanceVariableAndWriteNode node) -> void
 
     # Visit a InstanceVariableOperatorWriteNode node
-    # --
+    #
     # : (InstanceVariableOperatorWriteNode node) -> void
     def visit_instance_variable_operator_write_node: (InstanceVariableOperatorWriteNode node) -> void
 
     # Visit a InstanceVariableOrWriteNode node
-    # --
+    #
     # : (InstanceVariableOrWriteNode node) -> void
     def visit_instance_variable_or_write_node: (InstanceVariableOrWriteNode node) -> void
 
     # Visit a InstanceVariableReadNode node
-    # --
+    #
     # : (InstanceVariableReadNode node) -> void
     def visit_instance_variable_read_node: (InstanceVariableReadNode node) -> void
 
     # Visit a InstanceVariableTargetNode node
-    # --
+    #
     # : (InstanceVariableTargetNode node) -> void
     def visit_instance_variable_target_node: (InstanceVariableTargetNode node) -> void
 
     # Visit a InstanceVariableWriteNode node
-    # --
+    #
     # : (InstanceVariableWriteNode node) -> void
     def visit_instance_variable_write_node: (InstanceVariableWriteNode node) -> void
 
     # Visit a IntegerNode node
-    # --
+    #
     # : (IntegerNode node) -> void
     def visit_integer_node: (IntegerNode node) -> void
 
     # Visit a InterpolatedMatchLastLineNode node
-    # --
+    #
     # : (InterpolatedMatchLastLineNode node) -> void
     def visit_interpolated_match_last_line_node: (InterpolatedMatchLastLineNode node) -> void
 
     # Visit a InterpolatedRegularExpressionNode node
-    # --
+    #
     # : (InterpolatedRegularExpressionNode node) -> void
     def visit_interpolated_regular_expression_node: (InterpolatedRegularExpressionNode node) -> void
 
     # Visit a InterpolatedStringNode node
-    # --
+    #
     # : (InterpolatedStringNode node) -> void
     def visit_interpolated_string_node: (InterpolatedStringNode node) -> void
 
     # Visit a InterpolatedSymbolNode node
-    # --
+    #
     # : (InterpolatedSymbolNode node) -> void
     def visit_interpolated_symbol_node: (InterpolatedSymbolNode node) -> void
 
     # Visit a InterpolatedXStringNode node
-    # --
+    #
     # : (InterpolatedXStringNode node) -> void
     def visit_interpolated_x_string_node: (InterpolatedXStringNode node) -> void
 
     # Visit a ItLocalVariableReadNode node
-    # --
+    #
     # : (ItLocalVariableReadNode node) -> void
     def visit_it_local_variable_read_node: (ItLocalVariableReadNode node) -> void
 
     # Visit a ItParametersNode node
-    # --
+    #
     # : (ItParametersNode node) -> void
     def visit_it_parameters_node: (ItParametersNode node) -> void
 
     # Visit a KeywordHashNode node
-    # --
+    #
     # : (KeywordHashNode node) -> void
     def visit_keyword_hash_node: (KeywordHashNode node) -> void
 
     # Visit a KeywordRestParameterNode node
-    # --
+    #
     # : (KeywordRestParameterNode node) -> void
     def visit_keyword_rest_parameter_node: (KeywordRestParameterNode node) -> void
 
     # Visit a LambdaNode node
-    # --
+    #
     # : (LambdaNode node) -> void
     def visit_lambda_node: (LambdaNode node) -> void
 
     # Visit a LocalVariableAndWriteNode node
-    # --
+    #
     # : (LocalVariableAndWriteNode node) -> void
     def visit_local_variable_and_write_node: (LocalVariableAndWriteNode node) -> void
 
     # Visit a LocalVariableOperatorWriteNode node
-    # --
+    #
     # : (LocalVariableOperatorWriteNode node) -> void
     def visit_local_variable_operator_write_node: (LocalVariableOperatorWriteNode node) -> void
 
     # Visit a LocalVariableOrWriteNode node
-    # --
+    #
     # : (LocalVariableOrWriteNode node) -> void
     def visit_local_variable_or_write_node: (LocalVariableOrWriteNode node) -> void
 
     # Visit a LocalVariableReadNode node
-    # --
+    #
     # : (LocalVariableReadNode node) -> void
     def visit_local_variable_read_node: (LocalVariableReadNode node) -> void
 
     # Visit a LocalVariableTargetNode node
-    # --
+    #
     # : (LocalVariableTargetNode node) -> void
     def visit_local_variable_target_node: (LocalVariableTargetNode node) -> void
 
     # Visit a LocalVariableWriteNode node
-    # --
+    #
     # : (LocalVariableWriteNode node) -> void
     def visit_local_variable_write_node: (LocalVariableWriteNode node) -> void
 
     # Visit a MatchLastLineNode node
-    # --
+    #
     # : (MatchLastLineNode node) -> void
     def visit_match_last_line_node: (MatchLastLineNode node) -> void
 
     # Visit a MatchPredicateNode node
-    # --
+    #
     # : (MatchPredicateNode node) -> void
     def visit_match_predicate_node: (MatchPredicateNode node) -> void
 
     # Visit a MatchRequiredNode node
-    # --
+    #
     # : (MatchRequiredNode node) -> void
     def visit_match_required_node: (MatchRequiredNode node) -> void
 
     # Visit a MatchWriteNode node
-    # --
+    #
     # : (MatchWriteNode node) -> void
     def visit_match_write_node: (MatchWriteNode node) -> void
 
     # Visit a ModuleNode node
-    # --
+    #
     # : (ModuleNode node) -> void
     def visit_module_node: (ModuleNode node) -> void
 
     # Visit a MultiTargetNode node
-    # --
+    #
     # : (MultiTargetNode node) -> void
     def visit_multi_target_node: (MultiTargetNode node) -> void
 
     # Visit a MultiWriteNode node
-    # --
+    #
     # : (MultiWriteNode node) -> void
     def visit_multi_write_node: (MultiWriteNode node) -> void
 
     # Visit a NextNode node
-    # --
+    #
     # : (NextNode node) -> void
     def visit_next_node: (NextNode node) -> void
 
     # Visit a NilNode node
-    # --
+    #
     # : (NilNode node) -> void
     def visit_nil_node: (NilNode node) -> void
 
     # Visit a NoBlockParameterNode node
-    # --
+    #
     # : (NoBlockParameterNode node) -> void
     def visit_no_block_parameter_node: (NoBlockParameterNode node) -> void
 
     # Visit a NoKeywordsParameterNode node
-    # --
+    #
     # : (NoKeywordsParameterNode node) -> void
     def visit_no_keywords_parameter_node: (NoKeywordsParameterNode node) -> void
 
     # Visit a NumberedParametersNode node
-    # --
+    #
     # : (NumberedParametersNode node) -> void
     def visit_numbered_parameters_node: (NumberedParametersNode node) -> void
 
     # Visit a NumberedReferenceReadNode node
-    # --
+    #
     # : (NumberedReferenceReadNode node) -> void
     def visit_numbered_reference_read_node: (NumberedReferenceReadNode node) -> void
 
     # Visit a OptionalKeywordParameterNode node
-    # --
+    #
     # : (OptionalKeywordParameterNode node) -> void
     def visit_optional_keyword_parameter_node: (OptionalKeywordParameterNode node) -> void
 
     # Visit a OptionalParameterNode node
-    # --
+    #
     # : (OptionalParameterNode node) -> void
     def visit_optional_parameter_node: (OptionalParameterNode node) -> void
 
     # Visit a OrNode node
-    # --
+    #
     # : (OrNode node) -> void
     def visit_or_node: (OrNode node) -> void
 
     # Visit a ParametersNode node
-    # --
+    #
     # : (ParametersNode node) -> void
     def visit_parameters_node: (ParametersNode node) -> void
 
     # Visit a ParenthesesNode node
-    # --
+    #
     # : (ParenthesesNode node) -> void
     def visit_parentheses_node: (ParenthesesNode node) -> void
 
     # Visit a PinnedExpressionNode node
-    # --
+    #
     # : (PinnedExpressionNode node) -> void
     def visit_pinned_expression_node: (PinnedExpressionNode node) -> void
 
     # Visit a PinnedVariableNode node
-    # --
+    #
     # : (PinnedVariableNode node) -> void
     def visit_pinned_variable_node: (PinnedVariableNode node) -> void
 
     # Visit a PostExecutionNode node
-    # --
+    #
     # : (PostExecutionNode node) -> void
     def visit_post_execution_node: (PostExecutionNode node) -> void
 
     # Visit a PreExecutionNode node
-    # --
+    #
     # : (PreExecutionNode node) -> void
     def visit_pre_execution_node: (PreExecutionNode node) -> void
 
     # Visit a ProgramNode node
-    # --
+    #
     # : (ProgramNode node) -> void
     def visit_program_node: (ProgramNode node) -> void
 
     # Visit a RangeNode node
-    # --
+    #
     # : (RangeNode node) -> void
     def visit_range_node: (RangeNode node) -> void
 
     # Visit a RationalNode node
-    # --
+    #
     # : (RationalNode node) -> void
     def visit_rational_node: (RationalNode node) -> void
 
     # Visit a RedoNode node
-    # --
+    #
     # : (RedoNode node) -> void
     def visit_redo_node: (RedoNode node) -> void
 
     # Visit a RegularExpressionNode node
-    # --
+    #
     # : (RegularExpressionNode node) -> void
     def visit_regular_expression_node: (RegularExpressionNode node) -> void
 
     # Visit a RequiredKeywordParameterNode node
-    # --
+    #
     # : (RequiredKeywordParameterNode node) -> void
     def visit_required_keyword_parameter_node: (RequiredKeywordParameterNode node) -> void
 
     # Visit a RequiredParameterNode node
-    # --
+    #
     # : (RequiredParameterNode node) -> void
     def visit_required_parameter_node: (RequiredParameterNode node) -> void
 
     # Visit a RescueModifierNode node
-    # --
+    #
     # : (RescueModifierNode node) -> void
     def visit_rescue_modifier_node: (RescueModifierNode node) -> void
 
     # Visit a RescueNode node
-    # --
+    #
     # : (RescueNode node) -> void
     def visit_rescue_node: (RescueNode node) -> void
 
     # Visit a RestParameterNode node
-    # --
+    #
     # : (RestParameterNode node) -> void
     def visit_rest_parameter_node: (RestParameterNode node) -> void
 
     # Visit a RetryNode node
-    # --
+    #
     # : (RetryNode node) -> void
     def visit_retry_node: (RetryNode node) -> void
 
     # Visit a ReturnNode node
-    # --
+    #
     # : (ReturnNode node) -> void
     def visit_return_node: (ReturnNode node) -> void
 
     # Visit a SelfNode node
-    # --
+    #
     # : (SelfNode node) -> void
     def visit_self_node: (SelfNode node) -> void
 
     # Visit a ShareableConstantNode node
-    # --
+    #
     # : (ShareableConstantNode node) -> void
     def visit_shareable_constant_node: (ShareableConstantNode node) -> void
 
     # Visit a SingletonClassNode node
-    # --
+    #
     # : (SingletonClassNode node) -> void
     def visit_singleton_class_node: (SingletonClassNode node) -> void
 
     # Visit a SourceEncodingNode node
-    # --
+    #
     # : (SourceEncodingNode node) -> void
     def visit_source_encoding_node: (SourceEncodingNode node) -> void
 
     # Visit a SourceFileNode node
-    # --
+    #
     # : (SourceFileNode node) -> void
     def visit_source_file_node: (SourceFileNode node) -> void
 
     # Visit a SourceLineNode node
-    # --
+    #
     # : (SourceLineNode node) -> void
     def visit_source_line_node: (SourceLineNode node) -> void
 
     # Visit a SplatNode node
-    # --
+    #
     # : (SplatNode node) -> void
     def visit_splat_node: (SplatNode node) -> void
 
     # Visit a StatementsNode node
-    # --
+    #
     # : (StatementsNode node) -> void
     def visit_statements_node: (StatementsNode node) -> void
 
     # Visit a StringNode node
-    # --
+    #
     # : (StringNode node) -> void
     def visit_string_node: (StringNode node) -> void
 
     # Visit a SuperNode node
-    # --
+    #
     # : (SuperNode node) -> void
     def visit_super_node: (SuperNode node) -> void
 
     # Visit a SymbolNode node
-    # --
+    #
     # : (SymbolNode node) -> void
     def visit_symbol_node: (SymbolNode node) -> void
 
     # Visit a TrueNode node
-    # --
+    #
     # : (TrueNode node) -> void
     def visit_true_node: (TrueNode node) -> void
 
     # Visit a UndefNode node
-    # --
+    #
     # : (UndefNode node) -> void
     def visit_undef_node: (UndefNode node) -> void
 
     # Visit a UnlessNode node
-    # --
+    #
     # : (UnlessNode node) -> void
     def visit_unless_node: (UnlessNode node) -> void
 
     # Visit a UntilNode node
-    # --
+    #
     # : (UntilNode node) -> void
     def visit_until_node: (UntilNode node) -> void
 
     # Visit a WhenNode node
-    # --
+    #
     # : (WhenNode node) -> void
     def visit_when_node: (WhenNode node) -> void
 
     # Visit a WhileNode node
-    # --
+    #
     # : (WhileNode node) -> void
     def visit_while_node: (WhileNode node) -> void
 
     # Visit a XStringNode node
-    # --
+    #
     # : (XStringNode node) -> void
     def visit_x_string_node: (XStringNode node) -> void
 
     # Visit a YieldNode node
-    # --
+    #
     # : (YieldNode node) -> void
     def visit_yield_node: (YieldNode node) -> void
   end

--- a/templates/lib/prism/compiler.rb.erb
+++ b/templates/lib/prism/compiler.rb.erb
@@ -21,21 +21,21 @@ module Prism
   #
   class Compiler < Visitor
     # Visit an individual node.
-    #--
+    #
     #: (node?) -> untyped
     def visit(node) # :nodoc:
       node&.accept(self)
     end
 
     # Visit a list of nodes.
-    #--
+    #
     #: (Array[node?]) -> untyped
     def visit_all(nodes) # :nodoc:
       nodes.map { |node| node&.accept(self) }
     end
 
     # Visit the child nodes of the given node.
-    #--
+    #
     #: (node) -> Array[untyped]
     def visit_child_nodes(node) # :nodoc:
       node.each_child_node.map { |node| node.accept(self) }

--- a/templates/lib/prism/dispatcher.rb.erb
+++ b/templates/lib/prism/dispatcher.rb.erb
@@ -40,14 +40,14 @@ module Prism
     attr_reader :listeners #: Hash[Symbol, Array[untyped]]
 
     # Initialize a new dispatcher.
-    #--
+    #
     #: () -> void
     def initialize
       @listeners = {}
     end
 
     # Register a listener for one or more events.
-    #--
+    #
     #: (untyped, *Symbol) -> void
     def register(listener, *events)
       register_events(listener, events)
@@ -55,14 +55,14 @@ module Prism
 
     # Register all public methods of a listener that match the pattern
     # `on_<node_name>_(enter|leave)`.
-    #--
+    #
     #: (untyped) -> void
     def register_public_methods(listener)
       register_events(listener, listener.public_methods(false).grep(/\Aon_.+_(?:enter|leave)\z/))
     end
 
     # Register a listener for the given events.
-    #--
+    #
     #: (untyped, Array[Symbol]) -> void
     private def register_events(listener, events) # :nodoc:
       events.each { |event| (listeners[event] ||= []) << listener }
@@ -72,7 +72,7 @@ module Prism
     alias dispatch visit
 
     # Dispatches a single event for `node` to all registered listeners.
-    #--
+    #
     #: (node node) -> void
     def dispatch_once(node)
       node.accept(DispatchOnce.new(listeners))
@@ -97,7 +97,7 @@ module Prism
       <%- nodes.each do |node| -%>
 
       # Dispatch enter and leave events for <%= node.name %> nodes.
-      #--
+      #
       #: (<%= node.name %> node) -> void
       def visit_<%= node.human %>(node)
         listeners[:on_<%= node.human %>_enter]&.each { |listener| listener.on_<%= node.human %>_enter(node) }

--- a/templates/lib/prism/dot_visitor.rb.erb
+++ b/templates/lib/prism/dot_visitor.rb.erb
@@ -112,14 +112,14 @@ module Prism
     attr_reader :digraph #: Digraph
 
     # Initialize a new dot visitor.
-    #--
+    #
     #: () -> void
     def initialize
       @digraph = Digraph.new
     end
 
     # Convert this visitor into a graphviz dot graph string.
-    #--
+    #
     #: () -> String
     def to_dot
       digraph.to_dot
@@ -185,14 +185,14 @@ module Prism
     private
 
     # Generate a unique node ID for a node throughout the digraph.
-    #--
+    #
     #: (node) -> String
     def node_id(node) # :nodoc:
       "Node_#{node.object_id}"
     end
 
     # Inspect a location to display the start and end line and columns in bytes.
-    #--
+    #
     #: (Location) -> String
     def location_inspect(location) # :nodoc:
       "(#{location.start_line},#{location.start_column})-(#{location.end_line},#{location.end_column})"
@@ -201,7 +201,7 @@ module Prism
 
     # Inspect a node that has <%= flag.human %> flags to display the flags as a
     # comma-separated list.
-    #--
+    #
     #: (<%= nodes.filter_map { |node| node.name if node.flags == flag }.join(" | ") %> node) -> String
     def <%= flag.human %>_inspect(node) # :nodoc:
       flags = [] #: Array[String]

--- a/templates/lib/prism/dsl.rb.erb
+++ b/templates/lib/prism/dsl.rb.erb
@@ -59,14 +59,14 @@ module Prism
     extend self
 
     # Create a new Source object.
-    #--
+    #
     #: (String string) -> Source
     def source(string)
       Source.for(string, 1, build_offsets(string))
     end
 
     # Create a new Location object.
-    #--
+    #
     #: (?source: Source, ?start_offset: Integer, ?length: Integer) -> Location
     def location(source: default_source, start_offset: 0, length: 0)
       Location.new(source, start_offset, length)
@@ -82,7 +82,7 @@ module Prism
     -%>
 
     # Create a new <%= node.name %> node.
-    #--
+    #
     #: (<%= params.map { |(name, type)| "?#{name}: #{type}" }.join(", ") %>) -> <%= node.name %>
     def <%= node.human %>(<%= ["source: default_source", "node_id: 0", "location: default_location", "flags: 0", *node.fields.map { |field|
       case field
@@ -117,7 +117,7 @@ module Prism
     <%- flags.each do |flag| -%>
 
     # Retrieve the value of one of the <%= flag.name %> flags.
-    #--
+    #
     #: (Symbol name) -> Integer
     def <%= flag.human.chomp("s") %>(name)
       case name
@@ -133,7 +133,7 @@ module Prism
 
     # The default source object that gets attached to nodes and locations if no
     # source is specified.
-    #--
+    #
     #: () -> Source
     def default_source
       Source.for("", 1, [0])
@@ -141,7 +141,7 @@ module Prism
 
     # The default location object that gets attached to nodes if no location is
     # specified, which uses the given source.
-    #--
+    #
     #: () -> Location
     def default_location
       Location.new(default_source, 0, 0)
@@ -149,7 +149,7 @@ module Prism
 
     # The default node that gets attached to nodes if no node is specified for a
     # required node field.
-    #--
+    #
     #: (Source source, Location location) -> node
     def default_node(source, location)
       ErrorRecoveryNode.new(source, -1, location, 0, nil)
@@ -158,7 +158,7 @@ module Prism
     private
 
     # Build the newline byte offset array for the given source string.
-    #--
+    #
     #: (String source) -> Array[Integer]
     def build_offsets(source)
       offsets = [0]

--- a/templates/lib/prism/inspect_visitor.rb.erb
+++ b/templates/lib/prism/inspect_visitor.rb.erb
@@ -38,7 +38,7 @@ module Prism
     end
 
     # Compose an inspect string for the given node.
-    #--
+    #
     #: (node node) -> String
     def self.compose(node)
       visitor = new
@@ -47,7 +47,7 @@ module Prism
     end
 
     # Compose the final string.
-    #--
+    #
     #: () -> String
     def compose # :nodoc:
       buffer = +""
@@ -126,7 +126,7 @@ module Prism
     private
 
     # Compose a header for the given node.
-    #--
+    #
     #: (String name, node node) -> String
     def inspect_node(name, node) # :nodoc:
       location = node.location
@@ -134,7 +134,7 @@ module Prism
     end
 
     # Compose a string representing the given inner location field.
-    #--
+    #
     #: (Location? location) -> String
     def inspect_location(location) # :nodoc:
       if location

--- a/templates/lib/prism/node.rb.erb
+++ b/templates/lib/prism/node.rb.erb
@@ -34,7 +34,7 @@ module Prism
     # @rbs @location: Location | Integer
 
     # Save this node using a saved source so that it can be retrieved later.
-    #--
+    #
     #: (_Repository repository) -> Relocation::Entry
     def save(repository)
       repository.enter(node_id, :itself)
@@ -42,7 +42,7 @@ module Prism
 
     # A Location instance that represents the location of this node in the
     # source.
-    #--
+    #
     #: () -> Location
     def location
       location = @location
@@ -51,7 +51,7 @@ module Prism
     end
 
     # Save the location using a saved source so that it can be retrieved later.
-    #--
+    #
     #: (_Repository repository) -> Relocation::Entry
     def save_location(repository)
       repository.enter(node_id, :location)
@@ -63,21 +63,21 @@ module Prism
     # --------------------------------------------------------------------------
 
     # Delegates to [`start_line`](rdoc-ref:Location#start_line) of the associated location object.
-    #--
+    #
     #: () -> Integer
     def start_line
       location.start_line
     end
 
     # Delegates to [`end_line`](rdoc-ref:Location#end_line) of the associated location object.
-    #--
+    #
     #: () -> Integer
     def end_line
       location.end_line
     end
 
     # Delegates to [`start_offset`](rdoc-ref:Location#start_offset) of the associated location object.
-    #--
+    #
     #: () -> Integer
     def start_offset
       location = @location
@@ -85,7 +85,7 @@ module Prism
     end
 
     # Delegates to [`end_offset`](rdoc-ref:Location#end_offset) of the associated location object.
-    #--
+    #
     #: () -> Integer
     def end_offset
       location = @location
@@ -94,7 +94,7 @@ module Prism
 
     # Delegates to [`start_character_offset`](rdoc-ref:Location#start_character_offset)
     # of the associated location object.
-    #--
+    #
     #: () -> Integer
     def start_character_offset
       location.start_character_offset
@@ -102,7 +102,7 @@ module Prism
 
     # Delegates to [`end_character_offset`](rdoc-ref:Location#end_character_offset)
     # of the associated location object.
-    #--
+    #
     #: () -> Integer
     def end_character_offset
       location.end_character_offset
@@ -110,7 +110,7 @@ module Prism
 
     # Delegates to [`cached_start_code_units_offset`](rdoc-ref:Location#cached_start_code_units_offset)
     # of the associated location object.
-    #--
+    #
     #: (_CodeUnitsCache cache) -> Integer
     def cached_start_code_units_offset(cache)
       location.cached_start_code_units_offset(cache)
@@ -118,21 +118,21 @@ module Prism
 
     # Delegates to [`cached_end_code_units_offset`](rdoc-ref:Location#cached_end_code_units_offset)
     # of the associated location object.
-    #--
+    #
     #: (_CodeUnitsCache cache) -> Integer
     def cached_end_code_units_offset(cache)
       location.cached_end_code_units_offset(cache)
     end
 
     # Delegates to [`start_column`](rdoc-ref:Location#start_column) of the associated location object.
-    #--
+    #
     #: () -> Integer
     def start_column
       location.start_column
     end
 
     # Delegates to [`end_column`](rdoc-ref:Location#end_column) of the associated location object.
-    #--
+    #
     #: () -> Integer
     def end_column
       location.end_column
@@ -140,7 +140,7 @@ module Prism
 
     # Delegates to [`start_character_column`](rdoc-ref:Location#start_character_column)
     # of the associated location object.
-    #--
+    #
     #: () -> Integer
     def start_character_column
       location.start_character_column
@@ -148,7 +148,7 @@ module Prism
 
     # Delegates to [`end_character_column`](rdoc-ref:Location#end_character_column)
     # of the associated location object.
-    #--
+    #
     #: () -> Integer
     def end_character_column
       location.end_character_column
@@ -156,7 +156,7 @@ module Prism
 
     # Delegates to [`cached_start_code_units_column`](rdoc-ref:Location#cached_start_code_units_column)
     # of the associated location object.
-    #--
+    #
     #: (_CodeUnitsCache cache) -> Integer
     def cached_start_code_units_column(cache)
       location.cached_start_code_units_column(cache)
@@ -164,28 +164,28 @@ module Prism
 
     # Delegates to [`cached_end_code_units_column`](rdoc-ref:Location#cached_end_code_units_column)
     # of the associated location object.
-    #--
+    #
     #: (_CodeUnitsCache cache) -> Integer
     def cached_end_code_units_column(cache)
       location.cached_end_code_units_column(cache)
     end
 
     # Delegates to [`leading_comments`](rdoc-ref:Location#leading_comments) of the associated location object.
-    #--
+    #
     #: () -> Array[Comment]
     def leading_comments
       location.leading_comments
     end
 
     # Delegates to [`trailing_comments`](rdoc-ref:Location#trailing_comments) of the associated location object.
-    #--
+    #
     #: () -> Array[Comment]
     def trailing_comments
       location.trailing_comments
     end
 
     # Delegates to [`comments`](rdoc-ref:Location#comments) of the associated location object.
-    #--
+    #
     #: () -> Array[Comment]
     def comments
       location.comments
@@ -194,7 +194,7 @@ module Prism
     # :section:
 
     # Returns all of the lines of the source code associated with this node.
-    #--
+    #
     #: () -> Array[String]
     def source_lines
       location.source_lines
@@ -205,7 +205,7 @@ module Prism
     alias script_lines source_lines
 
     # Slice the location of the node from the source.
-    #--
+    #
     #: () -> String
     def slice
       location.slice
@@ -214,7 +214,7 @@ module Prism
     # Slice the location of the node from the source, starting at the beginning
     # of the line that the location starts on, ending at the end of the line
     # that the location ends on.
-    #--
+    #
     #: () -> String
     def slice_lines
       location.slice_lines
@@ -228,14 +228,14 @@ module Prism
     # :startdoc:
 
     # Returns true if the node has the newline flag set.
-    #--
+    #
     #: () -> bool
     def newline?
       flags.anybits?(NodeFlags::NEWLINE)
     end
 
     # Returns true if the node has the static literal flag set.
-    #--
+    #
     #: () -> bool
     def static_literal?
       flags.anybits?(NodeFlags::STATIC_LITERAL)
@@ -243,7 +243,7 @@ module Prism
 
     # Similar to inspect, but respects the current level of indentation given by
     # the pretty print object.
-    #--
+    #
     #: (PP q) -> void
     def pretty_print(q) # :nodoc:
       q.seplist(inspect.chomp.each_line, -> { q.breakable }) do |line|
@@ -253,7 +253,7 @@ module Prism
     end
 
     # Convert this node into a graphviz dot graph string.
-    #--
+    #
     #: () -> String
     def to_dot
       # @type self: node
@@ -266,7 +266,7 @@ module Prism
     #
     # Important to note is that the column given to this method should be in
     # bytes, as opposed to characters or code units.
-    #--
+    #
     #: (Integer line, Integer column) -> Array[node]
     def tunnel(line, column)
       queue = [self] #: Array[node]
@@ -292,7 +292,7 @@ module Prism
     # particular condition.
     #
     #     node.breadth_first_search { |node| node.node_id == node_id }
-    #--
+    #
     #: () { (node) -> bool } -> node?
     def breadth_first_search(&blk)
       queue = [self] #: Array[node]
@@ -311,7 +311,7 @@ module Prism
     # particular condition.
     #
     #     node.breadth_first_search_all { |node| node.is_a?(Prism::CallNode) }
-    #--
+    #
     #: () { (node) -> bool } -> Array[node]
     def breadth_first_search_all(&blk)
       queue = [self] #: Array[Prism::node]
@@ -329,7 +329,7 @@ module Prism
     # Returns a list of the fields that exist for this node class. Fields
     # describe the structure of the node. This kind of reflection is useful for
     # things like recursively visiting each node _and_ field in the tree.
-    #--
+    #
     #: () -> Array[Reflection::Field]
     def self.fields
       # This method should only be called on subclasses of Node, not Node
@@ -346,7 +346,7 @@ module Prism
     # --------------------------------------------------------------------------
 
     # Accepts a visitor and calls back into the specialized visit function.
-    #--
+    #
     #: (_Visitor visitor) -> untyped
     def accept(visitor)
       raise NoMethodError, "undefined method `accept' for #{inspect}"
@@ -354,7 +354,7 @@ module Prism
 
     # Returns an array of child nodes, including `nil`s in the place of optional
     # nodes that were not present.
-    #--
+    #
     #: () -> Array[node?]
     def child_nodes
       raise NoMethodError, "undefined method `child_nodes' for #{inspect}"
@@ -365,7 +365,7 @@ module Prism
     # With a block given, yields each child node. Without a block, returns
     # an enumerator that contains each child node. Excludes any `nil`s in
     # the place of optional nodes that were not present.
-    #--
+    #
     #: () -> Enumerator[node, void]
     #: () { (node) -> void } -> void
     def each_child_node(&blk)
@@ -374,7 +374,7 @@ module Prism
 
     # Returns an array of child nodes, excluding any `nil`s in the place of
     # optional nodes that were not present.
-    #--
+    #
     #: () -> Array[node]
     def compact_child_nodes
       raise NoMethodError, "undefined method `compact_child_nodes' for #{inspect}"
@@ -382,14 +382,14 @@ module Prism
 
     # Returns an array of child nodes and locations that could potentially have
     # comments attached to them.
-    #--
+    #
     #: () -> Array[node | Location]
     def comment_targets
       raise NoMethodError, "undefined method `comment_targets' for #{inspect}"
     end
 
     # Returns a string representation of the node.
-    #--
+    #
     #: () -> String
     def inspect
       raise NoMethodError, "undefined method `inspect' for #{inspect}"
@@ -407,7 +407,7 @@ module Prism
     # it uses a single integer comparison, but also because if you're on CRuby
     # you can take advantage of the fact that case statements with all symbol
     # keys will use a jump table.
-    #--
+    #
     #: () -> Symbol
     def type
       raise NoMethodError, "undefined method `type' for #{inspect}"
@@ -417,7 +417,7 @@ module Prism
     # splitting on the type of the node without having to do a long === chain.
     # Note that like #type, it will still be slower than using == for a single
     # class, but should be faster in a case statement or an array comparison.
-    #--
+    #
     #: () -> Symbol
     def self.type
       raise NoMethodError, "undefined method `type' for #{inspect}"
@@ -434,7 +434,7 @@ module Prism
     <%- end -%>
 
     # Initialize a new <%= node.name %> node.
-    #--
+    #
     #: (Source source, Integer node_id, Location location, Integer flags, <%= node.fields.map { |field| "#{field.rbs_class} #{field.name}" }.join(", ") %>) -> void
     def initialize(<%= ["source", "node_id", "location", "flags", *node.fields.map(&:name)].join(", ") %>)
       @source = source
@@ -461,14 +461,14 @@ module Prism
     # ----------------------------------------------------------------------------------
 
     # See Node.accept.
-    #--
+    #
     #: (_Visitor visitor) -> untyped
     def accept(visitor)
       visitor.visit_<%= node.human %>(self)
     end
 
     # See Node.child_nodes.
-    #--
+    #
     #: () -> Array[node?]
     def child_nodes
       [<%= node.fields.map { |field|
@@ -480,7 +480,7 @@ module Prism
     end
 
     # See Node.each_child_node.
-    #--
+    #
     #: () -> Enumerator[node, void]
     #: () { (node) -> void } -> void
     def each_child_node(&blk)
@@ -499,7 +499,7 @@ module Prism
     end
 
     # See Node.compact_child_nodes.
-    #--
+    #
     #: () -> Array[node]
     def compact_child_nodes
       <%- if node.fields.any? { |field| field.is_a?(Prism::Template::OptionalNodeField) } -%>
@@ -526,7 +526,7 @@ module Prism
     end
 
     # See Node.comment_targets.
-    #--
+    #
     #: () -> Array[node | Location]
     def comment_targets
       [<%= node.fields.map { |field|
@@ -541,7 +541,7 @@ module Prism
     #   copy(**fields) -> <%= node.name %>
     #
     # Creates a copy of self with the given fields, using self as the template.
-    #--
+    #
     #: (?node_id: Integer, ?location: Location, ?flags: Integer, <%= node.fields.map { |field| "?#{field.name}: #{field.rbs_class}" }.join(", ") %>) -> <%= node.name %>
     def copy(<%= (["node_id", "location", "flags"] + node.fields.map(&:name)).map { |field| "#{field}: self.#{field}" }.join(", ") %>)
       <%= node.name %>.new(<%= ["source", "node_id", "location", "flags", *node.fields.map(&:name)].join(", ") %>)
@@ -564,14 +564,14 @@ module Prism
     end
 
     # See `Node#type`.
-    #--
+    #
     #: () -> :<%= node.human %>
     def type
       :<%= node.human %>
     end
 
     # See `Node.type`.
-    #--
+    #
     #: () -> :<%= node.human %>
     def self.type
       :<%= node.human %>
@@ -588,7 +588,7 @@ module Prism
     <%- node_flags.values.each do |value| -%>
     # :category: Flags
     # <%= value.comment %>
-    #--
+    #
     #: () -> bool
     def <%= value.name.downcase %>?
       flags.anybits?(<%= node_flags.name %>::<%= value.name %>)
@@ -610,7 +610,7 @@ module Prism
     #<%= line %>
     <%- end -%>
     <%- end -%>
-    #--
+    #
     #: () -> Location
     def <%= field.name %>
       location = @<%= field.name %>
@@ -621,7 +621,7 @@ module Prism
     # :category: Repository
     # Save the <%= field.name %> location using the given saved source so that
     # it can be retrieved later.
-    #--
+    #
     #: (_Repository repository) -> Relocation::Entry
     def save_<%= field.name %>(repository)
       repository.enter(node_id, :<%= field.name %>)
@@ -639,7 +639,7 @@ module Prism
     #<%= line %>
     <%- end -%>
     <%- end -%>
-    #--
+    #
     #: () -> Location?
     def <%= field.name %>
       location = @<%= field.name %>
@@ -656,7 +656,7 @@ module Prism
     # :category: Repository
     # Save the <%= field.name %> location using the given saved source so that
     # it can be retrieved later.
-    #--
+    #
     #: (_Repository repository) -> Relocation::Entry?
     def save_<%= field.name %>(repository)
       repository.enter(node_id, :<%= field.name %>) unless @<%= field.name %>.nil?
@@ -672,7 +672,7 @@ module Prism
     #<%= line %>
     <%- end -%>
     <%- end -%>
-    #--
+    #
     #: () -> <%= field.rbs_class %>
     def <%= field.name %>
       @<%= field.name %>
@@ -691,7 +691,7 @@ module Prism
     #   <%= field.name.delete_suffix("_loc") %> -> String
     #
     # Slice the location of <%= field.name %> from the source.
-    #--
+    #
     #: () -> String
     def <%= field.name.delete_suffix("_loc") %>
       <%= field.name %>.slice
@@ -704,7 +704,7 @@ module Prism
     #   <%= field.name.delete_suffix("_loc") %> -> String | nil
     #
     # Slice the location of <%= field.name %> from the source.
-    #--
+    #
     #: () -> String?
     def <%= field.name.delete_suffix("_loc") %>
       <%= field.name %>&.slice

--- a/templates/lib/prism/reflection.rb.erb
+++ b/templates/lib/prism/reflection.rb.erb
@@ -13,7 +13,7 @@ module Prism
       attr_reader :name #: Symbol
 
       # Initializes the field with the given name.
-      #--
+      #
       #: (Symbol name) -> void
       def initialize(name)
         @name = name
@@ -91,7 +91,7 @@ module Prism
       attr_reader :flags #: Array[Symbol]
 
       # Initializes the flags field with the given name and flags.
-      #--
+      #
       #: (Symbol name, Array[Symbol] flags) -> void
       def initialize(name, flags)
         super(name)
@@ -100,7 +100,7 @@ module Prism
     end
 
     # Returns the fields for the given node.
-    #--
+    #
     #: (singleton(Node) node) -> Array[Field]
     def self.fields_for(node)
       case node.type

--- a/templates/lib/prism/serialize.rb.erb
+++ b/templates/lib/prism/serialize.rb.erb
@@ -23,7 +23,7 @@ module Prism
     #
     # The formatting of the source of this method is purposeful to illustrate
     # the structure of the serialized data.
-    #--
+    #
     #: (String input, String serialized, bool freeze) -> ParseResult
     def self.load_parse(input, serialized, freeze)
       input = input.dup
@@ -79,7 +79,7 @@ module Prism
     #
     # The formatting of the source of this method is purposeful to illustrate
     # the structure of the serialized data.
-    #--
+    #
     #: (String input, String serialized, bool freeze) -> LexResult
     def self.load_lex(input, serialized, freeze)
       source = Source.for(input, 1, [])
@@ -126,7 +126,7 @@ module Prism
     #
     # The formatting of the source of this method is purposeful to illustrate
     # the structure of the serialized data.
-    #--
+    #
     #: (String input, String serialized, bool freeze) -> Array[Comment]
     def self.load_parse_comments(input, serialized, freeze)
       source = Source.for(input, 1, [])
@@ -152,7 +152,7 @@ module Prism
     #
     # The formatting of the source of this method is purposeful to illustrate
     # the structure of the serialized data.
-    #--
+    #
     #: (String input, String serialized, bool freeze) -> ParseLexResult
     def self.load_parse_lex(input, serialized, freeze)
       source = Source.for(input, 1, [])
@@ -453,7 +453,7 @@ module Prism
 
       # variable-length integer using https://en.wikipedia.org/wiki/LEB128
       # This is also what protobuf uses: https://protobuf.dev/programming-guides/encoding/#varints
-      #--
+      #
       #: () -> Integer
       def load_varuint
         n = (io.getbyte or raise)
@@ -525,7 +525,7 @@ module Prism
       # Load a location object from the serialized data. Note that we are lying
       # about the signature a bit here, because we sometimes load it as a packed
       # integer instead of an object.
-      #--
+      #
       #: (bool freeze) -> Location
       def load_location(freeze)
         return load_location_object(freeze) if freeze
@@ -535,7 +535,7 @@ module Prism
       # Load an optional location object from the serialized data if it is
       # present. Note that we are lying about the signature a bit here, because
       # we sometimes load it as a packed integer instead of an object.
-      #--
+      #
       #: (bool freeze) -> Location?
       def load_optional_location(freeze)
         load_location(freeze) if io.getbyte != 0

--- a/templates/lib/prism/visitor.rb.erb
+++ b/templates/lib/prism/visitor.rb.erb
@@ -16,7 +16,7 @@ module Prism
   class BasicVisitor
     # Calls `accept` on the given node if it is not `nil`, which in turn should
     # call back into this visitor by calling the appropriate `visit_*` method.
-    #--
+    #
     #: (node? node) -> void
     def visit(node)
       # @type self: _Visitor
@@ -24,7 +24,7 @@ module Prism
     end
 
     # Visits each node in `nodes` by calling `accept` on each one.
-    #--
+    #
     #: (Array[node?] nodes) -> void
     def visit_all(nodes)
       # @type self: _Visitor
@@ -32,7 +32,7 @@ module Prism
     end
 
     # Visits the child nodes of `node` by calling `accept` on each one.
-    #--
+    #
     #: (node node) -> void
     def visit_child_nodes(node)
       # @type self: _Visitor
@@ -63,7 +63,7 @@ module Prism
     <%- nodes.each_with_index do |node, index| -%>
 <%= "\n" if index != 0 -%>
     # Visit a <%= node.name %> node
-    #--
+    #
     #: (<%= node.name %> node) -> void
     def visit_<%= node.human %>(node)
       node.each_child_node { |node| node.accept(self) }


### PR DESCRIPTION
RDoc 8 parses rbs (including inline) and so
automatically removes the annotations for us