### PR TITLE
Fix `Comment#trailing` for syntax invalid edgecase

### DIFF
--- a/lib/prism/parse_result.rb
+++ b/lib/prism/parse_result.rb
@@ -744,6 +744,8 @@ module Prism
     #: () -> bool
     def trailing?
       !location.start_line_slice.strip.empty?
+    rescue ArgumentError # invalid bytes, never whitespace only
+      false
     end
 
     # Returns a string representation of this comment.

--- a/test/prism/result/comments_test.rb
+++ b/test/prism/result/comments_test.rb
@@ -39,6 +39,16 @@ module Prism
       )
     end
 
+    def test_comment_trailing
+      comment = Prism.parse_comments("x # trailing")[0]
+      assert_predicate(comment, :trailing?)
+    end
+
+    def test_comment_syntax_invalid_bytes_trailing
+      comment = Prism.parse_comments("\xFF\xFE# not trailing")[0]
+      refute_predicate(comment, :trailing?)
+    end
+
     def test___END__
       result = Prism.parse(<<~RUBY)
         __END__


### PR DESCRIPTION
When prism encounter invalid bytes and still  switches over to parsing comments, `strip` will raise

`syntax_suggest` might run into this via `ruby/spec`: https://github.com/ruby/syntax_suggest/issues/258